### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from RemoteLayerBackingStoreCollection

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -114,13 +114,13 @@ RemoteLayerBackingStore::RemoteLayerBackingStore(PlatformCALayerRemote& layer)
     : m_layer(layer)
     , m_lastDisplayTime(-MonotonicTime::infinity())
 {
-    if (auto* collection = backingStoreCollection())
+    if (RefPtr collection = backingStoreCollection())
         collection->backingStoreWasCreated(*this);
 }
 
 RemoteLayerBackingStore::~RemoteLayerBackingStore()
 {
-    if (auto* collection = backingStoreCollection())
+    if (RefPtr collection = backingStoreCollection())
         collection->backingStoreWillBeDestroyed(*this);
 }
 
@@ -223,7 +223,7 @@ void RemoteLayerBackingStoreProperties::dump(TextStream& ts) const
 
 bool RemoteLayerBackingStore::layerWillBeDisplayed()
 {
-    auto* collection = backingStoreCollection();
+    RefPtr collection = backingStoreCollection();
     if (!collection) {
         ASSERT_NOT_REACHED();
         return false;
@@ -234,7 +234,7 @@ bool RemoteLayerBackingStore::layerWillBeDisplayed()
 
 bool RemoteLayerBackingStore::layerWillBeDisplayedWithRenderingSuppression()
 {
-    auto* collection = backingStoreCollection();
+    RefPtr collection = backingStoreCollection();
     if (!collection) {
         ASSERT_NOT_REACHED();
         return false;
@@ -331,7 +331,7 @@ void RemoteLayerBackingStore::setDelegatedContents(const PlatformCALayerRemoteDe
 
 bool RemoteLayerBackingStore::needsDisplay() const
 {
-    auto* collection = backingStoreCollection();
+    RefPtr collection = backingStoreCollection();
     if (!collection) {
         ASSERT_NOT_REACHED();
         return false;
@@ -611,19 +611,19 @@ Vector<std::unique_ptr<ThreadSafeImageBufferSetFlusher>> RemoteLayerBackingStore
 
 void RemoteLayerBackingStore::purgeFrontBufferForTesting()
 {
-    if (auto* collection = backingStoreCollection())
+    if (RefPtr collection = backingStoreCollection())
         collection->purgeFrontBufferForTesting(*this);
 }
 
 void RemoteLayerBackingStore::purgeBackBufferForTesting()
 {
-    if (auto* collection = backingStoreCollection())
+    if (RefPtr collection = backingStoreCollection())
         collection->purgeBackBufferForTesting(*this);
 }
 
 void RemoteLayerBackingStore::markFrontBufferVolatileForTesting()
 {
-    if (auto* collection = backingStoreCollection())
+    if (RefPtr collection = backingStoreCollection())
         collection->markFrontBufferVolatileForTesting(*this);
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -33,15 +33,6 @@
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
-namespace WebKit {
-class RemoteLayerBackingStoreCollection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLayerBackingStoreCollection> : std::true_type { };
-}
-
 namespace WebCore {
 class ImageBuffer;
 class ThreadSafeImageBufferFlusher;
@@ -67,6 +58,9 @@ class RemoteLayerBackingStoreCollection : public CanMakeWeakPtr<RemoteLayerBacki
 public:
     RemoteLayerBackingStoreCollection(RemoteLayerTreeContext&);
     virtual ~RemoteLayerBackingStoreCollection();
+
+    void ref() const;
+    void deref() const;
 
     void markFrontBufferVolatileForTesting(RemoteLayerBackingStore&);
     virtual void backingStoreWasCreated(RemoteLayerBackingStore&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -56,6 +56,16 @@ RemoteLayerBackingStoreCollection::RemoteLayerBackingStoreCollection(RemoteLayer
 
 RemoteLayerBackingStoreCollection::~RemoteLayerBackingStoreCollection() = default;
 
+void RemoteLayerBackingStoreCollection::ref() const
+{
+    return m_layerTreeContext->ref();
+}
+
+void RemoteLayerBackingStoreCollection::deref() const
+{
+    return m_layerTreeContext->deref();
+}
+
 void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLayerTreeTransaction& transaction)
 {
     Vector<RemoteRenderingBackendProxy::LayerPrepareBuffersData> prepareBuffersData;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -228,7 +228,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay()
 {
     ASSERT(!m_frontBufferFlushers.size());
 
-    auto* collection = backingStoreCollection();
+    RefPtr collection = backingStoreCollection();
     if (!collection) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -44,7 +44,7 @@ using namespace WebCore;
 RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote& layer)
     : RemoteLayerBackingStore(layer)
 {
-    auto* collection = backingStoreCollection();
+    RefPtr collection = backingStoreCollection();
     if (!collection) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -126,7 +126,7 @@ private:
 
     HashSet<WeakRef<GraphicsLayerCARemote>> m_liveGraphicsLayers;
 
-    std::unique_ptr<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
+    UniqueRef<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
 
     WebCore::LayerPool m_layerPool;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -51,8 +51,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeContext);
 
 RemoteLayerTreeContext::RemoteLayerTreeContext(WebPage& webPage)
     : m_webPage(webPage)
+    , m_backingStoreCollection(makeUniqueRef<RemoteLayerBackingStoreCollection>(*this))
 {
-    m_backingStoreCollection = makeUnique<RemoteLayerBackingStoreCollection>(*this);
 }
 
 RemoteLayerTreeContext::~RemoteLayerTreeContext()


### PR DESCRIPTION
#### 72098fe0eefef7982e83a598c02ba3ec02c37035
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from RemoteLayerBackingStoreCollection
<a href="https://bugs.webkit.org/show_bug.cgi?id=281476">https://bugs.webkit.org/show_bug.cgi?id=281476</a>

Reviewed by Chris Dumez.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::RemoteLayerBackingStore):
(WebKit::RemoteLayerBackingStore::~RemoteLayerBackingStore):
(WebKit::RemoteLayerBackingStore::layerWillBeDisplayed):
(WebKit::RemoteLayerBackingStore::layerWillBeDisplayedWithRenderingSuppression):
(WebKit::RemoteLayerBackingStore::needsDisplay const):
(WebKit::RemoteLayerBackingStore::purgeFrontBufferForTesting):
(WebKit::RemoteLayerBackingStore::purgeBackBufferForTesting):
(WebKit::RemoteLayerBackingStore::markFrontBufferVolatileForTesting):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::ref const):
(WebKit::RemoteLayerBackingStoreCollection::deref const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::RemoteLayerTreeContext):

Canonical link: <a href="https://commits.webkit.org/285266@main">https://commits.webkit.org/285266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a00f0b2d4e2e67408962113121ac77019f5ea9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23028 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43286 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19028 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16285 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62047 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Skipped layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64538 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6373 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2001 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->