### PR TITLE
Replaced the DECLARE_VIRTUAL_REFCOUNTED macro with an abstract base class

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -39,9 +39,11 @@
 		0FE4479C1B7AAA03009498EB /* WordLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE4479A1B7AAA03009498EB /* WordLock.cpp */; };
 		0FEC3C5E1F368A9700F59B6C /* ReadWriteLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC3C5C1F368A9700F59B6C /* ReadWriteLock.cpp */; };
 		0FFF19DC1BB334EB00886D91 /* ParallelHelperPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFF19DA1BB334EB00886D91 /* ParallelHelperPool.cpp */; };
+		1404B3E52CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 1404B3E42CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		140ECC342C99057100473E19 /* RefCountedAndCanMakeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 140ECC332C99057100473E19 /* RefCountedAndCanMakeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		143DDE9620C8BC37007F76FA /* Entitlements.mm in Sources */ = {isa = PBXBuildFile; fileRef = 143DDE9520C8BC37007F76FA /* Entitlements.mm */; };
 		143F611F1565F0F900DB514A /* RAMSize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 143F611D1565F0F900DB514A /* RAMSize.cpp */; };
+		144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 144EB7452CBC94B100926E1B /* AbstractRefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1469419D16EAB10A0024E146 /* AutodrainedPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */; };
 		1470EAF32BD6F6D900E26254 /* WeakPtrImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF22BD6F6D900E26254 /* WeakPtrImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF52BD6F8AF00E26254 /* WeakPtrFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF42BD6F8AF00E26254 /* WeakPtrFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1098,6 +1100,7 @@
 		0FFF19DA1BB334EB00886D91 /* ParallelHelperPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParallelHelperPool.cpp; sourceTree = "<group>"; };
 		0FFF19DB1BB334EB00886D91 /* ParallelHelperPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParallelHelperPool.h; sourceTree = "<group>"; };
 		132743924FC54E469F5A8E6E /* StdUnorderedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdUnorderedSet.h; sourceTree = "<group>"; };
+		1404B3E42CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AbstractRefCountedAndCanMakeWeakPtr.h; path = wtf/AbstractRefCountedAndCanMakeWeakPtr.h; sourceTree = "<group>"; };
 		140ECC332C99057100473E19 /* RefCountedAndCanMakeWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RefCountedAndCanMakeWeakPtr.h; sourceTree = "<group>"; };
 		140ECC352C9906DF00473E19 /* RefCountedAndCanMakeWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RefCountedAndCanMakeWeakPtr.h; path = wtf/RefCountedAndCanMakeWeakPtr.h; sourceTree = "<group>"; };
 		143DDE9520C8BC37007F76FA /* Entitlements.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Entitlements.mm; sourceTree = "<group>"; };
@@ -1106,6 +1109,7 @@
 		143F611E1565F0F900DB514A /* RAMSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RAMSize.h; sourceTree = "<group>"; };
 		1447AEC518FCE57700B3D7FF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		1447AECA18FCE5B900B3D7FF /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = /usr/lib/libicucore.dylib; sourceTree = "<absolute>"; };
+		144EB7452CBC94B100926E1B /* AbstractRefCounted.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AbstractRefCounted.h; path = wtf/AbstractRefCounted.h; sourceTree = "<group>"; };
 		1469419416EAAFF80024E146 /* SchedulePair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SchedulePair.h; sourceTree = "<group>"; };
 		1469419A16EAB10A0024E146 /* AutodrainedPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutodrainedPool.h; sourceTree = "<group>"; };
 		1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AutodrainedPool.cpp; sourceTree = "<group>"; };
@@ -1981,6 +1985,8 @@
 		5D247B5714689B8600E78B76 = {
 			isa = PBXGroup;
 			children = (
+				1404B3E42CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h */,
+				144EB7452CBC94B100926E1B /* AbstractRefCounted.h */,
 				140ECC352C9906DF00473E19 /* RefCountedAndCanMakeWeakPtr.h */,
 				5D247B6D14689C4700E78B76 /* Configurations */,
 				DDE9931F278D0FAA00F60D26 /* Frameworks */,
@@ -3144,6 +3150,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */,
+				144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */,
+				1404B3E52CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h in Headers */,
 				E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */,
 				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,

--- a/Source/WTF/wtf/AbstractRefCounted.h
+++ b/Source/WTF/wtf/AbstractRefCounted.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +25,19 @@
 
 #pragma once
 
-#include <span>
-#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+namespace WTF {
 
-namespace WebCore {
-
-class ResourceError;
-class ResourceResponse;
-class SharedBuffer;
-
-class BackgroundFetchRecordLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<BackgroundFetchRecordLoaderClient> {
+// Use this class when an abstract base class needs refcounting, and the
+// refcounting implementation will be in a concrete subclass.
+class AbstractRefCounted {
 public:
-    virtual ~BackgroundFetchRecordLoaderClient() = default;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
-    virtual void didSendData(uint64_t) = 0;
-    virtual void didReceiveResponse(ResourceResponse&&) = 0;
-    virtual void didReceiveResponseBodyChunk(const SharedBuffer&) = 0;
-    virtual void didFinish(const ResourceError&) = 0;
+protected:
+    virtual ~AbstractRefCounted() = default;
 };
 
-class BackgroundFetchRecordLoader : public AbstractRefCounted {
-public:
-    virtual ~BackgroundFetchRecordLoader() = default;
+} // namespace WTF
 
-    virtual void abort() = 0;
-};
-
-} // namespace WebCore
+using WTF::AbstractRefCounted;

--- a/Source/WTF/wtf/AbstractRefCountedAndCanMakeWeakPtr.h
+++ b/Source/WTF/wtf/AbstractRefCountedAndCanMakeWeakPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +25,20 @@
 
 #pragma once
 
-#include <span>
-#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/CanMakeWeakPtr.h>
 
-namespace WebCore {
+namespace WTF {
 
-class ResourceError;
-class ResourceResponse;
-class SharedBuffer;
-
-class BackgroundFetchRecordLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<BackgroundFetchRecordLoaderClient> {
-public:
-    virtual ~BackgroundFetchRecordLoaderClient() = default;
-
-    virtual void didSendData(uint64_t) = 0;
-    virtual void didReceiveResponse(ResourceResponse&&) = 0;
-    virtual void didReceiveResponseBodyChunk(const SharedBuffer&) = 0;
-    virtual void didFinish(const ResourceError&) = 0;
+template<typename T>
+class AbstractRefCountedAndCanMakeWeakPtr : public AbstractRefCounted, public CanMakeWeakPtr<T> {
 };
 
-class BackgroundFetchRecordLoader : public AbstractRefCounted {
-public:
-    virtual ~BackgroundFetchRecordLoader() = default;
-
-    virtual void abort() = 0;
+template<typename T>
+class AbstractRefCountedAndCanMakeSingleThreadWeakPtr : public AbstractRefCounted, public CanMakeSingleThreadWeakPtr<T> {
 };
 
-} // namespace WebCore
+} // namespace WTF
+
+using WTF::AbstractRefCountedAndCanMakeWeakPtr;
+using WTF::AbstractRefCountedAndCanMakeSingleThreadWeakPtr;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(WTF_PUBLIC_HEADERS
+    AbstractRefCounted.h
+    AbstractRefCountedAndCanMakeWeakPtr.h
     ASCIICType.h
     AccessibleAddress.h
     AggregateLogger.h

--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -52,7 +52,8 @@ public:
 // A RefCountedSerialFunctionDispatcher guarantees that a dispatched function will always be run.
 class RefCountedSerialFunctionDispatcher : public SerialFunctionDispatcher {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 };
 
 inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)

--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -39,10 +39,6 @@ namespace WTF {
 #define CHECK_REF_COUNTED_LIFECYCLE 0
 #endif
 
-#define DECLARE_VIRTUAL_REFCOUNTED \
-    virtual void ref() const = 0; \
-    virtual void deref() const = 0;
-
 #define DEFINE_VIRTUAL_REFCOUNTED \
     void ref() const final { RefCounted::ref(); } \
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -27,6 +27,7 @@
 
 #include "WebGPURequestAdapterOptions.h"
 #include <optional>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -73,10 +74,8 @@ class XRView;
 
 struct PresentationContextDescriptor;
 
-class GPU {
+class GPU : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~GPU() = default;
 
     virtual void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) = 0;

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
@@ -27,6 +27,7 @@
 
 #include "JSDOMPromiseDeferredForward.h"
 #include "PushSubscription.h"
+#include <wtf/AbstractRefCounted.h>
 
 namespace WebCore {
 
@@ -34,10 +35,8 @@ class PushSubscription;
 
 enum class PushPermissionState : uint8_t;
 
-class PushSubscriptionOwner {
+class PushSubscriptionOwner : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~PushSubscriptionOwner() = default;
 
     virtual bool isActive() const = 0;

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -30,14 +30,13 @@
 
 #include "JSDOMPromiseDeferredForward.h"
 #include "ReadableStreamDefaultController.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class ReadableStreamSource {
+class ReadableStreamSource : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     WEBCORE_EXPORT ReadableStreamSource();
     WEBCORE_EXPORT virtual ~ReadableStreamSource();
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <span>
-#include <wtf/RefCounted.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
@@ -39,10 +39,8 @@ class WritableStreamSink;
 
 struct WebTransportBidirectionalStreamConstructionParameters;
 
-class WEBCORE_EXPORT WebTransportSession {
+class WEBCORE_EXPORT WebTransportSession : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~WebTransportSession();
 
     virtual void sendDatagram(std::span<const uint8_t>, CompletionHandler<void()>&&) = 0;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -31,6 +31,7 @@
 #include "Settings.h"
 #include "TextFlags.h"
 #include <memory>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakHashSet.h>
@@ -204,10 +205,8 @@ private:
     Timer m_timeoutTimer;
 };
 
-class CSSFontFaceClient : public CanMakeWeakPtr<CSSFontFaceClient> {
+class CSSFontFaceClient : public AbstractRefCountedAndCanMakeWeakPtr<CSSFontFaceClient> {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~CSSFontFaceClient() = default;
     virtual void fontLoaded(CSSFontFace&) { }
     virtual void fontStateChanged(CSSFontFace&, CSSFontFace::Status /*oldState*/, CSSFontFace::Status /*newState*/) { }

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -31,12 +32,10 @@ namespace WebCore {
 class CSSRule;
 class CSSStyleSheet;
 
-class CSSRuleList {
+class CSSRuleList : public AbstractRefCounted {
     WTF_MAKE_NONCOPYABLE(CSSRuleList);
 public:
     virtual ~CSSRuleList();
-
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual unsigned length() const = 0;
     virtual CSSRule* item(unsigned index) const = 0;

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -24,6 +24,7 @@
 #include "CSSPropertyNames.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 
 namespace WebCore {
@@ -36,12 +37,10 @@ class MutableStyleProperties;
 class StyleProperties;
 class StyledElement;
 
-class CSSStyleDeclaration : public ScriptWrappable, public CanMakeSingleThreadWeakPtr<CSSStyleDeclaration> {
+class CSSStyleDeclaration : public ScriptWrappable, public AbstractRefCountedAndCanMakeSingleThreadWeakPtr<CSSStyleDeclaration> {
     WTF_MAKE_NONCOPYABLE(CSSStyleDeclaration);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSStyleDeclaration);
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~CSSStyleDeclaration() = default;
 
     virtual StyledElement* parentElement() const { return nullptr; }

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -28,6 +28,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "TaskSource.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Assertions.h>
 #include <wtf/CancellableTask.h>
 #include <wtf/Forward.h>
@@ -49,10 +50,8 @@ enum class ReasonForSuspension : uint8_t {
     PageWillBeSuspended,
 };
 
-class WEBCORE_EXPORT ActiveDOMObject : public ContextDestructionObserver {
+class WEBCORE_EXPORT ActiveDOMObject : public AbstractRefCounted, public ContextDestructionObserver {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     // The suspendIfNeeded must be called exactly once after object construction to update
     // the suspended state to match that of the ScriptExecutionContext.
     void suspendIfNeeded();

--- a/Source/WebCore/loader/ContentFilterClient.h
+++ b/Source/WebCore/loader/ContentFilterClient.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(CONTENT_FILTERING)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class ContentFilterClient;
@@ -46,10 +46,8 @@ class ResourceError;
 class SharedBuffer;
 class SubstituteData;
 
-class ContentFilterClient : public CanMakeWeakPtr<ContentFilterClient> {
+class ContentFilterClient : public AbstractRefCountedAndCanMakeWeakPtr<ContentFilterClient> {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~ContentFilterClient() = default;
 
     virtual void dataReceivedThroughContentFilter(const SharedBuffer&, size_t) = 0;

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
-#include <wtf/WeakPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,12 +35,9 @@ class PlatformSpeechSynthesisUtterance;
 class SpeechSynthesisClientObserver;
 class PlatformSpeechSynthesisVoice;
     
-class SpeechSynthesisClient : public CanMakeWeakPtr<SpeechSynthesisClient> {
+class SpeechSynthesisClient : public AbstractRefCountedAndCanMakeWeakPtr<SpeechSynthesisClient> {
 public:
     virtual ~SpeechSynthesisClient() = default;
-
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 
     virtual void setObserver(WeakPtr<SpeechSynthesisClientObserver>) = 0;
     virtual WeakPtr<SpeechSynthesisClientObserver> observer() const = 0;
@@ -54,12 +51,9 @@ public:
 
 };
 
-class SpeechSynthesisClientObserver : public CanMakeWeakPtr<SpeechSynthesisClientObserver>  {
+class SpeechSynthesisClientObserver : public AbstractRefCountedAndCanMakeWeakPtr<SpeechSynthesisClientObserver>  {
 public:
     virtual ~SpeechSynthesisClientObserver() = default;
-
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 
     virtual void didStartSpeaking() = 0;
     virtual void didFinishSpeaking() = 0;

--- a/Source/WebCore/platform/DateTimeChooser.h
+++ b/Source/WebCore/platform/DateTimeChooser.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
@@ -38,13 +39,10 @@ namespace WebCore {
 
 struct DateTimeChooserParameters;
 
-class DateTimeChooser : public CanMakeWeakPtr<DateTimeChooser> {
+class DateTimeChooser : public AbstractRefCountedAndCanMakeWeakPtr<DateTimeChooser> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(DateTimeChooser);
 public:
     virtual ~DateTimeChooser() = default;
-
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 
     virtual void endChooser() = 0;
     virtual void showChooser(const DateTimeChooserParameters&) = 0;

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -27,6 +27,7 @@
 
 #include "DeferrableTask.h"
 #include "PlatformMediaSession.h"
+#include <wtf/AbstractRefCounted.h>
 
 namespace WebCore {
 
@@ -36,10 +37,8 @@ public:
     virtual void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) = 0;
 };
 
-class WEBCORE_EXPORT RemoteCommandListener {
+class WEBCORE_EXPORT RemoteCommandListener : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     static RefPtr<RemoteCommandListener> create(RemoteCommandListenerClient&);
     RemoteCommandListener(RemoteCommandListenerClient&);
     virtual ~RemoteCommandListener();

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -32,6 +32,7 @@
 #include "AudioBus.h"
 #include "AudioIOCallback.h"
 #include <memory>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -43,10 +44,8 @@ namespace WebCore {
 // The audio hardware periodically calls the AudioIOCallback render() method asking it to render/output the next render quantum of audio.
 // It optionally will pass in local/live audio input when it calls render().
 
-class AudioDestination {
+class AudioDestination : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     // Pass in (numberOfInputChannels > 0) if live/local audio input is desired.
     // Port-specific device identification information for live/local input streams can be passed in the inputDeviceId.
     WEBCORE_EXPORT static Ref<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
 
 namespace WebCore {
     
@@ -36,7 +36,7 @@ enum class AudioHardwareActivityType {
     IsInactive
 };
 
-class AudioHardwareListener {
+class AudioHardwareListener : public AbstractRefCounted {
 public:
     class Client {
     public:
@@ -45,8 +45,6 @@ public:
         virtual void audioHardwareDidBecomeInactive() = 0;
         virtual void audioOutputDeviceChanged() = 0;
     };
-
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     using CreationFunction = Function<Ref<AudioHardwareListener>(AudioHardwareListener::Client&)>;
     WEBCORE_EXPORT static void setCreationFunction(CreationFunction&&);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -33,6 +33,7 @@
 #include "PlatformTimeRanges.h"
 #include "ProcessIdentity.h"
 #include <optional>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -43,13 +44,11 @@ namespace WebCore {
 
 class VideoFrame;
 
-class MediaPlayerPrivateInterface {
+// MediaPlayerPrivateInterface subclasses should be ref-counted, but each subclass may choose whether
+// to be RefCounted or ThreadSafeRefCounted. Therefore, each subclass must implement a pair of
+// virtual ref()/deref() methods. See NullMediaPlayerPrivate for an example.
+class MediaPlayerPrivateInterface : public AbstractRefCounted {
 public:
-    // MediaPlayerPrivateInterface subclasses should be ref-counted, but each subclass may choose whether
-    // to be RefCounted or ThreadSafeRefCounted. Therefore, each subclass must implement a pair of
-    // virtual ref()/deref() methods. See NullMediaPlayerPrivate for an example.
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     WEBCORE_EXPORT MediaPlayerPrivateInterface();
     WEBCORE_EXPORT virtual ~MediaPlayerPrivateInterface();
 

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PlatformLayer.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -43,10 +44,8 @@ enum class VideoFrameRotation : uint16_t;
 
 using LayerHostingContextID = uint32_t;
 
-class SampleBufferDisplayLayerClient : public CanMakeWeakPtr<SampleBufferDisplayLayerClient> {
+class SampleBufferDisplayLayerClient : public AbstractRefCountedAndCanMakeWeakPtr<SampleBufferDisplayLayerClient> {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual ~SampleBufferDisplayLayerClient() = default;
     virtual void sampleBufferDisplayLayerStatusDidFail() = 0;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -47,6 +47,7 @@
 #include "RealtimeMediaSourceFactory.h"
 #include "RealtimeMediaSourceIdentifier.h"
 #include "VideoFrameTimeMetadata.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -112,9 +113,9 @@ public:
     virtual void hasStartedProducingData() { }
 };
 
-class WEBCORE_EXPORT RealtimeMediaSource
+class WEBCORE_EXPORT RealtimeMediaSource : public AbstractRefCounted
 #if !RELEASE_LOG_DISABLED
-    : public LoggerHelper
+    , public LoggerHelper
 #endif
 {
 public:
@@ -142,8 +143,6 @@ public:
         virtual GUniquePtr<GstStructure> queryAdditionalStats() { return nullptr; }
 #endif
     };
-
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual ~RealtimeMediaSource();
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -31,8 +31,8 @@
 #include "RealtimeMediaSource.h"
 #include "RealtimeMediaSourceSettings.h"
 #include "UserActivity.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Observer.h>
-#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
@@ -58,15 +58,13 @@ class CaptureDeviceInfo;
 class ImageTransferSessionVT;
 class PixelBufferConformerCV;
 
-class CapturerObserver : public CanMakeWeakPtr<CapturerObserver> {
+class CapturerObserver : public AbstractRefCountedAndCanMakeWeakPtr<CapturerObserver> {
 public:
     virtual ~CapturerObserver() = default;
 
     virtual void capturerIsRunningChanged(bool) { }
     virtual void capturerFailed() { };
     virtual void capturerConfigurationChanged() { };
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 };
 
 class DisplayCaptureSourceCocoa final

--- a/Source/WebCore/platform/network/curl/CurlRequestClient.h
+++ b/Source/WebCore/platform/network/curl/CurlRequestClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -36,10 +37,8 @@ class NetworkLoadMetrics;
 class ResourceError;
 class SharedBuffer;
 
-class CurlRequestClient {
+class CurlRequestClient : public AbstractRefCounted {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual void curlDidSendData(CurlRequest&, unsigned long long bytesSent, unsigned long long totalBytesToBeSent) = 0;
     virtual void curlDidReceiveResponse(CurlRequest&, CurlResponse&&) = 0;
     virtual void curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&&) = 0;

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -33,6 +33,7 @@
 #include "ServiceWorkerClientQueryOptions.h"
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerThreadProxy.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -50,10 +51,8 @@ class SWContextManager {
 public:
     WEBCORE_EXPORT static SWContextManager& singleton();
 
-    class Connection {
+    class Connection : public AbstractRefCounted {
     public:
-        DECLARE_VIRTUAL_REFCOUNTED;
-
         virtual ~Connection() { }
 
         virtual void establishConnection(CompletionHandler<void()>&&) = 0;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -34,6 +34,7 @@
 #include "UseDownloadPlaceholder.h"
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/NotImplemented.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -70,10 +71,8 @@ class DownloadManager : public CanMakeCheckedPtr<DownloadManager> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DownloadManager);
 public:
-    class Client {
+    class Client : public AbstractRefCounted {
     public:
-        DECLARE_VIRTUAL_REFCOUNTED;
-
         virtual ~Client() { }
 
         // CheckedPtr interface

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -35,6 +35,7 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -60,10 +61,8 @@ using RedirectCompletionHandler = CompletionHandler<void(WebCore::ResourceReques
 using ChallengeCompletionHandler = CompletionHandler<void(AuthenticationChallengeDisposition, const WebCore::Credential&)>;
 using ResponseCompletionHandler = CompletionHandler<void(WebCore::PolicyAction)>;
 
-class NetworkDataTaskClient : public CanMakeWeakPtr<NetworkDataTaskClient> {
+class NetworkDataTaskClient : public AbstractRefCountedAndCanMakeWeakPtr<NetworkDataTaskClient> {
 public:
-    DECLARE_VIRTUAL_REFCOUNTED;
-
     virtual void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) = 0;
     virtual void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) = 0;
     virtual void didReceiveInformationalResponse(WebCore::ResourceResponse&&) { };

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
@@ -45,9 +46,8 @@ class MediaCapability;
 class WebPageProxy;
 class WebProcessProxy;
 
-struct ExtensionCapabilityGranterClient : public CanMakeWeakPtr<ExtensionCapabilityGranterClient> {
+struct ExtensionCapabilityGranterClient : public AbstractRefCountedAndCanMakeWeakPtr<ExtensionCapabilityGranterClient> {
     virtual ~ExtensionCapabilityGranterClient() = default;
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) = 0;
     virtual RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) = 0;

--- a/Source/WebKit/UIProcess/FrameLoadState.h
+++ b/Source/WebKit/UIProcess/FrameLoadState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/URL.h>
 #include <wtf/WeakHashSet.h>
 
@@ -32,11 +33,9 @@ namespace WebKit {
 
 enum class IsMainFrame : bool;
 
-class FrameLoadStateObserver : public CanMakeWeakPtr<FrameLoadStateObserver> {
+class FrameLoadStateObserver : public AbstractRefCountedAndCanMakeWeakPtr<FrameLoadStateObserver> {
 public:
     virtual ~FrameLoadStateObserver() = default;
-
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual void didReceiveProvisionalURL(const URL&) { }
     virtual void didStartProvisionalLoad(const URL&) { }

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -28,6 +28,7 @@
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/URL.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -36,11 +37,9 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class PageLoadStateObserverBase : public CanMakeWeakPtr<PageLoadStateObserverBase> {
+class PageLoadStateObserverBase : public AbstractRefCountedAndCanMakeWeakPtr<PageLoadStateObserverBase> {
 public:
     virtual ~PageLoadStateObserverBase() = default;
-
-    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual void willChangeIsLoading() = 0;
     virtual void didChangeIsLoading() = 0;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -26,6 +26,7 @@
 #ifndef ResponsivenessTimer_h
 #define ResponsivenessTimer_h
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakRef.h>
 
@@ -33,10 +34,8 @@ namespace WebKit {
 
 class ResponsivenessTimer {
 public:
-    class Client : public CanMakeWeakPtr<Client> {
+    class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:
-        DECLARE_VIRTUAL_REFCOUNTED;
-
         virtual ~Client() { }
         virtual void didBecomeUnresponsive() = 0;
         virtual void didBecomeResponsive() = 0;

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -31,6 +31,7 @@
 #include "WebAuthenticationRequestData.h"
 #include <WebCore/AuthenticatorResponse.h>
 #include <WebCore/ExceptionData.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -47,7 +48,7 @@ namespace WebKit {
 class Authenticator;
 using AuthenticatorObserverRespond = std::variant<Ref<WebCore::AuthenticatorResponse>, WebCore::ExceptionData>;
 
-class AuthenticatorObserver : public CanMakeWeakPtr<AuthenticatorObserver> {
+class AuthenticatorObserver : public AbstractRefCountedAndCanMakeWeakPtr<AuthenticatorObserver> {
 public:
     virtual ~AuthenticatorObserver() = default;
     virtual void respondReceived(AuthenticatorObserverRespond&&) = 0;
@@ -58,12 +59,9 @@ public:
     virtual void decidePolicyForLocalAuthenticator(CompletionHandler<void(LocalAuthenticatorPolicy)>&&) = 0;
     virtual void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) = 0;
     virtual void cancelRequest() = 0;
-
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 };
 
-class Authenticator : public RefCounted<Authenticator>, public CanMakeWeakPtr<Authenticator> {
+class Authenticator : public RefCountedAndCanMakeWeakPtr<Authenticator> {
 public:
     virtual ~Authenticator() = default;
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -39,6 +39,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/SharedMemory.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
@@ -123,10 +124,8 @@ public:
     void createGPU(WebGPUIdentifier, RenderingBackendIdentifier, IPC::StreamServerConnection::Handle&&);
     void releaseGPU(WebGPUIdentifier);
 
-    class Client {
+    class Client : public AbstractRefCounted {
     public:
-        DECLARE_VIRTUAL_REFCOUNTED;
-
         virtual ~Client() = default;
 
         virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -29,6 +29,7 @@
 
 #include "Connection.h"
 #include "MessageReceiverMap.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -64,10 +65,8 @@ public:
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
-    class Client {
+    class Client : public AbstractRefCounted {
     public:
-        DECLARE_VIRTUAL_REFCOUNTED;
-
         virtual ~Client() = default;
 
         virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -29,6 +29,7 @@
 
 #include "RTCNetwork.h"
 #include <WebCore/LibWebRTCProvider.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 
@@ -41,12 +42,9 @@ namespace WebKit {
 
 struct NetworksChangedData;
 
-class WebRTCMonitorObserver : public CanMakeWeakPtr<WebRTCMonitorObserver> {
+class WebRTCMonitorObserver : public AbstractRefCountedAndCanMakeWeakPtr<WebRTCMonitorObserver> {
 public:
     virtual ~WebRTCMonitorObserver() = default;
-
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 
     virtual void networksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&) = 0;
     virtual void networkProcessCrashed() = 0;

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -34,6 +34,7 @@
 #import <WebCore/PushMessageCrypto.h>
 #import <WebCore/SecurityOrigin.h>
 #import <notify.h>
+#import <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/OSObjectPtr.h>
@@ -210,7 +211,7 @@ static PushSubscriptionData makePushSubscriptionFromRecord(PushRecord&& record)
     };
 }
 
-class PushServiceRequest : public CanMakeWeakPtr<PushServiceRequest> {
+class PushServiceRequest : public AbstractRefCountedAndCanMakeWeakPtr<PushServiceRequest> {
 public:
     virtual ~PushServiceRequest() = default;
 
@@ -220,8 +221,6 @@ public:
     const String& scope() const { return m_scope; };
 
     virtual void start() = 0;
-    virtual void ref() const = 0;
-    virtual void deref() const = 0;
 
     String key() const { return makePushTopic(m_identifier, m_scope); }
 


### PR DESCRIPTION
#### 59ca354ec983a0f06f75fb8bdb0983d88eb1c785
<pre>
Replaced the DECLARE_VIRTUAL_REFCOUNTED macro with an abstract base class
<a href="https://bugs.webkit.org/show_bug.cgi?id=281428">https://bugs.webkit.org/show_bug.cgi?id=281428</a>
<a href="https://rdar.apple.com/137875169">rdar://137875169</a>

Reviewed by Chris Dumez.

Chris pointed out that macros are hard to read/understand, and can interfere
with debugging.

We can use an abstract base class instead.

I like having a class for this because it matches how we declare concrete
refcounting.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/FunctionDispatcher.h:
* Source/WTF/wtf/RefCounted.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
* Source/WebCore/Modules/push-api/PushSubscriptionOwner.h:
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSRuleList.h:
* Source/WebCore/css/CSSStyleDeclaration.h:
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/loader/ContentFilterClient.h:
* Source/WebCore/page/SpeechSynthesisClient.h:
* Source/WebCore/platform/DateTimeChooser.h:
* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebCore/platform/audio/AudioDestination.h:
* Source/WebCore/platform/audio/AudioHardwareListener.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
(WebCore::CapturerObserver::capturerConfigurationChanged):
* Source/WebCore/platform/network/curl/CurlRequestClient.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordLoader.h:
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h:
* Source/WebKit/UIProcess/FrameLoadState.h:
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:
* Source/WebKit/webpushd/PushService.mm:

Canonical link: <a href="https://commits.webkit.org/285138@main">https://commits.webkit.org/285138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9261aeae7d39a407d230fd3acff3f3571842154

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56596 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15079 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21201 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77489 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70905 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18736 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64307 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6098 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92690 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10987 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1647 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20434 "Failed to compile JSC") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47939 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->