### PR TITLE
[WTF] Narrow scope of ignored -Wunsafe-buffer-usage warnings from ASCIILiteral.h to SuperFastHash.h

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -89,7 +89,7 @@ Vector<String> IntlCollator::sortLocaleData(const String& locale, RelevantExtens
             int32_t length = 0;
             while ((pointer = uenum_next(enumeration.get(), &length, &status)) && U_SUCCESS(status)) {
                 // 10.2.3 "The values "standard" and "search" must not be used as elements in any [[sortLocaleData]][locale].co and [[searchLocaleData]][locale].co array."
-                String collation({ pointer, static_cast<size_t>(length) });
+                String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
                 if (collation == "standard"_s || collation == "search"_s)
                     continue;
                 if (auto mapped = mapICUCollationKeywordToBCP47(collation))

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -156,7 +156,7 @@ Vector<String> IntlDateTimeFormat::localeData(const String& locale, RelevantExte
         int32_t nameLength;
         while (const char* availableName = uenum_next(calendars, &nameLength, &status)) {
             ASSERT(U_SUCCESS(status));
-            String calendar = String({ availableName, static_cast<size_t>(nameLength) });
+            String calendar = String(unsafeForgeSpan(availableName, static_cast<size_t>(nameLength)));
             keyLocaleData.append(calendar);
             // Adding "islamicc" candidate for backward compatibility.
             if (calendar == "islamic-civil"_s)

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -598,7 +598,7 @@ JSArray* IntlLocale::calendars(JSGlobalObject* globalObject)
     const char* pointer;
     int32_t length = 0;
     while ((pointer = uenum_next(calendars.get(), &length, &status)) && U_SUCCESS(status)) {
-        String calendar({ pointer, static_cast<size_t>(length) });
+        String calendar(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
         if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
             elements.append(WTFMove(mapped.value()));
         else
@@ -636,7 +636,7 @@ JSArray* IntlLocale::collations(JSGlobalObject* globalObject)
     const char* pointer;
     int32_t length = 0;
     while ((pointer = uenum_next(enumeration.get(), &length, &status)) && U_SUCCESS(status)) {
-        String collation({ pointer, static_cast<size_t>(length) });
+        String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
         // 1.1.3 step 4, The values "standard" and "search" must be excluded from list.
         if (collation == "standard"_s || collation == "search"_s)
             continue;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1631,7 +1631,7 @@ const Vector<String>& intlAvailableCalendars()
             int32_t length = 0;
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
-            String calendar({ pointer, static_cast<size_t>(length) });
+            String calendar(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
             if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
                 return createImmortalThreadSafeString(WTFMove(mapped.value()));
             return createImmortalThreadSafeString(WTFMove(calendar));
@@ -1702,7 +1702,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
             throwTypeError(globalObject, scope, "failed to enumerate available collations"_s);
             return { };
         }
-        String collation({ pointer, static_cast<size_t>(length) });
+        String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
         if (collation == "standard"_s || collation == "search"_s)
             continue;
         if (auto mapped = mapICUCollationKeywordToBCP47(collation))
@@ -1759,7 +1759,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
             throwTypeError(globalObject, scope, "failed to enumerate available currencies"_s);
             return { };
         }
-        String currency({ pointer, static_cast<size_t>(length) });
+        String currency(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
         if (currency == "EQE"_s)
             continue;
         if (currency == "LSM"_s)
@@ -1868,7 +1868,7 @@ const Vector<String>& intlAvailableTimeZones()
             int32_t length = 0;
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
-            String timeZone({ pointer, static_cast<size_t>(length) });
+            String timeZone(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
             if (isValidTimeZoneNameFromICUTimeZone(timeZone)) {
                 if (auto mapped = canonicalizeTimeZoneNameFromICUTimeZone(WTFMove(timeZone)))
                     temporary.append(WTFMove(mapped.value()));

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -190,7 +190,7 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
     unsigned index = 0;
     while (const char* result = uenum_next(keywords.get(), &resultLength, &status)) {
         ASSERT(U_SUCCESS(status));
-        categories->putDirectIndex(globalObject, index++, jsNontrivialString(vm, String({ result, static_cast<size_t>(resultLength) })));
+        categories->putDirectIndex(globalObject, index++, jsNontrivialString(vm, String(unsafeForgeSpan(result, static_cast<size_t>(resultLength)))));
         RETURN_IF_EXCEPTION(scope, { });
     }
     options->putDirect(vm, Identifier::fromString(vm, "pluralCategories"_s), categories);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -174,7 +174,7 @@ static inline String gap(JSGlobalObject* globalObject, JSValue space)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const unsigned maxGapLength = 10;
+    constexpr unsigned maxGapLength = 10;
     space = unwrapBoxedPrimitive(globalObject, space);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -191,7 +191,7 @@ static inline String gap(JSGlobalObject* globalObject, JSValue space)
         char spaces[maxGapLength];
         for (size_t i = 0; i < count; ++i)
             spaces[i] = ' ';
-        return String({ spaces, count });
+        return String(std::span { spaces }.first(count));
     }
 
     // If the space value is a string, use it as the gap string, otherwise use no gap string.

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -70,7 +70,7 @@ FunctionAllowlist::FunctionAllowlist(const char* filename)
         if (!length)
             continue;
         
-        m_entries.add(String({ line, length }));
+        m_entries.add(String(unsafeForgeSpan(line, length)));
     }
 
     int result = fclose(f);

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -218,13 +218,13 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
     const char* delimiterEnd = strchr(delimiterStart, '{');
     if (!delimiterEnd)
         FAIL_WITH_ERROR(SYNTAX_ERROR, ("Missing { after '", keyword, "' clause start delimiter:\n", line, "\n"));
-    
+
     size_t delimiterLength = delimiterEnd - delimiterStart;
-    String delimiter({ delimiterStart, delimiterLength });
+    String delimiter(unsafeForgeSpan(delimiterStart, delimiterLength));
 
     if (hasDisallowedCharacters(delimiterStart, delimiterLength))
         FAIL_WITH_ERROR(SYNTAX_ERROR, ("Delimiter '", delimiter, "' cannot have '{', '}', or whitespace:\n", line, "\n"));
-    
+
     CString terminatorCString = makeString('}', delimiter).ascii();
     const char* terminator = terminatorCString.data();
     line = delimiterEnd; // Start from the {.

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -762,11 +762,11 @@ template<typename OptionalType> auto valueOrDefault(OptionalType&& optionalValue
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
 template<typename T, typename U, std::size_t Extent>
-std::span<T, Extent == std::dynamic_extent ? std::dynamic_extent : (sizeof(U) * Extent) / sizeof(T)> spanReinterpretCast(std::span<U, Extent> span)
+constexpr std::span<T, Extent == std::dynamic_extent ? std::dynamic_extent : (sizeof(U) * Extent) / sizeof(T)> spanReinterpretCast(std::span<U, Extent> span)
 {
     if constexpr (Extent == std::dynamic_extent) {
         if constexpr (sizeof(U) < sizeof(T) || sizeof(U) % sizeof(T))
-            RELEASE_ASSERT_WITH_MESSAGE(!(span.size_bytes() % sizeof(T)), "spanReinterpretCast will not change size in bytes from source");
+            RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(!(span.size_bytes() % sizeof(T))); // Refuse to change size in bytes from source.
     } else
         static_assert(!((sizeof(U) * Extent) % sizeof(T)), "spanReinterpretCast will not change size in bytes from source");
 
@@ -827,7 +827,7 @@ void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
 // Use this when we can't edit the imported API and it doesn't offer
 // begin() / end() or a span accessor.
 template<typename T, std::size_t Extent = std::dynamic_extent>
-inline auto unsafeForgeSpan(T* ptr, size_t size)
+inline constexpr auto unsafeForgeSpan(T* ptr, size_t size)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return std::span<T, Extent> { ptr, size };

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -22,7 +22,10 @@
 #pragma once
 
 #include <span>
+#include <wtf/Compiler.h>
 #include <wtf/text/StringHasher.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -273,5 +276,7 @@ private:
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using WTF::SuperFastHash;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1505,7 +1505,7 @@ WKURLRef TestController::createTestURL(const char* pathOrURL)
     if (length >= 7 && strstr(pathOrURL, "file://")) {
         auto url = adoptWK(WKURLCreateWithUTF8CString(pathOrURL));
         auto path = testPath(url.get());
-        if (!m_usingServerMode && !WTF::FileSystemImpl::fileExists(String({ path.c_str(), path.length() }))) {
+        if (!m_usingServerMode && !WTF::FileSystemImpl::fileExists(String(std::span { path }))) {
             printf("Failed: File for URL ‘%s’ was not found or is inaccessible\n", pathOrURL);
             return 0;
         }
@@ -1540,7 +1540,7 @@ WKURLRef TestController::createTestURL(const char* pathOrURL)
     auto cPath = buffer.get();
     auto url = adoptWK(WKURLCreateWithUTF8CString(cPath));
     auto path = testPath(url.get());
-    if (!m_usingServerMode && !WTF::FileSystemImpl::fileExists(String({ path.c_str(), path.length() }))) {
+    if (!m_usingServerMode && !WTF::FileSystemImpl::fileExists(String(std::span { path }))) {
         printf("Failed: File ‘%s’ was not found or is inaccessible\n", pathOrURL);
         return 0;
     }


### PR DESCRIPTION
#### 00e4ae32b87a36717be7ed03a9f62cf6bdc456ce
<pre>
[WTF] Narrow scope of ignored -Wunsafe-buffer-usage warnings from ASCIILiteral.h to SuperFastHash.h
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281506">https://bugs.webkit.org/show_bug.cgi?id=281506</a>&gt;
&lt;<a href="https://rdar.apple.com/137973769">rdar://137973769</a>&gt;

Reviewed by Geoffrey Garen.

Additional changes in JavaScriptCore and WebKitTestRunner were due to
temporarily introducing an overloaded ASCIILiteral::fromLiteralUnsafe()
with a second size_t argument, which was later removed.  This caused a
disambiguation build failure on gcc, but these changes will be needed
later anyway, so they were kept.

* Source/WTF/wtf/text/ASCIILiteral.h:
- Move WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} macros to
  SuperFastHash.h.
(WTF::ASCIILiteral::fromLiteralUnsafe):
- Move call to std::char_traits&lt;char&gt;::length() into this method from
  the ASCIILiteral constructor.
- Construct a std::span that includes NUL terminator byte using
  unsafeForgeSpan() now that the ASCIILiteral constructor takes a
  std::span.
(WTF::ASCIILiteral::span8):
- Use std::span::first() to fix unsafe buffer usage warning.
(WTF::ASCIILiteral::ASCIILiteral):
- Change to take a std::span argument that includes the NUL terminator
  byte.
- Fix indentation of code in ASSERT_ENABLED.
(WTF::StringLiterals::operator&quot;&quot; _span):
- Create std::span first, then use that to check characters in Debug
  builds. This fixes an unsafe buffer usage warning.
- Use unsafeForgeSpan() to silence false positive warning.
* Source/WTF/wtf/StdLibExtras.h:
(WTF::spanReinterpretCast):
- Make constexpr by updating release assertion.
(WTF::unsafeForgeSpan):
- Make constexpr.
* Source/WTF/wtf/text/SuperFastHash.h:
- Move WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} macros to this header.

* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::sortLocaleData):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::localeData):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::calendars):
(JSC::IntlLocale::collations):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlAvailableCalendars):
(JSC::availableCollations):
(JSC::availableCurrencies):
(JSC::intlAvailableTimeZones):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::gap):
- Construct std::span safely from C-array, then use first().
* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::FunctionAllowlist):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause):
- Make use of unsafeForgeSpan(), except where noted above.  Many of
  these are after a call to uenum_next().

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createTestURL):
- Convert std::string directly to std::span.

Canonical link: <a href="https://commits.webkit.org/285440@main">https://commits.webkit.org/285440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7bbc5517e948bc97dca09826dccd6692613cce0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62534 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20001 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22188 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78484 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19490 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62543 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6809 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93660 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11157 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47848 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20614 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->