### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
@@ -27,6 +27,7 @@
 #include "RegExpSubstringGlobalAtomCache.h"
 
 #include "JSGlobalObjectInlines.h"
+#include "RegExpObjectInlines.h"
 
 namespace JSC {
 
@@ -67,30 +68,36 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
     auto input = substring->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
-    RETURN_IF_EXCEPTION(scope, { });
+    const String& pattern = regExp->atom();
+    ASSERT(!pattern.isEmpty());
 
-    if (result) {
-        do {
-            if (numberOfMatches > MAX_STORAGE_VECTOR_LENGTH) {
-                throwOutOfMemoryError(globalObject, scope);
-                return jsUndefined();
-            }
+    if (pattern.is8Bit()) {
+        if (input->is8Bit()) {
+            if (pattern.length() == 1)
+                oneCharMatches(input->span8(), pattern.span8()[0], numberOfMatches, startIndex);
+            else
+                genericMatches(input, pattern, numberOfMatches, startIndex);
+        } else {
+            if (pattern.length() == 1)
+                oneCharMatches(input->span16(), pattern.characterAt(0), numberOfMatches, startIndex);
+            else
+                genericMatches(input, pattern, numberOfMatches, startIndex);
+        }
+    } else {
+        if (input->is8Bit())
+            genericMatches(input, pattern, numberOfMatches, startIndex);
+        else {
+            if (pattern.length() == 1)
+                oneCharMatches(input->span16(), pattern.characterAt(0), numberOfMatches, startIndex);
+            else
+                genericMatches(input, pattern, numberOfMatches, startIndex);
+        }
+    }
 
-            numberOfMatches++;
-            startIndex = result.end;
-            if (result.empty())
-                startIndex++;
-
-            result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
-            RETURN_IF_EXCEPTION(scope, { });
-        } while (result);
-    } else if (!numberOfMatches)
+    if (!numberOfMatches)
         return jsNull();
 
     // Construct the array
-    const String& pattern = regExp->atom();
-    ASSERT(!pattern.isEmpty());
     JSArray* array = createPatternFilledArray(globalObject, jsString(vm, pattern), numberOfMatches);
     RETURN_IF_EXCEPTION(scope, { });
 


### PR DESCRIPTION
#### 0fd22570ba8e8653e86bc3069c897899070df468
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Tried to apply string search for substring match with global and atom.
Not sure why this is a significant regression.

                                       before                    after

global-atom-substring-match        1.6292+-0.0065     !      1.7279+-0.0059        ! definitely 1.0606x slower

* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fd22570ba8e8653e86bc3069c897899070df468

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24447 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22878 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22698 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61739 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19206 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77507 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70923 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64320 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92708 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46886 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20440 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49241 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->