### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaKeySystemPermissionRequestManagerProxy

### DIFF
--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -122,4 +122,14 @@ Ref<MediaKeySystemPermissionRequestProxy> MediaKeySystemPermissionRequestManager
     return request;
 }
 
+void MediaKeySystemPermissionRequestManagerProxy::ref() const
+{
+    m_page->ref();
+}
+
+void MediaKeySystemPermissionRequestManagerProxy::deref() const
+{
+    m_page->deref();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -34,15 +34,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class MediaKeySystemPermissionRequestManagerProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::MediaKeySystemPermissionRequestManagerProxy> : std::true_type { };
-}
-
 namespace WebCore {
 class SecurityOrigin;
 };
@@ -65,6 +56,9 @@ public:
 
     void grantRequest(MediaKeySystemPermissionRequestProxy&);
     void denyRequest(MediaKeySystemPermissionRequestProxy&, const String& message = { });
+
+    void ref() const;
+    void deref() const;
 
 private:
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp
@@ -47,20 +47,22 @@ MediaKeySystemPermissionRequestProxy::MediaKeySystemPermissionRequestProxy(Media
 
 void MediaKeySystemPermissionRequestProxy::allow()
 {
-    ASSERT(m_manager);
-    if (!m_manager)
+    RefPtr manager = m_manager.get();
+    ASSERT(manager);
+    if (!manager)
         return;
 
-    m_manager->grantRequest(*this);
+    manager->grantRequest(*this);
     invalidate();
 }
 
 void MediaKeySystemPermissionRequestProxy::deny()
 {
-    if (!m_manager)
+    RefPtr manager = m_manager.get();
+    if (!manager)
         return;
 
-    m_manager->denyRequest(*this);
+    manager->denyRequest(*this);
     invalidate();
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11942,7 +11942,7 @@ MediaKeySystemPermissionRequestManagerProxy& WebPageProxy::mediaKeySystemPermiss
     if (m_mediaKeySystemPermissionRequestManager)
         return *m_mediaKeySystemPermissionRequestManager;
 
-    m_mediaKeySystemPermissionRequestManager = makeUnique<MediaKeySystemPermissionRequestManagerProxy>(*this);
+    m_mediaKeySystemPermissionRequestManager = makeUniqueWithoutRefCountedCheck<MediaKeySystemPermissionRequestManagerProxy>(*this);
     return *m_mediaKeySystemPermissionRequestManager;
 }
 #endif


### PR DESCRIPTION
#### 2b9a9afa5dc704f76ddc4e4f66922fea2bd141d7
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaKeySystemPermissionRequestManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281459">https://bugs.webkit.org/show_bug.cgi?id=281459</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::ref const):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::deref const):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestProxy::allow):
(WebKit::MediaKeySystemPermissionRequestProxy::deny):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mediaKeySystemPermissionRequestManager):

Canonical link: <a href="https://commits.webkit.org/285192@main">https://commits.webkit.org/285192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc203bfa983c77eecb9c592b0bc75570d300cef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75844 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56634 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15120 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43059 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77563 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64354 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64358 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12520 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6159 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11012 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->