### PR TITLE
Add WKDownloadDelegate methods related to download placeholder policy

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h
@@ -38,6 +38,16 @@ typedef NS_ENUM(NSInteger, WKDownloadRedirectPolicy) {
     WKDownloadRedirectPolicyAllow,
 } NS_SWIFT_NAME(WKDownload.RedirectPolicy) WK_API_AVAILABLE(macos(11.3), ios(14.5));
 
+/* @enum WKDownloadPlaceholderPolicy
+ @abstract The policy for creating a placeholder file in the Downloads directory during downloads.
+ @constant WKDownloadPlaceholderPolicyDisable   Do not create a placeholder file.
+ @constant WKDownloadPlaceholderPolicyEnable    Create a placeholder file.
+ */
+typedef NS_ENUM(NSInteger, WKDownloadPlaceholderPolicy) {
+    WKDownloadPlaceholderPolicyDisable,
+    WKDownloadPlaceholderPolicyEnable,
+} NS_SWIFT_NAME(WKDownload.PlaceholderPolicy) WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 NS_ASSUME_NONNULL_BEGIN
 
 WK_SWIFT_UI_ACTOR
@@ -94,6 +104,42 @@ WK_SWIFT_UI_ACTOR
  @param resumeData This data can be passed to WKWebView resumeDownloadFromResumeData: to attempt to resume this download.
  */
 - (void)download:(WKDownload *)download didFailWithError:(NSError *)error resumeData:(nullable NSData *)resumeData;
+
+/* @abstract Invoked when the download needs a placeholder policy from the client.
+ @param download The download for which we need a placeholder policy
+ @param completionHandler The completion handler that should be invoked with the chosen policy.
+ If the client implements it's own placeholder, it can choose to provide an alternate placeholder
+ URL, which progress will be published against.
+ The download will not proceed until the completion handler is called.
+ @discussion The placeholder policy specifies whether a placeholder file should be created in
+ the Downloads directory when the download is in progress. This function is called after
+ the destination for the download has been decided, and before the download begins.
+ If the client opts into the placeholder feature, the system will create a placeholder file in
+ the Downloads directory, which is updated with the download's progress. When the download is
+ done, the placeholder file is replaced with the actual downloaded file. If the client opts
+ out of the placeholder feature, it can choose to provide a custom URL to publish progress
+ against. This is useful if the client maintains it's own placeholder file. If this delegate
+ is not implemented, the placeholder feature will be disabled.
+ */
+- (void)download:(WKDownload *)download decidePlaceholderPolicy:(WK_SWIFT_UI_ACTOR void (^)(WKDownloadPlaceholderPolicy, NSURL * _Nullable))completionHandler WK_SWIFT_ASYNC_NAME(placeholderPolicy(forDownload:)) WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Called when the download receives a placeholder URL
+ @param download The download for which we received a placeholder URL
+ @param completionHandler The completion handler that should be called by the client in response to this call.
+ The didReceiveFinalURL function will not be called until the completion handler has been called.
+ @discussion This function is called only if the client opted into the placeholder feature, and it is called
+ before receiving the final URL of the download. The placeholder URL will normally refer to a file in the
+ Downloads directory.
+ */
+- (void)download:(WKDownload *)download didReceivePlaceholderURL:(NSURL *)url completionHandler:(WK_SWIFT_UI_ACTOR void (^)(void))completionHandler WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Called when the download receives a final URL
+ @param download The download for which we received a final URL
+ @param url The URL of the final download location
+ @discussion This function is called after didReceivePlaceholderURL was called and after the download finished.
+ The final URL will normally refer to a file in the Downloads directory
+ */
+- (void)download:(WKDownload *)download didReceiveFinalURL:(NSURL *)url WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 


### PR DESCRIPTION
#### 3ea7ef01144f83e424bab09a60b1e8adbc3a5b00
<pre>
Add WKDownloadDelegate methods related to download placeholder policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281503">https://bugs.webkit.org/show_bug.cgi?id=281503</a>
<a href="https://rdar.apple.com/137967222">rdar://137967222</a>

Reviewed by Alex Christensen.

Add WKDownloadDelegate methods related to download placeholder policy. This patch is promoting
existing SPI to API.

* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h:

Canonical link: <a href="https://commits.webkit.org/285579@main">https://commits.webkit.org/285579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/557e01322aa5e7cda0a7d26577f0f97b620487f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43762 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22209 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65779 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62552 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64870 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13175 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6816 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11262 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->