### PR TITLE
Fix BBQ tail call stack pointer restore site

### DIFF
--- a/JSTests/wasm/stress/tail-call-js-to-wasm.js
+++ b/JSTests/wasm/stress/tail-call-js-to-wasm.js
@@ -1,0 +1,63 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let count = 10;
+function splat(strOrGen, num = count) {
+    let result = Array(num).fill(strOrGen); // need to fill the array otherwise map yields nothing.
+    if (typeof strOrGen == "function")
+        result = result.map((_, i) => strOrGen(i));
+    return result.join(" ");
+}
+
+async function testTail() {
+    let wat = `
+    (module
+        (func (export "test") (result ${splat("i32")})
+            (return_call $tail ${splat((i) => "(i32.const " + i + ")\n", count * 2)})
+        )
+
+        (func $tail (param ${splat("i32", count * 2)}) (result ${splat("i32")})
+            ${splat((i) => "(local.get " + (i) + ")\n")}
+        )
+    )
+    `
+
+    let instance = await instantiate(wat, {}, { tail_call: true });
+    let func = instance.exports.test;
+
+    for (let i = 0; i < 1e4; ++i) {
+        let results = func();
+        for (let j = 0; j < count; ++j)
+            assert.eq(results[j], j);
+    }
+}
+
+async function testCallToTail() {
+    let wat = `
+    (module
+        (func (export "test") (result ${splat("i32")})
+            (call $callee ${splat((i) => "(i32.const " + i + ")\n")})
+        )
+        (func $callee (param ${splat("i32")}) (result ${splat("i32")})
+            ${splat((i) => "(local.get " + (i % count) + ")\n", count * 2)}
+            (return_call $tail)
+        )
+
+        (func $tail (param ${splat("i32", count * 2)}) (result ${splat("i32")})
+            ${splat((i) => "(local.get " + (i) + ")\n")}
+        )
+    )
+    `
+
+    let instance = await instantiate(wat, {}, { tail_call: true });
+    let func = instance.exports.test;
+
+    for (let i = 0; i < 1e4; ++i) {
+        let results = func();
+        for (let j = 0; j < count; ++j)
+            assert.eq(results[j], j);
+    }
+}
+
+assert.asyncTest(testTail());
+assert.asyncTest(testCallToTail());

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -840,6 +840,7 @@ asm (
 
 void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth savedFPWidth)
 {
+    JIT_COMMENT(*this, "Probe start");
     sub64(TrustedImm32(sizeof(IncomingProbeRecord)), sp);
 
     storePair64(x24, x25, sp, TrustedImm32(offsetof(IncomingProbeRecord, x24)));
@@ -858,6 +859,7 @@ void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth sav
     // ctiMasmProbeTrampoline should have restored every register except for lr and the sp.
     load64(Address(sp, offsetof(LRRestorationRecord, lr)), lr);
     add64(TrustedImm32(sizeof(LRRestorationRecord)), sp);
+    JIT_COMMENT(*this, "First non-probe instruction");
 }
 
 void MacroAssemblerARM64::collectCPUFeatures()

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2029,6 +2029,8 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
 
         jit.storeWasmCalleeCallee(params[patchArgsIndex + 1].gpr());
         jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
+        // Restore the stack pointer since it may have been lowered if our callee did a tail call.
+        jit.addPtr(CCallHelpers::TrustedImm32(-params.code().frameSize()), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
     });
     auto callResult = patchpoint;
 
@@ -5643,8 +5645,11 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
                     handle->generate(jit, params, this);
                 if (isTailCall)
                     jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
-                else
+                else {
                     jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
+                    // Restore the stack pointer since it may have been lowered if our callee did a tail call.
+                    jit.addPtr(CCallHelpers::TrustedImm32(-params.code().frameSize()), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+                }
             });
         };
 

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -727,7 +727,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
     JIT_COMMENT(jit, "Make the call");
     jit.call(stackLimitGPR, WasmEntryPtrTag);
 
-    // Restore stack pointer after call
+    // Restore stack pointer after call. We want to do this before marshalling results since stack results are stored at the top of the frame we created.
     jit.addPtr(MacroAssembler::TrustedImm32(-static_cast<int32_t>(totalFrameSize)), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
 
     CCallHelpers::JumpList exceptionChecks;


### PR DESCRIPTION
#### e2679aee4b9cff97b802d66ac933c28da2fc1d40
<pre>
Fix BBQ tail call stack pointer restore site
<a href="https://bugs.webkit.org/show_bug.cgi?id=281529">https://bugs.webkit.org/show_bug.cgi?id=281529</a>
<a href="https://rdar.apple.com/137994450">rdar://137994450</a>

Reviewed by David Degazio.

When adding tail calls to BBQ the restore site for sp was after
getting the results. However, since stack results are at the
*top* of the reserved frame we want to address from where the
caller thought sp should be not where the tail callee&apos;s frame pointer
was.

Also, restore sp in OMG after calls since I think it&apos;s possible to
stack overflow in a way that would be unexpected if we don&apos;t.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
(JSC::MacroAssembler::probe):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitTailCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::addCall):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):

Canonical link: <a href="https://commits.webkit.org/285268@main">https://commits.webkit.org/285268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fb4267f5e1012f91b24c978f40e9a0dc5517fdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37209 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21471 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65045 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77757 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71169 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18970 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64986 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 68 flakes 119 failures; Uploaded test results; 45 flakes 58 failures; Compiled WebKit; 6 flakes 52 failures; Passed layout tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64493 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12669 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92952 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47135 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->