### PR TITLE
[CoordinatedGraphics] Move CoordinatedGraphicsBackingStoreTile to its own file

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -15,7 +15,6 @@ list(APPEND WebCore_SOURCES
     platform/graphics/texmap/TextureMapperLayer.cpp
     platform/graphics/texmap/TextureMapperPlatformLayer.cpp
     platform/graphics/texmap/TextureMapperShaderProgram.cpp
-    platform/graphics/texmap/TextureMapperTile.cpp
 )
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -50,6 +49,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -63,6 +63,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -96,7 +97,14 @@ if (USE_COORDINATED_GRAPHICS)
 else ()
     list(APPEND WebCore_SOURCES
         platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+        platform/graphics/texmap/TextureMapperTile.cpp
         platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
+    )
+
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/texmap/GraphicsLayerTextureMapper.h
+        platform/graphics/texmap/TextureMapperTile.h
+        platform/graphics/texmap/TextureMapperTiledBackingStore.h
     )
 endif ()
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -20,43 +20,14 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
-#include "IntRect.h"
+#include "CoordinatedBackingStoreTile.h"
 #include "TextureMapperBackingStore.h"
-#include "TextureMapperTile.h"
 #include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 class CoordinatedTileBuffer;
 class TextureMapper;
-
-class CoordinatedBackingStoreTile final : public TextureMapperTile {
-public:
-    explicit CoordinatedBackingStoreTile(float scale = 1)
-        : TextureMapperTile(FloatRect())
-        , m_scale(scale)
-    {
-    }
-    ~CoordinatedBackingStoreTile() = default;
-
-    float scale() const { return m_scale; }
-
-    struct Update {
-        RefPtr<CoordinatedTileBuffer> buffer;
-        IntRect sourceRect;
-        IntRect tileRect;
-        IntPoint bufferOffset;
-    };
-    void addUpdate(Update&&);
-
-    void swapBuffers(TextureMapper&);
-
-private:
-    Vector<Update> m_updates;
-    float m_scale { 1. };
-};
 
 class CoordinatedBackingStore final : public RefCounted<CoordinatedBackingStore>, public TextureMapperBackingStore {
 public:
@@ -72,7 +43,7 @@ public:
     void removeTile(uint32_t tileID);
     void updateTile(uint32_t tileID, const IntRect&, const IntRect&, RefPtr<CoordinatedTileBuffer>&&, const IntPoint&);
 
-    void swapBuffers(TextureMapper&);
+    void processPendingUpdates(TextureMapper&);
 
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
     void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
@@ -80,10 +51,6 @@ public:
 
 private:
     CoordinatedBackingStore() = default;
-
-    void paintTilesToTextureMapper(Vector<TextureMapperTile*>&, TextureMapper&, const TransformationMatrix&, float, const FloatRect&);
-    TransformationMatrix adjustedTransformForRect(const FloatRect&);
-    FloatRect rect() const { return FloatRect(FloatPoint::zero(), m_size); }
 
     HashMap<uint32_t, CoordinatedBackingStoreTile> m_tiles;
     FloatSize m_size;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2012 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "CoordinatedBackingStoreTile.h"
+
+#if USE(COORDINATED_GRAPHICS)
+#include "BitmapTexture.h"
+#include "CoordinatedTileBuffer.h"
+#include "GraphicsLayer.h"
+#include "TextureMapper.h"
+#include <wtf/SystemTracing.h>
+
+namespace WebCore {
+
+CoordinatedBackingStoreTile::CoordinatedBackingStoreTile(float scale)
+    : m_scale(scale)
+{
+}
+
+CoordinatedBackingStoreTile::~CoordinatedBackingStoreTile() = default;
+
+void CoordinatedBackingStoreTile::addUpdate(Update&& update)
+{
+    m_updates.append(WTFMove(update));
+}
+
+void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMapper)
+{
+    auto updates = WTFMove(m_updates);
+    auto updatesCount = updates.size();
+    if (!updatesCount)
+        return;
+
+    WTFBeginSignpost(this, CoordinatedSwapBuffers, "%lu updates", updatesCount);
+    for (unsigned updateIndex = 0; updateIndex < updatesCount; ++updateIndex) {
+        auto& update = updates[updateIndex];
+        if (!update.buffer)
+            continue;
+
+        WTFBeginSignpost(this, CoordinatedSwapBuffer, "%u/%lu, rect %ix%i+%i+%i", updateIndex + 1, updatesCount, update.tileRect.x(), update.tileRect.y(), update.tileRect.width(), update.tileRect.height());
+
+        ASSERT(textureMapper.maxTextureSize().width() >= update.tileRect.size().width());
+        ASSERT(textureMapper.maxTextureSize().height() >= update.tileRect.size().height());
+
+        FloatRect unscaledTileRect(update.tileRect);
+        unscaledTileRect.scale(1. / m_scale);
+
+        OptionSet<BitmapTexture::Flags> flags;
+        if (update.buffer->supportsAlpha())
+            flags.add(BitmapTexture::Flags::SupportsAlpha);
+
+        WTFBeginSignpost(this, AcquireTexture);
+        if (!m_texture || unscaledTileRect != m_rect) {
+            m_rect = unscaledTileRect;
+            m_texture = textureMapper.acquireTextureFromPool(update.tileRect.size(), flags);
+        } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
+            m_texture->reset(update.tileRect.size(), flags);
+        WTFEndSignpost(this, AcquireTexture);
+
+        WTFBeginSignpost(this, WaitPaintingCompletion);
+        update.buffer->waitUntilPaintingComplete();
+        WTFEndSignpost(this, WaitPaintingCompletion);
+
+#if USE(SKIA)
+        if (update.buffer->isBackedByOpenGL()) {
+            WTFBeginSignpost(this, CopyTextureGPUToGPU);
+            auto& buffer = static_cast<CoordinatedAcceleratedTileBuffer&>(*update.buffer);
+
+            // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
+            if (update.sourceRect.size() == update.tileRect.size()) {
+                ASSERT(update.sourceRect.location().isZero());
+                m_texture->swapTexture(buffer.texture());
+            } else
+                m_texture->copyFromExternalTexture(buffer.texture().id(), update.sourceRect, toIntSize(update.bufferOffset));
+
+            update.buffer = nullptr;
+            WTFEndSignpost(this, CopyTextureGPUToGPU);
+            WTFEndSignpost(this, CoordinatedSwapBuffer);
+            continue;
+        }
+#endif
+
+        WTFBeginSignpost(this, CopyTextureCPUToGPU);
+        ASSERT(!update.buffer->isBackedByOpenGL());
+        auto& buffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(*update.buffer);
+        m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), buffer.pixelFormat());
+        update.buffer = nullptr;
+        WTFEndSignpost(this, CopyTextureCPUToGPU);
+
+        WTFEndSignpost(this, CoordinatedSwapBuffer);
+    }
+    WTFEndSignpost(this, CoordinatedSwapBuffers);
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2012 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+#include "FloatRect.h"
+#include "IntRect.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+class BitmapTexture;
+class CoordinatedTileBuffer;
+class TextureMapper;
+
+class CoordinatedBackingStoreTile {
+public:
+    explicit CoordinatedBackingStoreTile(float scale = 1);
+    ~CoordinatedBackingStoreTile();
+
+    BitmapTexture& texture() { ASSERT(canBePainted()); return *m_texture; }
+    float scale() const { return m_scale; }
+    const FloatRect& rect() { return m_rect; }
+
+    struct Update {
+        RefPtr<CoordinatedTileBuffer> buffer;
+        IntRect sourceRect;
+        IntRect tileRect;
+        IntPoint bufferOffset;
+    };
+    void addUpdate(Update&&);
+
+    void processPendingUpdates(TextureMapper&);
+
+    bool canBePainted() const { return !!m_texture; }
+
+private:
+    RefPtr<BitmapTexture> m_texture;
+    Vector<Update> m_updates;
+    float m_scale { 1. };
+    FloatRect m_rect;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -380,7 +380,7 @@ void CoordinatedGraphicsScene::updateSceneState()
     }
 
     for (auto& backingStore : backingStoresWithPendingBuffers)
-        backingStore->swapBuffers(*m_textureMapper);
+        backingStore->processPendingUpdates(*m_textureMapper);
 
     for (auto& proxy : proxiesForSwapping)
         proxy->swapBuffer();


### PR DESCRIPTION
#### 2cac601421e467d250af342c55ff42351a69564e
<pre>
[CoordinatedGraphics] Move CoordinatedGraphicsBackingStoreTile to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=281488">https://bugs.webkit.org/show_bug.cgi?id=281488</a>

Reviewed by Miguel Gomez.

And simplify it. We don&apos;t really need to inherit from
TextureMapperTile, since we are using it just as a wrapper of a
BitmapTexture.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::processPendingUpdates):
(WebCore::CoordinatedBackingStore::resize):
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
(WebCore::CoordinatedBackingStore::drawBorder):
(WebCore::CoordinatedBackingStore::drawRepaintCounter):
(WebCore::CoordinatedBackingStoreTile::addUpdate): Deleted.
(WebCore::CoordinatedBackingStoreTile::swapBuffers): Deleted.
(WebCore::CoordinatedBackingStore::paintTilesToTextureMapper): Deleted.
(WebCore::CoordinatedBackingStore::adjustedTransformForRect): Deleted.
(WebCore::CoordinatedBackingStore::swapBuffers): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp: Added.
(WebCore::CoordinatedBackingStoreTile::CoordinatedBackingStoreTile):
(WebCore::CoordinatedBackingStoreTile::addUpdate):
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h: Added.
(WebCore::CoordinatedBackingStoreTile::texture):
(WebCore::CoordinatedBackingStoreTile::scale const):
(WebCore::CoordinatedBackingStoreTile::rect):
(WebCore::CoordinatedBackingStoreTile::canBePainted const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::updateSceneState):

Canonical link: <a href="https://commits.webkit.org/285252@main">https://commits.webkit.org/285252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db09e0942926e757df4d2ddc3bebe2be46619914

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76186 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23055 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21581 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16266 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16312 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11050 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47244 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->