### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from LockdownModeObserver

### DIFF
--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -39,7 +39,7 @@ namespace API {
 
 WebsitePolicies::WebsitePolicies()
 #if PLATFORM(COCOA)
-    : m_lockdownModeObserver(makeUnique<WebKit::WebPagePreferencesLockdownModeObserver>(*this))
+    : m_lockdownModeObserver(makeUniqueWithoutRefCountedCheck<WebKit::WebPagePreferencesLockdownModeObserver>(*this))
 #endif
 {
 }
@@ -52,7 +52,7 @@ Ref<WebsitePolicies> WebsitePolicies::copy() const
     policies->setUserContentController(m_userContentController.get());
     policies->setLockdownModeEnabled(m_lockdownModeEnabled);
 #if PLATFORM(COCOA)
-    policies->m_lockdownModeObserver = makeUnique<WebKit::WebPagePreferencesLockdownModeObserver>(policies);
+    policies->m_lockdownModeObserver = makeUniqueWithoutRefCountedCheck<WebKit::WebPagePreferencesLockdownModeObserver>(policies);
 #endif
     return policies;
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
@@ -43,6 +43,9 @@ public:
     explicit WebPagePreferencesLockdownModeObserver(API::WebsitePolicies&);
     ~WebPagePreferencesLockdownModeObserver();
 
+    void ref() const final;
+    void deref() const final;
+
 private:
     void willChangeLockdownMode() final;
     void didChangeLockdownMode() final;

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
@@ -64,4 +64,14 @@ void WebPagePreferencesLockdownModeObserver::didChangeLockdownMode()
     }
 }
 
+void WebPagePreferencesLockdownModeObserver::ref() const
+{
+    m_policies->ref();
 }
+
+void WebPagePreferencesLockdownModeObserver::deref() const
+{
+    m_policies->deref();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1088,9 +1088,9 @@ void WebProcessPool::lockdownModeStateChanged()
 {
     auto isNowEnabled = isLockdownModeEnabledBySystemIgnoringCaching();
     if (cachedLockdownModeEnabledGlobally() != isNowEnabled) {
-        lockdownModeObservers().forEach([](auto& observer) { observer.willChangeLockdownMode(); });
+        lockdownModeObservers().forEach([](Ref<LockdownModeObserver> observer) { observer->willChangeLockdownMode(); });
         cachedLockdownModeEnabledGlobally() = isNowEnabled;
-        lockdownModeObservers().forEach([](auto& observer) { observer.didChangeLockdownMode(); });
+        lockdownModeObservers().forEach([](Ref<LockdownModeObserver> observer) { observer->didChangeLockdownMode(); });
     }
 
     WEBPROCESSPOOL_RELEASE_LOG(Loading, "WebProcessPool::lockdownModeStateChanged() isNowEnabled=%d", isNowEnabled);

--- a/Source/WebKit/UIProcess/LockdownModeObserver.h
+++ b/Source/WebKit/UIProcess/LockdownModeObserver.h
@@ -28,15 +28,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class LockdownModeObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::LockdownModeObserver> : std::true_type { };
-}
-
-namespace WebKit {
 
 class LockdownModeObserver : public CanMakeWeakPtr<LockdownModeObserver> {
 public:
@@ -44,6 +35,9 @@ public:
 
     virtual void willChangeLockdownMode() = 0;
     virtual void didChangeLockdownMode() = 0;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 558891212f9cb0353ec575d033591699d24c6bde
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from LockdownModeObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=281446">https://bugs.webkit.org/show_bug.cgi?id=281446</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::WebsitePolicies):
(API::WebsitePolicies::copy const):
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h:
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm:
(WebKit::WebPagePreferencesLockdownModeObserver::ref const):
(WebKit::WebPagePreferencesLockdownModeObserver::deref const):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::lockdownModeStateChanged):
* Source/WebKit/UIProcess/LockdownModeObserver.h:

Canonical link: <a href="https://commits.webkit.org/285163@main">https://commits.webkit.org/285163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5834ea49b11f5905fe7c292f521a2eb4b08bd24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22899 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15106 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43033 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18775 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64338 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6132 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11000 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1686 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->