### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from IPC::MessageObserver

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -592,7 +592,7 @@ Error Connection::sendMessageImpl(UniqueRef<Encoder>&& encoder, OptionSet<SendOp
     if (isMainRunLoop()) {
         bool hasDeadObservers = false;
         for (auto& observerWeakPtr : m_messageObservers) {
-            if (auto* observer = observerWeakPtr.get())
+            if (RefPtr observer = observerWeakPtr.get())
                 observer->willSendMessage(encoder.get(), sendOptions);
             else
                 hasDeadObservers = true;
@@ -1369,7 +1369,7 @@ void Connection::dispatchMessage(Decoder& decoder)
     if (isMainRunLoop()) {
         bool hasDeadObservers = false;
         for (auto& observerWeakPtr : m_messageObservers) {
-            if (auto* observer = observerWeakPtr.get())
+            if (RefPtr observer = observerWeakPtr.get())
                 observer->didReceiveMessage(decoder);
             else
                 hasDeadObservers = true;

--- a/Source/WebKit/Platform/IPC/MessageObserver.h
+++ b/Source/WebKit/Platform/IPC/MessageObserver.h
@@ -27,17 +27,8 @@
 
 #if ENABLE(IPC_TESTING_API)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/OptionSet.h>
-#include <wtf/WeakPtr.h>
-
-namespace IPC {
-class MessageObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<IPC::MessageObserver> : std::true_type { };
-}
 
 namespace IPC {
 
@@ -46,7 +37,7 @@ class Encoder;
 
 enum class SendOption : uint8_t;
 
-class MessageObserver : public CanMakeWeakPtr<MessageObserver> {
+class MessageObserver : public AbstractRefCountedAndCanMakeWeakPtr<MessageObserver> {
 public:
     virtual ~MessageObserver() = default;
     virtual void willSendMessage(const Encoder&, OptionSet<SendOption>) = 0;


### PR DESCRIPTION
#### cdfced65d6dad803c57ae0bc3c2553865d9afeba
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from IPC::MessageObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=281432">https://bugs.webkit.org/show_bug.cgi?id=281432</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessageImpl):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/MessageObserver.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::addMessageListener):

Canonical link: <a href="https://commits.webkit.org/285167@main">https://commits.webkit.org/285167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c97c78b13713d50e68a21caf5f5c1120bba03828

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22728 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15111 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43040 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21249 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18784 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64343 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6141 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11002 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->