### PR TITLE
[css-anchor-position-1] Support ::before/::after as anchors

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8104,6 +8104,8 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-001.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-003.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-007.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-abs-inline-container.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-inline-container.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL ::before as anchor dynamically generated assert_equals: expected 100 but got 0
-FAIL ::after as anchor dynamically generated assert_equals: expected 100 but got 0
+PASS ::before as anchor dynamically generated
+PASS ::after as anchor dynamically generated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL ::before as anchor assert_equals: expected 100 but got 0
-FAIL ::after as anchor assert_equals: expected 100 but got 0
+PASS ::before as anchor
+PASS ::after as anchor
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -160,6 +160,8 @@ void RenderBox::willBeDestroyed()
             view().unregisterBoxWithScrollSnapPositions(*this);
         if (style().containerType() != ContainerType::Normal)
             view().unregisterContainerQueryBox(*this);
+        if (!style().anchorNames().isEmpty())
+            view().unregisterAnchor(*this);
     }
 
     RenderBoxModelObject::willBeDestroyed();
@@ -299,6 +301,11 @@ void RenderBox::styleWillChange(StyleDifference diff, const RenderStyle& newStyl
         view().registerContainerQueryBox(*this);
     else if (oldStyle && oldStyle->containerType() != ContainerType::Normal)
         view().unregisterContainerQueryBox(*this);
+
+    if (!style().anchorNames().isEmpty())
+        view().registerAnchor(*this);
+    else if (oldStyle && !oldStyle->anchorNames().isEmpty())
+        view().unregisterAnchor(*this);
 
     RenderBoxModelObject::styleWillChange(diff, newStyle);
 }

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -136,6 +136,18 @@ static FirstLetterRemainingTextMap& firstLetterRemainingTextMap()
     return map;
 }
 
+void RenderBoxModelObject::styleWillChange(StyleDifference diff, const RenderStyle& newStyle)
+{
+    const RenderStyle* oldStyle = hasInitializedStyle() ? &style() : nullptr;
+
+    if (!style().anchorNames().isEmpty())
+        view().registerAnchor(*this);
+    else if (oldStyle && !oldStyle->anchorNames().isEmpty())
+        view().unregisterAnchor(*this);
+
+    RenderLayerModelObject::styleWillChange(diff, newStyle);
+}
+
 void RenderBoxModelObject::setSelectionState(HighlightState state)
 {
     if (state == HighlightState::Inside && selectionState() != HighlightState::None)

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -217,6 +217,8 @@ protected:
 
     void willBeDestroyed() override;
 
+    void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
+
     LayoutPoint adjustedPositionRelativeToOffsetParent(const LayoutPoint&) const;
 
     bool hasVisibleBoxDecorationStyle() const;

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1089,6 +1089,16 @@ void RenderView::unregisterContainerQueryBox(const RenderBox& box)
     m_containerQueryBoxes.remove(box);
 }
 
+void RenderView::registerAnchor(const RenderBoxModelObject& renderer)
+{
+    m_anchors.add(renderer);
+}
+
+void RenderView::unregisterAnchor(const RenderBoxModelObject& renderer)
+{
+    m_anchors.remove(renderer);
+}
+
 void RenderView::addCounterNeedingUpdate(RenderCounter& renderer)
 {
     m_countersNeedingUpdate.add(renderer);

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -208,6 +208,10 @@ public:
     void unregisterContainerQueryBox(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
 
+    void registerAnchor(const RenderBoxModelObject&);
+    void unregisterAnchor(const RenderBoxModelObject&);
+    const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const { return m_anchors; }
+
     SingleThreadWeakPtr<RenderElement> viewTransitionRoot() const;
     void setViewTransitionRoot(RenderElement& renderer);
 
@@ -278,6 +282,7 @@ private:
 
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;
+    SingleThreadWeakHashSet<const RenderBoxModelObject> m_anchors;
 
     SingleThreadWeakPtr<RenderElement> m_viewTransitionRoot;
 };

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1034,17 +1034,9 @@ Element* hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
 
 void Scope::clearAnchorPositioningState()
 {
-    if (m_anchorPositionedStates.isEmptyIgnoringNullReferences() && m_anchorElements.isEmptyIgnoringNullReferences())
-        return;
-
     for (auto keyAndValue : m_anchorPositionedStates)
         keyAndValue.key.invalidateStyle();
 
-    for (auto& anchorElement : m_anchorElements)
-        anchorElement.invalidateStyle();
-
-    m_anchorElements.clear();
-    m_anchorsForAnchorName.clear();
     m_anchorPositionedStates.clear();
 }
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -157,10 +157,8 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData>& anchorElements() { return m_anchorElements; }
     AnchorPositionedStates& anchorPositionedStates() { return m_anchorPositionedStates; }
     const AnchorPositionedStates& anchorPositionedStates() const { return m_anchorPositionedStates; }
-    AnchorsForAnchorName& anchorsForAnchorName() { return m_anchorsForAnchorName; }
     void clearAnchorPositioningState();
 
 private:
@@ -258,8 +256,6 @@ private:
     // FIXME: These (and some things above) are only relevant for the root scope.
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_anchorElements;
-    AnchorsForAnchorName m_anchorsForAnchorName;
     AnchorPositionedStates m_anchorPositionedStates;
 };
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1203,7 +1203,7 @@ auto TreeResolver::updateStateForQueryContainer(Element& element, const RenderSt
 std::unique_ptr<Update> TreeResolver::resolve()
 {
     m_hasUnresolvedQueryContainers = false;
-    m_hasUnresolvedAnchorPositionedElements = false;
+    auto hadUnresolvedAnchorPositionedElements = std::exchange(m_hasUnresolvedAnchorPositionedElements, false);
 
     Element* documentElement = m_document->documentElement();
     if (!documentElement) {
@@ -1214,10 +1214,8 @@ std::unique_ptr<Update> TreeResolver::resolve()
     if (!documentElement->childNeedsStyleRecalc() && !documentElement->needsStyleRecalc())
         return WTFMove(m_update);
 
-    for (auto elementAndState : m_document->styleScope().anchorPositionedStates()) {
-        if (elementAndState.value->stage == AnchorPositionResolutionStage::Resolved)
-            elementAndState.value->stage = AnchorPositionResolutionStage::Positioned;
-    }
+    if (hadUnresolvedAnchorPositionedElements)
+        AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout(m_document);
 
     m_didSeePendingStylesheet = m_document->styleScope().hasPendingSheetsBeforeBody();
 
@@ -1255,6 +1253,20 @@ std::unique_ptr<Update> TreeResolver::resolve()
     Adjuster::propagateToDocumentElementAndInitialContainingBlock(*m_update, m_document);
 
     return WTFMove(m_update);
+}
+
+auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderStyle* style) -> AnchorPositionedElementAction
+{
+    if (!style)
+        return AnchorPositionedElementAction::None;
+
+    auto* anchorPositionedState = m_document->styleScope().anchorPositionedStates().get(element);
+    if (!anchorPositionedState || anchorPositionedState->stage >= AnchorPositionResolutionStage::Resolved)
+        return AnchorPositionedElementAction::None;
+
+    m_hasUnresolvedAnchorPositionedElements = true;
+
+    return AnchorPositionedElementAction::SkipDescendants;
 }
 
 static Vector<Function<void ()>>& postResolutionCallbackQueue()
@@ -1327,52 +1339,6 @@ PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler()
 bool postResolutionCallbacksAreSuspended()
 {
     return resolutionNestingDepth;
-}
-
-auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderStyle* style) -> AnchorPositionedElementAction
-{
-    if (!style)
-        return AnchorPositionedElementAction::None;
-
-    bool isAnchor = generatesBox(*style) && !style->anchorNames().isEmpty();
-    auto* anchorPositionedState = m_document->styleScope().anchorPositionedStates().get(element);
-    if (!isAnchor && !anchorPositionedState)
-        return AnchorPositionedElementAction::None;
-
-    // Mark anchor as eligible target for anchor-positioned elements
-    if (isAnchor) {
-        bool isNewAnchor = m_document->styleScope().anchorElements().add(element).isNewEntry;
-
-        if (isNewAnchor) {
-            for (auto& anchorName : style->anchorNames()) {
-                m_document->styleScope().anchorsForAnchorName().ensure(anchorName, [&] {
-                    return Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>> { };
-                }).iterator->value.append(element);
-            }
-        }
-    }
-
-    if (!anchorPositionedState || anchorPositionedState->stage == AnchorPositionResolutionStage::Resolved)
-        return AnchorPositionedElementAction::None;
-
-    m_hasUnresolvedAnchorPositionedElements = true;
-    if (anchorPositionedState->stage == AnchorPositionResolutionStage::Initial) {
-        // We are seeing this anchor-positioned element for the first time during
-        // style & layout interleaving. Wait until we have relevant render tree
-        // information before further processing this anchor-positioned element.
-        if (!style->positionAnchor().isNull())
-            anchorPositionedState->anchorNames.add(style->positionAnchor());
-        anchorPositionedState->stage = AnchorPositionResolutionStage::FinishedCollectingAnchorNames;
-        return AnchorPositionedElementAction::SkipDescendants;
-    }
-
-    // Now we should have render tree information. Let's find the
-    // appropriate anchors for this anchor-positioned element.
-    ASSERT(element.renderer());
-    if (anchorPositionedState->stage == AnchorPositionResolutionStage::FinishedCollectingAnchorNames)
-        AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(element);
-
-    return AnchorPositionedElementAction::SkipDescendants;
 }
 
 }


### PR DESCRIPTION
#### f16c267dbdee11b9090e666477a9fd5dd57756f6
<pre>
[css-anchor-position-1] Support ::before/::after as anchors
<a href="https://bugs.webkit.org/show_bug.cgi?id=281509">https://bugs.webkit.org/show_bug.cgi?id=281509</a>
<a href="https://rdar.apple.com/137975699">rdar://137975699</a>

Reviewed by Alan Baradlay.

Also simplify the data structures and logic.

* LayoutTests/TestExpectations:

Scrolling feature is not implemented yet, passes were not real.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::RenderBox::styleWillChange):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::styleWillChange):

Refactor to track anchors as RenderBoxModelObjects instead of Elements.
Register and unregister anchors.

* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::registerAnchor):
(WebCore::RenderView::unregisterAnchor):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::evaluate):

Remove FinishedCollectingAnchorNames state which is not needed.
Add name from position-anchor property here too.

(WebCore::Style::penultimateContainingBlockChainElement):
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::collectAnchorsForAnchorName):

Build a temporary map of anchor names using currently registered anchors.

(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):

Move the state update code from TreeResolver here.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:

Remove anchor maps. AnchorPositioningState is the only persistent state now.
This will make invalidation etc easier.

(WebCore::Style::Scope::clearAnchorPositioningState):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):

If we have performanced an interleaved layout update the anchor states.

(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Almost nothing needs to be done here now.
We also avoid one unnecessary resolution round.

Canonical link: <a href="https://commits.webkit.org/285254@main">https://commits.webkit.org/285254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69aa3dd9f773b752122dc8fb0ad9819c3620ca7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15326 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62046 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21582 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77869 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16267 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62069 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15912 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12749 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6395 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47245 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->