### PR TITLE
[MotionMark] De-virtualize some `CanvasRenderingContext` methods

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -46,6 +46,10 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
+#if USE(SKIA)
+#include "CanvasRenderingContext2DBase.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CanvasRenderingContext);
@@ -101,7 +105,11 @@ bool CanvasRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) cons
 
 bool CanvasRenderingContext::delegatesDisplay() const
 {
-    return false;
+#if USE(SKIA)
+    if (auto* context2D = dynamicDowncast<CanvasRenderingContext2DBase>(*this))
+        return context2D->isAccelerated();
+#endif
+    return isPlaceholder() || isGPUBased();
 }
 
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerContentsDisplayDelegate()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -92,7 +92,7 @@ public:
     // Draws the source buffer to the canvasBase().buffer().
     virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer);
     virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const;
-    virtual bool delegatesDisplay() const;
+    bool delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -58,6 +58,7 @@
 #include "ImageBuffer.h"
 #include "ImageData.h"
 #include "OffscreenCanvas.h"
+#include "PaintRenderingContext2D.h"
 #include "Path2D.h"
 #include "PixelBufferConversion.h"
 #include "RenderElement.h"
@@ -268,11 +269,6 @@ bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer
 }
 
 #if USE(SKIA)
-bool CanvasRenderingContext2DBase::delegatesDisplay() const
-{
-    return isAccelerated();
-}
-
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext2DBase::layerContentsDisplayDelegate()
 {
     if (auto buffer = canvasBase().buffer())
@@ -2391,6 +2387,8 @@ const Vector<CanvasRenderingContext2DBase::State, 1>& CanvasRenderingContext2DBa
 
 GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
 {
+    if (auto* paintContext = dynamicDowncast<PaintRenderingContext2D>(*this))
+        return paintContext->ensureDrawingContext();
     if (auto* buffer = canvasBase().buffer())
         return &buffer->context();
     return nullptr;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -325,9 +325,11 @@ protected:
     void realizeSaves();
     State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
-    virtual GraphicsContext* drawingContext() const;
+    // These methods are de-virtualized for performance reasons.
+    GraphicsContext* drawingContext() const;
+    GraphicsContext* effectiveDrawingContext() const;
+
     virtual GraphicsContext* existingDrawingContext() const;
-    virtual GraphicsContext* effectiveDrawingContext() const;
     virtual AffineTransform baseTransform() const;
 
     enum class DidDrawOption {
@@ -466,7 +468,6 @@ private:
 
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
 #if USE(SKIA)
-    bool delegatesDisplay() const override;
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 #endif
     bool hasDeferredOperations() const final;

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -40,8 +40,6 @@ public:
     void ref() const final { CanvasRenderingContext::ref(); }
     void deref() const final { CanvasRenderingContext::deref(); }
 
-    bool delegatesDisplay() const override { return true; }
-
     virtual void reshape() = 0;
 protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
@@ -53,7 +53,7 @@ CustomPaintCanvas& PaintRenderingContext2D::canvas() const
     return downcast<CustomPaintCanvas>(canvasBase());
 }
 
-GraphicsContext* PaintRenderingContext2D::drawingContext() const
+GraphicsContext* PaintRenderingContext2D::ensureDrawingContext() const
 {
     if (!m_recordingContext)
         m_recordingContext = makeUnique<DisplayList::DrawingContext>(canvasBase().size());

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -42,9 +42,8 @@ public:
 
     virtual ~PaintRenderingContext2D();
 
-    GraphicsContext* drawingContext() const final;
+    GraphicsContext* ensureDrawingContext() const;
     GraphicsContext* existingDrawingContext() const final;
-    GraphicsContext* effectiveDrawingContext() const final { return drawingContext(); }
     AffineTransform baseTransform() const final;
 
     CustomPaintCanvas& canvas() const;

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -71,7 +71,6 @@ public:
 
 private:
     PlaceholderRenderingContext(HTMLCanvasElement&);
-    bool delegatesDisplay() const final { return true; }
     void setContentsToLayer(GraphicsLayer&) final;
 
     Ref<PlaceholderRenderingContextSource> m_source;


### PR DESCRIPTION
#### f7b96500104a93774bc5fd08848886fc2d64626d
<pre>
[MotionMark] De-virtualize some `CanvasRenderingContext` methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=281462">https://bugs.webkit.org/show_bug.cgi?id=281462</a>
<a href="https://rdar.apple.com/137913852">rdar://137913852</a>

Reviewed by Simon Fraser.

De-virtualize these methods which show up a non-trivial amount in the traces:
- CanvasRenderingContext::delegatesDisplay()
- CanvasRenderingContext2DBase::effectiveDrawingContext()
- CanvasRenderingContext2DBase::drawingContext()

This offers a ~2% improvement on the Canvas Lines test suite.

* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::delegatesDisplay const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::effectiveDrawingContext const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/PaintRenderingContext2D.cpp:
(WebCore::PaintRenderingContext2D::ensureDrawingContext const):
(WebCore::PaintRenderingContext2D::drawingContext const): Deleted.
* Source/WebCore/html/canvas/PaintRenderingContext2D.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:

Canonical link: <a href="https://commits.webkit.org/285225@main">https://commits.webkit.org/285225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1da06aa2dd4ceb2bce80ddd6e57d6c230066dda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24688 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22932 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74970 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16143 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16189 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15891 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47121 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->