### PR TITLE
[WPE][Skia] Build Skia on WPE-Android

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -5,6 +5,10 @@ find_package(Freetype 2.9.0 REQUIRED)
 find_package(Fontconfig 2.13.0 REQUIRED)
 find_package(WebP REQUIRED COMPONENTS mux)
 
+if (ANDROID)
+    find_package(EXPAT REQUIRED)
+endif ()
+
 #
 # SKIA_ROOT_DIR may point to a checkout from the upstream Skia repository,
 # where a static build has been done under "out/Static" as follows:
@@ -873,13 +877,11 @@ add_library(Skia STATIC
     src/opts/SkOpts_hsw.cpp
     src/opts/SkOpts_skx.cpp
 
-    src/ports/SkDebug_stdio.cpp
     src/ports/SkFontConfigInterface.cpp
     src/ports/SkFontConfigInterface_direct.cpp
     src/ports/SkFontConfigInterface_direct_factory.cpp
     src/ports/SkFontHost_FreeType.cpp
     src/ports/SkFontHost_FreeType_common.cpp
-    src/ports/SkFontMgr_fontconfig.cpp
     src/ports/SkGlobalInitialization_default.cpp
     src/ports/SkImageGenerator_skia.cpp
     src/ports/SkMemory_malloc.cpp
@@ -895,9 +897,25 @@ add_library(Skia STATIC
     modules/skcms/src/skcms_TransformSkx.cc
 )
 
+if (ANDROID)
+    target_sources(Skia PRIVATE src/ports/SkDebug_android.cpp)
+    target_sources(Skia PRIVATE src/ports/SkFontMgr_android.cpp)
+    target_sources(Skia PRIVATE src/ports/SkFontMgr_android_parser.cpp)
+
+    target_link_libraries(Skia PRIVATE
+        EXPAT::EXPAT
+    )
+else ()
+    target_sources(Skia PRIVATE src/ports/SkDebug_stdio.cpp)
+    target_sources(Skia PRIVATE src/ports/SkFontMgr_fontconfig.cpp)
+
+    target_link_libraries(Skia PRIVATE
+       Fontconfig::Fontconfig
+    )
+endif ()
+
 target_link_libraries(Skia PRIVATE
     Epoxy::Epoxy
-    Fontconfig::Fontconfig
     Freetype::Freetype
     JPEG::JPEG
     PNG::PNG

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -29,7 +29,11 @@
 #include "Font.h"
 #include "FontDescription.h"
 #include "StyleFontSizeFunctions.h"
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <skia/ports/SkFontMgr_android.h>
+#else
 #include <skia/ports/SkFontMgr_fontconfig.h>
+#endif
 #include <wtf/Assertions.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/CharacterProperties.h>
@@ -47,8 +51,13 @@ void FontCache::platformInit()
 
 SkFontMgr& FontCache::fontManager() const
 {
-    if (!m_fontManager)
+    if (!m_fontManager) {
+#if defined(__ANDROID__) || defined(ANDROID)
+        m_fontManager = SkFontMgr_New_Android(nullptr);
+#else
         m_fontManager = SkFontMgr_New_FontConfig(FcConfigReference(nullptr));
+#endif
+    }
     RELEASE_ASSERT(m_fontManager);
     return *m_fontManager.get();
 }


### PR DESCRIPTION
#### 9bdd310f0173111eb6060a447aa623d62816cb7c
<pre>
[WPE][Skia] Build Skia on WPE-Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=281452">https://bugs.webkit.org/show_bug.cgi?id=281452</a>

Reviewed by Adrian Perez de Castro.

Build and enable Skia on WPE-Android

* Source/ThirdParty/skia/CMakeLists.txt:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::fontManager const):

Canonical link: <a href="https://commits.webkit.org/285349@main">https://commits.webkit.org/285349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e6c35c4646b37b82cd6c2aa51e9143075ea43f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25135 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62303 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19775 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21906 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78194 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19270 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62321 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12974 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47566 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->