### PR TITLE
duolingo.com: [iPhone] Listening text is cut off on several prompts

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<meta charset="UTF-8">
+<title>width:min-content on div containing implicit ruby bases causes line break</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+body {
+  font: 16px Ahem;
+}
+</style>
+<div><ruby>み<rt>mi</rt></ruby><br><ruby>ず<rt>zu</rt></ruby></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<meta charset="UTF-8">
+<title>width:min-content on div containing implicit ruby bases causes line break</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+body {
+  font: 16px Ahem;
+}
+</style>
+<div><ruby>み<rt>mi</rt></ruby><br><ruby>ず<rt>zu</rt></ruby></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<meta charset="UTF-8">
+<title>width:min-content on div containing implicit ruby bases causes line break</title>
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#break-between">
+<link rel="match" href="ruby-min-content-wrap-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+body {
+  font: 16px Ahem;
+}
+div {
+  width: min-content;
+}
+</style>
+<div><ruby>み<rt>mi</rt>ず<rt>zu</rt></ruby></div>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4534,6 +4534,8 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
             float childMin = 0;
             float childMax = 0;
 
+            bool isImplicitRubyBase = child->parent()->style().display() == DisplayType::Ruby && (childStyle.display() == DisplayType::RubyBase || childStyle.display() == DisplayType::Inline);
+
             if (!child->isRenderText()) {
                 if (child->isLineBreakOpportunity()) {
                     minLogicalWidth = preferredWidth(minLogicalWidth, inlineMin);
@@ -4548,13 +4550,18 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                     childMin += bpm;
                     childMax += bpm;
 
-                    if (childStyle.display() == DisplayType::RubyBase && !childIterator.endOfInline)
-                        rubyBaseMinimumMaximumWidthStack.append(std::pair { inlineMin, inlineMax });
-
                     inlineMin += childMin;
                     inlineMax += childMax;
 
-                    if (childStyle.display() == DisplayType::RubyBase && childIterator.endOfInline) {
+                    if (isImplicitRubyBase) {
+                        minLogicalWidth = preferredWidth(minLogicalWidth, inlineMin);
+                        inlineMin = 0;
+                    }
+
+                    if (isImplicitRubyBase && !childIterator.endOfInline)
+                        rubyBaseMinimumMaximumWidthStack.append(std::pair { inlineMin, inlineMax });
+
+                    if (isImplicitRubyBase && childIterator.endOfInline) {
                         if (!rubyBaseMinimumMaximumWidthStack.isEmpty()) {
                             auto rubyBaseStart = rubyBaseMinimumMaximumWidthStack.last();
                             rubyBaseMinimumMaximumWidthStack.last() = std::pair { inlineMin - rubyBaseStart.first, inlineMax - rubyBaseStart.second };


### PR DESCRIPTION
#### 5030057b3da609317c1e6bdbe6b4ee746c9d54a0
<pre>
duolingo.com: [iPhone] Listening text is cut off on several prompts
<a href="https://bugs.webkit.org/show_bug.cgi?id=281466">https://bugs.webkit.org/show_bug.cgi?id=281466</a>
<a href="https://rdar.apple.com/131571396">rdar://131571396</a>

Reviewed by NOBODY (OOPS!).

These changes correct the calculation of the min-content width for implicit ruby bases within ruby elements. This fixes text wrapping for ruby elements, allowing the text to wrap to a newline rather than simply running offscreen. A layout test checking for this behavior has been added as well.

* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-min-content-wrap-ref.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5030057b3da609317c1e6bdbe6b4ee746c9d54a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56775 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77745 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64489 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6308 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->