### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for UIDelegate

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -415,7 +415,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     _navigationState = makeUniqueWithoutRefCountedCheck<WebKit::NavigationState>(self);
     _page->setNavigationClient(_navigationState->createNavigationClient());
 
-    _uiDelegate = makeUnique<WebKit::UIDelegate>(self);
+    _uiDelegate = makeUniqueWithoutRefCountedCheck<WebKit::UIDelegate>(self);
     _page->setFindClient(makeUnique<WebKit::FindClient>(self));
     _page->setDiagnosticLoggingClient(makeUnique<WebKit::DiagnosticLoggingClient>(self));
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -39,15 +39,6 @@
 @class WKWebView;
 @protocol WKUIDelegate;
 
-namespace WebKit {
-class UIDelegate;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::UIDelegate> : std::true_type { };
-}
-
 namespace API {
 class FrameInfo;
 class SecurityOrigin;
@@ -67,6 +58,9 @@ class UIDelegate : public CanMakeWeakPtr<UIDelegate> {
 public:
     explicit UIDelegate(WKWebView *);
     ~UIDelegate();
+
+    void ref() const;
+    void deref() const;
 
 #if ENABLE(CONTEXT_MENUS)
     std::unique_ptr<API::ContextMenuClient> createContextMenuClient();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -88,14 +88,21 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UIDelegate);
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(UIDelegateUIClient, UIDelegate::UIClient);
 
-
 UIDelegate::UIDelegate(WKWebView *webView)
     : m_webView(webView)
 {
 }
 
-UIDelegate::~UIDelegate()
+UIDelegate::~UIDelegate() = default;
+
+void UIDelegate::ref() const
 {
+    [m_webView retain];
+}
+
+void UIDelegate::deref() const
+{
+    [m_webView release];
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -261,22 +268,23 @@ UIDelegate::ContextMenuClient::~ContextMenuClient()
 
 void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSMenu *menu, const ContextMenuContextData& data, API::Object* userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(menu);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewContextMenuForElement
-        && !m_uiDelegate->m_delegateMethods.webViewContextMenuForElementUserInfo
-        && !m_uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewContextMenuForElement
+        && !uiDelegate->m_delegateMethods.webViewContextMenuForElementUserInfo
+        && !uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler)
         return completionHandler(menu);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler(menu);
 
     auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data, page);
-    if (m_uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler) {
+    if (uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:));
-        [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSMenu *menu) mutable {
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSMenu *menu) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -286,10 +294,10 @@ void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSM
     }
     
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (m_uiDelegate->m_delegateMethods.webViewContextMenuForElement)
-        return completionHandler([(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() contextMenu:menu forElement:wrapper(contextMenuElementInfo.get())]);
+    if (uiDelegate->m_delegateMethods.webViewContextMenuForElement)
+        return completionHandler([(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:wrapper(contextMenuElementInfo.get())]);
 
-    completionHandler([(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() contextMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil]);
+    completionHandler([(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil]);
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 #endif
@@ -299,20 +307,19 @@ UIDelegate::UIClient::UIClient(UIDelegate& uiDelegate)
 {
 }
 
-UIDelegate::UIClient::~UIClient()
-{
-}
+UIDelegate::UIClient::~UIClient() = default;
 
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, API::Object* userInfo)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewMouseDidMoveOverElementWithFlagsUserInfo)
+    if (!uiDelegate->m_delegateMethods.webViewMouseDidMoveOverElementWithFlagsUserInfo)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -322,26 +329,27 @@ void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const Web
 #else
     auto modifierFlags = WebKit::WebIOSEventFactory::toUIKeyModifierFlags(modifiers);
 #endif
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() mouseDidMoveOverElement:wrapper(apiHitTestResult.get()) withFlags:modifierFlags userInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() mouseDidMoveOverElement:wrapper(apiHitTestResult.get()) withFlags:modifierFlags userInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 #endif
 
 void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageConfiguration>&& configuration, Ref<API::NavigationAction>&& navigationAction, CompletionHandler<void(RefPtr<WebPageProxy>&&)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(nullptr);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     ASSERT(delegate);
 
     ASSERT(configuration->windowFeatures());
     auto apiWindowFeatures = API::WindowFeatures::create(*configuration->windowFeatures());
     auto openerInfo = configuration->openerInfo();
 
-    if (m_uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeaturesAsync) {
+    if (uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeaturesAsync) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:completionHandler:));
 
-        [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker), relatedWebView = m_uiDelegate->m_webView.get(), openerInfo] (WKWebView *webView) mutable {
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker), relatedWebView = uiDelegate->m_webView.get(), openerInfo] (WKWebView *webView) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -362,15 +370,15 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
         }).get()];
         return;
     }
-    if (!m_uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures)
+    if (!uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures)
         return completionHandler(nullptr);
 
-    RetainPtr<WKWebView> webView = [delegate webView:m_uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures)];
+    RetainPtr<WKWebView> webView = [delegate webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures)];
     if (!webView)
         return completionHandler(nullptr);
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([webView.get()->_configuration _relatedWebView] != m_uiDelegate->m_webView.get().get())
+    if ([webView.get()->_configuration _relatedWebView] != uiDelegate->m_webView.get().get())
         [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -382,15 +390,16 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
 
 void UIDelegate::UIClient::runJavaScriptAlert(WebPageProxy& page, const WTF::String& message, WebFrameProxy*, FrameInfoData&& frameInfo, Function<void()>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler();
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler) {
         completionHandler();
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler();
         return;
@@ -399,7 +408,7 @@ void UIDelegate::UIClient::runJavaScriptAlert(WebPageProxy& page, const WTF::Str
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler();
@@ -409,15 +418,16 @@ void UIDelegate::UIClient::runJavaScriptAlert(WebPageProxy& page, const WTF::Str
 
 void UIDelegate::UIClient::runJavaScriptConfirm(WebPageProxy& page, const WTF::String& message, WebFrameProxy* webFrameProxy, FrameInfoData&& frameInfo, Function<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(false);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler) {
         completionHandler(false);
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(false);
         return;
@@ -426,7 +436,7 @@ void UIDelegate::UIClient::runJavaScriptConfirm(WebPageProxy& page, const WTF::S
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -436,15 +446,16 @@ void UIDelegate::UIClient::runJavaScriptConfirm(WebPageProxy& page, const WTF::S
 
 void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::String& message, const WTF::String& defaultValue, WebFrameProxy*, FrameInfoData&& frameInfo, Function<void(const WTF::String&)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler({ });
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler) {
         completionHandler(String());
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(String());
         return;
@@ -453,7 +464,7 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message defaultText:defaultValue initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message defaultText:defaultValue initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -463,10 +474,11 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
 
 void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProxy, WebFrameProxy*, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&& organizationStorageAccessPromptQuirk, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(false);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(false);
         return;
@@ -476,7 +488,7 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
     auto additionalLoginDomain = WebCore::NetworkStorageSession::findAdditionalLoginDomain(currentDomain, requestingDomain);
 
     if (organizationStorageAccessPromptQuirk || additionalLoginDomain) {
-        if (m_uiDelegate->m_delegateMethods.webViewRequestStorageAccessPanelForDomainUnderCurrentDomainForQuirkDomainsCompletionHandler) {
+        if (uiDelegate->m_delegateMethods.webViewRequestStorageAccessPanelForDomainUnderCurrentDomainForQuirkDomainsCompletionHandler) {
 
             NSMutableDictionary<NSString *, NSArray<NSString *> *> *quirkDomains = [NSMutableDictionary dictionaryWithCapacity:1];
             if (organizationStorageAccessPromptQuirk) {
@@ -490,7 +502,7 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
                 [quirkDomains setObject:@[additionalLoginDomain->string()] forKey:currentDomain.string()];
 
             auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:forQuirkDomains:completionHandler:));
-            [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() forQuirkDomains:quirkDomains completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+            [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() forQuirkDomains:quirkDomains completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
                 if (checker->completionHandlerHasBeenCalled())
                     return;
                 completionHandler(result);
@@ -502,7 +514,7 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
 
     if (organizationStorageAccessPromptQuirk) {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-        presentStorageAccessAlertSSOQuirk(m_uiDelegate->m_webView.get().get(), organizationStorageAccessPromptQuirk->organizationName, organizationStorageAccessPromptQuirk->quirkDomains, WTFMove(completionHandler));
+        presentStorageAccessAlertSSOQuirk(uiDelegate->m_webView.get().get(), organizationStorageAccessPromptQuirk->organizationName, organizationStorageAccessPromptQuirk->quirkDomains, WTFMove(completionHandler));
 #endif
         return;
     }
@@ -510,20 +522,20 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
     // Some sites have quirks where multiple login domains require storage access.
     if (additionalLoginDomain) {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-        presentStorageAccessAlertQuirk(m_uiDelegate->m_webView.get().get(), requestingDomain, *additionalLoginDomain, currentDomain, WTFMove(completionHandler));
+        presentStorageAccessAlertQuirk(uiDelegate->m_webView.get().get(), requestingDomain, *additionalLoginDomain, currentDomain, WTFMove(completionHandler));
 #endif
         return;
     }
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRequestStorageAccessPanelUnderFirstPartyCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRequestStorageAccessPanelUnderFirstPartyCompletionHandler) {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-        presentStorageAccessAlert(m_uiDelegate->m_webView.get().get(), requestingDomain, currentDomain, WTFMove(completionHandler));
+        presentStorageAccessAlert(uiDelegate->m_webView.get().get(), requestingDomain, currentDomain, WTFMove(completionHandler));
 #endif
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:completionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -533,14 +545,15 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
 
 void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::WebPageProxy& page, WebKit::WebFrameProxy& frame, const FrameInfoData& frameInfo, Function<void(bool)>& completionHandler)
 {
-    if (!m_uiDelegate || (!m_uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForFrameDecisionHandler && !m_uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler))
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || (!uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForFrameDecisionHandler && !uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler))
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    if (m_uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler) {
+    if (uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler) {
         auto securityOrigin = WebCore::SecurityOrigin::createFromString(page.pageLoadState().activeURL());
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:));
         auto decisionHandler = makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), securityOrigin = securityOrigin->data(), checker = WTFMove(checker), page = WeakPtr { page }] (WKPermissionDecision decision) mutable {
@@ -563,12 +576,12 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
                 break;
             }
         });
-        [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:decisionHandler.get()];
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestGeolocationPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:decisionHandler.get()];
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestGeolocationPermissionForFrame:decisionHandler:));
-    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestGeolocationPermissionForFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -578,44 +591,44 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
 
 void UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object* userInfo)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
-    if (!m_uiDelegate->m_delegateMethods.webViewDidResignInputElementStrongPasswordAppearanceWithUserInfo)
+    if (!uiDelegate->m_delegateMethods.webViewDidResignInputElementStrongPasswordAppearanceWithUserInfo)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() didResignInputElementStrongPasswordAppearanceWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didResignInputElementStrongPasswordAppearanceWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 
 bool UIDelegate::UIClient::canRunBeforeUnloadConfirmPanel() const
 {
-    if (!m_uiDelegate)
-        return false;
-
-    return m_uiDelegate->m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler;
+    RefPtr uiDelegate = m_uiDelegate.get();
+    return uiDelegate && uiDelegate->m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler;
 }
 
 void UIDelegate::UIClient::runBeforeUnloadConfirmPanel(WebPageProxy& page, const WTF::String& message, WebFrameProxy*, FrameInfoData&& frameInfo, Function<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(false);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler) {
         completionHandler(false);
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(false);
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -628,15 +641,16 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
     // Use 50 MB as the default database quota.
     unsigned long long defaultPerOriginDatabaseQuota = 50 * 1024 * 1024;
 
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(defaultPerOriginDatabaseQuota);
-    if (!m_uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler && !m_uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler && !uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
 
         completionHandler(defaultPerOriginDatabaseQuota);
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(defaultPerOriginDatabaseQuota);
         return;
@@ -644,9 +658,9 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
 
     ASSERT(securityOrigin);
 
-    if (m_uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
+    if (uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:databaseName:displayName:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-        [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName displayName:displayName currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
+        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName displayName:displayName currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -656,7 +670,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -684,15 +698,16 @@ static _WKScreenOrientationType toWKScreenOrientationType(WebCore::ScreenOrienta
 bool UIDelegate::UIClient::lockScreenOrientation(WebPageProxy&, WebCore::ScreenOrientationType orientation)
 {
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return false;
-    if (!m_uiDelegate->m_delegateMethods.webViewLockScreenOrientation)
+    if (!uiDelegate->m_delegateMethods.webViewLockScreenOrientation)
         return false;
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return false;
 
-    return [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationType(orientation)];
+    return [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationType(orientation)];
 #else
     UNUSED_PARAM(orientation);
     return false;
@@ -702,12 +717,13 @@ bool UIDelegate::UIClient::lockScreenOrientation(WebPageProxy&, WebCore::ScreenO
 void UIDelegate::UIClient::unlockScreenOrientation(WebPageProxy&)
 {
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
-    if (!m_uiDelegate->m_delegateMethods.webViewUnlockScreenOrientation)
+    if (!uiDelegate->m_delegateMethods.webViewUnlockScreenOrientation)
         return;
-    if (auto delegate = m_uiDelegate->m_delegate.get())
-        [(id<WKUIDelegatePrivate>)delegate _webViewUnlockScreenOrientation:m_uiDelegate->m_webView.get().get()];
+    if (auto delegate = uiDelegate->m_delegate.get())
+        [(id<WKUIDelegatePrivate>)delegate _webViewUnlockScreenOrientation:uiDelegate->m_webView.get().get()];
 #endif
 }
 
@@ -725,17 +741,18 @@ static inline _WKFocusDirection toWKFocusDirection(WKFocusDirection direction)
 
 bool UIDelegate::UIClient::takeFocus(WebPageProxy*, WKFocusDirection direction)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return false;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewTakeFocus)
+    if (!uiDelegate->m_delegateMethods.webViewTakeFocus)
         return false;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return false;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() takeFocus:toWKFocusDirection(direction)];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() takeFocus:toWKFocusDirection(direction)];
     return true;
 }
 
@@ -770,33 +787,35 @@ static _WKAutoplayEvent toWKAutoplayEvent(WebCore::AutoplayEvent event)
 
 void UIDelegate::UIClient::handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayEvent event, OptionSet<WebCore::AutoplayEventFlags> flags)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewHandleAutoplayEventWithFlags)
+    if (!uiDelegate->m_delegateMethods.webViewHandleAutoplayEventWithFlags)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() handleAutoplayEvent:toWKAutoplayEvent(event) withFlags:toWKAutoplayEventFlags(flags)];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() handleAutoplayEvent:toWKAutoplayEvent(event) withFlags:toWKAutoplayEventFlags(flags)];
 }
 
 void UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest(WebKit::WebPageProxy&, API::SecurityOrigin& securityOrigin, CompletionHandler<void(bool allowed)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(false);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRequestNotificationPermissionForSecurityOriginDecisionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewRequestNotificationPermissionForSecurityOriginDecisionHandler)
         return completionHandler(false);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler(false);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:wrapper(securityOrigin) decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:wrapper(securityOrigin) decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -807,19 +826,20 @@ void UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest(WebKit::
 
 void UIDelegate::UIClient::requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&& completion)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completion(WebCore::CookieConsentDecisionResult::NotSupported);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRequestCookieConsentWithMoreInfoHandlerDecisionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewRequestCookieConsentWithMoreInfoHandlerDecisionHandler)
         return completion(WebCore::CookieConsentDecisionResult::NotSupported);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completion(WebCore::CookieConsentDecisionResult::NotSupported);
 
     // FIXME: Add support for the 'more info' handler.
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestCookieConsentWithMoreInfoHandler:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestCookieConsentWithMoreInfoHandler:nil decisionHandler:makeBlockPtr([completion = WTFMove(completion), checker = WTFMove(checker)] (BOOL decision) mutable {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestCookieConsentWithMoreInfoHandler:nil decisionHandler:makeBlockPtr([completion = WTFMove(completion), checker = WTFMove(checker)] (BOOL decision) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -829,10 +849,11 @@ void UIDelegate::UIClient::requestCookieConsent(CompletionHandler<void(WebCore::
 
 bool UIDelegate::UIClient::focusFromServiceWorker(WebKit::WebPageProxy& proxy)
 {
-    bool hasImplementation = m_uiDelegate && m_uiDelegate->m_delegateMethods.focusWebViewFromServiceWorker && m_uiDelegate->m_delegate.get();
+    RefPtr uiDelegate = m_uiDelegate.get();
+    bool hasImplementation = uiDelegate && uiDelegate->m_delegateMethods.focusWebViewFromServiceWorker && uiDelegate->m_delegate.get();
     if (!hasImplementation) {
 #if PLATFORM(MAC)
-        auto* webView = m_uiDelegate ? m_uiDelegate->m_webView.get().get() : nullptr;
+        auto* webView = uiDelegate ? uiDelegate->m_webView.get().get() : nullptr;
         if (!webView || !webView.window)
             return false;
 
@@ -844,18 +865,19 @@ bool UIDelegate::UIClient::focusFromServiceWorker(WebKit::WebPageProxy& proxy)
         return false;
 #endif
     }
-    return [(id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get() _focusWebViewFromServiceWorker:m_uiDelegate->m_webView.get().get()];
+    return [(id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get() _focusWebViewFromServiceWorker:uiDelegate->m_webView.get().get()];
 }
 
 bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFrameProxy, FrameInfoData&& frameInfo, API::OpenPanelParameters* openPanelParameters, WebOpenPanelResultListenerProxy* listener)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return false;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunOpenPanelWithParametersInitiatedByFrameCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewRunOpenPanelWithParametersInitiatedByFrameCompletionHandler)
         return false;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return false;
 
@@ -863,7 +885,7 @@ bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFr
 
     Ref checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:));
 
-    [delegate webView:m_uiDelegate->m_webView.get().get() runOpenPanelWithParameters:wrapper(*openPanelParameters) initiatedByFrame:wrapper(frame) completionHandler:makeBlockPtr([checker = WTFMove(checker), openPanelParameters = Ref { *openPanelParameters }, listener = RefPtr { listener }] (NSArray *URLs) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runOpenPanelWithParameters:wrapper(*openPanelParameters) initiatedByFrame:wrapper(frame) completionHandler:makeBlockPtr([checker = WTFMove(checker), openPanelParameters = Ref { *openPanelParameters }, listener = RefPtr { listener }] (NSArray *URLs) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -895,190 +917,200 @@ bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFr
 #if PLATFORM(MAC)
 bool UIDelegate::UIClient::canRunModal() const
 {
-    if (!m_uiDelegate)
-        return false;
-
-    return m_uiDelegate->m_delegateMethods.webViewRunModal;
+    RefPtr uiDelegate = m_uiDelegate.get();
+    return uiDelegate && uiDelegate->m_delegateMethods.webViewRunModal;
 }
 
 void UIDelegate::UIClient::runModal(WebPageProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunModal)
+    if (!uiDelegate->m_delegateMethods.webViewRunModal)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewRunModal:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _webViewRunModal:uiDelegate->m_webView.get().get()];
 }
 
 float UIDelegate::UIClient::headerHeight(WebPageProxy&, WebFrameProxy& webFrameProxy)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return 0;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewHeaderHeight)
+    if (!uiDelegate->m_delegateMethods.webViewHeaderHeight)
         return 0;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return 0;
     
-    return [(id <WKUIDelegatePrivate>)delegate _webViewHeaderHeight:m_uiDelegate->m_webView.get().get()];
+    return [(id <WKUIDelegatePrivate>)delegate _webViewHeaderHeight:uiDelegate->m_webView.get().get()];
 }
 
 float UIDelegate::UIClient::footerHeight(WebPageProxy&, WebFrameProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return 0;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewFooterHeight)
+    if (!uiDelegate->m_delegateMethods.webViewFooterHeight)
         return 0;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return 0;
     
-    return [(id <WKUIDelegatePrivate>)delegate _webViewFooterHeight:m_uiDelegate->m_webView.get().get()];
+    return [(id <WKUIDelegatePrivate>)delegate _webViewFooterHeight:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::drawHeader(WebPageProxy&, WebFrameProxy& frame, WebCore::FloatRect&& rect)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDrawHeaderInRectForPageWithTitleURL)
+    if (!uiDelegate->m_delegateMethods.webViewDrawHeaderInRectForPageWithTitleURL)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
 }
 
 void UIDelegate::UIClient::drawFooter(WebPageProxy&, WebFrameProxy& frame, WebCore::FloatRect&& rect)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDrawFooterInRectForPageWithTitleURL)
+    if (!uiDelegate->m_delegateMethods.webViewDrawFooterInRectForPageWithTitleURL)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
 }
 
 void UIDelegate::UIClient::pageDidScroll(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidScroll)
+    if (!uiDelegate->m_delegateMethods.webViewDidScroll)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidScroll:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _webViewDidScroll:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::focus(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.focusWebView)
+    if (!uiDelegate->m_delegateMethods.focusWebView)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _focusWebView:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _focusWebView:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::unfocus(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.unfocusWebView)
+    if (!uiDelegate->m_delegateMethods.unfocusWebView)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _unfocusWebView:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _unfocusWebView:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didNotHandleWheelEvent(WebPageProxy*, const NativeWebWheelEvent& event)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidNotHandleWheelEvent)
+    if (!uiDelegate->m_delegateMethods.webViewDidNotHandleWheelEvent)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() didNotHandleWheelEvent:event.nativeEvent()];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didNotHandleWheelEvent:event.nativeEvent()];
 }
 
 void UIDelegate::UIClient::setIsResizable(WebKit::WebPageProxy&, bool resizable)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewSetResizable)
+    if (!uiDelegate->m_delegateMethods.webViewSetResizable)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() setResizable:resizable];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setResizable:resizable];
 }
 
 void UIDelegate::UIClient::setWindowFrame(WebKit::WebPageProxy&, const WebCore::FloatRect& frame)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewSetWindowFrame)
+    if (!uiDelegate->m_delegateMethods.webViewSetWindowFrame)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() setWindowFrame:frame];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setWindowFrame:frame];
 }
 
 void UIDelegate::UIClient::windowFrame(WebKit::WebPageProxy&, Function<void(WebCore::FloatRect)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler({ });
 
-    if (!m_uiDelegate->m_delegateMethods.webViewGetWindowFrameWithCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewGetWindowFrameWithCompletionHandler)
         return completionHandler({ });
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler({ });
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() getWindowFrameWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getWindowFrameWithCompletionHandler:))](CGRect frame) {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getWindowFrameWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getWindowFrameWithCompletionHandler:))](CGRect frame) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1088,17 +1120,18 @@ void UIDelegate::UIClient::windowFrame(WebKit::WebPageProxy&, Function<void(WebC
 
 void UIDelegate::UIClient::toolbarsAreVisible(WebPageProxy&, Function<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(true);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewGetToolbarsAreVisibleWithCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewGetToolbarsAreVisibleWithCompletionHandler)
         return completionHandler(true);
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler(true);
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() getToolbarsAreVisibleWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getToolbarsAreVisibleWithCompletionHandler:))](BOOL visible) {
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getToolbarsAreVisibleWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getToolbarsAreVisibleWithCompletionHandler:))](BOOL visible) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1108,92 +1141,98 @@ void UIDelegate::UIClient::toolbarsAreVisible(WebPageProxy&, Function<void(bool)
 
 void UIDelegate::UIClient::didClickAutoFillButton(WebPageProxy&, API::Object* userInfo)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidClickAutoFillButtonWithUserInfo)
+    if (!uiDelegate->m_delegateMethods.webViewDidClickAutoFillButtonWithUserInfo)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() didClickAutoFillButtonWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didClickAutoFillButtonWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 
 void UIDelegate::UIClient::showPage(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.showWebView)
+    if (!uiDelegate->m_delegateMethods.showWebView)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _showWebView:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _showWebView:uiDelegate->m_webView.get().get()];
 }
     
 void UIDelegate::UIClient::saveDataToFileInDownloadsFolder(WebPageProxy*, const WTF::String& suggestedFilename, const WTF::String& mimeType, const URL& originatingURL, API::Data& data)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewSaveDataToFileSuggestedFilenameMimeTypeOriginatingURL)
+    if (!uiDelegate->m_delegateMethods.webViewSaveDataToFileSuggestedFilenameMimeTypeOriginatingURL)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename mimeType:mimeType originatingURL:originatingURL];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename mimeType:mimeType originatingURL:originatingURL];
 }
 
 Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return API::InspectorConfiguration::create();
 
-    if (!m_uiDelegate->m_delegateMethods.webViewConfigurationForLocalInspector)
+    if (!uiDelegate->m_delegateMethods.webViewConfigurationForLocalInspector)
         return API::InspectorConfiguration::create();
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return API::InspectorConfiguration::create();
 
-    return static_cast<API::InspectorConfiguration&>([[(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() configurationForLocalInspector:wrapper(inspector)] _apiObject]);
+    return static_cast<API::InspectorConfiguration&>([[(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() configurationForLocalInspector:wrapper(inspector)] _apiObject]);
 }
 
 void UIDelegate::UIClient::didAttachLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidAttachLocalInspector)
+    if (!uiDelegate->m_delegateMethods.webViewDidAttachLocalInspector)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() didAttachLocalInspector:wrapper(inspector)];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didAttachLocalInspector:wrapper(inspector)];
 }
 
 void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewWillCloseLocalInspector)
+    if (!uiDelegate->m_delegateMethods.webViewWillCloseLocalInspector)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() willCloseLocalInspector:wrapper(inspector)];
+    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() willCloseLocalInspector:wrapper(inspector)];
 }
 
 #endif
@@ -1201,13 +1240,14 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
 #if ENABLE(DEVICE_ORIENTATION)
 void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy& page, WebFrameProxy& webFrameProxy, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto securityOrigin = WebCore::SecurityOrigin::createFromString(page.pageLoadState().activeURL());
-    if (!m_uiDelegate || !m_uiDelegate->m_delegate.get() || !m_uiDelegate->m_delegateMethods.webViewRequestDeviceOrientationAndMotionPermissionForOriginDecisionHandler) {
+    Ref securityOrigin = WebCore::SecurityOrigin::createFromString(page.pageLoadState().activeURL());
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || !uiDelegate->m_delegate.get() || !uiDelegate->m_delegateMethods.webViewRequestDeviceOrientationAndMotionPermissionForOriginDecisionHandler) {
         alertForPermission(page, MediaPermissionReason::DeviceOrientation, securityOrigin->data(), WTFMove(completionHandler));
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:requestDeviceOrientationAndMotionPermissionForOrigin:initiatedByFrame:decisionHandler:));
     auto decisionHandler = makeBlockPtr([completionHandler = WTFMove(completionHandler), securityOrigin = securityOrigin->data(), checker = WTFMove(checker), page = WeakPtr { page }](WKPermissionDecision decision) mutable {
         if (checker->completionHandlerHasBeenCalled())
@@ -1229,25 +1269,27 @@ void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::W
             break;
         }
     });
-    [delegate webView:m_uiDelegate->m_webView.get().get() requestDeviceOrientationAndMotionPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() decisionHandler:decisionHandler.get()];
+    [delegate webView:uiDelegate->m_webView.get().get() requestDeviceOrientationAndMotionPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() decisionHandler:decisionHandler.get()];
 }
 #endif
 
 void UIDelegate::UIClient::didChangeFontAttributes(const WebCore::FontAttributes& fontAttributes)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
     if (!needsFontAttributes())
         return;
 
-    auto privateUIDelegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
-    [privateUIDelegate _webView:m_uiDelegate->m_webView.get().get() didChangeFontAttributes:fontAttributes.createDictionary().get()];
+    auto privateUIDelegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    [privateUIDelegate _webView:uiDelegate->m_webView.get().get() didChangeFontAttributes:fontAttributes.createDictionary().get()];
 }
 
 void UIDelegate::UIClient::callDisplayCapturePermissionDelegate(WebPageProxy& page, WebFrameProxy& frame, API::SecurityOrigin& userMediaOrigin, API::SecurityOrigin& topLevelOrigin, UserMediaPermissionRequestProxy& request)
 {
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    RefPtr uiDelegate = m_uiDelegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     ASSERT([delegate respondsToSelector:@selector(_webView:requestDisplayCapturePermissionForOrigin:initiatedByFrame:withSystemAudio:decisionHandler:)]);
 
     auto checker = CompletionHandlerCallChecker::create(delegate, @selector(_webView:requestDisplayCapturePermissionForOrigin:initiatedByFrame:withSystemAudio:decisionHandler:));
@@ -1279,16 +1321,17 @@ void UIDelegate::UIClient::callDisplayCapturePermissionDelegate(WebPageProxy& pa
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
     BOOL requestSystemAudio = !!request.requiresDisplayCaptureWithAudio();
-    [delegate _webView:m_uiDelegate->m_webView.get().get() requestDisplayCapturePermissionForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() withSystemAudio:requestSystemAudio decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() requestDisplayCapturePermissionForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() withSystemAudio:requestSystemAudio decisionHandler:decisionHandler.get()];
 
 }
 void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProxy& page, WebFrameProxy& frame, API::SecurityOrigin& userMediaOrigin, API::SecurityOrigin& topLevelOrigin, UserMediaPermissionRequestProxy& request)
 {
 #if ENABLE(MEDIA_STREAM)
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         ensureOnMainRunLoop([protectedRequest = Ref { request }]() {
             protectedRequest->doDefaultAction();
@@ -1352,7 +1395,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         WKMediaCaptureType type = WKMediaCaptureTypeCamera;
         if (request.requiresAudioCapture())
             type = request.requiresVideoCapture() ? WKMediaCaptureTypeCameraAndMicrophone : WKMediaCaptureTypeMicrophone;
-        [delegate webView:m_uiDelegate->m_webView.get().get() requestMediaCapturePermissionForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() type:type decisionHandler:decisionHandler.get()];
+        [delegate webView:uiDelegate->m_webView.get().get() requestMediaCapturePermissionForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() type:type decisionHandler:decisionHandler.get()];
         return;
     }
 
@@ -1386,18 +1429,19 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         const String& audioDeviceUID = protectedRequest->requiresAudioCapture() ? protectedRequest->audioDeviceUIDs().first() : String();
         protectedRequest->allow(audioDeviceUID, videoDeviceUID);
     });
-    [delegate _webView:m_uiDelegate->m_webView.get().get() requestUserMediaAuthorizationForDevices:devices url:requestFrameURL mainFrameURL:mainFrameURL decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() requestUserMediaAuthorizationForDevices:devices url:requestFrameURL mainFrameURL:mainFrameURL decisionHandler:decisionHandler.get()];
 #endif
 }
 
 void UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting(WebPageProxy& page, WebFrameProxy& frame, API::SecurityOrigin& userMediaOrigin, API::SecurityOrigin& topLevelOrigin, CompletionHandler<void(bool isAllowed)>&& completionHandler)
 {
-    if (!m_uiDelegate) {
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate) {
         completionHandler(false);
         return;
     }
 
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(false);
         return;
@@ -1425,16 +1469,17 @@ void UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting(WebPageProxy& pa
     FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID, frame.process().processID(), frame.isFocused() };
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
-    [delegate _webView:m_uiDelegate->m_webView.get().get() decidePolicyForScreenCaptureUnmutingForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() decidePolicyForScreenCaptureUnmutingForOrigin:wrapper(topLevelOrigin) initiatedByFrame:frameInfoWrapper.get() decisionHandler:decisionHandler.get()];
 }
 
 void UIDelegate::UIClient::checkUserMediaPermissionForOrigin(WebPageProxy& page, WebFrameProxy& frame, API::SecurityOrigin& userMediaOrigin, API::SecurityOrigin& topLevelOrigin, UserMediaPermissionCheckProxy& request)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
-    if (!delegate || !m_uiDelegate->m_delegateMethods.webViewIsMediaCaptureAuthorizedForFrameDecisionHandler) {
+    auto delegate = uiDelegate->m_delegate.get();
+    if (!delegate || !uiDelegate->m_delegateMethods.webViewIsMediaCaptureAuthorizedForFrameDecisionHandler) {
         request.setUserMediaAccessInfo(false);
         return;
     }
@@ -1451,7 +1496,7 @@ void UIDelegate::UIClient::checkUserMediaPermissionForOrigin(WebPageProxy& page,
             protectedRequest->setUserMediaAccessInfo(includeSensitiveDetails);
         });
 
-        [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() includeSensitiveMediaDeviceDetails:decisionHandler.get()];
+        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() includeSensitiveMediaDeviceDetails:decisionHandler.get()];
         return;
     }
 
@@ -1467,20 +1512,21 @@ void UIDelegate::UIClient::checkUserMediaPermissionForOrigin(WebPageProxy& page,
     URL requestFrameURL { frame.url() };
     URL mainFrameURL { mainFrame->url() };
 
-    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() checkUserMediaPermissionForURL:requestFrameURL mainFrameURL:mainFrameURL frameIdentifier:frame.frameID().object().toUInt64() decisionHandler:decisionHandler.get()];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() checkUserMediaPermissionForURL:requestFrameURL mainFrameURL:mainFrameURL frameIdentifier:frame.frameID().object().toUInt64() decisionHandler:decisionHandler.get()];
 }
 
 void UIDelegate::UIClient::mediaCaptureStateDidChange(WebCore::MediaProducerMediaStateFlags state)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    auto webView = m_uiDelegate->m_webView;
+    auto webView = uiDelegate->m_webView;
 
     [webView didChangeValueForKey:@"mediaCaptureState"];
 
-    auto delegate = m_uiDelegate->m_delegate.get();
-    if (!delegate || !m_uiDelegate->m_delegateMethods.webViewMediaCaptureStateDidChange)
+    auto delegate = uiDelegate->m_delegate.get();
+    if (!delegate || !uiDelegate->m_delegateMethods.webViewMediaCaptureStateDidChange)
         return;
 
     [(id <WKUIDelegatePrivate>)delegate _webView:webView.get().get() mediaCaptureStateDidChange:toWKMediaCaptureStateDeprecated(state)];
@@ -1488,17 +1534,18 @@ void UIDelegate::UIClient::mediaCaptureStateDidChange(WebCore::MediaProducerMedi
 
 void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProxy, const WebCore::FloatSize& pdfFirstPageSize, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler();
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler();
 
     auto handle = API::FrameHandle::create(webFrameProxy.frameID());
-    if (m_uiDelegate->m_delegateMethods.webViewPrintFramePDFFirstPageSizeCompletionHandler) {
+    if (uiDelegate->m_delegateMethods.webViewPrintFramePDFFirstPageSizeCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:printFrame:pdfFirstPageSize:completionHandler:));
-        [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() printFrame:wrapper(handle) pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTFMove(checker), completionHandler = WTFMove(completionHandler)] () mutable {
+        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle) pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTFMove(checker), completionHandler = WTFMove(completionHandler)] () mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -1507,189 +1554,200 @@ void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProx
         return;
     }
 
-    if (m_uiDelegate->m_delegateMethods.webViewPrintFrame)
-        [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() printFrame:wrapper(handle)];
+    if (uiDelegate->m_delegateMethods.webViewPrintFrame)
+        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle)];
     completionHandler();
 }
 
 void UIDelegate::UIClient::close(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (m_uiDelegate->m_delegateMethods.webViewClose) {
-        auto delegate = m_uiDelegate->m_delegate.get();
+    if (uiDelegate->m_delegateMethods.webViewClose) {
+        auto delegate = uiDelegate->m_delegate.get();
         if (!delegate)
             return;
 
-        [(id <WKUIDelegatePrivate>)delegate _webViewClose:m_uiDelegate->m_webView.get().get()];
+        [(id <WKUIDelegatePrivate>)delegate _webViewClose:uiDelegate->m_webView.get().get()];
         return;
     }
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidClose)
+    if (!uiDelegate->m_delegateMethods.webViewDidClose)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webViewDidClose:m_uiDelegate->m_webView.get().get()];
+    [delegate webViewDidClose:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::fullscreenMayReturnToInline(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewFullscreenMayReturnToInline)
+    if (!uiDelegate->m_delegateMethods.webViewFullscreenMayReturnToInline)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webViewFullscreenMayReturnToInline:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _webViewFullscreenMayReturnToInline:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didEnterFullscreen(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidEnterFullscreen)
+    if (!uiDelegate->m_delegateMethods.webViewDidEnterFullscreen)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidEnterFullscreen:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _webViewDidEnterFullscreen:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didExitFullscreen(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidExitFullscreen)
+    if (!uiDelegate->m_delegateMethods.webViewDidExitFullscreen)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidExitFullscreen:m_uiDelegate->m_webView.get().get()];
+    [(id <WKUIDelegatePrivate>)delegate _webViewDidExitFullscreen:uiDelegate->m_webView.get().get()];
 }
     
 #if PLATFORM(IOS_FAMILY)
 #if HAVE(APP_LINKS)
 bool UIDelegate::UIClient::shouldIncludeAppLinkActionsForElement(_WKActivatedElementInfo *elementInfo)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return true;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewShouldIncludeAppLinkActionsForElement)
+    if (!uiDelegate->m_delegateMethods.webViewShouldIncludeAppLinkActionsForElement)
         return true;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return true;
 
-    return [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() shouldIncludeAppLinkActionsForElement:elementInfo];
+    return [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() shouldIncludeAppLinkActionsForElement:elementInfo];
 }
 #endif
 
 RetainPtr<NSArray> UIDelegate::UIClient::actionsForElement(_WKActivatedElementInfo *elementInfo, RetainPtr<NSArray> defaultActions)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return defaultActions;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewActionsForElementDefaultActions)
+    if (!uiDelegate->m_delegateMethods.webViewActionsForElementDefaultActions)
         return defaultActions;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return defaultActions;
 
-    return [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() actionsForElement:elementInfo defaultActions:defaultActions.get()];
+    return [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() actionsForElement:elementInfo defaultActions:defaultActions.get()];
 }
 
 void UIDelegate::UIClient::didNotHandleTapAsClick(const WebCore::IntPoint& point)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidNotHandleTapAsClickAtPoint)
+    if (!uiDelegate->m_delegateMethods.webViewDidNotHandleTapAsClickAtPoint)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() didNotHandleTapAsClickAtPoint:point];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() didNotHandleTapAsClickAtPoint:point];
 }
 
 void UIDelegate::UIClient::statusBarWasTapped()
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewStatusBarWasTapped)
+    if (!uiDelegate->m_delegateMethods.webViewStatusBarWasTapped)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewStatusBarWasTapped:m_uiDelegate->m_webView.get().get()];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewStatusBarWasTapped:uiDelegate->m_webView.get().get()];
 }
 
 bool UIDelegate::UIClient::setShouldKeepScreenAwake(bool shouldKeepScreenAwake)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return false;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewSetShouldKeepScreenAwake)
+    if (!uiDelegate->m_delegateMethods.webViewSetShouldKeepScreenAwake)
         return false;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return false;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() setShouldKeepScreenAwake:shouldKeepScreenAwake];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() setShouldKeepScreenAwake:shouldKeepScreenAwake];
     return true;
 }
 #endif // PLATFORM(IOS_FAMILY)
 
 PlatformViewController *UIDelegate::UIClient::presentingViewController()
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return nullptr;
 
-    if (!m_uiDelegate->m_delegateMethods.presentingViewControllerForWebView)
+    if (!uiDelegate->m_delegateMethods.presentingViewControllerForWebView)
         return nullptr;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return nullptr;
 
-    return [static_cast<id <WKUIDelegatePrivate>>(delegate) _presentingViewControllerForWebView:m_uiDelegate->m_webView.get().get()];
+    return [static_cast<id <WKUIDelegatePrivate>>(delegate) _presentingViewControllerForWebView:uiDelegate->m_webView.get().get()];
 }
 
 std::optional<double> UIDelegate::UIClient::dataDetectionReferenceDate()
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return std::nullopt;
 
-    if (!m_uiDelegate->m_delegateMethods.dataDetectionContextForWebView)
+    if (!uiDelegate->m_delegateMethods.dataDetectionContextForWebView)
         return std::nullopt;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return std::nullopt;
 
 #if ENABLE(DATA_DETECTION)
-    return WebCore::DataDetection::extractReferenceDate([static_cast<id<WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:m_uiDelegate->m_webView.get().get()]);
+    return WebCore::DataDetection::extractReferenceDate([static_cast<id<WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:uiDelegate->m_webView.get().get()]);
 #else
     return std::nullopt;
 #endif
@@ -1699,23 +1757,24 @@ std::optional<double> UIDelegate::UIClient::dataDetectionReferenceDate()
 
 void UIDelegate::UIClient::requestPointerLock(WebPageProxy* page)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRequestPointerLock && !m_uiDelegate->m_delegateMethods.webViewDidRequestPointerLockCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewRequestPointerLock && !uiDelegate->m_delegateMethods.webViewDidRequestPointerLockCompletionHandler)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    if (m_uiDelegate->m_delegateMethods.webViewRequestPointerLock) {
-        [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewRequestPointerLock:m_uiDelegate->m_webView.get().get()];
+    if (uiDelegate->m_delegateMethods.webViewRequestPointerLock) {
+        [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewRequestPointerLock:uiDelegate->m_webView.get().get()];
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webViewDidRequestPointerLock:completionHandler:));
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidRequestPointerLock:m_uiDelegate->m_webView.get().get() completionHandler:makeBlockPtr([checker = WTFMove(checker), page = RefPtr { page }] (BOOL allow) {
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidRequestPointerLock:uiDelegate->m_webView.get().get() completionHandler:makeBlockPtr([checker = WTFMove(checker), page = RefPtr { page }] (BOOL allow) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1729,50 +1788,53 @@ void UIDelegate::UIClient::requestPointerLock(WebPageProxy* page)
 
 void UIDelegate::UIClient::didLosePointerLock(WebPageProxy*)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidLosePointerLock)
+    if (!uiDelegate->m_delegateMethods.webViewDidLosePointerLock)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidLosePointerLock:m_uiDelegate->m_webView.get().get()];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidLosePointerLock:uiDelegate->m_webView.get().get()];
 }
 
 #endif
     
 void UIDelegate::UIClient::didShowSafeBrowsingWarning()
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidShowSafeBrowsingWarning)
+    if (!uiDelegate->m_delegateMethods.webViewDidShowSafeBrowsingWarning)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidShowSafeBrowsingWarning:m_uiDelegate->m_webView.get().get()];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidShowSafeBrowsingWarning:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::confirmPDFOpening(WebPageProxy& page, const WTF::URL& fileURL, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(true);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewShouldAllowPDFAtURLToOpenFromFrameCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewShouldAllowPDFAtURLToOpenFromFrameCompletionHandler)
         return completionHandler(true);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler(true);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:shouldAllowPDFAtURL:toOpenFromFrame:completionHandler:));
-    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1798,22 +1860,23 @@ static WebAuthenticationPanelResult webAuthenticationPanelResult(_WKWebAuthentic
 
 void UIDelegate::UIClient::runWebAuthenticationPanel(WebPageProxy& page, API::WebAuthenticationPanel& panel, WebFrameProxy&, FrameInfoData&& frameInfo, CompletionHandler<void(WebAuthenticationPanelResult)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(WebAuthenticationPanelResult::Unavailable);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRunWebAuthenticationPanelInitiatedByFrameCompletionHandler) {
+    if (!uiDelegate->m_delegateMethods.webViewRunWebAuthenticationPanelInitiatedByFrameCompletionHandler) {
         completionHandler(WebAuthenticationPanelResult::Unavailable);
         return;
     }
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(WebAuthenticationPanelResult::Unavailable);
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runWebAuthenticationPanel:initiatedByFrame:completionHandler:));
-    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runWebAuthenticationPanel:wrapper(panel) initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKWebAuthenticationPanelResult result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() runWebAuthenticationPanel:wrapper(panel) initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKWebAuthenticationPanelResult result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1823,18 +1886,19 @@ void UIDelegate::UIClient::runWebAuthenticationPanel(WebPageProxy& page, API::We
 
 void UIDelegate::UIClient::requestWebAuthenticationConditonalMediationRegistration(WTF::String&& username, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return completionHandler(false);
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRequestWebAuthenticationConditionalMediationRegistrationForUserCompletionHandler)
+    if (!uiDelegate->m_delegateMethods.webViewRequestWebAuthenticationConditionalMediationRegistrationForUserCompletionHandler)
         return completionHandler(false);
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return completionHandler(false);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestWebAuthenticationConditionalMediationRegistrationForUser:completionHandler:));
-    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestWebAuthenticationConditionalMediationRegistrationForUser:username completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestWebAuthenticationConditionalMediationRegistrationForUser:username completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1845,42 +1909,45 @@ void UIDelegate::UIClient::requestWebAuthenticationConditonalMediationRegistrati
 
 void UIDelegate::UIClient::hasVideoInPictureInPictureDidChange(WebPageProxy*, bool hasVideoInPictureInPicture)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewHasVideoInPictureInPictureDidChange)
+    if (!uiDelegate->m_delegateMethods.webViewHasVideoInPictureInPictureDidChange)
         return;
     
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
     
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() hasVideoInPictureInPictureDidChange:hasVideoInPictureInPicture];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() hasVideoInPictureInPictureDidChange:hasVideoInPictureInPicture];
 }
 
 void UIDelegate::UIClient::imageOrMediaDocumentSizeChanged(const WebCore::IntSize& newSize)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewImageOrMediaDocumentSizeChanged)
+    if (!uiDelegate->m_delegateMethods.webViewImageOrMediaDocumentSizeChanged)
         return;
 
-    auto delegate = m_uiDelegate->m_delegate.get();
+    auto delegate = uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() imageOrMediaDocumentSizeChanged:newSize];
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() imageOrMediaDocumentSizeChanged:newSize];
 }
 
 void UIDelegate::UIClient::queryPermission(const String& permissionName, API::SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& callback)
 {
-    if (!m_uiDelegate) {
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate) {
         callback(WebCore::PermissionState::Prompt);
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         callback(WebCore::PermissionState::Prompt);
         return;
@@ -1892,7 +1959,7 @@ void UIDelegate::UIClient::queryPermission(const String& permissionName, API::Se
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate, @selector(_webView:queryPermission:forOrigin:completionHandler:));
-    [delegate _webView:m_uiDelegate->m_webView.get().get() queryPermission:permissionName forOrigin:wrapper(origin) completionHandler:makeBlockPtr([callback = WTFMove(callback), checker = WTFMove(checker)](WKPermissionDecision permissionState) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() queryPermission:permissionName forOrigin:wrapper(origin) completionHandler:makeBlockPtr([callback = WTFMove(callback), checker = WTFMove(checker)](WKPermissionDecision permissionState) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1912,43 +1979,46 @@ void UIDelegate::UIClient::queryPermission(const String& permissionName, API::Se
 
 void UIDelegate::UIClient::didEnableInspectorBrowserDomain(WebPageProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidEnableInspectorBrowserDomain)
+    if (!uiDelegate->m_delegateMethods.webViewDidEnableInspectorBrowserDomain)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate _webViewDidEnableInspectorBrowserDomain:m_uiDelegate->m_webView.get().get()];
+    [delegate _webViewDidEnableInspectorBrowserDomain:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didDisableInspectorBrowserDomain(WebPageProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidDisableInspectorBrowserDomain)
+    if (!uiDelegate->m_delegateMethods.webViewDidDisableInspectorBrowserDomain)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate _webViewDidDisableInspectorBrowserDomain:m_uiDelegate->m_webView.get().get()];
+    [delegate _webViewDidDisableInspectorBrowserDomain:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::updateAppBadge(WebPageProxy&, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewUpdatedAppBadge)
+    if (!uiDelegate->m_delegateMethods.webViewUpdatedAppBadge)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -1958,18 +2028,19 @@ void UIDelegate::UIClient::updateAppBadge(WebPageProxy&, const WebCore::Security
 
 
     auto apiOrigin = API::SecurityOrigin::create(origin);
-    [delegate _webView:m_uiDelegate->m_webView.get().get() updatedAppBadge:nsBadge fromSecurityOrigin:wrapper(apiOrigin.get())];
+    [delegate _webView:uiDelegate->m_webView.get().get() updatedAppBadge:nsBadge fromSecurityOrigin:wrapper(apiOrigin.get())];
 }
 
 void UIDelegate::UIClient::updateClientBadge(WebPageProxy&, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewUpdatedClientBadge)
+    if (!uiDelegate->m_delegateMethods.webViewUpdatedClientBadge)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -1978,54 +2049,57 @@ void UIDelegate::UIClient::updateClientBadge(WebPageProxy&, const WebCore::Secur
         nsBadge = @(*badge);
 
     auto apiOrigin = API::SecurityOrigin::create(origin);
-    [delegate _webView:m_uiDelegate->m_webView.get().get() updatedClientBadge:nsBadge fromSecurityOrigin:wrapper(apiOrigin.get())];
+    [delegate _webView:uiDelegate->m_webView.get().get() updatedClientBadge:nsBadge fromSecurityOrigin:wrapper(apiOrigin.get())];
 }
 
 void UIDelegate::UIClient::didAdjustVisibilityWithSelectors(WebPageProxy&, Vector<String>&& selectors)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewDidAdjustVisibilityWithSelectors)
+    if (!uiDelegate->m_delegateMethods.webViewDidAdjustVisibilityWithSelectors)
         return;
 
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
     RetainPtr nsSelectors = createNSArray(WTFMove(selectors));
-    [delegate _webView:m_uiDelegate->m_webView.get().get() didAdjustVisibilityWithSelectors:nsSelectors.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() didAdjustVisibilityWithSelectors:nsSelectors.get()];
 }
 
 #if ENABLE(GAMEPAD)
 void UIDelegate::UIClient::recentlyAccessedGamepadsForTesting(WebPageProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewRecentlyAccessedGamepadsForTesting)
+    if (!uiDelegate->m_delegateMethods.webViewRecentlyAccessedGamepadsForTesting)
         return;
 
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate _webViewRecentlyAccessedGamepadsForTesting:m_uiDelegate->m_webView.get().get()];
+    [delegate _webViewRecentlyAccessedGamepadsForTesting:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::stoppedAccessingGamepadsForTesting(WebPageProxy&)
 {
-    if (!m_uiDelegate)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate)
         return;
 
-    if (!m_uiDelegate->m_delegateMethods.webViewStoppedAccessingGamepadsForTesting)
+    if (!uiDelegate->m_delegateMethods.webViewStoppedAccessingGamepadsForTesting)
         return;
 
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate _webViewStoppedAccessingGamepadsForTesting:m_uiDelegate->m_webView.get().get()];
+    [delegate _webViewStoppedAccessingGamepadsForTesting:uiDelegate->m_webView.get().get()];
 }
 #endif
 
@@ -2095,12 +2169,13 @@ static std::optional<PlatformXR::Device::FeatureList> toPlatformXRFeatures(_WKXR
 
 void UIDelegate::UIClient::requestPermissionOnXRSessionFeatures(WebPageProxy&, const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& consentRequired, const PlatformXR::Device::FeatureList& consentOptional, const PlatformXR::Device::FeatureList& requiredFeaturesRequested, const PlatformXR::Device::FeatureList& optionalFeaturesRequested, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler)
 {
-    if (!m_uiDelegate || !m_uiDelegate->m_delegateMethods.webViewRequestPermissionForXRSessionOriginModeAndFeaturesWithCompletionHandler) {
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || !uiDelegate->m_delegateMethods.webViewRequestPermissionForXRSessionOriginModeAndFeaturesWithCompletionHandler) {
         completionHandler(granted);
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(granted);
         return;
@@ -2115,14 +2190,14 @@ void UIDelegate::UIClient::requestPermissionOnXRSessionFeatures(WebPageProxy&, c
 
     auto checker = CompletionHandlerCallChecker::create(delegate, requestPermissionSelector);
     if (!usingOldDelegateMethod) {
-        [delegate _webView:m_uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) requiredFeaturesRequested:toWKXRSessionFeatureFlags(requiredFeaturesRequested) optionalFeaturesRequested:toWKXRSessionFeatureFlags(optionalFeaturesRequested) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) requiredFeaturesRequested:toWKXRSessionFeatureFlags(requiredFeaturesRequested) optionalFeaturesRequested:toWKXRSessionFeatureFlags(optionalFeaturesRequested) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
             completionHandler(toPlatformXRFeatures(userGrantedFeatures));
         }).get()];
     } else {
-        [delegate _webView:m_uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -2133,13 +2208,14 @@ void UIDelegate::UIClient::requestPermissionOnXRSessionFeatures(WebPageProxy&, c
 
 void UIDelegate::UIClient::supportedXRSessionFeatures(PlatformXR::Device::FeatureList& vrFeatures, PlatformXR::Device::FeatureList& arFeatures)
 {
-    if (m_uiDelegate && m_uiDelegate->m_delegateMethods.webViewSupportedXRSessionFeatures) {
-        auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (uiDelegate && uiDelegate->m_delegateMethods.webViewSupportedXRSessionFeatures) {
+        auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
         if (delegate) {
             _WKXRSessionFeatureFlags wkVRfeatures = _WKXRSessionFeatureFlagsNone;
             _WKXRSessionFeatureFlags wkARfeatures = _WKXRSessionFeatureFlagsNone;
 
-            [delegate _webView:m_uiDelegate->m_webView.get().get() supportedXRSessionFeatures:&wkVRfeatures arFeatures:&wkARfeatures];
+            [delegate _webView:uiDelegate->m_webView.get().get() supportedXRSessionFeatures:&wkVRfeatures arFeatures:&wkARfeatures];
 
             vrFeatures = toPlatformXRFeatures(wkVRfeatures).value_or(PlatformXR::Device::FeatureList());
             arFeatures = toPlatformXRFeatures(wkARfeatures).value_or(PlatformXR::Device::FeatureList());
@@ -2150,12 +2226,13 @@ void UIDelegate::UIClient::supportedXRSessionFeatures(PlatformXR::Device::Featur
 #if PLATFORM(IOS_FAMILY)
 void UIDelegate::UIClient::startXRSession(WebPageProxy&, const PlatformXR::Device::FeatureList& sessionFeatures, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&& completionHandler)
 {
-    if (!m_uiDelegate || !m_uiDelegate->m_delegateMethods.webViewStartXRSessionWithCompletionHandler) {
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || !uiDelegate->m_delegateMethods.webViewStartXRSessionWithCompletionHandler) {
         completionHandler(nil, nil);
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(nil, nil);
         return;
@@ -2163,7 +2240,7 @@ void UIDelegate::UIClient::startXRSession(WebPageProxy&, const PlatformXR::Devic
 
     if ([delegate respondsToSelector:@selector(_webView:startXRSessionWithFeatures:completionHandler:)]) {
         auto checker = CompletionHandlerCallChecker::create(delegate, @selector(_webView:startXRSessionWithFeatures:completionHandler:));
-        [delegate _webView:m_uiDelegate->m_webView.get().get() startXRSessionWithFeatures:toWKXRSessionFeatureFlags(sessionFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (id result, UIViewController *viewController) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() startXRSessionWithFeatures:toWKXRSessionFeatureFlags(sessionFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (id result, UIViewController *viewController) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -2173,7 +2250,7 @@ void UIDelegate::UIClient::startXRSession(WebPageProxy&, const PlatformXR::Devic
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate, @selector(_webView:startXRSessionWithCompletionHandler:));
-    [delegate _webView:m_uiDelegate->m_webView.get().get() startXRSessionWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (id result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() startXRSessionWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (id result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -2183,19 +2260,20 @@ void UIDelegate::UIClient::startXRSession(WebPageProxy&, const PlatformXR::Devic
 
 void UIDelegate::UIClient::endXRSession(WebPageProxy&, PlatformXRSessionEndReason reason)
 {
-    if (!m_uiDelegate || !m_uiDelegate->m_delegateMethods.webViewEndXRSession)
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || !uiDelegate->m_delegateMethods.webViewEndXRSession)
         return;
 
-    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
     if ([delegate respondsToSelector:@selector(_webViewEndXRSession:withReason:)]) {
-        [delegate _webViewEndXRSession:m_uiDelegate->m_webView.get().get() withReason:static_cast<_WKXRSessionEndReason>(reason)];
+        [delegate _webViewEndXRSession:uiDelegate->m_webView.get().get() withReason:static_cast<_WKXRSessionEndReason>(reason)];
         return;
     }
 
-    [delegate _webViewEndXRSession:m_uiDelegate->m_webView.get().get()];
+    [delegate _webViewEndXRSession:uiDelegate->m_webView.get().get()];
 }
 #endif // PLATFORM(IOS_FAMILY)
 


### PR DESCRIPTION
#### d45a6c852ecbf51f6bdae6a0d56826db8be2d7db
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for UIDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=281443">https://bugs.webkit.org/show_bug.cgi?id=281443</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ref const):
(WebKit::UIDelegate::deref const):
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
(WebKit::UIDelegate::UIClient::mouseDidMoveOverElement):
(WebKit::UIDelegate::UIClient::createNewPage):
(WebKit::UIDelegate::UIClient::runJavaScriptAlert):
(WebKit::UIDelegate::UIClient::runJavaScriptConfirm):
(WebKit::UIDelegate::UIClient::runJavaScriptPrompt):
(WebKit::UIDelegate::UIClient::requestStorageAccessConfirm):
(WebKit::UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest):
(WebKit::UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance):
(WebKit::UIDelegate::UIClient::canRunBeforeUnloadConfirmPanel const):
(WebKit::UIDelegate::UIClient::runBeforeUnloadConfirmPanel):
(WebKit::UIDelegate::UIClient::exceededDatabaseQuota):
(WebKit::UIDelegate::UIClient::lockScreenOrientation):
(WebKit::UIDelegate::UIClient::unlockScreenOrientation):
(WebKit::UIDelegate::UIClient::takeFocus):
(WebKit::UIDelegate::UIClient::handleAutoplayEvent):
(WebKit::UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest):
(WebKit::UIDelegate::UIClient::requestCookieConsent):
(WebKit::UIDelegate::UIClient::focusFromServiceWorker):
(WebKit::UIDelegate::UIClient::runOpenPanel):
(WebKit::UIDelegate::UIClient::canRunModal const):
(WebKit::UIDelegate::UIClient::runModal):
(WebKit::UIDelegate::UIClient::headerHeight):
(WebKit::UIDelegate::UIClient::footerHeight):
(WebKit::UIDelegate::UIClient::drawHeader):
(WebKit::UIDelegate::UIClient::drawFooter):
(WebKit::UIDelegate::UIClient::pageDidScroll):
(WebKit::UIDelegate::UIClient::focus):
(WebKit::UIDelegate::UIClient::unfocus):
(WebKit::UIDelegate::UIClient::didNotHandleWheelEvent):
(WebKit::UIDelegate::UIClient::setIsResizable):
(WebKit::UIDelegate::UIClient::setWindowFrame):
(WebKit::UIDelegate::UIClient::windowFrame):
(WebKit::UIDelegate::UIClient::toolbarsAreVisible):
(WebKit::UIDelegate::UIClient::didClickAutoFillButton):
(WebKit::UIDelegate::UIClient::showPage):
(WebKit::UIDelegate::UIClient::saveDataToFileInDownloadsFolder):
(WebKit::UIDelegate::UIClient::configurationForLocalInspector):
(WebKit::UIDelegate::UIClient::didAttachLocalInspector):
(WebKit::UIDelegate::UIClient::willCloseLocalInspector):
(WebKit::UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::UIDelegate::UIClient::didChangeFontAttributes):
(WebKit::UIDelegate::UIClient::callDisplayCapturePermissionDelegate):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
(WebKit::UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting):
(WebKit::UIDelegate::UIClient::checkUserMediaPermissionForOrigin):
(WebKit::UIDelegate::UIClient::mediaCaptureStateDidChange):
(WebKit::UIDelegate::UIClient::printFrame):
(WebKit::UIDelegate::UIClient::close):
(WebKit::UIDelegate::UIClient::fullscreenMayReturnToInline):
(WebKit::UIDelegate::UIClient::didEnterFullscreen):
(WebKit::UIDelegate::UIClient::didExitFullscreen):
(WebKit::UIDelegate::UIClient::shouldIncludeAppLinkActionsForElement):
(WebKit::UIDelegate::UIClient::actionsForElement):
(WebKit::UIDelegate::UIClient::didNotHandleTapAsClick):
(WebKit::UIDelegate::UIClient::statusBarWasTapped):
(WebKit::UIDelegate::UIClient::setShouldKeepScreenAwake):
(WebKit::UIDelegate::UIClient::presentingViewController):
(WebKit::UIDelegate::UIClient::dataDetectionReferenceDate):
(WebKit::UIDelegate::UIClient::requestPointerLock):
(WebKit::UIDelegate::UIClient::didLosePointerLock):
(WebKit::UIDelegate::UIClient::didShowSafeBrowsingWarning):
(WebKit::UIDelegate::UIClient::confirmPDFOpening):
(WebKit::UIDelegate::UIClient::runWebAuthenticationPanel):
(WebKit::UIDelegate::UIClient::requestWebAuthenticationConditonalMediationRegistration):
(WebKit::UIDelegate::UIClient::hasVideoInPictureInPictureDidChange):
(WebKit::UIDelegate::UIClient::imageOrMediaDocumentSizeChanged):
(WebKit::UIDelegate::UIClient::queryPermission):
(WebKit::UIDelegate::UIClient::didEnableInspectorBrowserDomain):
(WebKit::UIDelegate::UIClient::didDisableInspectorBrowserDomain):
(WebKit::UIDelegate::UIClient::updateAppBadge):
(WebKit::UIDelegate::UIClient::updateClientBadge):
(WebKit::UIDelegate::UIClient::didAdjustVisibilityWithSelectors):
(WebKit::UIDelegate::UIClient::recentlyAccessedGamepadsForTesting):
(WebKit::UIDelegate::UIClient::stoppedAccessingGamepadsForTesting):
(WebKit::UIDelegate::UIClient::requestPermissionOnXRSessionFeatures):
(WebKit::UIDelegate::UIClient::supportedXRSessionFeatures):
(WebKit::UIDelegate::UIClient::startXRSession):
(WebKit::UIDelegate::UIClient::endXRSession):
(WebKit::UIDelegate::~UIDelegate): Deleted.
(WebKit::UIDelegate::UIClient::~UIClient): Deleted.

Canonical link: <a href="https://commits.webkit.org/285162@main">https://commits.webkit.org/285162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/547cf8ef3696bcec3133d82d54f06e97d88b099c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71688 "56 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22713 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15102 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43023 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21234 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18770 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64337 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6127 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10999 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->