### PR TITLE
Remove back/forward cache state from `HistoryItem`

### DIFF
--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BackForwardItemIdentifier.h"
 #include "HistoryItem.h"
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
@@ -72,6 +73,9 @@ public:
     void markPagesForCaptionPreferencesChanged();
 #endif
 
+    bool isInBackForwardCache(BackForwardItemIdentifier) const;
+    bool hasCachedPageExpired(BackForwardItemIdentifier) const;
+
 private:
     BackForwardCache();
     ~BackForwardCache() = delete; // Make sure nobody accidentally calls delete -- WebCore does not delete singletons.
@@ -83,7 +87,8 @@ private:
     void prune(PruningReason);
     void dump() const;
 
-    ListHashSet<RefPtr<HistoryItem>> m_items;
+    HashMap<BackForwardItemIdentifier, std::variant<PruningReason, UniqueRef<CachedPage>>> m_cachedPageMap;
+    ListHashSet<BackForwardItemIdentifier> m_items;
     unsigned m_maxSize {0};
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -54,7 +54,7 @@ public:
 
     bool hasExpired() const;
     
-    CachedFrame* cachedMainFrame() { return m_cachedMainFrame.get(); }
+    CachedFrame* cachedMainFrame() const { return m_cachedMainFrame.get(); }
 
 #if ENABLE(VIDEO)
     void markForCaptionPreferencesChanged() { m_needsCaptionPreferencesChanged = true; }

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -59,7 +59,6 @@ class FormData;
 class HistoryItem;
 class Image;
 class ResourceRequest;
-enum class PruningReason;
 
 class HistoryItemClient : public RefCounted<HistoryItemClient> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(HistoryItemClient, WEBCORE_EXPORT);
@@ -71,8 +70,6 @@ protected:
 };
 
 class HistoryItem : public RefCounted<HistoryItem>, public CanMakeWeakPtr<HistoryItem> {
-    friend class BackForwardCache;
-
 public:
     using Client = HistoryItemClient;
     static Ref<HistoryItem> create(Client& client, const String& urlString = { }, const String& title = { }, const String& alternateTitle = { }, std::optional<BackForwardItemIdentifier> identifier = { })
@@ -97,7 +94,7 @@ public:
     WEBCORE_EXPORT const String& urlString() const;
     WEBCORE_EXPORT const String& title() const;
     
-    bool isInBackForwardCache() const { return m_cachedPage.get(); }
+    WEBCORE_EXPORT bool isInBackForwardCache() const;
     WEBCORE_EXPORT bool hasCachedPageExpired() const;
 
     WEBCORE_EXPORT void setAlternateTitle(const String&);
@@ -228,9 +225,6 @@ public:
 private:
     WEBCORE_EXPORT HistoryItem(Client&, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier>);
 
-    void setCachedPage(std::unique_ptr<CachedPage>&&);
-    std::unique_ptr<CachedPage> takeCachedPage();
-
     HistoryItem(const HistoryItem&);
 
     static int64_t generateSequenceNumber();
@@ -279,10 +273,6 @@ private:
     // info used to repost form data
     RefPtr<FormData> m_formData;
     String m_formContentType;
-
-    // BackForwardCache controls these fields.
-    std::unique_ptr<CachedPage> m_cachedPage;
-    PruningReason m_pruningReason;
 
 #if PLATFORM(IOS_FAMILY)
     FloatRect m_exposedContentRect;


### PR DESCRIPTION
#### e72901245a13f0e051a65f1b15bb08fcae0f39a8
<pre>
Remove back/forward cache state from `HistoryItem`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281467">https://bugs.webkit.org/show_bug.cgi?id=281467</a>
<a href="https://rdar.apple.com/137923224">rdar://137923224</a>

Reviewed by Alex Christensen.

To prepare for site isolation, most history state is being moved to the UI process rather than being
stored in the history item maps within the web process, which will eventually be removed. Since the
back/forward cache state on `HistoryItem` cannot be stored in the UI process, it should be moved into
maps on `BackForwardCache`.

Modify `m_items` to store a `BackForwardItemIdentifier`, and add `m_cachedPageMap` to store the pruning
reason when an item is removed from the back/forward cache.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::dump const):
(WebCore::BackForwardCache::frameCount):
(WebCore::BackForwardCache::markPagesForDeviceOrPageScaleChanged):
(WebCore::BackForwardCache::markPagesForContentsSizeChanged):
(WebCore::BackForwardCache::markPagesForCaptionPreferencesChanged):
(WebCore::BackForwardCache::addIfCacheable):
(WebCore::BackForwardCache::take):
(WebCore::BackForwardCache::removeAllItemsForPage):
(WebCore::BackForwardCache::get):
(WebCore::BackForwardCache::remove):
(WebCore::BackForwardCache::prune):
(WebCore::BackForwardCache::clearEntriesForOrigins):
(WebCore::BackForwardCache::isInBackForwardCache const):
(WebCore::BackForwardCache::hasCachedPageExpired const):
(WebCore::BackForwardCache::frameCount const):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::HistoryItem::~HistoryItem):
(WebCore::HistoryItem::isInBackForwardCache const):
(WebCore::HistoryItem::hasCachedPageExpired const):
(WebCore::HistoryItem::setCachedPage): Deleted.
(WebCore::HistoryItem::takeCachedPage): Deleted.
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::isInBackForwardCache const): Deleted.
* Source/WebCore/history/CachedPage.h:

Canonical link: <a href="https://commits.webkit.org/285233@main">https://commits.webkit.org/285233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baca9f709380272b3746414862c75ec85bceaaf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56732 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21415 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77701 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64700 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64462 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6279 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11040 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1863 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->