### PR TITLE
Fix wasm->JS when useJIT=0

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -904,35 +904,18 @@ end)
 
 # This is the interpreted analogue to WasmBinding.cpp:wasmToWasm
 op(wasm_to_wasm_wrapper_entry, macro()
-    loadp (Callee - PrologueStackPointerDelta)[sp], ws0
-    loadp [ws0], ws0
+    # We have only pushed PC (intel) or pushed nothing(others), and we
+    # are still in the caller frame.
+    loadp (Callee - CallerFrameAndPCSize + PrologueStackPointerDelta)[sp], ws0
 
 if JSVALUE64
     andp ~(constexpr JSValue::NativeCalleeTag), ws0
 end
+    leap WTFConfig + constexpr WTF::offsetOfWTFConfigLowestAccessibleAddress, ws1
+    loadp [ws1], ws1
+    addp ws1, ws0
 
-    loadi Wasm::Callee::m_index[ws0], ws1
-
-    const ImportFunctionInfoSize = constexpr (sizeof(JSWebAssemblyInstance::ImportFunctionInfo))
-    muli ImportFunctionInfoSize, ws1
-
-    # Store Callee's wasm callee for import function
-    leap (constexpr (JSWebAssemblyInstance::offsetOfTail()))[wasmInstance], ws0
-    addp ws0, ws1
-    # offsetOfBoxedTargetCalleeLoadLocation
-    loadp JSWebAssemblyInstance::ImportFunctionInfo::boxedTargetCalleeLoadLocation[ws1], ws0
-    loadp [ws0], ws0
-
-    const addressOfCalleeCalleeFromCallerPerspectiveBase = constexpr CallFrameSlot::callee * SlotSize
-if JSVALUE64
-    storep ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta[sp]
-else
-    storep ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + PayloadOffset[sp]
-    storep constexpr JSValue::NativeCalleeTag, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + TagOffset[sp]
-end
-
-    loadp JSWebAssemblyInstance::ImportFunctionInfo::wasmEntrypointLoadLocation[ws1], ws0
-    loadp JSWebAssemblyInstance::ImportFunctionInfo::targetInstance[ws1], wasmInstance
+    loadp JSC::Wasm::LLIntCallee::m_entrypoint[ws0], ws0
 
     # Memory
     if ARM64 or ARM64E
@@ -945,30 +928,42 @@ end
         cagedPrimitiveMayBeNull(memoryBase, ws1)
     end
 
-    loadp [ws0], ws0
     jmp ws0, WasmEntryPtrTag
 end)
 
-# This is the interpreted analogue to WasmBinding.cpp:wasmToJS
+# This is the interpreted analogue to WasmToJS.cpp:wasmToJS
 op(wasm_to_js_wrapper_entry, macro()
+    # We have only pushed PC (intel) or pushed nothing(others), and we
+    # are still in the caller frame.
     # Load this before we create the stack frame, since we lose old cfr, which we wrote Callee to
-    loadp (Callee - PrologueStackPointerDelta)[sp], ws1
+
+    # We repurpose this slot temporarily for a WasmCallableFunction* from doWasmCall and friends.
+    loadp (CodeBlock - CallerFrameAndPCSize + PrologueStackPointerDelta)[sp], ws0
+    loadp (Callee - CallerFrameAndPCSize + PrologueStackPointerDelta)[sp], ws1
 
     tagReturnAddress sp
     preserveCallerPCAndCFR()
 
-    subp 0x10, sp
-if ARM64 or ARM64E
-    storepairq ws1, wasmInstance, -0x10[cfr]
-elsif JSVALUE64
-    storeq ws1, -0x10[cfr]
-    storeq wasmInstance, -8[cfr]
-else
-    storep ws1, -0x10[cfr]
-    storep wasmInstance, -8[cfr]
-end
+    const ScratchSpaceSize = 0x8 * 3 + 0x8 # alignment
+    const CalleeScratch = -0x10
+    const WasmInstanceScratch = -0x8
+    const WasmCallableFunctionScratch = -0x18
 
-    subp 0x80, sp
+    subp ScratchSpaceSize, sp
+
+if ARM64 or ARM64E
+    storepairq ws1, wasmInstance, CalleeScratch[cfr]
+elsif JSVALUE64
+    storeq ws1, CalleeScratch[cfr]
+    storeq wasmInstance, WasmInstanceScratch[cfr]
+else
+    storep ws1, CalleeScratch[cfr]
+    storep wasmInstance, WasmInstanceScratch[cfr]
+end
+    storep ws0, WasmCallableFunctionScratch[cfr]
+
+    const RegisterSpaceScratchSize = 0x80
+    subp RegisterSpaceScratchSize, sp
 
     # Store all the registers here
 
@@ -1016,61 +1011,42 @@ end
     break
 
 .safe:
-
-    move r0, t2
-    loadp JSWebAssemblyInstance::ImportFunctionInfo::importFunction[t2], t0
+    loadp WasmCallableFunctionScratch[cfr], t2
+    loadp JSC::Wasm::WasmOrJSImportableFunction::importFunction[t2], t0
 if not JSVALUE64
     move (constexpr JSValue::CellTag), t1
 end
 
-    leap JSWebAssemblyInstance::ImportFunctionInfo::callLinkInfo[t2], t2
-    # emitDataICFastPath
-    #   emitFastPathImpl(nullptr, jit, false, nullptr)
-
-if not JSVALUE64
-    # branchIfNotCell(t0)
-    bineq t0, constexpr(JSValue::CellTag), .notacell
-end
+    leap JSC::Wasm::WasmOrJSImportableFunction::callLinkInfo[t2], t2
 
     # calleeGPR = t0
     # callLinkInfoGPR = t2
     # callTargetGPR = t5
     loadp CallLinkInfo::m_monomorphicCallDestination[t2], t5
 
-if RISCV64
-    bpeq CallLinkInfo::m_callee[t2], t0, .found
-    btpnz CallLinkInfo::m_callee[t2], (constexpr CallLinkInfo::polymorphicCalleeMask), .found
-else
     # scratch = t3
     loadp CallLinkInfo::m_callee[t2], t3
     bpeq t3, t0, .found
     btpnz t3, (constexpr CallLinkInfo::polymorphicCalleeMask), .found
-end
 
-if not JSVALUE64
-.notacell:
-end
-
-.found:
 if ARM64 or ARM64E
     pcrtoaddr _llint_default_call_trampoline, t5
 else
     leap (_llint_default_call_trampoline), t5
 end
-    # not a tail call
-    # jit.transferPtr (constexpr CallLinkInfo::offsetOfCodeBlock())[t2], CodeBlock[cfr]
+.found:
+    # jit.transferPtr CallLinkInfo::codeBlock[t2], CodeBlock[cfr]
     loadp CallLinkInfo::m_codeBlock[t2], t3
-    const offset = constexpr (CallerFrameAndPC::sizeInRegisters*sizeof(Register))
-    storep t3, (CodeBlock - offset)[sp]
-    call t5
-    
-    subp 0x80, sp
+    storep t3, (CodeBlock - CallerFrameAndPCSize)[sp]
+    call t5, JSEntryPtrTag
+
+    subp RegisterSpaceScratchSize, sp
     storep r0, [sp]
     move sp, a0
     move cfr, a1
     move wasmInstance, a2
     cCall3(_operationWasmToJSExitMarshalReturnValues)
-    btpnz r1, .handleException
+    btpnz r0, .handleException
 
     macro forEachReturnWasmJSR(fn)
         if ARM64 or ARM64E
@@ -1122,8 +1098,8 @@ else
     end)
 end
 
-    loadp -8[cfr], wasmInstance
-    addp 0x10, sp
+    loadp WasmInstanceScratch[cfr], wasmInstance
+    addp (ScratchSpaceSize + RegisterSpaceScratchSize), sp
 
     restoreCallerPCAndCFR()
     ret

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -780,7 +780,7 @@ void Options::notifyOptionsChanged()
         Options::useJIT() = false; // We don't support JIT with !allowDoubleShape. So disable it.
 
     // When reenabling JITLess wasm we should unskip the tests disabled in https://bugs.webkit.org/show_bug.cgi?id=281857
-    if (!Options::useWasm() || !Options::useJIT())
+    if (!Options::useWasm() || (!Options::useJIT() && !OptionsHelper::wasOverridden(useWasmID)))
         disableAllWasmOptions();
 
     if (!Options::useJIT())

--- a/Source/JavaScriptCore/wasm/WasmBinding.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBinding.cpp
@@ -49,7 +49,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
     ASSERT(noOverlap(scratch, GPRInfo::wasmContextInstancePointer));
 
     JIT_COMMENT(jit, "Store Callee's wasm callee for import function ", importIndex);
-    jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfBoxedTargetCalleeLoadLocation(importIndex)), scratch);
+    jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfBoxedWasmCalleeLoadLocation(importIndex)), scratch);
     jit.loadPtr(JIT::Address(scratch), scratch);
     // We are halfway between being the caller and the callee: we have already made the call, but not yet completed the prologue.
     // On ARM64 this doesn't really matter, but on intel we need to worry about the pushed pc.
@@ -58,7 +58,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
     // FIXME: This could be a load pair.
     // B3's call codegen ensures that the JSCell is a WebAssemblyFunction.
     // While we're accessing that cacheline, also get the wasm entrypoint so we can tail call to it below.
-    jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfWasmEntrypointLoadLocation(importIndex)), scratch);
+    jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfEntrypointLoadLocation(importIndex)), scratch);
     // Get the callee's JSWebAssemblyInstance and set it as WasmContext's instance. The caller will take care of restoring its own JSWebAssemblyInstance.
     // This switches the current instance.
     jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfTargetInstance(importIndex)), GPRInfo::wasmContextInstancePointer); // JSWebAssemblyInstance*.

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -788,27 +788,44 @@ struct InternalFunction {
     unsigned osrEntryScratchBufferSize { 0 };
 };
 
-static constexpr uintptr_t NullWasmCallee = 0;
+struct WasmCallableFunction {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    using LoadLocation = CodePtr<WasmEntryPtrTag>*;
+    static constexpr ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, entrypointLoadLocation); }
+    static constexpr ptrdiff_t offsetOfBoxedWasmCalleeLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, boxedWasmCalleeLoadLocation); }
+
+    const uintptr_t* boxedWasmCalleeLoadLocation { nullptr };
+    // Target instance and entrypoint are only set for wasm->wasm calls, and are otherwise nullptr. The js-specific logic occurs through import function.
+    WriteBarrier<JSWebAssemblyInstance> targetInstance { };
+    LoadLocation entrypointLoadLocation { };
+};
 
 // WebAssembly direct calls and call_indirect use indices into "function index space". This space starts
 // with all imports, and then all internal functions. WasmToWasmImportableFunction and FunctionIndexSpace are only
 // meant as fast lookup tables for these opcodes and do not own code.
-struct WasmToWasmImportableFunction {
+struct WasmToWasmImportableFunction : public WasmCallableFunction {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    using LoadLocation = CodePtr<WasmEntryPtrTag>*;
     static constexpr ptrdiff_t offsetOfSignatureIndex() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, typeIndex); }
-    static constexpr ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, entrypointLoadLocation); }
-    static constexpr ptrdiff_t offsetOfBoxedWasmCalleeLoadLocation() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, boxedWasmCalleeLoadLocation); }
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, rtt); }
 
     // FIXME: Pack type index and code pointer into one 64-bit value. See <https://bugs.webkit.org/show_bug.cgi?id=165511>.
     TypeIndex typeIndex { TypeDefinition::invalidIndex };
-    LoadLocation entrypointLoadLocation { };
-    const uintptr_t* boxedWasmCalleeLoadLocation { &NullWasmCallee };
     // Used when GC proposal is enabled, otherwise can be null.
     const RTT* rtt;
 };
 using FunctionIndexSpace = Vector<WasmToWasmImportableFunction>;
+
+struct WasmOrJSImportableFunction final : public WasmToWasmImportableFunction {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    using LoadLocation = CodePtr<WasmEntryPtrTag>*;
+
+    CodePtr<WasmEntryPtrTag> importFunctionStub;
+    WriteBarrier<JSObject> importFunction { };
+    DataOnlyCallLinkInfo callLinkInfo;
+    uintptr_t boxedCallee { 0xBEEF };
+
+    static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(WasmOrJSImportableFunction, callLinkInfo); }
+};
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -503,13 +503,9 @@ static inline UGPRPair doWasmCall(JSWebAssemblyInstance* instance, Wasm::Functio
     EncodedJSValue boxedCallee = CalleeBits::encodeNullCallee();
 
     if (functionIndex < importFunctionCount) {
-        JSWebAssemblyInstance::ImportFunctionInfo* functionInfo = instance->importFunctionInfo(functionIndex);
+        auto* functionInfo = instance->importFunctionInfo(functionIndex);
         codePtr = functionInfo->importFunctionStub;
-#if USE(JSVALUE64)
-        *callee = bitwise_cast<uint64_t>(functionInfo->boxedTargetCalleeLoadLocation);
-#else
-        *callee = bitwise_cast<uint32_t>(functionInfo->boxedTargetCalleeLoadLocation);
-#endif
+        *callee = *bitwise_cast<uintptr_t*>(functionInfo->boxedWasmCalleeLoadLocation);
     } else {
         // Target is a wasm function within the same instance
         codePtr = *instance->calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -269,11 +269,11 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
     OPERATION_RETURN(scope, JSValue::encode(resultArray));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWebAssemblyInstance* instance, Wasm::Callee* callee))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationGetWasmCalleeStackSize, unsigned, (JSWebAssemblyInstance* instance, CalleeBits callee))
 {
     auto& module = instance->module();
 
-    auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(callee->index());
+    auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(static_cast<Wasm::Callee*>(callee.asNativeCallee())->index());
     const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     const auto& signature = *typeDefinition.as<FunctionSignature>();
     unsigned argCount = signature.argumentCount();
@@ -288,10 +288,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWeb
     const unsigned numberOfBytesForSavedResults = savedResultRegisters.sizeOfAreaInBytes();
     const unsigned stackOffset = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(numberOfBytesForCall, numberOfBytesForSavedResults));
 
-    VM& vm = instance->vm();
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    OPERATION_RETURN(scope, stackOffset);
+    return stackOffset;
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp, CallFrame* cfr, void* argumentRegisters, JSWebAssemblyInstance* instance))
@@ -306,7 +303,9 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
     VM& vm = instance->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    Wasm::Callee* callee = *access.operator()<Wasm::Callee*>(cfr, -0x10);
+    constexpr int calleeScratchOffset = -0x10;
+
+    auto* callee = static_cast<Wasm::Callee*>(access.operator()<CalleeBits>(cfr, calleeScratchOffset)->asNativeCallee());
     auto functionIndex = callee->index();
     auto& module = instance->module();
     auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(functionIndex);
@@ -443,7 +442,9 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
 
     auto scope = DECLARE_THROW_SCOPE(instance->vm());
 
-    Wasm::Callee* callee = *access.operator()<Wasm::Callee*>(cfr, -0x10);
+    constexpr int calleeScratchOffset = -0x10;
+
+    auto* callee = static_cast<Wasm::Callee*>(access.operator()<CalleeBits>(cfr, calleeScratchOffset)->asNativeCallee());
     auto functionIndex = callee->index();
     auto& module = instance->module();
     auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -53,7 +53,7 @@ typedef int64_t EncodedWasmValue;
 
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSEntrypointCallee*, (void*, CallFrame*, WebAssemblyFunction*));
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJSValue, (void*, CallFrame*));
-JSC_DECLARE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWebAssemblyInstance*, Wasm::Callee*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmCalleeStackSize, unsigned, (JSWebAssemblyInstance*, CalleeBits));
 JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void*, CallFrame*, void*, JSWebAssemblyInstance*));
 JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* sp, CallFrame* cfr, JSWebAssemblyInstance*));
 

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -292,6 +292,13 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
     ASSERT_WITH_SECURITY_IMPLICATION(isSubtype(function->type(), wasmType()));
     auto& slot = m_importableFunctions.get()[index];
     slot.m_function = function->importableFunction();
+    if (!slot.m_function.targetInstance) {
+        // This is a JS function.
+        ASSERT(!slot.m_function.boxedWasmCalleeLoadLocation);
+        slot.m_protectedJSCallee = adoptRef(*new WasmToJSCallee(FunctionSpaceIndex(index), { nullptr, nullptr }));
+        slot.m_boxedProtectedJSCallee = CalleeBits::encodeNativeCallee(slot.m_protectedJSCallee.get());
+        slot.m_function.boxedWasmCalleeLoadLocation = &slot.m_boxedProtectedJSCallee;
+    }
     slot.m_instance = function->instance();
     slot.m_value.set(function->instance()->vm(), m_owner, function);
 }

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "SlotVisitorMacros.h"
+#include "WasmCallee.h"
 #include "WasmFormat.h"
 #include "WasmLimits.h"
 #include "WriteBarrier.h"
@@ -132,6 +133,12 @@ public:
         WasmToWasmImportableFunction m_function;
         JSWebAssemblyInstance* m_instance { nullptr };
         WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
+        // In the case when we do not JIT, we cannot use the WasmToJSCallee singleton.
+        // This callee gives the jitless wasm_to_js thunk the info it needs to call the imported
+        // function with the correct wasm type.
+        // Note that wasm to js calls will have m_function's boxedWasmCalleeLoadLocation already set.
+        RefPtr<WasmToJSCallee> m_protectedJSCallee;
+        uintptr_t m_boxedProtectedJSCallee;
 
         static constexpr ptrdiff_t offsetOfFunction() { return OBJECT_OFFSETOF(Function, m_function); }
         static constexpr ptrdiff_t offsetOfInstance() { return OBJECT_OFFSETOF(Function, m_instance); }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -55,6 +55,7 @@ class WebAssemblyModuleRecord;
 
 class JSWebAssemblyInstance final : public JSNonFinalObject {
     friend class LLIntOffsetsExtractor;
+    using WasmOrJSImportableFunction = Wasm::WasmOrJSImportableFunction;
 
 public:
     using Base = JSNonFinalObject;
@@ -251,39 +252,23 @@ public:
     // Tail accessors.
     static constexpr size_t offsetOfTail() { return WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(JSWebAssemblyInstance)); }
 
-    static constexpr uintptr_t NullWasmCallee = 0;
-
-    struct ImportFunctionInfo {
-        // Target instance and entrypoint are only set for wasm->wasm calls, and are otherwise nullptr. The js-specific logic occurs through import function.
-        WriteBarrier<JSWebAssemblyInstance> targetInstance { };
-        WasmToWasmImportableFunction::LoadLocation wasmEntrypointLoadLocation { nullptr };
-        CodePtr<WasmEntryPtrTag> importFunctionStub;
-        WriteBarrier<JSObject> importFunction { };
-        // This is only used when we need to jump directly into the LLInt/IPInt.
-        const uintptr_t* boxedTargetCalleeLoadLocation { &NullWasmCallee };
-        DataOnlyCallLinkInfo callLinkInfo;
-#if CPU(ADDRESS32)
-        void* _ { nullptr }; // padding
-#endif
-        static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(ImportFunctionInfo, callLinkInfo); }
-    };
     unsigned numImportFunctions() const { return m_numImportFunctions; }
-    ImportFunctionInfo* importFunctionInfo(size_t importFunctionNum)
+    WasmOrJSImportableFunction* importFunctionInfo(size_t importFunctionNum)
     {
         RELEASE_ASSERT(importFunctionNum < m_numImportFunctions);
-        return &bitwise_cast<ImportFunctionInfo*>(bitwise_cast<char*>(this) + offsetOfTail())[importFunctionNum];
+        return &bitwise_cast<WasmOrJSImportableFunction*>(bitwise_cast<char*>(this) + offsetOfTail())[importFunctionNum];
     }
-    static size_t offsetOfTargetInstance(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + OBJECT_OFFSETOF(ImportFunctionInfo, targetInstance); }
-    static size_t offsetOfWasmEntrypointLoadLocation(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + OBJECT_OFFSETOF(ImportFunctionInfo, wasmEntrypointLoadLocation); }
-    static size_t offsetOfBoxedTargetCalleeLoadLocation(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + OBJECT_OFFSETOF(ImportFunctionInfo, boxedTargetCalleeLoadLocation); }
-    static size_t offsetOfImportFunctionStub(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + OBJECT_OFFSETOF(ImportFunctionInfo, importFunctionStub); }
-    static size_t offsetOfImportFunction(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + OBJECT_OFFSETOF(ImportFunctionInfo, importFunction); }
-    static size_t offsetOfCallLinkInfo(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(ImportFunctionInfo) + ImportFunctionInfo::offsetOfCallLinkInfo(); }
+    static size_t offsetOfTargetInstance(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + OBJECT_OFFSETOF(Wasm::WasmCallableFunction, targetInstance); }
+    static size_t offsetOfEntrypointLoadLocation(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + OBJECT_OFFSETOF(Wasm::WasmCallableFunction, entrypointLoadLocation); }
+    static size_t offsetOfBoxedWasmCalleeLoadLocation(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + OBJECT_OFFSETOF(Wasm::WasmCallableFunction, boxedWasmCalleeLoadLocation); }
+    static size_t offsetOfImportFunctionStub(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + OBJECT_OFFSETOF(WasmOrJSImportableFunction, importFunctionStub); }
+    static size_t offsetOfImportFunction(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + OBJECT_OFFSETOF(WasmOrJSImportableFunction, importFunction); }
+    static size_t offsetOfCallLinkInfo(size_t importFunctionNum) { return offsetOfTail() + importFunctionNum * sizeof(WasmOrJSImportableFunction) + WasmOrJSImportableFunction::offsetOfCallLinkInfo(); }
     WriteBarrier<JSObject>& importFunction(unsigned importFunctionNum) { return importFunctionInfo(importFunctionNum)->importFunction; }
 
-    static_assert(sizeof(ImportFunctionInfo) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(ImportFunctionInfo)), "We rely on this for the alignment to be correct");
-    static constexpr size_t offsetOfTablePtr(unsigned numImportFunctions, unsigned i) { return offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Wasm::Table*) * i; }
-    static constexpr size_t offsetOfGlobalPtr(unsigned numImportFunctions, unsigned numTables, unsigned i) { return roundUpToMultipleOf<sizeof(Wasm::Global::Value)>(offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Wasm::Table*) * numTables) + sizeof(Wasm::Global::Value) * i; }
+    static_assert(sizeof(WasmOrJSImportableFunction) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(WasmOrJSImportableFunction)), "We rely on this for the alignment to be correct");
+    static constexpr size_t offsetOfTablePtr(unsigned numImportFunctions, unsigned i) { return offsetOfTail() + sizeof(WasmOrJSImportableFunction) * numImportFunctions + sizeof(Wasm::Table*) * i; }
+    static constexpr size_t offsetOfGlobalPtr(unsigned numImportFunctions, unsigned numTables, unsigned i) { return roundUpToMultipleOf<sizeof(Wasm::Global::Value)>(offsetOfTail() + sizeof(WasmOrJSImportableFunction) * numImportFunctions + sizeof(Wasm::Table*) * numTables) + sizeof(Wasm::Global::Value) * i; }
 
     const Wasm::Tag& tag(unsigned i) const { return *m_tags[i]; }
     void setTag(unsigned, Ref<const Wasm::Tag>&&);
@@ -304,7 +289,7 @@ private:
 
     static size_t allocationSize(Checked<size_t> numImportFunctions, Checked<size_t> numTables, Checked<size_t> numGlobals)
     {
-        return roundUpToMultipleOf<sizeof(Wasm::Global::Value)>(offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Wasm::Table*) * numTables) + sizeof(Wasm::Global::Value) * numGlobals;
+        return roundUpToMultipleOf<sizeof(Wasm::Global::Value)>(offsetOfTail() + sizeof(WasmOrJSImportableFunction) * numImportFunctions + sizeof(Wasm::Table*) * numTables) + sizeof(Wasm::Global::Value) * numGlobals;
     }
 
     bool evaluateConstantExpression(uint64_t, Wasm::Type, uint64_t&);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -95,7 +95,7 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
 }
 
 WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
-    : Base { vm, executable, globalObject, structure, instance, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation, &m_boxedWasmCallee, rtt.get() } }
+    : Base { vm, executable, globalObject, structure, instance, Wasm::WasmOrJSImportableFunction { { { &m_boxedWasmCallee, { vm, globalObject, instance }, wasmToWasmEntrypointLoadLocation }, typeIndex, rtt.get() }, { }, { }, { } }, }
     , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
     , m_jsToWasmCallee { jsEntrypoint }
 { }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
@@ -39,7 +39,7 @@ namespace JSC {
 
 const ClassInfo WebAssemblyFunctionBase::s_info = { "WebAssemblyFunctionBase"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyFunctionBase) };
 
-WebAssemblyFunctionBase::WebAssemblyFunctionBase(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, WasmToWasmImportableFunction importableFunction)
+WebAssemblyFunctionBase::WebAssemblyFunctionBase(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, WasmOrJSImportableFunction importableFunction)
     : Base(vm, executable, globalObject, structure)
     , m_importableFunction(importableFunction)
     , m_instance(instance, WriteBarrierEarlyInit)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -35,6 +35,7 @@ namespace JSC {
 class JSGlobalObject;
 class JSWebAssemblyInstance;
 using Wasm::WasmToWasmImportableFunction;
+using Wasm::WasmOrJSImportableFunction;
 
 class WebAssemblyFunctionBase : public JSFunction {
 public:
@@ -50,7 +51,7 @@ public:
     Wasm::Type type() const { return { Wasm::TypeKind::Ref, typeIndex() }; }
     WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation() const { return m_importableFunction.entrypointLoadLocation; }
     const uintptr_t* boxedWasmCalleeLoadLocation() const { return m_importableFunction.boxedWasmCalleeLoadLocation; }
-    WasmToWasmImportableFunction importableFunction() const { return m_importableFunction; }
+    WasmOrJSImportableFunction importableFunction() const { return m_importableFunction; }
     const Wasm::RTT* rtt() const { return m_importableFunction.rtt; }
     const Wasm::FunctionSignature& signature() const;
 
@@ -66,12 +67,12 @@ public:
 protected:
     DECLARE_VISIT_CHILDREN;
     void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
-    WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, WasmToWasmImportableFunction);
+    WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, WasmOrJSImportableFunction);
 
     // It's safe to just hold the raw WasmToWasmImportableFunction because we have a reference
     // to our Instance, which points to the CodeBlock, which points to the Module
     // that exported us, which ensures that the actual Signature/RTT/code doesn't get deallocated.
-    WasmToWasmImportableFunction m_importableFunction;
+    WasmOrJSImportableFunction m_importableFunction;
     WriteBarrier<JSWebAssemblyInstance> m_instance;
 };
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -203,7 +203,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
             JSWebAssemblyInstance* calleeInstance = nullptr;
             WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = nullptr;
-            const uintptr_t* boxedTargetCalleeLoadLocation = nullptr;
+            const uintptr_t* boxedWasmCalleeLoadLocation = nullptr;
             JSObject* function = jsCast<JSObject*>(value);
 
             // ii. If v is an Exported Function Exotic Object:
@@ -216,11 +216,12 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                     importedTypeIndex = wasmFunction->typeIndex();
                     calleeInstance = wasmFunction->instance();
                     entrypointLoadLocation = wasmFunction->entrypointLoadLocation();
-                    boxedTargetCalleeLoadLocation = wasmFunction->boxedWasmCalleeLoadLocation();
+                    boxedWasmCalleeLoadLocation = wasmFunction->boxedWasmCalleeLoadLocation();
                 } else {
                     importedTypeIndex = wasmWrapperFunction->typeIndex();
                     // b. Let closure be v.[[Closure]].
                     function = wasmWrapperFunction->function();
+                    boxedWasmCalleeLoadLocation = wasmWrapperFunction->boxedWasmCalleeLoadLocation();
                 }
                 Wasm::TypeIndex expectedTypeIndex = moduleInformation.importFunctionTypeIndices[import.kindIndex];
                 if (!Wasm::isSubtypeIndex(importedTypeIndex, expectedTypeIndex))
@@ -234,8 +235,8 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
             auto* info = m_instance->importFunctionInfo(import.kindIndex);
             info->targetInstance.setMayBeNull(vm, m_instance.get(), calleeInstance);
-            info->wasmEntrypointLoadLocation = entrypointLoadLocation;
-            info->boxedTargetCalleeLoadLocation = boxedTargetCalleeLoadLocation;
+            info->entrypointLoadLocation = entrypointLoadLocation;
+            info->boxedWasmCalleeLoadLocation = boxedWasmCalleeLoadLocation;
             m_instance->importFunction(import.kindIndex).set(vm, m_instance.get(), function);
             break;
         }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -40,7 +40,7 @@ static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunction);
 static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunctionIncludingV128);
 
 WebAssemblyWrapperFunction::WebAssemblyWrapperFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, JSObject* function, Wasm::WasmToWasmImportableFunction importableFunction)
-    : Base(vm, executable, globalObject, structure, instance, importableFunction)
+    : Base(vm, executable, globalObject, structure, instance, { importableFunction, { }, { }, { } })
     , m_function(function, WriteBarrierEarlyInit)
 { }
 
@@ -57,7 +57,14 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
         executable = vm.getHostFunction(callWebAssemblyWrapperFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
 
     RELEASE_ASSERT(JSValue(function).isCallable());
-    WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, instance, function, Wasm::WasmToWasmImportableFunction { typeIndex, &instance->importFunctionInfo(importIndex)->importFunctionStub, &Wasm::NullWasmCallee, rtt.get() });
+    WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, instance, function,
+        Wasm::WasmOrJSImportableFunction {
+            {
+                { nullptr, { },
+                &instance->importFunctionInfo(importIndex)->importFunctionStub },
+                typeIndex,
+                rtt.get() },
+            { }, { }, { } });
     result->finishCreation(vm, executable, signature.argumentCount(), name);
     return result;
 }


### PR DESCRIPTION
#### 52cdfcda53e751eae2487f29e716e898e8b0c50b
<pre>
Fix wasm-&gt;JS when useJIT=0
<a href="https://bugs.webkit.org/show_bug.cgi?id=281512">https://bugs.webkit.org/show_bug.cgi?id=281512</a>

Reviewed by NOBODY (OOPS!).

1) Generally clean up this code, and remove magic numbers
2) Ensure that the Callee stack slot is always a boxed callee; This did
    not seem to break any tests somehow, but it would be wrong when we
    try to unwind.
3) Abstract both an imported JS or wasm function, or a function in a table
    into a WasmCallableFunction, and pass that from LLint to LLInt calls.
    The JIT case does not need this.

This should fix the last remaining ARMv7 test failure, although this feature
in particular is broken on all platforms.

* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitTailCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::WasmCallableFunction::offsetOfEntrypointLoadLocation):
(JSC::Wasm::WasmCallableFunction::offsetOfBoxedWasmCalleeLoadLocation):
(JSC::Wasm::WasmToWasmImportableFunction::offsetOfSignatureIndex): Deleted.
(JSC::Wasm::WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation): Deleted.
(JSC::Wasm::WasmToWasmImportableFunction::offsetOfBoxedWasmCalleeLoadLocation): Deleted.
(JSC::Wasm::WasmToWasmImportableFunction::offsetOfRTT): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::doWasmCall):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::doWasmCall):
(JSC::LLInt::doWasmCallIndirect):
(JSC::LLInt::doWasmCallRef):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::~JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::finalizeCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::WebAssemblyFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/859abf1d34e33bd3dd8475ea13fc4eb36ad6f14a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/73914 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/53343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25152 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/62476 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/1128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25152 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/76981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/62476 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/62476 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23485 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/67051 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/62476 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/73172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/1231 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/1128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/79804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/1374 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/26725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/94953 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/1195 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/94953 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1224 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1211 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/1230 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->