### PR TITLE
Fix moveTo to not use screenAvailableRect as an origin but as a boundary

### DIFF
--- a/LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt
@@ -43,8 +43,8 @@ PASS window.moveTo(x) threw exception TypeError: Not enough arguments.
 PASS window.screenX is resetX
 PASS window.screenY is resetY
 Testing - moveTo with more than 2 arguments
-PASS window.screenX is x + screen.availLeft
-PASS window.screenY is y + screen.availTop
+PASS window.screenX is Math.max(x, screen.availLeft)
+PASS window.screenY is Math.max(y, screen.availTop)
 
 window.moveBy Tests
 

--- a/LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html
+++ b/LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script language="JavaScript" type="text/javascript">
@@ -17,7 +17,7 @@
 
     function reset()
     {
-        window.moveTo(0, 0);
+        window.moveTo(screen.availLeft + 100, screen.availTop + 100);
         window.resizeTo(300, 200);
         resetWidth = window.outerWidth;
         resetHeight = window.outerHeight;
@@ -99,8 +99,8 @@
 
     debug("Testing - moveTo with more than 2 arguments");
     window.moveTo(x, y, 200, "text");
-    shouldBe('window.screenX', 'x + screen.availLeft');
-    shouldBe('window.screenY', 'y + screen.availTop');
+    shouldBe('window.screenX', 'Math.max(x, screen.availLeft)');
+    shouldBe('window.screenY', 'Math.max(y, screen.availTop)');
     reset();
 
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1802,12 +1802,12 @@ void LocalDOMWindow::moveTo(int x, int y) const
         return;
 
     RefPtr page = frame()->page();
-    auto fr = page->chrome().windowRect();
+    auto update = page->chrome().windowRect();
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
 
-    auto sr = screenAvailableRect(page->mainFrame().virtualView());
-    fr.setLocation(sr.location());
-    auto update = fr;
-    update.move(x, y);
+    update.setLocation(LayoutPoint(x, y));
     page->chrome().setWindowRect(adjustWindowRect(*page, update));
 }
 


### PR DESCRIPTION
#### ee0481b506b24b70a72113d10f37947a64cde525
<pre>
Fix moveTo to not use screenAvailableRect as an origin but as a boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=250800">https://bugs.webkit.org/show_bug.cgi?id=250800</a>
<a href="https://rdar.apple.com/104670843">rdar://104670843</a>

Reviewed by Ryosuke Niwa.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/f7557ab98c0e2bb380f9bfc6355666434c6e481f">https://chromium.googlesource.com/chromium/blink/+/f7557ab98c0e2bb380f9bfc6355666434c6e481f</a>

This patch is to fix a bug where we use `screenAvailableRect` as an origin,
which can lead to window being offset based on menu bar height. It changes
`screenAvailableRect` from origin to boundary.

* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::moveTo const):
* LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt:
* LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html:

Canonical link: <a href="https://commits.webkit.org/285205@main">https://commits.webkit.org/285205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed0042302d71a52591dcb2b68a33fd639c031f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56676 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64412 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6221 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->