### PR TITLE
[JSC] Fix rounding error for `Intl.DurationFormat`

### DIFF
--- a/JSTests/stress/intl-durationformat-rounding-errors.js
+++ b/JSTests/stress/intl-durationformat-rounding-errors.js
@@ -1,0 +1,41 @@
+function sameValue(actual, expected) {
+  if (actual !== expected)
+    throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+{
+  // This is calculated as 9.123456788999999 in double
+  const duration = {
+    seconds: 9,
+    milliseconds: 123,
+    microseconds: 456,
+    nanoseconds: 789,
+  };
+
+  const df = new Intl.DurationFormat('en', { style: "digital" });
+  sameValue(df.format(duration), "0:00:09.123456789");
+}
+
+{
+  // This is calculated as 10000000.000000002 in double
+  const duration = {
+    seconds: 10_000_000,
+    nanoseconds: 1,
+  };
+
+  const df = new Intl.DurationFormat('en', { style: "digital" });
+  sameValue(df.format(duration), "0:00:10,000,000.000000001");
+}
+
+{
+  // This is calculated as 0:00:9,007,199,254,740,992 in double
+  const duration = {
+    // Actual value is: 4503599627370497024
+    milliseconds: 4503599627370497_000,
+    // Actual value is: 4503599627370494951424
+    microseconds: 4503599627370495_000000,
+  };
+
+  const df = new Intl.DurationFormat('en', { style: 'digital' });
+  sameValue(df.format(duration), '0:00:9,007,199,254,740,991.975424');
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1051,9 +1051,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
-  default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
-  strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
   strict mode: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -69,6 +69,7 @@ public:
     const_iterator end() const { return m_data.end(); }
     void clear() { m_data.fill(0); }
 
+    template<TemporalUnit unit>
     std::optional<Int128> totalNanoseconds() const;
 
     Duration operator-() const


### PR DESCRIPTION
#### 48d36047a83e40ddfa90ea614825f0f772a4f4e0
<pre>
[JSC] Fix rounding error for `Intl.DurationFormat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281501">https://bugs.webkit.org/show_bug.cgi?id=281501</a>

Reviewed by Yusuke Suzuki.

Our `Intl.DurationFormat` is affected by rounding errors because each unit is summed as a double.
Additionally, very large values cannot fit within a double.

This patch introduces the following changes:

- Each unit is summed using `Int128`.
- Since `Int128` values cannot be formatted with ICU’s `unumf_formatDouble`[1], so we build a
  decimal-formatted string from the `Int128` value and use `unumf_formatDecimal`[2] for formatting.

[1]: <a href="https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/unumberformatter_8h.html#a54193ed406316485803e3dac3a96615f">https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/unumberformatter_8h.html#a54193ed406316485803e3dac3a96615f</a>
[2]: <a href="https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/unumberformatter_8h.html#a6183aa03b43b63b231341770035bace9">https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/unumberformatter_8h.html#a6183aa03b43b63b231341770035bace9</a>

* JSTests/stress/intl-durationformat-rounding-errors.js: Added.
(sameValue):
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::Duration::totalNanoseconds const):
(JSC::ISO8601::isValidDuration):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::int128ToString):
(JSC::buildDecimalFormat):
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/285482@main">https://commits.webkit.org/285482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c2b27aca931d5afd2a20b513a13985f167fa1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23541 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23363 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62293 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21891 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65461 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78178 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71586 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6599 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93367 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47551 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20545 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->