### PR TITLE
Remove WebCore::Style::BuilderState::useSVGZoomRules()

### DIFF
--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -88,11 +88,6 @@ BuilderState::BuilderState(Builder& builder, RenderStyle& style, BuilderContext&
 // width/height/border/padding/... from the RenderStyle -> for SVG these values would never scale,
 // if we'd pass a 1.0 zoom factor everyhwere. So we only pass a zoom factor of 1.0 for specific
 // properties that are NOT allowed to scale within a zoomed SVG document (letter/word-spacing/font-size).
-bool BuilderState::useSVGZoomRules() const
-{
-    return is<SVGElement>(element());
-}
-
 bool BuilderState::useSVGZoomRulesForLength() const
 {
     return is<SVGElement>(element()) && !(is<SVGSVGElement>(*element()) && element()->parentNode());
@@ -261,7 +256,7 @@ void BuilderState::updateFontForOrientationChange()
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)
 {
     fontDescription.setSpecifiedSize(size);
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), false, &style(), document()));
+    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), &style(), document()));
 }
 
 CSSPropertyID BuilderState::cssPropertyID() const

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -90,7 +90,6 @@ public:
     bool applyPropertyToRegularStyle() const { return m_linkMatch != SelectorChecker::MatchVisited; }
     bool applyPropertyToVisitedLinkStyle() const { return m_linkMatch != SelectorChecker::MatchLink; }
 
-    bool useSVGZoomRules() const;
     bool useSVGZoomRulesForLength() const;
     ScopeOrdinal styleScopeOrdinal() const { return m_currentProperty->styleScopeOrdinal; }
 

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -82,16 +82,13 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     return std::min(maximumAllowedFontSize, zoomedSize);
 }
 
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle* style, const Document& document)
+float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, const RenderStyle* style, const Document& document)
 {
-    float zoomFactor = 1.0f;
-    if (!useSVGZoomRules) {
-        zoomFactor = style->usedZoom();
-        auto* frame = document.frame();
-        if (frame && style->textZoom() != TextZoom::Reset)
-            zoomFactor *= frame->textZoomFactor();
-    }
-    return computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues());
+    float zoomFactor = style->usedZoom();
+    auto* frame = document.frame();
+    if (frame && style->textZoom() != TextZoom::Reset)
+        zoomFactor *= frame->textZoomFactor();
+    return computedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues());
 }
 
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -40,7 +40,7 @@ namespace Style {
 enum class MinimumFontSizeRule : uint8_t { None, Absolute, AbsoluteAndRelative };
 
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const Settings::Values&);
-float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
+float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float adjustedFontSize(float size, const FontSizeAdjust&, const FontMetrics&);
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -91,8 +91,7 @@ RenderStyle resolveForDocument(const Document& document)
     fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
     int size = fontSizeForKeyword(CSSValueMedium, false, document);
     fontDescription.setSpecifiedSize(size);
-    bool useSVGZoomRules = document.isSVGDocument();
-    fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, &documentStyle, document));
+    fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), &documentStyle, document));
 
     auto [fontOrientation, glyphOrientation] = documentStyle.fontAndGlyphOrientation();
     fontDescription.setOrientation(fontOrientation);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -252,7 +252,7 @@ auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionC
         } else
             state.style()->inheritFrom(*state.parentStyle());
     } else {
-        state.setStyle(defaultStyleForElement(&element));
+        state.setStyle(defaultStyleForElement());
         state.setParentStyle(RenderStyle::clonePtr(*state.style()));
     }
 
@@ -515,7 +515,7 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, c
         state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
         state.style()->inheritFrom(*state.parentStyle());
     } else {
-        state.setStyle(defaultStyleForElement(&element));
+        state.setStyle(defaultStyleForElement());
         state.setParentStyle(RenderStyle::clonePtr(*state.style()));
     }
 
@@ -575,7 +575,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)
     return state.takeStyle();
 }
 
-std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* element)
+std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement()
 {
     auto style = RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry());
 
@@ -585,7 +585,7 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
 
     auto size = fontSizeForKeyword(CSSValueMedium, false, document());
     fontDescription.setSpecifiedSize(size);
-    fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), style.get(), document()));
+    fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), style.get(), document()));
 
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
     style->setFontDescription(WTFMove(fontDescription));

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -100,7 +100,7 @@ public:
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(Element&, const PseudoElementRequest&, const ResolutionContext&);
 
     std::unique_ptr<RenderStyle> styleForPage(int pageIndex);
-    std::unique_ptr<RenderStyle> defaultStyleForElement(const Element*);
+    std::unique_ptr<RenderStyle> defaultStyleForElement();
 
     Document& document();
     const Document& document() const;


### PR DESCRIPTION
#### 98a585cdf128de8685e8b4929de5cb6afd4a2d7a
<pre>
Remove WebCore::Style::BuilderState::useSVGZoomRules()
<a href="https://bugs.webkit.org/show_bug.cgi?id=281478">https://bugs.webkit.org/show_bug.cgi?id=281478</a>

Reviewed by NOBODY (OOPS!).

After &lt;<a href="https://commits.webkit.org/284310@main">https://commits.webkit.org/284310@main</a>&gt;, we no longer need
WebCore::Style::BuilderState::useSVGZoomRules(). The computed
font-size for HTML and SVG elements are same.

* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::setFontSize):
(WebCore::Style::BuilderState::useSVGZoomRules const): Deleted.
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::computedFontSizeFromSpecifiedSize):
* Source/WebCore/style/StyleFontSizeFunctions.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::initializeStateAndStyle):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::defaultStyleForElement):
* Source/WebCore/style/StyleResolver.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98a585cdf128de8685e8b4929de5cb6afd4a2d7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22817 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56665 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74858 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46446 "Found 1 new test failure: svg/zoom/text/zoom-foreignObject.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61839 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37123 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43107 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19306 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65014 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19669 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77626 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16026 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18856 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64387 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64400 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12570 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6208 "Found 2 new test failures: svg/zoom/page/zoom-foreignObject.svg svg/zoom/text/zoom-foreignObject.svg (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47005 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1784 "Found 1 new failure in style/StyleFontSizeFunctions.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->