### PR TITLE
[MotionMark] De-virtualize `CanvasRenderingContext` type checks

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -63,8 +63,9 @@ Lock& CanvasRenderingContext::instancesLock()
     return s_instancesLock;
 }
 
-CanvasRenderingContext::CanvasRenderingContext(CanvasBase& canvas)
+CanvasRenderingContext::CanvasRenderingContext(CanvasBase& canvas, Type type)
     : m_canvas(canvas)
+    , m_type(type)
 {
     Locker locker { instancesLock() };
     instances().add(this);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -65,17 +65,17 @@ public:
 
     CanvasBase& canvasBase() const { return m_canvas; }
 
-    virtual bool is2dBase() const { return false; }
-    virtual bool is2d() const { return false; }
-    virtual bool isWebGL1() const { return false; }
-    virtual bool isWebGL2() const { return false; }
+    bool is2dBase() const { return is2d() || isOffscreen2d() || isPaint(); }
+    bool is2d() const { return m_type == Type::CanvasElement2D; }
+    bool isWebGL1() const { return m_type == Type::WebGL1; }
+    bool isWebGL2() const { return m_type == Type::WebGL2; }
     bool isWebGL() const { return isWebGL1() || isWebGL2(); }
-    virtual bool isWebGPU() const { return false; }
-    virtual bool isGPUBased() const { return false; }
-    virtual bool isBitmapRenderer() const { return false; }
-    virtual bool isPlaceholder() const { return false; }
-    virtual bool isOffscreen2d() const { return false; }
-    virtual bool isPaint() const { return false; }
+    bool isWebGPU() const { return m_type == Type::WebGPU; }
+    bool isGPUBased() const { return isWebGPU() || isWebGL(); }
+    bool isBitmapRenderer() const { return m_type == Type::BitmapRenderer; }
+    bool isPlaceholder() const { return m_type == Type::Placeholder; }
+    bool isOffscreen2d() const { return m_type == Type::Offscreen2D; }
+    bool isPaint() const { return m_type == Type::Paint; }
 
     virtual void clearAccumulatedDirtyRect() { }
 
@@ -122,7 +122,18 @@ public:
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
 protected:
-    explicit CanvasRenderingContext(CanvasBase&);
+    enum class Type : uint8_t {
+        CanvasElement2D,
+        Offscreen2D,
+        Paint,
+        BitmapRenderer,
+        Placeholder,
+        WebGL1,
+        WebGL2,
+        WebGPU,
+    };
+
+    explicit CanvasRenderingContext(CanvasBase&, Type);
     bool taintsOrigin(const CanvasPattern*);
     bool taintsOrigin(const CanvasBase*);
     bool taintsOrigin(const CachedImage*);
@@ -147,6 +158,7 @@ private:
     static Lock s_instancesLock;
 
     CanvasBase& m_canvas;
+    const Type m_type;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<CanvasRenderingContext2D> CanvasRenderingContext2D::create(Canva
 }
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
-    : CanvasRenderingContext2DBase(canvas, WTFMove(settings), usesCSSCompatibilityParseMode)
+    : CanvasRenderingContext2DBase(canvas, Type::CanvasElement2D, WTFMove(settings), usesCSSCompatibilityParseMode)
 {
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -56,7 +56,6 @@ public:
 private:
     CanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
 
-    bool is2d() const final { return true; }
     const FontProxy* fontProxy() final;
 
     std::optional<FilterOperations> setFilterStringWithoutUpdatingStyle(const String&) override;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -225,12 +225,13 @@ static TextBaseline fromCanvasTextBaseline(CanvasTextBaseline canvasTextBaseline
     return TopTextBaseline;
 }
 
-CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
-    : CanvasRenderingContext(canvas)
+CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, CanvasRenderingContext::Type type, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
+    : CanvasRenderingContext(canvas, type)
     , m_stateStack(1)
     , m_usesCSSCompatibilityParseMode(usesCSSCompatibilityParseMode)
     , m_settings(WTFMove(settings))
 {
+    ASSERT(is2dBase());
 }
 
 void CanvasRenderingContext2DBase::unwindStateStack()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -94,7 +94,7 @@ class CanvasRenderingContext2DBase : public CanvasRenderingContext, public Canva
     friend class CanvasFilterContextSwitcher;
     friend class CanvasLayerContextSwitcher;
 protected:
-    CanvasRenderingContext2DBase(CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
+    CanvasRenderingContext2DBase(CanvasBase&, CanvasRenderingContext::Type, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
 
 public:
     virtual ~CanvasRenderingContext2DBase();
@@ -396,7 +396,6 @@ private:
     void applyShadow();
     bool shouldDrawShadows() const;
 
-    bool is2dBase() const final { return true; }
     bool needsPreparationForDisplay() const final;
     void prepareForDisplay() final;
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
@@ -32,10 +32,11 @@
 
 namespace WebCore {
 
-GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext(CanvasBase& canvas)
-    : CanvasRenderingContext(canvas)
+GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext(CanvasBase& canvas, CanvasRenderingContext::Type type)
+    : CanvasRenderingContext(canvas, type)
     , ActiveDOMObject(canvas.scriptExecutionContext())
 {
+    ASSERT(isGPUBased());
 }
 
 HTMLCanvasElement* GPUBasedCanvasRenderingContext::htmlCanvas() const

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -40,12 +40,11 @@ public:
     void ref() const final { CanvasRenderingContext::ref(); }
     void deref() const final { CanvasRenderingContext::deref(); }
 
-    bool isGPUBased() const override { return true; }
     bool delegatesDisplay() const override { return true; }
 
     virtual void reshape() = 0;
 protected:
-    explicit GPUBasedCanvasRenderingContext(CanvasBase&);
+    explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);
 
     HTMLCanvasElement* htmlCanvas() const;
     void markCanvasChanged();

--- a/Source/WebCore/html/canvas/GPUCanvasContext.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase&, GPU&)
 #endif
 
 GPUCanvasContext::GPUCanvasContext(CanvasBase& canvas)
-    : GPUBasedCanvasRenderingContext(canvas)
+    : GPUBasedCanvasRenderingContext(canvas, Type::WebGPU)
 {
 }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -62,8 +62,6 @@ public:
     virtual std::optional<GPUCanvasConfiguration> getConfiguration() const = 0;
     virtual ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() = 0;
 
-    bool isWebGPU() const override { return true; }
-
 protected:
     GPUCanvasContext(CanvasBase&);
 };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -75,8 +75,6 @@ public:
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 
-    bool isWebGPU() const override { return true; }
-
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&);
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<ImageBitmapRenderingContext> ImageBitmapRenderingContext::create
 }
 
 ImageBitmapRenderingContext::ImageBitmapRenderingContext(CanvasBase& canvas, ImageBitmapRenderingContextSettings&& settings)
-    : CanvasRenderingContext(canvas)
+    : CanvasRenderingContext(canvas, Type::BitmapRenderer)
     , m_settings(WTFMove(settings))
 {
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -66,7 +66,6 @@ public:
 private:
     ImageBitmapRenderingContext(CanvasBase&, ImageBitmapRenderingContextSettings&&);
 
-    bool isBitmapRenderer() const final { return true; }
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
     void setOutputBitmap(RefPtr<ImageBitmap>);

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<OffscreenCanvasRenderingContext2D> OffscreenCanvasRenderingConte
 }
 
 OffscreenCanvasRenderingContext2D::OffscreenCanvasRenderingContext2D(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings)
-    : CanvasRenderingContext2DBase(canvas, WTFMove(settings), false)
+    : CanvasRenderingContext2DBase(canvas, Type::Offscreen2D, WTFMove(settings), false)
 {
 }
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -53,7 +53,6 @@ public:
 
 private:
     OffscreenCanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&);
-    bool isOffscreen2d() const final { return true; }
     RefPtr<ImageBuffer> transferToImageBuffer() final;
     const FontProxy* fontProxy() final;
 };

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<PaintRenderingContext2D> PaintRenderingContext2D::create(CustomP
 }
 
 PaintRenderingContext2D::PaintRenderingContext2D(CustomPaintCanvas& canvas)
-    : CanvasRenderingContext2DBase(canvas, { }, false)
+    : CanvasRenderingContext2DBase(canvas, Type::Paint, { }, false)
 {
 }
 

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -52,7 +52,6 @@ public:
 
 private:
     PaintRenderingContext2D(CustomPaintCanvas&);
-    bool isPaint() const override { return true; }
     mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
 };
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<PlaceholderRenderingContext> PlaceholderRenderingContext::create
 }
 
 PlaceholderRenderingContext::PlaceholderRenderingContext(HTMLCanvasElement& canvas)
-    : CanvasRenderingContext(canvas)
+    : CanvasRenderingContext(canvas, Type::Placeholder)
     , m_source(PlaceholderRenderingContextSource::create(*this))
 {
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -71,7 +71,6 @@ public:
 
 private:
     PlaceholderRenderingContext(HTMLCanvasElement&);
-    bool isPlaceholder() const final { return true; }
     bool delegatesDisplay() const final { return true; }
     void setContentsToLayer(GraphicsLayer&) final;
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -113,7 +113,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGL2RenderingContext);
 
 std::unique_ptr<WebGL2RenderingContext> WebGL2RenderingContext::create(CanvasBase& canvas, WebGLContextAttributes&& attributes)
 {
-    return std::unique_ptr<WebGL2RenderingContext>(new WebGL2RenderingContext(canvas, WTFMove(attributes)));
+    return std::unique_ptr<WebGL2RenderingContext>(new WebGL2RenderingContext(canvas, Type::WebGL2, WTFMove(attributes)));
 }
 
 WebGL2RenderingContext::~WebGL2RenderingContext()

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -261,9 +261,6 @@ public:
 
 private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
-
-    bool isWebGL2() const final { return true; }
-
     void initializeContextState() final;
 
     RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, unsigned startByte, unsigned bytelength);

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -114,7 +114,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebGLRenderingContext);
 
 std::unique_ptr<WebGLRenderingContext> WebGLRenderingContext::create(CanvasBase& canvas, WebGLContextAttributes&& attributes)
 {
-    return std::unique_ptr<WebGLRenderingContext>(new WebGLRenderingContext(canvas, WTFMove(attributes)));
+    return std::unique_ptr<WebGLRenderingContext>(new WebGLRenderingContext(canvas, Type::WebGL1, WTFMove(attributes)));
 }
 
 WebGLRenderingContext::~WebGLRenderingContext()

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -41,8 +41,6 @@ public:
 
     ~WebGLRenderingContext();
 
-    bool isWebGL1() const final { return true; }
-
     std::optional<WebGLExtensionAny> getExtension(const String&) final;
     std::optional<Vector<String>> getSupportedExtensions() final;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -486,13 +486,14 @@ std::unique_ptr<WebGLRenderingContextBase> WebGLRenderingContextBase::create(Can
     return renderingContext;
 }
 
-WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, WebGLContextAttributes&& attributes)
-    : GPUBasedCanvasRenderingContext(canvas)
+WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, CanvasRenderingContext::Type type, WebGLContextAttributes&& attributes)
+    : GPUBasedCanvasRenderingContext(canvas, type)
     , m_generatedImageCache(4)
     , m_attributes(WTFMove(attributes))
     , m_creationAttributes(m_attributes)
     , m_numGLErrorsToConsoleAllowed(canvas.scriptExecutionContext()->settingsValues().webGLErrorsToConsoleEnabled ? maxGLErrorsAllowedToConsole : 0)
 {
+    ASSERT(isWebGL());
 }
 
 WebGLCanvas WebGLRenderingContextBase::canvas()

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -491,7 +491,7 @@ public:
     bool compositingResultsNeedUpdating() const final { return m_compositingResultsNeedUpdating; }
     void prepareForDisplay() final;
 protected:
-    WebGLRenderingContextBase(CanvasBase&, WebGLContextAttributes&&);
+    WebGLRenderingContextBase(CanvasBase&, CanvasRenderingContext::Type, WebGLContextAttributes&&);
 
     friend class EXTDisjointTimerQuery;
     friend class EXTDisjointTimerQueryWebGL2;


### PR DESCRIPTION
#### 0d0eb9fad9c72bea8953b25785768e796c9dadb3
<pre>
[MotionMark] De-virtualize `CanvasRenderingContext` type checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=281445">https://bugs.webkit.org/show_bug.cgi?id=281445</a>
<a href="https://rdar.apple.com/137897409">rdar://137897409</a>

Reviewed by Simon Fraser.

The following methods show up frequently on MotionMark traces and take up a non-negligeable amount of time:
- CanvasRenderingContext::delegatesDisplay()
- CanvasRenderingContext2DBase::effectiveDrawingContext()
- CanvasRenderingContext2DBase::drawingContext()

In order to de-virtualize them, type checks need to be used, so de-virtualize those first.

* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::CanvasRenderingContext):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::is2dBase const):
(WebCore::CanvasRenderingContext::is2d const):
(WebCore::CanvasRenderingContext::isWebGL1 const):
(WebCore::CanvasRenderingContext::isWebGL2 const):
(WebCore::CanvasRenderingContext::isWebGPU const):
(WebCore::CanvasRenderingContext::isGPUBased const):
(WebCore::CanvasRenderingContext::isBitmapRenderer const):
(WebCore::CanvasRenderingContext::isPlaceholder const):
(WebCore::CanvasRenderingContext::isOffscreen2d const):
(WebCore::CanvasRenderingContext::isPaint const):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::CanvasRenderingContext2D):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::CanvasRenderingContext2DBase):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp:
(WebCore::GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext):
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::GPUCanvasContext):
* Source/WebCore/html/canvas/GPUCanvasContext.h:
(): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::ImageBitmapRenderingContext):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::OffscreenCanvasRenderingContext2D):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/PaintRenderingContext2D.cpp:
(WebCore::PaintRenderingContext2D::PaintRenderingContext2D):
* Source/WebCore/html/canvas/PaintRenderingContext2D.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::PlaceholderRenderingContext):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::create):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::create):
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/285213@main">https://commits.webkit.org/285213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e69cb029962a69a643a42de3db18533e31e4c0d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24654 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22898 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74936 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61914 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21423 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16109 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12637 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47087 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->