### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from SpeechRecognitionPermissionManager

### DIFF
--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -69,6 +69,11 @@ static SpeechRecognitionPermissionManager::CheckResult computeSpeechRecognitionS
 #endif
 }
 
+Ref<SpeechRecognitionPermissionManager> SpeechRecognitionPermissionManager::create(WebPageProxy& page)
+{
+    return adoptRef(*new SpeechRecognitionPermissionManager(page));
+}
+
 SpeechRecognitionPermissionManager::SpeechRecognitionPermissionManager(WebPageProxy& page)
     : m_page(page)
 {
@@ -80,7 +85,7 @@ SpeechRecognitionPermissionManager::~SpeechRecognitionPermissionManager()
         request->complete(WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::NotAllowed, "Permission manager has exited"_s });
 }
 
-Ref<WebPageProxy> SpeechRecognitionPermissionManager::protectedPage() const
+RefPtr<WebPageProxy> SpeechRecognitionPermissionManager::protectedPage() const
 {
     return m_page.get();
 }
@@ -90,6 +95,11 @@ void SpeechRecognitionPermissionManager::request(WebCore::SpeechRecognitionReque
     m_requests.append(SpeechRecognitionPermissionRequest::create(request, WTFMove(completiontHandler)));
     if (m_requests.size() == 1)
         startNextRequest();
+}
+
+WebPageProxy* SpeechRecognitionPermissionManager::page()
+{
+    return m_page.get();
 }
 
 void SpeechRecognitionPermissionManager::startNextRequest()
@@ -247,7 +257,10 @@ void SpeechRecognitionPermissionManager::requestUserPermission(WebCore::SpeechRe
 void SpeechRecognitionPermissionManager::decideByDefaultAction(const WebCore::SecurityOriginData& origin, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if PLATFORM(COCOA)
-    alertForPermission(protectedPage(), MediaPermissionReason::SpeechRecognition, origin, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        alertForPermission(*page, MediaPermissionReason::SpeechRecognition, origin, WTFMove(completionHandler));
+    else
+        completionHandler(false);
 #else
     completionHandler(false);
 #endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -27,35 +27,29 @@
 
 #include "SpeechRecognitionPermissionRequest.h"
 #include <wtf/Deque.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class SpeechRecognitionPermissionManager;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SpeechRecognitionPermissionManager> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebPageProxy;
 
-class SpeechRecognitionPermissionManager : public CanMakeWeakPtr<SpeechRecognitionPermissionManager> {
+class SpeechRecognitionPermissionManager : public RefCountedAndCanMakeWeakPtr<SpeechRecognitionPermissionManager> {
     WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionPermissionManager);
 public:
     enum class CheckResult { Denied, Granted, Unknown };
-    explicit SpeechRecognitionPermissionManager(WebPageProxy&);
+    static Ref<SpeechRecognitionPermissionManager> create(WebPageProxy&);
     ~SpeechRecognitionPermissionManager();
+
     void request(WebCore::SpeechRecognitionRequest&, SpeechRecognitionPermissionRequestCallback&&);
 
     void decideByDefaultAction(const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&);
-    WebPageProxy& page() { return m_page; }
+    WebPageProxy* page();
 
 private:
-    Ref<WebPageProxy> protectedPage() const;
+    explicit SpeechRecognitionPermissionManager(WebPageProxy&);
+    RefPtr<WebPageProxy> protectedPage() const;
 
     void startNextRequest();
     void startProcessingRequest();
@@ -65,7 +59,7 @@ private:
     void requestSpeechRecognitionServiceAccess();
     void requestUserPermission(WebCore::SpeechRecognitionRequest& request);
 
-    WeakRef<WebPageProxy> m_page;
+    WeakPtr<WebPageProxy> m_page;
     Deque<Ref<SpeechRecognitionPermissionRequest>> m_requests;
     CheckResult m_microphoneCheck { CheckResult::Unknown };
     CheckResult m_speechRecognitionServiceCheck { CheckResult::Unknown };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14426,19 +14426,20 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteA
 void WebPageProxy::requestSpeechRecognitionPermission(WebCore::SpeechRecognitionRequest& request, CompletionHandler<void(std::optional<SpeechRecognitionError>&&)>&& completionHandler)
 {
     if (!m_speechRecognitionPermissionManager)
-        m_speechRecognitionPermissionManager = makeUnique<SpeechRecognitionPermissionManager>(*this);
+        m_speechRecognitionPermissionManager = SpeechRecognitionPermissionManager::create(*this);
 
     m_speechRecognitionPermissionManager->request(request, WTFMove(completionHandler));
 }
 
 void WebPageProxy::requestSpeechRecognitionPermissionByDefaultAction(const WebCore::SecurityOriginData& origin, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_speechRecognitionPermissionManager) {
+    RefPtr speechRecognitionPermissionManager = m_speechRecognitionPermissionManager.get();
+    if (!speechRecognitionPermissionManager) {
         completionHandler(false);
         return;
     }
 
-    m_speechRecognitionPermissionManager->decideByDefaultAction(origin, WTFMove(completionHandler));
+    speechRecognitionPermissionManager->decideByDefaultAction(origin, WTFMove(completionHandler));
 }
 
 void WebPageProxy::requestUserMediaPermissionForSpeechRecognition(FrameIdentifier frameIdentifier, const WebCore::SecurityOrigin& requestingOrigin, const WebCore::SecurityOrigin& topOrigin, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3611,7 +3611,7 @@ private:
 
     mutable RefPtr<Logger> m_logger;
 
-    std::unique_ptr<SpeechRecognitionPermissionManager> m_speechRecognitionPermissionManager;
+    RefPtr<SpeechRecognitionPermissionManager> m_speechRecognitionPermissionManager;
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     RefPtr<RemoteMediaSessionCoordinatorProxy> m_mediaSessionCoordinatorProxy;


### PR DESCRIPTION
#### 5d444d47a5ada79301508f50bfbfb1e16ef0b1af
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from SpeechRecognitionPermissionManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=281480">https://bugs.webkit.org/show_bug.cgi?id=281480</a>

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::create):
(WebKit::SpeechRecognitionPermissionManager::protectedPage const):
(WebKit::SpeechRecognitionPermissionManager::page):
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
(WebKit::SpeechRecognitionPermissionManager::page): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestSpeechRecognitionPermission):
(WebKit::WebPageProxy::requestSpeechRecognitionPermissionByDefaultAction):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/285238@main">https://commits.webkit.org/285238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05ed71bb735c5ad0d6ce53dbe2d2f34b458e8f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61948 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43220 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18968 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61971 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6309 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11042 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1909 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->