### PR TITLE
Enable -Wunsafe-buffer-usage in bmalloc

### DIFF
--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -147,3 +147,17 @@
 #define BALLOW_DEPRECATED_DECLARATIONS_BEGIN
 #define BALLOW_DEPRECATED_DECLARATIONS_END
 #endif
+
+/* BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN and BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END */
+
+#if BCOMPILER(CLANG)
+#define BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"")
+
+#define BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END \
+    _Pragma("clang diagnostic pop")
+#else
+#define BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#define BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END
+#endif

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BCompiler.h"
 #include "BExport.h"
 #include "BPlatform.h"
 
@@ -172,6 +173,8 @@ private:
         return 8;
     }
 
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     BINLINE unsigned tzoneBucketForKey(UniqueLockHolder&, bmalloc_type* type, unsigned bucketCountForSize)
     {
         SHA256ResultAsUnsigned sha256Result;
@@ -213,6 +216,8 @@ private:
     Vector<SizeAndAlign> m_typeSizes;
     Map<SizeAndAlign, TZoneTypeBuckets*, SizeAndAlign> m_heapRefsBySizeAndAlignment;
 };
+
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } } // namespace bmalloc::api
 

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "BAssert.h"
+#include "BCompiler.h"
 #include "BSyscall.h"
 #include "BVMTags.h"
 #include "Logging.h"
@@ -38,6 +39,8 @@
 #if BOS(DARWIN)
 #include <mach/vm_page_size.h>
 #endif
+
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace bmalloc {
 
@@ -264,3 +267,5 @@ inline void vmAllocatePhysicalPagesSloppy(void* p, size_t size)
 }
 
 } // namespace bmalloc
+
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### a2efa2223c0550b7830a854f52a759163f0c891e
<pre>
Enable -Wunsafe-buffer-usage in bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=281460">https://bugs.webkit.org/show_bug.cgi?id=281460</a>
<a href="https://rdar.apple.com/137911788">rdar://137911788</a>

Reviewed by Geoffrey Garen.

Same kind of changes to bmalloc that were done for WebKit code in <a href="https://commits.webkit.org/285046@main.">https://commits.webkit.org/285046@main.</a>

* Source/bmalloc/bmalloc/BCompiler.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
* Source/bmalloc/bmalloc/VMAllocate.h:

Canonical link: <a href="https://commits.webkit.org/285164@main">https://commits.webkit.org/285164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76b13bde94d462b144565861e2d05f985187f8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24519 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22770 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61803 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21291 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64870 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77579 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70995 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61836 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12535 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92780 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46958 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20450 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->