### PR TITLE
[UnifiedPDF] There's a tile flicker after resizing has finished

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -939,20 +939,16 @@ PDFPageCoverage PDFDiscretePresentationController::pageCoverageForContentsRect(c
     }
 
     auto contentsRect = convertFromPaintingToContents(paintingRect, row->pages[0]);
-
-    auto drawingRect = IntRect { { }, m_plugin->documentSize() };
-    drawingRect.intersect(enclosingIntRect(contentsRect));
-
-    auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatRect { drawingRect });
+    auto paintRectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, contentsRect);
 
     auto pageCoverage = PDFPageCoverage { };
 
     auto addPageToCoverage = [&](PDFDocumentLayout::PageIndex pageIndex) {
         auto pageBounds = layoutBoundsForPageAtIndex(pageIndex);
-        if (!pageBounds.intersects(rectInPDFLayoutCoordinates))
+        if (!pageBounds.intersects(paintRectInPDFLayoutCoordinates))
             return;
 
-        pageCoverage.append(PerPageInfo { pageIndex, pageBounds });
+        pageCoverage.append(PerPageInfo { pageIndex, pageBounds, paintRectInPDFLayoutCoordinates });
     };
 
     for (auto pageIndex : row->pages)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -37,7 +37,8 @@ namespace WebKit {
 
 struct PerPageInfo {
     PDFDocumentLayout::PageIndex pageIndex { 0 };
-    WebCore::FloatRect pageBounds;
+    WebCore::FloatRect pageBounds; // These are in "PDFDocumentLayout" coordinates.
+    WebCore::FloatRect rectInPageLayoutCoordinates; // Some arbirary rect converted into "PDFDocumentLayout" coordinates.
 
     bool operator==(const PerPageInfo&) const = default;
 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
@@ -32,13 +32,13 @@ namespace WebKit {
 
 TextStream& operator<<(TextStream& ts, const PerPageInfo& pageInfo)
 {
-    ts << "PerPageInfo " << pageInfo.pageIndex << " bounds " << pageInfo.pageBounds;
+    ts << "PerPageInfo " << pageInfo.pageIndex << " bounds " << pageInfo.pageBounds << " rect in page bounds " << pageInfo.rectInPageLayoutCoordinates;
     return ts;
 }
 
 TextStream& operator<<(TextStream& ts, const PDFPageCoverageAndScales& coverage)
 {
-    ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " tiling scale " << coverage.tilingScaleFactor << " contents offst " << coverage.contentsOffset;
+    ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " tiling scale " << coverage.tilingScaleFactor << " contents offset " << coverage.contentsOffset;
     return ts;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -108,9 +108,7 @@ PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(
     if (m_plugin->visibleOrDocumentSizeIsEmpty())
         return { };
 
-    auto drawingRect = IntRect { { }, m_plugin->documentSize() };
-    drawingRect.intersect(enclosingIntRect(contentsRect));
-    auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatRect { drawingRect });
+    auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, contentsRect);
 
     auto& documentLayout = m_plugin->documentLayout();
     auto pageCoverage = PDFPageCoverage { };
@@ -123,7 +121,7 @@ PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(
         if (!pageBounds.intersects(rectInPDFLayoutCoordinates))
             continue;
 
-        pageCoverage.append(PerPageInfo { i, pageBounds });
+        pageCoverage.append(PerPageInfo { i, pageBounds, rectInPDFLayoutCoordinates });
     }
 
     return pageCoverage;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -763,11 +763,11 @@ void UnifiedPDFPlugin::paintPDFContent(const WebCore::GraphicsLayer* layer, Grap
             context.clip(pageBoundsInPaintingCoordinates);
 
             ASSERT(layer);
-            bool paintedPageContent = asyncRenderer->paintTilesForPage(layer, context, documentScale, clipRect, pageBoundsInPaintingCoordinates, pageInfo.pageIndex);
-            LOG_WITH_STREAM(PDFAsyncRendering, stream << "UnifiedPDFPlugin::paintPDFContent - painting tiles for page " << pageInfo.pageIndex << " dest rect " << pageBoundsInPaintingCoordinates << " clip " << clipRect << " - painted cached tile " << paintedPageContent);
 
-            if (!paintedPageContent && showDebugIndicators)
+            if (showDebugIndicators)
                 context.fillRect(pageBoundsInPaintingCoordinates, Color::yellow.colorWithAlphaByte(128));
+
+            asyncRenderer->paintTilesForPage(layer, context, documentScale, clipRect, pageInfo.rectInPageLayoutCoordinates, pageBoundsInPaintingCoordinates, pageInfo.pageIndex);
         }
 
         bool currentPageHasAnnotation = pageWithAnnotation && *pageWithAnnotation == pageInfo.pageIndex;


### PR DESCRIPTION
#### ea9faa806d568971180b321b28271beb4dd1db8c
<pre>
[UnifiedPDF] There&apos;s a tile flicker after resizing has finished
<a href="https://bugs.webkit.org/show_bug.cgi?id=270041">https://bugs.webkit.org/show_bug.cgi?id=270041</a>
<a href="https://rdar.apple.com/123566595">rdar://123566595</a>

Reviewed by Abrar Rahman Protyasha.

In UnifiedPDF, which uses TiledBacking for tiling, there are a couple of cases where we drop all our
rendered tiles, and temporarily show the low-resolution page previews, which is jarring. Those
two cases are when the tile size changes, and when the scale changes.

This PR avoids the display of the low-resolution page preview by keeping tiles around from
the previous state, and painting them before the high-resolution tiles. These tiles correspond
to what the use saw last time, so painting them is never lower resolution than earlier frames.

To track when we should keep old tiles around, respond to the TiledBackingClient functions that
tell us when it&apos;s doing a full tile revalidation, and when it&apos;s repainting after a scale change,
by tracking some per-TileGrid state. When we get `willRepaintTile` or `willRemoveTile` in those
states, instead of deleting the old buffers, move them to `m_rendereredTilesForOldState`.

Now we have to figure out when to clear `m_rendereredTilesForOldState` (otherwise we&apos;ll just
accumulate memory). Do so in `didRevalidateTiles()` by storing a set of all the tile renders
for the new tiles; when those renders are complete, we can clear `m_rendereredTilesForOldState`.
These are also tracked on a per-TileGrid basis.

We paint the old tiles in `AsyncPDFRenderer::paintTilesForPage()` before the current tiles.
Because their geometry no longer matches the current tiles, we have to map the correct parts
of their ImageBuffers into the current painting coordinates. We can do so by converting
geometry into PDF layout coordinates. To do this, we need to store data on how painting rects (&quot;clip rects&quot;)
mapped into PDF layout coordinates per tile, so enhance `PerPageInfo` in `PDFPageCoverage` to store an
additional per-page rect, which is some arbitrary rect mapped into PDF layout coordinates. For our
purposes, this rect is a painting clip rect. The painting code then uses `mapRect()` to compute
source and destination rects for the relevant portion of the stale tile&apos;s ImageBuffer.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::stopTrackingLayer):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::enqueueTilePaintForTileGridRepaint):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRevalidateTiles):
(WebKit::AsyncPDFRenderer::didRevalidateTiles):
(WebKit::AsyncPDFRenderer::revalidationStateForGrid):
(WebKit::AsyncPDFRenderer::trackRendersForStaleTileMaintenance):
(WebKit::AsyncPDFRenderer::trackRenderCompletionForStaleTileMaintenance):
(WebKit::AsyncPDFRenderer::willRepaintTilesAfterScaleFactorChange):
(WebKit::AsyncPDFRenderer::didRepaintTilesAfterScaleFactorChange):
(WebKit::AsyncPDFRenderer::clearRequestsAndCachedTiles):
(WebKit::AsyncPDFRenderer::enqueueTilePaintIfNecessary):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::didCompleteTileRender):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::pageCoverageForContentsRect const):
    Don&apos;t intersect with the document bounds. First this wasn&apos;t necessary because elsewhere we clip
    to PDF page bounds which are inside the content rect. Second, this clipping would mutate the clipRects
    that we need later to correctly map subsets of the tile buffers.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm:
(WebKit::operator&lt;&lt;):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::pageCoverageForContentsRect const):
    Don&apos;t intersect with the document bounds. First this wasn&apos;t necessary because elsewhere we clip
    to PDF page bounds which are inside the content rect. Second, this clipping would mutate the clipRects
    that we need later to correctly map subsets of the tile buffers.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent):
    Just paint the yellow first so other things paint over it.

Canonical link: <a href="https://commits.webkit.org/285170@main">https://commits.webkit.org/285170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d7bcc3b3da4842ad28c3bfadfe7492bdc548c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22949 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22769 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43069 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6170 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46957 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->