### PR TITLE
[TZone] Add annotations for X86_64 Darwin builds

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -33,8 +33,11 @@
 #include "ProbeContext.h"
 #include <wtf/PrintStream.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MacroAssemblerBase);
 
 const double MacroAssembler::twoToThe32 = (double)0x100000000ull;
 

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASSEMBLER)
 
 #include "JSCJSValue.h"
+#include <wtf/TZoneMalloc.h>
 
 #define DEFINE_SIMD_FUNC(name, func, lane) \
     template <typename ...Args> \
@@ -119,6 +120,7 @@ typedef Vector<PrintRecord> PrintRecordList;
 using MacroAssemblerBase = TARGET_MACROASSEMBLER;
 
 class MacroAssembler : public MacroAssemblerBase {
+    WTF_MAKE_TZONE_ALLOCATED(MacroAssemblerBase);
 public:
     using Base = MacroAssemblerBase;
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
@@ -37,6 +37,7 @@
 #include "JSCConfig.h"
 #include "JSCPtrTag.h"
 #include "MacroAssemblerARM64.h"
+#include <wtf/TZoneMalloc.h>
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>
@@ -47,6 +48,7 @@ namespace JSC {
 using Assembler = TARGET_ASSEMBLER;
 
 class MacroAssemblerARM64E : public MacroAssemblerARM64 {
+    WTF_MAKE_TZONE_ALLOCATED(MacroAssemblerARM64E);
 public:
     static constexpr unsigned numberOfPointerBits = sizeof(void*) * CHAR_BIT;
     static constexpr unsigned maxNumberOfAllowedPACBits = numberOfPointerBits - OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -30,6 +30,7 @@
 #include "X86Assembler.h"
 #include "AbstractMacroAssembler.h"
 #include <array>
+#include <wtf/TZoneMalloc.h>
 
 #define REPATCH_OFFSET_CALL_R11 3
 
@@ -40,6 +41,7 @@ namespace JSC {
 using Assembler = TARGET_ASSEMBLER;
 
 class MacroAssemblerX86_64 : public AbstractMacroAssembler<Assembler> {
+    WTF_MAKE_TZONE_ALLOCATED(MacroAssemblerX86_64);
 public:
     static constexpr size_t nearJumpRange = 2 * GB;
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1132,7 +1132,9 @@ private:
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FixedVMPoolExecutableAllocator);
+#if ENABLE(JUMP_ISLANDS)
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(FixedVMPoolExecutableAllocatorIslands, FixedVMPoolExecutableAllocator::Islands);
+#endif // ENABLE(JUMP_ISLANDS)
 
 // Keep this pointer in a mutable global variable to help Leaks find it.
 // But we do not use this pointer.

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -306,8 +306,7 @@
 #endif
 
 #if !defined(USE_TZONE_MALLOC)
-#if CPU(ARM64) && OS(DARWIN) && (__SIZEOF_POINTER__ == 8)
-// Only MacroAssemblerARM64 is known to build.
+#if (CPU(ARM64) || CPU(X86_64)) && OS(DARWIN) && (__SIZEOF_POINTER__ == 8)
 // Building with TZONE_MALLOC currently disabled for all platforms.
 #define USE_TZONE_MALLOC 0
 #else

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -375,7 +375,7 @@
 #endif
 
 #if !defined(BUSE_TZONE)
-#if BUSE(LIBPAS) && BOS(DARWIN) && BCPU(ARM64)
+#if BUSE(LIBPAS) && BOS(DARWIN) && (BCPU(ARM64) || BCPU(X86_64))
 #define BUSE_TZONE 1
 #else
 #define BUSE_TZONE 0

--- a/Source/bmalloc/bmalloc/Map.h
+++ b/Source/bmalloc/bmalloc/Map.h
@@ -44,6 +44,8 @@ public:
         Value value;
     };
 
+    Map();
+
     size_t size() { return m_keyCount; }
     size_t capacity() { return m_table.size(); }
 
@@ -141,6 +143,13 @@ private:
     unsigned m_tableMask;
     Vector<Bucket> m_table;
 };
+
+template<typename Key, typename Value, typename Hash, enum AllowDeleting allowDeleting>
+inline Map<Key, Value, Hash, allowDeleting>::Map()
+    : m_keyCount(0)
+    , m_tableMask(0)
+{
+}
 
 template<typename Key, typename Value, typename Hash, enum AllowDeleting allowDeleting>
 void Map<Key, Value, Hash, allowDeleting>::rehash()

--- a/Source/bmalloc/bmalloc/TZoneLog.cpp
+++ b/Source/bmalloc/bmalloc/TZoneLog.cpp
@@ -77,7 +77,7 @@ extern void TZoneLog::log(const char* format, ...)
 }
 
 #if BUSE(OS_LOG)
-BATTRIBUTE_PRINTF(3, 0)
+BATTRIBUTE_PRINTF(2, 0)
 void TZoneLog::osLogWithLineBuffer(const char* format, va_list list)
 {
     if (!format)


### PR DESCRIPTION
#### 9c0c04ed0b589af2bcf269574e9c221e15354630
<pre>
[TZone] Add annotations for X86_64 Darwin builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=281505">https://bugs.webkit.org/show_bug.cgi?id=281505</a>
<a href="https://rdar.apple.com/137973227">rdar://137973227</a>

Reviewed by Yijia Huang.

Added TZone annotations to X86_64 MacroAssembler.  Also filled out annotations for the MacroAssembler template class
tree including MacroAssemblerARM64E.  Needed to make the annotation for FixedVMPoolExecutableAllocator::Islands
conditional on ENABLE(JUMP_ISLANDS).  ASAN build found that bmalloc::Map had uninitialized members in the TZone paths,
so added a bmalloc::Map constructor to initialize its fields.  The X86 public SDK also found that the Printf
attributes for TZoneLog::osLogWithLineBuffer() needed fixing.

* Source/JavaScriptCore/assembler/MacroAssembler.cpp:
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/wtf/PlatformUse.h:
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/Map.h:
(bmalloc::allowDeleting&gt;::Map):
* Source/bmalloc/bmalloc/TZoneLog.cpp:

Canonical link: <a href="https://commits.webkit.org/285279@main">https://commits.webkit.org/285279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ef53e730af76fe000f7ff3df4c9e9cc7ad00f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56743 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21419 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77705 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71117 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18939 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64810 "Found 1 new test failure: compositing/shared-backing/overlap-after-end-sharing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64474 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6282 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92900 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11061 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47083 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->