### PR TITLE
[css-masonry] Fix masonry-intrinsic-sizing-rows-005.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1753,7 +1753,6 @@ webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
@@ -11,6 +11,11 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
+@font-face {
+  font-family: Ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -20,13 +25,15 @@ grid {
   padding: 0 1px 0 2px;
   vertical-align: top;
 }
+
 item {
   writing-mode: vertical-lr;
+  font-family: Ahem;
+  font-size: 9px;
 }
 </style>
 
 <body>
-
 <grid style="grid-template-rows: repeat(4, 3ch)">
   <item style="height:3ch">1</item>
   <item>2</item>
@@ -37,6 +44,7 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
 <grid style="grid-template-rows: repeat(4,3ch)">
@@ -49,29 +57,32 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+<grid style="grid-template-rows: repeat(4,3ch)">
   <item style="height:3ch; grid-row:1">5 5</item>
-  <item>6</item>
-  <item>7</item>
-  <item>8</item>
-  <item>9 9</item>
-</grid>
-
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
+</grid>
+
+<grid style="grid-template-rows: repeat(4,3ch)">
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-column:2; grid-row: 1;">5 5</item>
+  <item>6</item>
+  <item>7</item>
+  <item>8</item>
+  <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
@@ -11,6 +11,11 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
+@font-face {
+  font-family: Ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -20,13 +25,15 @@ grid {
   padding: 0 1px 0 2px;
   vertical-align: top;
 }
+
 item {
   writing-mode: vertical-lr;
+  font-family: Ahem;
+  font-size: 9px;
 }
 </style>
 
 <body>
-
 <grid style="grid-template-rows: repeat(4, 3ch)">
   <item style="height:3ch">1</item>
   <item>2</item>
@@ -37,6 +44,7 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
 <grid style="grid-template-rows: repeat(4,3ch)">
@@ -49,29 +57,32 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+<grid style="grid-template-rows: repeat(4,3ch)">
   <item style="height:3ch; grid-row:1">5 5</item>
-  <item>6</item>
-  <item>7</item>
-  <item>8</item>
-  <item>9 9</item>
-</grid>
-
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
+</grid>
+
+<grid style="grid-template-rows: repeat(4,3ch)">
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="height:3ch; grid-column:2; grid-row: 1;">5 5</item>
+  <item>6</item>
+  <item>7</item>
+  <item>8</item>
+  <item>9 9</item>
+  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
@@ -13,6 +13,11 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
+@font-face {
+  font-family: Ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -25,6 +30,8 @@ grid {
 
 item {
   writing-mode: vertical-lr;
+  font-family: Ahem;
+  font-size: 9px;
 }
 </style>
 


### PR DESCRIPTION
#### b79f7439f9580da79e784a83279751fecbb1e401
<pre>
[css-masonry] Fix masonry-intrinsic-sizing-rows-005.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=281438">https://bugs.webkit.org/show_bug.cgi?id=281438</a>
<a href="https://rdar.apple.com/problem/137890822">rdar://problem/137890822</a>

Reviewed by Sammy Gill.

Update test case to use Ahem font as the default font ends up resolving to 27.02 with 3 characters, which messes with the test case track sizes.

During sizing of the grid the min-content calculations will result in extra padding to the grid in the width direction. This needs to be accounted for too.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html:

Canonical link: <a href="https://commits.webkit.org/285235@main">https://commits.webkit.org/285235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d31055a9843e243af92718901d2127917fdebb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24730 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76105 "Build is in progress. Recent messages:") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22974 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/76105 "Build is in progress. Recent messages:") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15269 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61978 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/76105 "Build is in progress. Recent messages:") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19448 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18988 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62001 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6331 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->