### PR TITLE
[GStreamer] Fix VideoEncoderPrivateGStreamer build without WebCodecs

### DIFF
--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -809,7 +809,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             g_value_init(&intValue, G_TYPE_INT);
 
             switch (bitRateAllocation.scalabilityMode()) {
-            case VideoEncoder::ScalabilityMode::L1T1:
+            case WebCore::VideoEncoderScalabilityMode::L1T1:
                 numberLayers = 1;
                 scalabilityString = "L1T1"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 0)) {
@@ -822,7 +822,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     g_value_array_append(decimators.get(), &intValue);
                 }
                 break;
-            case VideoEncoder::ScalabilityMode::L1T2:
+            case WebCore::VideoEncoderScalabilityMode::L1T2:
                 numberLayers = 2;
                 scalabilityString = "L1T2"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 1)) {
@@ -855,7 +855,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     "no-upd-last+no-upd-alt>"_s;
                 layerSyncFlags = { false, true, false, false };
                 break;
-            case VideoEncoder::ScalabilityMode::L1T3:
+            case WebCore::VideoEncoderScalabilityMode::L1T3:
                 numberLayers = 3;
                 scalabilityString = "L1T3"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 2)) {

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include "GStreamerCommon.h"
-#include "VideoEncoder.h"
+#include "VideoEncoderScalabilityMode.h"
 #include <wtf/TZoneMalloc.h>
 
 #define WEBKIT_TYPE_VIDEO_ENCODER (webkit_video_encoder_get_type())
@@ -51,7 +51,7 @@ class WebKitVideoEncoderBitRateAllocation : public RefCounted<WebKitVideoEncoder
     WTF_MAKE_NONCOPYABLE(WebKitVideoEncoderBitRateAllocation);
 
 public:
-    static Ref<WebKitVideoEncoderBitRateAllocation> create(WebCore::VideoEncoder::ScalabilityMode scalabilityMode)
+    static Ref<WebKitVideoEncoderBitRateAllocation> create(WebCore::VideoEncoderScalabilityMode scalabilityMode)
     {
         return adoptRef(*new WebKitVideoEncoderBitRateAllocation(scalabilityMode));
     }
@@ -75,14 +75,14 @@ public:
         return m_bitRates[spatialLayerIndex][temporalLayerIndex];
     }
 
-    WebCore::VideoEncoder::ScalabilityMode scalabilityMode() const { return m_scalabilityMode; }
+    WebCore::VideoEncoderScalabilityMode scalabilityMode() const { return m_scalabilityMode; }
 
 private:
-    WebKitVideoEncoderBitRateAllocation(WebCore::VideoEncoder::ScalabilityMode scalabilityMode)
+    WebKitVideoEncoderBitRateAllocation(WebCore::VideoEncoderScalabilityMode scalabilityMode)
         : m_scalabilityMode(scalabilityMode)
     { }
 
-    WebCore::VideoEncoder::ScalabilityMode m_scalabilityMode;
+    WebCore::VideoEncoderScalabilityMode m_scalabilityMode;
     std::optional<uint32_t> m_bitRates[MaxSpatialLayers][MaxTemporalLayers];
 };
 


### PR DESCRIPTION
#### f364dfc9eccc0dc6a8b213142b3498900cfbab5d
<pre>
[GStreamer] Fix VideoEncoderPrivateGStreamer build without WebCodecs
<a href="https://bugs.webkit.org/show_bug.cgi?id=281487">https://bugs.webkit.org/show_bug.cgi?id=281487</a>

Reviewed by Philippe Normand.

VideoEncoderPrivateGStreamer.h included VideoEncoder.h for the ScalabilityMode
enum, but this is only available when WEB_CODECS is enabled.

To be able to use VideoEncoderPrivateGStreamer for MediaRecorder and MediaStream
when WebCodecs is disabled, use VideoEncoderScalabilityMode.h instead.

* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
(WebKitVideoEncoderBitRateAllocation::create):
(WebKitVideoEncoderBitRateAllocation::scalabilityMode const):
(WebKitVideoEncoderBitRateAllocation::WebKitVideoEncoderBitRateAllocation):

Canonical link: <a href="https://commits.webkit.org/285195@main">https://commits.webkit.org/285195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d8bed3ae4e914e65ef91f7563f1229e02f3bb7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24597 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15194 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61869 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61902 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6238 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->