### PR TITLE
Refactor VideoMediaSampleRenderer to support enqueuing decoded samples

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -75,6 +75,8 @@ public:
     KeyIDs& keyIDs() { return m_keyIDs; }
 #endif
 
+    static bool isCMSampleBufferNonDisplaying(CMSampleBufferRef);
+
 protected:
     WEBCORE_EXPORT MediaSampleAVFObjC(RetainPtr<CMSampleBufferRef>&&);
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -183,7 +183,7 @@ static bool isCMSampleBufferAttachmentNonDisplaying(CFDictionaryRef attachmentDi
     return CFDictionaryContainsKey(attachmentDict, PAL::kCMSampleAttachmentKey_DoNotDisplay);
 }
 
-static bool isCMSampleBufferNonDisplaying(CMSampleBufferRef sample)
+bool MediaSampleAVFObjC::isCMSampleBufferNonDisplaying(CMSampleBufferRef sample)
 {
     CFArrayRef attachments = PAL::CMSampleBufferGetSampleAttachmentsArray(sample, false);
     if (!attachments)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1099,7 +1099,7 @@ void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
     attachContentKeyToSampleIfNeeded(sample);
     WebSampleBufferVideoRendering *renderer = nil;
     if (m_videoRenderer) {
-        m_videoRenderer->enqueueSample(sample.platformSample().sample.cmSampleBuffer, !sample.isNonDisplaying());
+        m_videoRenderer->enqueueSample(sample);
 
         // Enqueuing a sample for display my synchronously fire an error, which can cause m_videoRenderer to become null.
         if (!m_videoRenderer)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -977,7 +977,7 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
         if (!m_videoRenderer)
             return;
 
-        m_videoRenderer->enqueueSample(platformSample.sample.cmSampleBuffer, !sample->isNonDisplaying());
+        m_videoRenderer->enqueueSample(sample);
         WebSampleBufferVideoRendering *renderer = m_videoRenderer->renderer();
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY)
         if (AVSampleBufferDisplayLayer *displayLayer = m_videoRenderer->displayLayer()) {
@@ -2035,6 +2035,8 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
         return;
 
     m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    m_videoRenderer->setPrefersDecompressionSession(true);
+    m_videoRenderer->setTimebase([m_synchronizer timebase]);
     configureVideoRenderer(*m_videoRenderer);
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -33,25 +33,39 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS AVSampleBufferDisplayLayer;
+OBJC_CLASS AVSampleBufferVideoRenderer;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
+typedef struct opaqueCMBufferQueue *CMBufferQueueRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
+typedef struct OpaqueCMTimebase* CMTimebaseRef;
 
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
 typedef struct __CVBuffer* CVPixelBufferRef;
 #endif
 
+namespace WTF {
+class WorkQueue;
+}
+
 namespace WebCore {
 
+class MediaSample;
 class WebCoreDecompressionSession;
 
-class VideoMediaSampleRenderer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoMediaSampleRenderer> {
+class VideoMediaSampleRenderer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoMediaSampleRenderer, WTF::DestructionThread::Main> {
 public:
     static Ref<VideoMediaSampleRenderer> create(WebSampleBufferVideoRendering *renderer) { return adoptRef(*new VideoMediaSampleRenderer(renderer)); }
     ~VideoMediaSampleRenderer();
 
+    bool prefersDecompressionSession() { return m_prefersDecompressionSession; }
+    void setPrefersDecompressionSession(bool);
+
+    void setTimebase(RetainPtr<CMTimebaseRef>&&);
+    RetainPtr<CMTimebaseRef> timebase() const { return m_timebase; }
+
     bool isReadyForMoreMediaData() const;
     void requestMediaDataWhenReady(Function<void()>&&);
-    void enqueueSample(CMSampleBufferRef, bool displaying = true);
+    void enqueueSample(const MediaSample&);
     void stopRequestingMediaData();
 
     void flush();
@@ -59,30 +73,48 @@ public:
     void expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime&);
     void resetUpcomingSampleBufferPresentationTimeExpectations();
 
-    WebSampleBufferVideoRendering *renderer() const { return m_renderer.get(); }
+    WebSampleBufferVideoRendering *renderer() const;
     AVSampleBufferDisplayLayer *displayLayer() const;
-#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
-    RetainPtr<CVPixelBufferRef> copyDisplayedPixelBuffer() const;
+    RetainPtr<CVPixelBufferRef> copyDisplayedPixelBuffer();
     CGRect bounds() const;
-#endif
 
-    void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
+    unsigned totalVideoFrames() const;
+    unsigned droppedVideoFrames() const;
+    unsigned corruptedVideoFrames() const;
+    MediaTime totalFrameDelay() const;
+
+    void setResourceOwner(const ProcessIdentity&);
 
 private:
     VideoMediaSampleRenderer(WebSampleBufferVideoRendering *);
+
+    void setPrefersDecompressionSessionInternal(bool);
+    void setTimebaseInternal(RetainPtr<CMTimebaseRef>&&);
+
     void resetReadyForMoreSample();
     void initializeDecompressionSession();
+    void decodeNextSample();
+    void decodedFrameAvailable(RetainPtr<CMSampleBufferRef>&&);
+    void flushCompressedSampleQueue();
+    void flushDecodedSampleQueue();
+    void purgeDecodedSampleQueue();
+    CMBufferQueueRef ensureCompressedSampleQueue();
+    CMBufferQueueRef ensureDecodedSampleQueue();
+    void assignResourceOwner(CMSampleBufferRef);
+    void maybeBecomeReadyForMoreMediaData();
 
-    RetainPtr<WebSampleBufferVideoRendering> m_renderer;
+    Ref<WTF::WorkQueue> m_workQueue;
+    RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
+    RetainPtr<AVSampleBufferVideoRenderer> m_renderer;
+    RetainPtr<CMTimebaseRef> m_timebase;
+    RetainPtr<CMBufferQueueRef> m_compressedSampleQueue;
+    RetainPtr<CMBufferQueueRef> m_decodedSampleQueue;
+    OSObjectPtr<dispatch_source_t> m_timerSource;
     RefPtr<WebCoreDecompressionSession> m_decompressionSession;
-    bool m_displayLayerReadyForMoreSample { false };
-    bool m_decompressionSessionReadyForMoreSample { false };
+    bool m_isDecodingSample { false };
     Function<void()> m_readyForMoreSampleFunction;
-    uint32_t m_decodePending { 0 };
-    bool m_wasNotDisplaying { false };
-    bool m_requestMediaDataWhenReadySet { false };
+    bool m_prefersDecompressionSession { false };
     std::optional<uint32_t> m_currentCodec;
-    std::optional<MediaTime> m_minimumUpcomingPresentationTime;
 
     ProcessIdentity m_resourceOwner;
 };

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "VideoMediaSampleRenderer.h"
 
+#import "MediaSampleAVFObjC.h"
 #import "WebCoreDecompressionSession.h"
 #import "WebSampleBufferVideoRendering.h"
 #import <AVFoundation/AVFoundation.h>
@@ -35,6 +36,7 @@
 
 #pragma mark - Soft Linking
 
+#import "CoreVideoSoftLink.h"
 #import "VideoToolboxSoftLink.h"
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -46,35 +48,121 @@
 
 namespace WebCore {
 
-VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering *renderer)
-    : m_renderer(renderer)
+static constexpr CMItemCount CompressedSampleQueueHighWaterMark = 30;
+static constexpr CMItemCount CompressedSampleQueueLowWaterMark = 15;
+
+VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering *renderering)
+    : m_workQueue(WorkQueue::create("VideoMediaSampleRenderer Queue"_s))
 {
+    if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderering, PAL::getAVSampleBufferDisplayLayerClass()))
+        m_displayLayer = displayLayer;
+    else if (auto *renderer = dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderering, PAL::getAVSampleBufferVideoRendererClass()))
+        m_renderer = renderer;
 }
 
 VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
 {
-    [m_renderer flush];
-    [m_renderer stopRequestingMediaData];
-    if (m_decompressionSession)
+    assertIsMainThread();
+
+    if (m_displayLayer) {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [m_displayLayer flush];
+        [m_displayLayer stopRequestingMediaData];
+        ALLOW_DEPRECATED_DECLARATIONS_END
+        m_displayLayer = nil;
+    }
+
+    if (m_renderer) {
+        [m_renderer flush];
+        [m_renderer stopRequestingMediaData];
+        m_renderer = nil;
+    }
+
+    if (m_decompressionSession) {
         m_decompressionSession->invalidate();
+        m_decompressionSession = nullptr;
+    }
+
+    setTimebase(nullptr);
 }
 
 bool VideoMediaSampleRenderer::isReadyForMoreMediaData() const
 {
-    return (!m_decompressionSession || m_decompressionSession->isReadyForMoreMediaData()) && [m_renderer isReadyForMoreMediaData];
+    assertIsMainThread();
+
+    if (m_compressedSampleQueue && PAL::CMBufferQueueGetBufferCount(m_compressedSampleQueue.get()) >= CompressedSampleQueueHighWaterMark)
+        return false;
+
+    return [renderer() isReadyForMoreMediaData];
+}
+
+void VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData()
+{
+    assertIsMainThread();
+
+    if (![renderer() isReadyForMoreMediaData])
+        return;
+
+    if (m_compressedSampleQueue && PAL::CMBufferQueueGetBufferCount(m_compressedSampleQueue.get()) >= CompressedSampleQueueLowWaterMark)
+        return;
+
+    if (m_readyForMoreSampleFunction)
+        m_readyForMoreSampleFunction();
 }
 
 void VideoMediaSampleRenderer::stopRequestingMediaData()
 {
-    [m_renderer stopRequestingMediaData];
+    assertIsMainThread();
+    [renderer() stopRequestingMediaData];
+
+    m_readyForMoreSampleFunction = nil;
 }
 
-void VideoMediaSampleRenderer::enqueueSample(CMSampleBufferRef sample, bool displaying)
+void VideoMediaSampleRenderer::setPrefersDecompressionSession(bool prefers)
 {
+    if (m_prefersDecompressionSession == prefers)
+        return;
+
+    m_prefersDecompressionSession = prefers;
+    if (!m_prefersDecompressionSession && m_decompressionSession) {
+        m_decompressionSession->invalidate();
+        m_decompressionSession = nullptr;
+    }
+}
+
+void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
+{
+    if (m_timebase) {
+        PAL::CMTimebaseRemoveTimerDispatchSource(m_timebase.get(), m_timerSource.get());
+        dispatch_source_cancel(m_timerSource.get());
+        m_timerSource = nullptr;
+    }
+
+    m_timebase = WTFMove(timebase);
+
+    if (m_timebase) {
+        m_timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_workQueue->dispatchQueue()));
+        dispatch_source_set_event_handler(m_timerSource.get(), [weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->purgeDecodedSampleQueue();
+        });
+        dispatch_activate(m_timerSource.get());
+        PAL::CMTimebaseAddTimerDispatchSource(m_timebase.get(), m_timerSource.get());
+    }
+}
+
+void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
+{
+    ASSERT(sample.platformSampleType() == PlatformSample::Type::CMSampleBufferType);
+    if (sample.platformSampleType() != PlatformSample::Type::CMSampleBufferType)
+        return;
+
+    auto cmSampleBuffer = sample.platformSample().sample.cmSampleBuffer;
+
 #if PLATFORM(IOS_FAMILY)
     if (!m_decompressionSession && !m_currentCodec) {
         // Only use a decompression session for vp8 or vp9 when software decoded.
-        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
+        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(cmSampleBuffer);
         auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
         if (fourCC == 'vp08' || (fourCC == 'vp09' && !(canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9))))
             initializeDecompressionSession();
@@ -82,107 +170,285 @@ void VideoMediaSampleRenderer::enqueueSample(CMSampleBufferRef sample, bool disp
     }
 #endif
 
+    if (!m_decompressionSession && prefersDecompressionSession() && !sample.isProtected())
+        initializeDecompressionSession();
+
     if (!m_decompressionSession) {
-        [m_renderer enqueueSampleBuffer:sample];
+        [renderer() enqueueSampleBuffer:cmSampleBuffer];
         return;
     }
-    m_decompressionSession->enqueueSample(sample, displaying);
-    ++m_decodePending;
-    m_wasNotDisplaying |= !displaying;
-    if (m_requestMediaDataWhenReadySet)
+
+    PAL::CMBufferQueueEnqueue(ensureCompressedSampleQueue(), cmSampleBuffer);
+    m_workQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->decodeNextSample();
+    });
+}
+
+void VideoMediaSampleRenderer::decodeNextSample()
+{
+    assertIsCurrent(m_workQueue);
+
+    if (!m_compressedSampleQueue)
         return;
-    m_requestMediaDataWhenReadySet = true;
-    // We set requestMediaDataWhenReady only after calling enqueueSample once, to avoid having the callback
-    // being called immediately.
-    m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this] {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (!--m_decodePending && m_minimumUpcomingPresentationTime) {
-                expectMinimumUpcomingSampleBufferPresentationTime(*m_minimumUpcomingPresentationTime);
-                m_minimumUpcomingPresentationTime.reset();
-            }
-            if (!m_wasNotDisplaying)
-                return;
-            m_wasNotDisplaying = false;
-            if (m_readyForMoreSampleFunction)
-                m_readyForMoreSampleFunction();
+
+    if (m_isDecodingSample)
+        return;
+
+    auto sample = adoptCF(checked_cf_cast<CMSampleBufferRef>(PAL::CMBufferQueueDequeueAndRetain(m_compressedSampleQueue.get())));
+    if (!sample)
+        return;
+
+    bool displaying = !MediaSampleAVFObjC::isCMSampleBufferNonDisplaying(sample.get());
+    auto decodePromise = m_decompressionSession->decodeSample(sample.get(), displaying);
+    m_isDecodingSample = true;
+    decodePromise->whenSettled(m_workQueue, [weakThis = ThreadSafeWeakPtr { *this }, displaying] (auto&& result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->m_isDecodingSample = false;
+
+        if (!result) {
+            ensureOnMainThread([protectedThis = WTFMove(protectedThis), status = result.error()] {
+                assertIsMainThread();
+
+                // Simulate AVSBDL decoding error.
+                RetainPtr error = [NSError errorWithDomain:@"com.apple.WebKit" code:status userInfo:nil];
+                NSDictionary *userInfoDict = @{ (__bridge NSString *)AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey: (__bridge NSError *)error.get() };
+                [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferDisplayLayerFailedToDecodeNotification object:protectedThis->renderer() userInfo:userInfoDict];
+                [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferVideoRendererDidFailToDecodeNotification object:protectedThis->renderer() userInfo:userInfoDict];
+            });
+            return;
         }
+
+        if (displaying && *result) {
+            RetainPtr<CMSampleBufferRef> retainedResult = *result;
+            protectedThis->decodedFrameAvailable(WTFMove(retainedResult));
+        }
+
+        protectedThis->decodeNextSample();
+    });
+
+    callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->maybeBecomeReadyForMoreMediaData();
     });
 }
 
 void VideoMediaSampleRenderer::initializeDecompressionSession()
 {
+    assertIsMainThread();
     if (m_decompressionSession)
         m_decompressionSession->invalidate();
+
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
-    m_decompressionSession->setTimebase([m_renderer timebase]);
+    m_decompressionSession->setTimebase(m_timebase.get());
     m_decompressionSession->setResourceOwner(m_resourceOwner);
-    m_decompressionSession->decodedFrameWhenAvailable([weakThis = ThreadSafeWeakPtr { *this }](RetainPtr<CMSampleBufferRef>&& sample) {
-        if (RefPtr protectedThis = weakThis.get())
-            [protectedThis->m_renderer enqueueSampleBuffer:sample.get()];
-    });
-    m_decompressionSession->setErrorListener([weakThis = ThreadSafeWeakPtr { *this }, this](OSStatus status) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            // Simulate AVSBDL decoding error.
-            RetainPtr error = [NSError errorWithDomain:@"com.apple.WebKit" code:status userInfo:nil];
-            NSDictionary *userInfoDict = @{ (__bridge NSString *)AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey: (__bridge NSError *)error.get() };
-            [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferDisplayLayerFailedToDecodeNotification object:m_renderer.get() userInfo:userInfoDict];
-            [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferVideoRendererDidFailToDecodeNotification object:m_renderer.get() userInfo:userInfoDict];
-        }
-    });
 
     resetReadyForMoreSample();
 }
 
+void VideoMediaSampleRenderer::decodedFrameAvailable(RetainPtr<CMSampleBufferRef>&& sample)
+{
+    assertIsCurrent(m_workQueue);
+
+    assignResourceOwner(sample.get());
+
+    if (m_timebase) {
+        purgeDecodedSampleQueue();
+        PAL::CMBufferQueueEnqueue(ensureDecodedSampleQueue(), sample.get());
+    }
+
+    if (m_renderer)
+        [m_renderer enqueueSampleBuffer:sample.get()];
+    else if (m_displayLayer) {
+        callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, sample = sample] {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            if (RefPtr protectedThis = weakThis.get())
+                [protectedThis->m_displayLayer enqueueSampleBuffer:sample.get()];
+            ALLOW_DEPRECATED_DECLARATIONS_END
+        });
+    }
+}
+
+void VideoMediaSampleRenderer::flushCompressedSampleQueue()
+{
+    assertIsCurrent(m_workQueue);
+    if (!m_compressedSampleQueue)
+        return;
+
+    PAL::CMBufferQueueReset(m_compressedSampleQueue.get());
+    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), PAL::kCMTimeInvalid, 0);
+}
+
+void VideoMediaSampleRenderer::flushDecodedSampleQueue()
+{
+    assertIsCurrent(m_workQueue);
+    if (!m_decodedSampleQueue)
+        return;
+
+    PAL::CMBufferQueueReset(m_decodedSampleQueue.get());
+    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), PAL::kCMTimeInvalid, 0);
+}
+
+void VideoMediaSampleRenderer::purgeDecodedSampleQueue()
+{
+    assertIsCurrent(m_workQueue);
+    if (!m_decodedSampleQueue)
+        return;
+
+    if (!m_timebase)
+        return;
+
+    CMTime currentTime = PAL::CMTimebaseGetTime(m_timebase.get());
+    CMTime nextPurgeTime = PAL::kCMTimeInvalid;
+
+    while (RetainPtr nextSample = (CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueGetHead(m_decodedSampleQueue.get()))) {
+        CMTime presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
+        CMTime duration = PAL::CMSampleBufferGetOutputDuration(nextSample.get());
+        CMTime presentationEndTime = PAL::CMTimeAdd(presentationTime, duration);
+        if (PAL::CMTimeCompare(presentationEndTime, currentTime) >= 0) {
+            nextPurgeTime = presentationEndTime;
+            break;
+        }
+
+        RetainPtr sampleToBePurged = adoptCF(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get()));
+        sampleToBePurged = nil;
+    }
+
+    if (!CMTIME_IS_VALID(nextPurgeTime))
+        return;
+
+    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), nextPurgeTime, 0);
+}
+
+CMBufferQueueRef VideoMediaSampleRenderer::ensureCompressedSampleQueue()
+{
+    assertIsMainThread();
+    if (!m_compressedSampleQueue)
+        m_compressedSampleQueue = WebCoreDecompressionSession::createBufferQueue();
+    return m_compressedSampleQueue.get();
+}
+
+CMBufferQueueRef VideoMediaSampleRenderer::ensureDecodedSampleQueue()
+{
+    assertIsCurrent(m_workQueue);
+    if (!m_decodedSampleQueue)
+        m_decodedSampleQueue = WebCoreDecompressionSession::createBufferQueue();
+    return m_decodedSampleQueue.get();
+}
+
 void VideoMediaSampleRenderer::flush()
 {
-    [m_renderer flush];
+    assertIsMainThread();
+    [renderer() flush];
+
     if (m_decompressionSession)
         m_decompressionSession->flush();
+
+    m_workQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] () mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->flushCompressedSampleQueue();
+        protectedThis->flushDecodedSampleQueue();
+
+        callOnMainThread([weakThis = WTFMove(weakThis)] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->maybeBecomeReadyForMoreMediaData();
+        });
+    });
 }
 
 void VideoMediaSampleRenderer::requestMediaDataWhenReady(Function<void()>&& function)
 {
+    assertIsMainThread();
     m_readyForMoreSampleFunction = WTFMove(function);
     resetReadyForMoreSample();
 }
 
 void VideoMediaSampleRenderer::resetReadyForMoreSample()
 {
+    assertIsMainThread();
     ThreadSafeWeakPtr weakThis { *this };
-    [m_renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_readyForMoreSampleFunction)
-            protectedThis->m_readyForMoreSampleFunction();
+    [renderer() requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->maybeBecomeReadyForMoreMediaData();
     }];
 }
 
 void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime& time)
 {
+    assertIsMainThread();
     if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
         return;
-    if (!m_decodePending)
-        [m_renderer expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
-    else
-        m_minimumUpcomingPresentationTime = time;
+    [renderer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
 }
 
 void VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations()
 {
+    assertIsMainThread();
     if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(resetUpcomingSampleBufferPresentationTimeExpectations)])
         return;
-    [m_renderer resetUpcomingSampleBufferPresentationTimeExpectations];
-    m_minimumUpcomingPresentationTime.reset();
+
+    [renderer() resetUpcomingSampleBufferPresentationTimeExpectations];
+}
+
+WebSampleBufferVideoRendering *VideoMediaSampleRenderer::renderer() const
+{
+    assertIsMainThread();
+    if (m_displayLayer)
+        return m_displayLayer.get();
+#if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+    return m_renderer.get();
+#else
+    return nil;
+#endif
 }
 
 AVSampleBufferDisplayLayer *VideoMediaSampleRenderer::displayLayer() const
 {
-    return dynamic_objc_cast<AVSampleBufferDisplayLayer>(m_renderer.get(), PAL::getAVSampleBufferDisplayLayerClass());
+    assertIsMainThread();
+    return m_displayLayer.get();
 }
 
-#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
-
-RetainPtr<CVPixelBufferRef> VideoMediaSampleRenderer::copyDisplayedPixelBuffer() const
+RetainPtr<CVPixelBufferRef> VideoMediaSampleRenderer::copyDisplayedPixelBuffer()
 {
-    return adoptCF([m_renderer copyDisplayedPixelBuffer]);
+    assertIsMainThread();
+
+#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+    if (auto buffer = adoptCF([renderer() copyDisplayedPixelBuffer]))
+        return buffer;
+#endif
+
+    RetainPtr<CVPixelBufferRef> imageBuffer;
+
+    m_workQueue->dispatchSync([&] {
+        if (!m_timebase)
+            return;
+
+        purgeDecodedSampleQueue();
+
+        CMTime currentTime = PAL::CMTimebaseGetTime(m_timebase.get());
+        auto nextSample = (CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueGetHead(m_decodedSampleQueue.get()));
+        CMTime presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample);
+
+        if (PAL::CMTimeCompare(presentationTime, currentTime) > 0)
+            return;
+
+        RetainPtr sampleToBePurged = adoptCF((CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get())));
+        imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(sampleToBePurged.get());
+    });
+
+    if (!imageBuffer)
+        return nullptr;
+
+    ASSERT(CFGetTypeID(imageBuffer.get()) == CVPixelBufferGetTypeID());
+    if (CFGetTypeID(imageBuffer.get()) != CVPixelBufferGetTypeID())
+        return nullptr;
+    return imageBuffer;
 }
 
 CGRect VideoMediaSampleRenderer::bounds() const
@@ -190,6 +456,52 @@ CGRect VideoMediaSampleRenderer::bounds() const
     return [displayLayer() bounds];
 }
 
-#endif
+unsigned VideoMediaSampleRenderer::totalVideoFrames() const
+{
+    if (m_decompressionSession)
+        return m_decompressionSession->totalVideoFrames();
+    return [renderer() videoPerformanceMetrics].totalNumberOfVideoFrames;
+}
+
+unsigned VideoMediaSampleRenderer::droppedVideoFrames() const
+{
+    if (m_decompressionSession)
+        return m_decompressionSession->droppedVideoFrames();
+    return [renderer() videoPerformanceMetrics].numberOfDroppedVideoFrames;
+}
+
+unsigned VideoMediaSampleRenderer::corruptedVideoFrames() const
+{
+    if (m_decompressionSession)
+        return m_decompressionSession->corruptedVideoFrames();
+    return [renderer() videoPerformanceMetrics].numberOfCorruptedVideoFrames;
+}
+
+MediaTime VideoMediaSampleRenderer::totalFrameDelay() const
+{
+    if (m_decompressionSession)
+        return m_decompressionSession->totalFrameDelay();
+    return MediaTime::createWithDouble([renderer() videoPerformanceMetrics].totalFrameDelay);
+}
+
+void VideoMediaSampleRenderer::setResourceOwner(const ProcessIdentity& resourceOwner)
+{
+    m_resourceOwner = resourceOwner;
+}
+
+void VideoMediaSampleRenderer::assignResourceOwner(CMSampleBufferRef sampleBuffer)
+{
+    assertIsCurrent(m_workQueue);
+    if (!m_resourceOwner || !sampleBuffer)
+        return;
+
+    RetainPtr<CVPixelBufferRef> imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!imageBuffer || CFGetTypeID(imageBuffer.get()) != CVPixelBufferGetTypeID())
+        return;
+
+    if (auto surface = CVPixelBufferGetIOSurface(imageBuffer.get()))
+        IOSurface::setOwnershipIdentity(surface, m_resourceOwner);
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -74,6 +74,9 @@ public:
 
     RetainPtr<CVPixelBufferRef> decodeSampleSync(CMSampleBufferRef);
 
+    using DecodingPromise = NativePromise<RetainPtr<CMSampleBufferRef>, OSStatus>;
+    Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
+
     void setTimebase(CMTimebaseRef);
     RetainPtr<CMTimebaseRef> timebase() const;
 
@@ -94,6 +97,8 @@ public:
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
+    static RetainPtr<CMBufferQueueRef> createBufferQueue();
+
 private:
     enum Mode {
         OpenGL,
@@ -105,8 +110,7 @@ private:
 
     void setTimebaseWithLockHeld(CMTimebaseRef);
     void enqueueCompressedSample(CMSampleBufferRef, bool displaying, uint32_t flushId);
-    using DecodingPromise = NativePromise<RetainPtr<CMSampleBufferRef>, OSStatus>;
-    Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
+    Ref<DecodingPromise> decodeSampleInternal(CMSampleBufferRef, bool displaying);
     void enqueueDecodedSample(CMSampleBufferRef);
     void maybeDecodeNextSample();
     void handleDecompressionOutput(bool displaying, OSStatus, VTDecodeInfoFlags, CVImageBufferRef, CMTime presentationTimeStamp, CMTime presentationDuration);

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -134,6 +134,33 @@ void WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData()
     });
 }
 
+RetainPtr<CMBufferQueueRef> WebCoreDecompressionSession::createBufferQueue()
+{
+    // CMBufferCallbacks contains 64-bit pointers that aren't 8-byte aligned. To suppress the linker
+    // warning about this, we prepend 4 bytes of padding when building.
+    const size_t padSize = 4;
+
+#pragma pack(push, 4)
+    struct BufferCallbacks { uint8_t pad[padSize]; CMBufferCallbacks callbacks; } callbacks { { }, {
+        0,
+        nullptr,
+        &getDecodeTime,
+        &getPresentationTime,
+        &getDuration,
+        nullptr,
+        &compareBuffers,
+        nullptr,
+        nullptr,
+    } };
+#pragma pack(pop)
+    static_assert(sizeof(callbacks.callbacks.version) == sizeof(uint32_t), "Version field must be 4 bytes");
+    static_assert(alignof(BufferCallbacks) == 4, "CMBufferCallbacks struct must have 4 byte alignment");
+
+    CMBufferQueueRef outQueue { nullptr };
+    PAL::CMBufferQueueCreate(kCFAllocatorDefault, kMaximumCapacity, &callbacks.callbacks, &outQueue);
+    return adoptCF(outQueue);
+}
+
 void WebCoreDecompressionSession::enqueueSample(CMSampleBufferRef sampleBuffer, bool displaying)
 {
     CMItemCount itemCount = 0;
@@ -145,31 +172,8 @@ void WebCoreDecompressionSession::enqueueSample(CMSampleBufferRef sampleBuffer, 
     if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(sampleBuffer, itemCount, timingInfoArray.data(), nullptr))
         return;
 
-    // CMBufferCallbacks contains 64-bit pointers that aren't 8-byte aligned. To suppress the linker
-    // warning about this, we prepend 4 bytes of padding when building.
-    const size_t padSize = 4;
-
-    if (!m_producerQueue) {
-        CMBufferQueueRef outQueue { nullptr };
-#pragma pack(push, 4)
-        struct BufferCallbacks { uint8_t pad[padSize]; CMBufferCallbacks callbacks; } callbacks { { }, {
-            0,
-            nullptr,
-            &getDecodeTime,
-            &getPresentationTime,
-            &getDuration,
-            nullptr,
-            &compareBuffers,
-            nullptr,
-            nullptr,
-        } };
-#pragma pack(pop)
-        static_assert(sizeof(callbacks.callbacks.version) == sizeof(uint32_t), "Version field must be 4 bytes");
-        static_assert(alignof(BufferCallbacks) == 4, "CMBufferCallbacks struct must have 4 byte alignment");
-
-        PAL::CMBufferQueueCreate(kCFAllocatorDefault, kMaximumCapacity, &callbacks.callbacks, &outQueue);
-        m_producerQueue = adoptCF(outQueue);
-    }
+    if (!m_producerQueue)
+        m_producerQueue = createBufferQueue();
 
     ++m_framesBeingDecoded;
 
@@ -277,7 +281,7 @@ void WebCoreDecompressionSession::maybeDecodeNextSample()
 
     m_isDecodingSample = true;
     auto tuple = m_pendingSamples.takeFirst();
-    decodeSample(std::get<RetainPtr<CMSampleBufferRef>>(tuple).get(), std::get<bool>(tuple))->whenSettled(m_decompressionQueue, [weakThis = ThreadSafeWeakPtr { *this }, this, flushId = std::get<uint32_t>(tuple)](auto&& result) {
+    decodeSampleInternal(std::get<RetainPtr<CMSampleBufferRef>>(tuple).get(), std::get<bool>(tuple))->whenSettled(m_decompressionQueue, [weakThis = ThreadSafeWeakPtr { *this }, this, flushId = std::get<uint32_t>(tuple)](auto&& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || isInvalidated())
             return;
@@ -323,7 +327,17 @@ void WebCoreDecompressionSession::maybeDecodeNextSample()
     });
 }
 
-Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::decodeSample(CMSampleBufferRef sample, bool displaying)
+auto WebCoreDecompressionSession::decodeSample(CMSampleBufferRef sample, bool displaying) -> Ref<DecodingPromise>
+{
+    DecodingPromise::Producer producer;
+    auto promise = producer.promise();
+    m_decompressionQueue->dispatch([protectedThis = RefPtr { this }, producer = WTFMove(producer), sample = RetainPtr { sample }, displaying] () mutable {
+        protectedThis->decodeSampleInternal(sample.get(), displaying)->chainTo(WTFMove(producer));
+    });
+    return promise;
+}
+
+Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::decodeSampleInternal(CMSampleBufferRef sample, bool displaying)
 {
     assertIsCurrent(m_decompressionQueue.get());
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -200,6 +200,9 @@ VideoFrameLibWebRTC::VideoFrameLibWebRTC(MediaTime presentationTime, bool isMirr
     case webrtc::VideoFrameBuffer::Type::kI420:
         m_videoPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
         break;
+    case webrtc::VideoFrameBuffer::Type::kI444:
+        m_videoPixelFormat = kCVPixelFormatType_444YpCbCr8BiPlanarFullRange;
+        break;
     case webrtc::VideoFrameBuffer::Type::kI010:
         m_videoPixelFormat = kCVPixelFormatType_420YpCbCr10BiPlanarFullRange;
         break;


### PR DESCRIPTION
#### b2e420a36ecb45db729eddb8dd38ec1d26b1e439
<pre>
Refactor VideoMediaSampleRenderer to support enqueuing decoded samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=281497">https://bugs.webkit.org/show_bug.cgi?id=281497</a>
<a href="https://rdar.apple.com/137964106">rdar://137964106</a>

Reviewed by Jean-Yves Avenard.

Currently, WebCoreDecompressionSession maintains a queue of decoded images. However,
when WebCoreDecompressionSession is used in a mode where those decoded images are
delivered to its clients, the queue is bypassed. VideoMediaSampleRenderer is a more
natural place for such a cue to belong, and eventually, all queueing behavior should
be migrated from WebCoreDecompressionSession to VideoMediaSampleRenderer. As a first
step, expose the promise-based WebCoreDecompressionSession::enqueueSample() function,
and expose a static method to create a CoreMedia buffer queue. Use these primitives
inside VideoMediaSampleRenderer to enqueue decoded images for retrieval by clients
later.

In this mode of operation, a VideoMediaSampleRenderer will feed decoded images to
its associated AVSampleBufferDisplayLayer or AVSampleBufferVideoRenderer, and store
those images in a queue for retrieval via copyDisplayedPixelBuffer(). This requires
a CMTimebaseRef, and to ensure the main thread doesn&apos;t excessively block these
operations, move most operations to a WorkQueue.

In the future, VideoMediaSampleRenderer can be extended to support having multiple
AVSBDLs or AVSBVRs simultaneously, allowing reconfigurations of layers or renderers
without having to tear down and re-build decoder pipelines.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
(WebCore::VideoMediaSampleRenderer::prefersDecompressionSession):
(WebCore::VideoMediaSampleRenderer::timebase const):
(WebCore::VideoMediaSampleRenderer::setResourceOwner): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::isReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::stopRequestingMediaData):
(WebCore::VideoMediaSampleRenderer::setPrefersDecompressionSession):
(WebCore::VideoMediaSampleRenderer::setPrefersDecompressionSessionInternal):
(WebCore::VideoMediaSampleRenderer::setTimebase):
(WebCore::VideoMediaSampleRenderer::setTimebaseInternal):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::ensureDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):
(WebCore::VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::totalVideoFrames const):
(WebCore::VideoMediaSampleRenderer::droppedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::corruptedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::totalFrameDelay const):
(WebCore::VideoMediaSampleRenderer::setResourceOwner):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer const): Deleted.
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::createBufferQueue):
(WebCore::WebCoreDecompressionSession::enqueueSample):

Canonical link: <a href="https://commits.webkit.org/285965@main">https://commits.webkit.org/285965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38dbc078aef11de7f6aed2c000201ab9a65bf635

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74261 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58375 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16707 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38784 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80156 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4330 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->