### PR TITLE
[JSC] Apply string search for substring match global, atom, and one char pattern

### DIFF
--- a/JSTests/microbenchmarks/global-atom-substring-match-multi-chars.js
+++ b/JSTests/microbenchmarks/global-atom-substring-match-multi-chars.js
@@ -10,4 +10,3 @@ let regexp = /aaaaaaaaaa/g;
 for (let i = 0; i < 1e4; i++) {
     test(str, regexp);
 }
-

--- a/JSTests/microbenchmarks/global-atom-substring-match-one-char.js
+++ b/JSTests/microbenchmarks/global-atom-substring-match-one-char.js
@@ -1,0 +1,13 @@
+
+function test(str, regexp) {
+    str.substring(0, 50).match(regexp);
+    str.substring(0, 60).match(regexp);
+}
+noInline(test);
+
+let str = "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
+let regexp = /\n/g;
+for (let i = 0; i < 1e4; i++) {
+    test(str, regexp);
+}
+

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1484,6 +1484,14 @@ JSC_DEFINE_JIT_OPERATION(operationRegExpMatchFastGlobalString, EncodedJSValue, (
 
     ASSERT(regExp->global());
 
+    if (regExp->hasValidAtom()) {
+        if (string->isSubstring()) {
+            auto& cache = globalObject->regExpGlobalData().substringGlobalAtomCache();
+            OPERATION_RETURN(scope, JSValue::encode(cache.collectMatches(globalObject, string->asRope(), regExp)));
+        }
+        OPERATION_RETURN(scope, JSValue::encode(collectGlobalAtomMatches(globalObject, string, regExp)));
+    }
+
     auto s = string->value(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
 

--- a/Source/JavaScriptCore/runtime/RegExpObject.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpObject.cpp
@@ -178,7 +178,7 @@ JSValue RegExpObject::matchGlobal(JSGlobalObject* globalObject, JSString* string
     setLastIndex(globalObject, 0);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (regExp->global() && regExp->hasValidAtom()) {
+    if (regExp->hasValidAtom()) {
         if (string->isSubstring()) {
             auto& cache = globalObject->regExpGlobalData().substringGlobalAtomCache();
             RELEASE_AND_RETURN(scope, cache.collectMatches(globalObject, string->asRope(), regExp));


### PR DESCRIPTION
#### 5d4d979260eea6c0c2d55beef34a3ade47905f01
<pre>
[JSC] Apply string search for substring match global, atom, and one char pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=281440">https://bugs.webkit.org/show_bug.cgi?id=281440</a>
<a href="https://rdar.apple.com/137891651">rdar://137891651</a>

Reviewed by Yusuke Suzuki.

RegExp match is slow. This patch applies string search for
substring match with global, atom, and one char pattern.

                                                   before                    after

global-atom-substring-match-multi-chars        1.6233+-0.0061     ?      1.6337+-0.0057        ?
global-atom-substring-match-one-char           4.8063+-0.0086     ^      1.9914+-0.0066        ^ definitely 2.4135x faster

* JSTests/microbenchmarks/global-atom-substring-match-multi-chars.js: Copied from JSTests/microbenchmarks/global-atom-substring-match.js.
(test):
* JSTests/microbenchmarks/global-atom-substring-match-one-char.js: Renamed from JSTests/microbenchmarks/global-atom-substring-match.js.
(test):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/RegExpObject.cpp:
(JSC::RegExpObject::matchGlobal):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):

Canonical link: <a href="https://commits.webkit.org/285201@main">https://commits.webkit.org/285201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76c54d88fe394bd3e8aee0002bc2d67930df44b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22889 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15097 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21230 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64809 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77518 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70934 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18764 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64327 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-animations/svg-transform-animation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6121 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92719 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11015 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46897 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20443 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->