### PR TITLE
Unreviewed, reverting 283749@main.

### DIFF
--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -67,7 +67,7 @@ CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
 
     ASSERT(std::holds_alternative<RefPtr<CSSNumericValue>>(value));
     auto numericValue = std::get<RefPtr<CSSNumericValue>>(value);
-    if (RefPtr unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
+    if (auto* unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
         if (unitValue->unitEnum() == CSSUnitType::CSS_NUMBER) {
             m_type = Type::Time;
             m_value = unitValue->value() / 1000;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -31,7 +31,6 @@
 #include "CSSScrollValue.h"
 #include "CSSValuePool.h"
 #include "Document.h"
-#include "DocumentInlines.h"
 #include "Element.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderView.h"
@@ -139,7 +138,7 @@ Ref<CSSValue> ScrollTimeline::toCSSValue(const RenderStyle&) const
 AnimationTimelinesController* ScrollTimeline::controller() const
 {
     if (m_source)
-        return &m_source->protectedDocument()->ensureTimelinesController();
+        return &m_source->document().ensureTimelinesController();
     return nullptr;
 }
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -38,7 +38,6 @@
 #include "CSSValuePool.h"
 #include "CSSViewValue.h"
 #include "Document.h"
-#include "DocumentInlines.h"
 #include "Element.h"
 #include "RenderBox.h"
 #include "ScrollAnchoringController.h"
@@ -189,7 +188,7 @@ Ref<CSSValue> ViewTimeline::toCSSValue(const RenderStyle& style) const
 AnimationTimelinesController* ViewTimeline::controller() const
 {
     if (m_subject)
-        return &m_subject->protectedDocument()->ensureTimelinesController();
+        return &m_subject->document().ensureTimelinesController();
     return nullptr;
 }
 

--- a/Source/WebCore/css/CSSFontVariationValue.cpp
+++ b/Source/WebCore/css/CSSFontVariationValue.cpp
@@ -39,14 +39,9 @@ CSSFontVariationValue::CSSFontVariationValue(FontTag tag, Ref<CSSPrimitiveValue>
 {
 }
 
-Ref<CSSPrimitiveValue> CSSFontVariationValue::protectedValue() const
-{
-    return m_value;
-}
-
 String CSSFontVariationValue::customCSSText() const
 {
-    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, protectedValue()->customCSSText());
+    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value->customCSSText());
 }
 
 bool CSSFontVariationValue::equals(const CSSFontVariationValue& other) const

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -40,7 +40,6 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     const CSSPrimitiveValue& value() const { return m_value; }
-    Ref<CSSPrimitiveValue> protectedValue() const;
     String customCSSText() const;
 
     bool equals(const CSSFontVariationValue&) const;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -111,8 +111,8 @@ WindowProxy* HTMLFrameOwnerElement::contentWindow() const
 void HTMLFrameOwnerElement::setSandboxFlags(SandboxFlags flags)
 {
     m_sandboxFlags = flags;
-    if (RefPtr contentFrame = m_contentFrame.get())
-        contentFrame->updateSandboxFlags(flags, Frame::NotifyUIProcess::Yes);
+    if (m_contentFrame)
+        m_contentFrame->updateSandboxFlags(flags, Frame::NotifyUIProcess::Yes);
 }
 
 bool HTMLFrameOwnerElement::isKeyboardFocusable(KeyboardEvent* event) const

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -44,21 +44,21 @@ FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect
 
 bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
-    Ref input = inputs[0];
-    Ref input2 = inputs[1];
+    auto& input = inputs[0].get();
+    auto& input2 = inputs[1].get();
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input->imageBuffer();
-    RefPtr inputImage2 = input2->imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage2 = input2.imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 
     auto& filterContext = resultImage->context();
-    auto inputImageRect = input->absoluteImageRectRelativeTo(result);
-    auto inputImageRect2 = input2->absoluteImageRectRelativeTo(result);
+    auto inputImageRect = input.absoluteImageRectRelativeTo(result);
+    auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
 
     switch (m_effect.operation()) {
     case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
@@ -71,14 +71,14 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
 
     case CompositeOperationType::FECOMPOSITE_OPERATOR_IN: {
         // Applies only to the intersected region.
-        IntRect destinationRect = input->absoluteImageRect();
-        destinationRect.intersect(input2->absoluteImageRect());
+        IntRect destinationRect = input.absoluteImageRect();
+        destinationRect.intersect(input2.absoluteImageRect());
         destinationRect.intersect(result.absoluteImageRect());
         if (destinationRect.isEmpty())
             break;
         IntRect adjustedDestinationRect = destinationRect - result.absoluteImageRect().location();
-        IntRect sourceRect = destinationRect - input->absoluteImageRect().location();
-        IntRect source2Rect = destinationRect - input2->absoluteImageRect().location();
+        IntRect sourceRect = destinationRect - input.absoluteImageRect().location();
+        IntRect source2Rect = destinationRect - input2.absoluteImageRect().location();
         filterContext.drawImageBuffer(*inputImage2, FloatRect(adjustedDestinationRect), FloatRect(source2Rect));
         filterContext.drawImageBuffer(*inputImage, FloatRect(adjustedDestinationRect), FloatRect(sourceRect), { CompositeOperator::SourceIn });
         break;

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -173,14 +173,14 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
 
 bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
 {
-    Ref input = inputs[0];
+    auto& input = inputs[0].get();
 
-    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+    input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
 
     // FIXME: support kernelUnitLengths other than (1,1). The issue here is that the W3
     // standard has no test case for them, and other browsers (like Firefox) has strange
@@ -206,7 +206,7 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVec
     data.lightSource = m_effect.lightSource().ptr();
     data.operatingColorSpace = &m_effect.operatingColorSpace();
 
-    data.pixels = destinationPixelBuffer.get();
+    data.pixels = destinationPixelBuffer;
     data.widthMultipliedByPixelSize = size.width() * cPixelSize;
     data.width = size.width();
     data.height = size.height();

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -32,10 +32,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceGraphicSoftwareApplier);
 
 bool SourceGraphicSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
-    Ref input = inputs[0];
+    auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input->imageBuffer();
+    RefPtr sourceImage = input.imageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -425,7 +425,7 @@ FontVariationSettings fontVariationSettingsFromCSSValue(const CSSValue& value, c
     FontVariationSettings settings;
     for (Ref item : downcast<CSSValueList>(value)) {
         auto& feature = downcast<CSSFontVariationValue>(item.get());
-        settings.insert({ feature.tag(), feature.protectedValue()->resolveAsNumber<float>(conversionData) });
+        settings.insert({ feature.tag(), feature.value().resolveAsNumber<float>(conversionData) });
     }
     return settings;
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h
@@ -43,8 +43,6 @@ private:
 
     Type type() const final { return Type::RemoteModel; }
 
-    Ref<WebCore::Model> protectedModel() const { return m_model; }
-
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;
     
     void populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties&, const RemoteLayerTreeContext&, WebCore::PlatformCALayer::LayerType) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
@@ -72,7 +72,7 @@ void PlatformCALayerRemoteModelHosting::populateCreationProperties(RemoteLayerTr
 void PlatformCALayerRemoteModelHosting::dumpAdditionalProperties(TextStream& ts, OptionSet<WebCore::PlatformLayerTreeAsTextFlags> flags)
 {
     if (flags.contains(WebCore::PlatformLayerTreeAsTextFlags::IncludeModels))
-        ts << indent << "(model data size " << protectedModel()->data()->size() << ")\n";
+        ts << indent << "(model data size " << m_model->data()->size() << ")\n";
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 2e7e9d53c9d0b2143450c9bb95be1d35fa1c09bd
<pre>
Unreviewed, reverting 283749@main.

Caused ~1.5% MotionMark regression.

* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::controller const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::controller const):
* Source/WebCore/css/CSSFontVariationValue.cpp:
(WebCore::CSSFontVariationValue::customCSSText const):
(WebCore::CSSFontVariationValue::protectedValue const): Deleted.
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::setSandboxFlags):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp:
(WebCore::SourceGraphicSoftwareApplier::apply const):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontVariationSettingsFromCSSValue):
* Source/WebKit/Shared/graphics/ImageBufferSet.cpp:
(WebKit::ImageBufferSet::swapBuffersForDisplay):
(WebKit::ImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm:
(WebKit::PlatformCALayerRemoteModelHosting::dumpAdditionalProperties):

Canonical link: <a href="https://commits.webkit.org/285217@main">https://commits.webkit.org/285217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9ebed7667729feb08746ce1b727864ee7fbf9f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24653 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22897 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61912 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16108 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12640 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47086 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->