### PR TITLE
update-safer-cpp-expectations should provide a link to post-commit results

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -135,7 +135,7 @@ def modify_expectations_for_checker(checker_type, unexpected_contents, project, 
 
 def update_expectations(args, project, add=False):
     if not project:
-        print(f'Could not find a project to update. Please include the project in the filename or pass in the --project argument.')
+        print(f'Could not find a project to update. Please pass in the --project argument.')
         return
     print(f"{'Adding' if add else 'Removing'} unexpected failures in {project}...\n")
     for checker_type in CHECKERS:
@@ -150,7 +150,7 @@ This currently checks against the files in your local checkout at SaferCPPExpect
 Ensure that it is up-to-date before using this script.
 '''
 def is_expected_file(expected_file):
-    print('This checks against local expectations. Ensure your checkout is up-to-date.')
+    print('This checks against local expectations. Ensure your checkout is up-to-date.\n')
     line = f'{expected_file}\n'
     issues = False
     for project in PROJECTS:
@@ -160,15 +160,20 @@ def is_expected_file(expected_file):
                 expectations = f.read()
                 if line in expectations:
                     if not issues:
-                        print(f'{expected_file} has issues:')
+                        print(f'{expected_file} has the following issues:')
                     issues = True
                     print(f'- {project} {checker}')
     if not issues:
         print(f'{expected_file} has no known issues!')
+    else:
+        print('Follow this link for the latest results: https://build.webkit.org/#/builders/Apple-Sonoma-Safer-CPP-Checks\n')
 
 
 def main():
     args = parser()
+    if args.expected_file:
+        is_expected_file(args.expected_file)
+        return
     if args.add:
         print('WARNING: Adding expected failures. Please only add expected failures when you fix false negatives in our tools.')
         user_input = input('Are you sure you want to proceed? [y/N]: ') or 'N'
@@ -178,8 +183,6 @@ def main():
         update_expectations_from_file(args.unexpected_results_file, args.project, args.add)
     else:
         update_expectations(vars(args), args.project, args.add)
-    if args.expected_file:
-        is_expected_file(args.expected_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### e74b10abd622d2784dd18fad39c638db67feaa3f
<pre>
update-safer-cpp-expectations should provide a link to post-commit results
<a href="https://bugs.webkit.org/show_bug.cgi?id=281454">https://bugs.webkit.org/show_bug.cgi?id=281454</a>
<a href="https://rdar.apple.com/137908874">rdar://137908874</a>

Reviewed by Ryosuke Niwa.

Add a link to post-commit results when --find-expectations is invoked.
Add better spacing and rephrase output.

* Tools/Scripts/update-safer-cpp-expectations:
(update_expectations):
(is_expected_file):
(main):

Canonical link: <a href="https://commits.webkit.org/285206@main">https://commits.webkit.org/285206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe285a656eebac4c65f7f8a4121a752755beed7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24644 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22888 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74926 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21413 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16099 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16145 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64460 "Build is in progress. Recent messages:") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11021 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47077 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->