### PR TITLE
Fix ASSERT failures in TestWebKitAPI.JavaScriptCore.Incremental*.

### DIFF
--- a/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
+++ b/Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 // MARK: JavaScriptCore
 
+extern "C" JS_EXPORT void JSAsynchronousGarbageCollectForDebugging(JSContextRef);
 extern "C" JS_EXPORT void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 extern "C" JS_EXPORT void JSSynchronousEdenCollectForDebugging(JSContextRef);
 


### PR DESCRIPTION
#### b85dcedba15edfb7322e625a8748a72f4a6fb225
<pre>
Fix ASSERT failures in TestWebKitAPI.JavaScriptCore.Incremental*.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281074">https://bugs.webkit.org/show_bug.cgi?id=281074</a>
<a href="https://rdar.apple.com/137526107">rdar://137526107</a>

Reviewed by NOBODY (OOPS!).

The issue is simply that the IncrementalSweeperMainThread and IncrementalSweeperSecondaryThread
had not initialized JSC before using it.  Added calls to WTF::initializeMainThread() and
JSC::initialize() to take care of this.

Also re-enabled these tests i.e. reverting 284925@main.

Lastly, the test is dependent on GC actually running, so that they can confirm that a destructor
was called.  Since JSGarbageCollect() is not guaranteed to trigger the GC, the tests may sometimes
time out.

Since the goal of the test isn&apos;t to test whether the GC gets triggered or not, but that the
IncrementalSweeper gets called by the RunLoop, this patch also changes the tests to call
JSAsynchronousGarbageCollectForDebugging() instead.

JSAsynchronousGarbageCollectForDebugging() is newly introduced, and is the asynchronous version of
JSSsynchronousGarbageCollectForDebugging().  JSSsynchronousGarbageCollectForDebugging() will not
work because it will also synchronously sweep the dead objects at the end of the GC cycle.  As a
result, no sweeping is left for the IncrementalSweeper to do as the test expects.

* Source/JavaScriptCore/API/ExtraSymbolsForTAPI.h:
* Source/JavaScriptCore/API/JSBase.cpp:
(garbageCollectForDebugging):
(JSAsynchronousGarbageCollectForDebugging):
(JSSynchronousGarbageCollectForDebugging):
* Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm:
(TestWebKitAPI::triggerGC):
(TestWebKitAPI::TEST(JavaScriptCore, IncrementalSweeperMainThread)):
(TestWebKitAPI::TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b85dcedba15edfb7322e625a8748a72f4a6fb225

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56767 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15275 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46595 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62023 "Found 1 new API test failure: TestWebKitAPI.JavaScriptCore.IncrementalSweeperMainThread (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19458 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21504 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65078 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65165 "2 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77790 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71202 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64507 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6341 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92985 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47168 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->