### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from AudioSessionRoutingArbitratorProxy

### DIFF
--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -85,6 +85,16 @@ WTFLogChannel& AudioSessionRoutingArbitratorProxy::logChannel() const
     return WebKit2LogMedia;
 }
 
+void AudioSessionRoutingArbitratorProxy::ref() const
+{
+    return m_process->ref();
 }
+
+void AudioSessionRoutingArbitratorProxy::deref() const
+{
+    return m_process->deref();
+}
+
+} // namespace WebKit
 
 #endif // ENABLE(ROUTING_ARBITRATION)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -39,15 +39,6 @@
 #endif
 
 namespace WebKit {
-class AudioSessionRoutingArbitratorProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AudioSessionRoutingArbitratorProxy> : std::true_type { };
-}
-
-namespace WebKit {
 
 class WebProcessProxy;
 
@@ -55,7 +46,7 @@ class AudioSessionRoutingArbitratorProxy
     : public IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(AudioSessionRoutingArbitratorProxy);
 public:
-    AudioSessionRoutingArbitratorProxy(WebProcessProxy&);
+    explicit AudioSessionRoutingArbitratorProxy(WebProcessProxy&);
     virtual ~AudioSessionRoutingArbitratorProxy();
 
     void processDidTerminate();
@@ -75,6 +66,9 @@ public:
 
     ArbitrationStatus arbitrationStatus() const { return m_arbitrationStatus; }
     WallTime arbitrationUpdateTime() const { return m_arbitrationUpdateTime; }
+
+    void ref() const;
+    void deref() const;
 
 protected:
     Logger& logger();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -732,8 +732,8 @@ void WebProcessProxy::shutDown()
         m_webLockRegistry->processDidExit();
 
 #if ENABLE(ROUTING_ARBITRATION)
-    if (m_routingArbitrator)
-        m_routingArbitrator->processDidTerminate();
+    if (RefPtr routingArbitrator = m_routingArbitrator.get())
+        routingArbitrator->processDidTerminate();
 #endif
 
     Ref<WebProcessPool> { processPool() }->disconnectProcess(*this);
@@ -1291,8 +1291,8 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
     }
 
 #if ENABLE(ROUTING_ARBITRATION)
-    if (m_routingArbitrator)
-        m_routingArbitrator->processDidTerminate();
+    if (RefPtr routingArbitrator = m_routingArbitrator.get())
+        routingArbitrator->processDidTerminate();
 #endif
 
     // There is a nested transaction in WebPageProxy::resetStateAfterProcessExited() that we don't want to commit before the client call below (dispatchProcessDidTerminate).
@@ -2259,7 +2259,7 @@ void WebProcessProxy::enableMediaPlaybackIfNecessary()
 
 #if ENABLE(ROUTING_ARBITRATION)
     ASSERT(!m_routingArbitrator);
-    m_routingArbitrator = makeUnique<AudioSessionRoutingArbitratorProxy>(*this);
+    m_routingArbitrator = makeUniqueWithoutRefCountedCheck<AudioSessionRoutingArbitratorProxy>(*this);
 #endif
 }
 


### PR DESCRIPTION
#### 4843a0800947f719e4f415aa2058901eb8f25df1
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from AudioSessionRoutingArbitratorProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281456">https://bugs.webkit.org/show_bug.cgi?id=281456</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
(WebKit::AudioSessionRoutingArbitratorProxy::ref const):
(WebKit::AudioSessionRoutingArbitratorProxy::deref const):
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::enableMediaPlaybackIfNecessary):

Canonical link: <a href="https://commits.webkit.org/285183@main">https://commits.webkit.org/285183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b7293d996079ca4386969234dbd5e37a1408472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22980 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22800 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15154 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43099 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18841 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6196 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->