### PR TITLE
AX: Implement NextSentenceEnd/PrevSentenceStart APIs off of the main thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt
@@ -2,22 +2,38 @@ This tests that sentence navigation is working correctly.
 
 Current character is: T
 Current sentence is: This is a sentence, right?
+Pre sentence start to next sentence end: This is a sentence, right?
 
 Current character is: t
 Current sentence is: test audio [ATTACHMENT]file.
+Pre sentence start to next sentence end: test audio [ATTACHMENT]file.
 
 Current character is: 巧
 Current sentence is: 巧克力 是食物吗?
+Pre sentence start to next sentence end: 巧克力 是食物吗?
 
 Current character is: ك
 Current sentence is: كيف حالك؟
+Pre sentence start to next sentence end: كيف حالك؟
 
 Current character is: b
 Current sentence is: both   spaces
+Pre sentence start to next sentence end: both   spaces
 
 Current character is: i
 Current sentence is: line breaks.
+Pre sentence start to next sentence end: line breaks.
 
+Sentence: This is my first sentence.
+Sentence:
+Sentence: This is my second sentence.
+Sentence: This is my third sentence.
+Sentence: This is my fourth sentence.
+Sentence: This is my fourth sentence.
+Sentence: This is my third sentence.
+Sentence: This is my second sentence.
+Sentence:
+Sentence: This is my first sentence.
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html
@@ -76,19 +76,17 @@ if (window.accessibilityController) {
     text = accessibilityController.accessibleElementById("text5");
     textMarkerRange = text.textMarkerRangeForElement(text);
     startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-
-    // FIXME: Add in verifySentences() to match the original test once next/previous sentence
-    // are implemented.
+    verifySentences(text, startMarker, 5);
 
     debug(output);
     
-    function advanceAndVerify(currentMarker, offset, obj) {
+    function advanceAndVerify(currentMarker, offset, axElement) {
         var previousMarker = currentMarker;
         for (var i = 0; i < offset; i++) {
             previousMarker = currentMarker;
-            currentMarker = obj.nextTextMarker(previousMarker);
+            currentMarker = axElement.nextTextMarker(previousMarker);
         }
-        verifySentenceRangeForTextMarker(previousMarker, currentMarker, obj);
+        verifySentenceRangeForTextMarker(previousMarker, currentMarker, axElement);
         output += "\n";
         return currentMarker;
     }
@@ -98,19 +96,44 @@ if (window.accessibilityController) {
         return str;
     }
     
-    function verifySentenceRangeForTextMarker(preMarker, textMarker, obj) {
-        var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
-        var currentCharacter = replaceAttachmentInString(obj.stringForTextMarkerRange(markerRange));
+    function verifySentenceRangeForTextMarker(preMarker, textMarker, axElement) {
+        var markerRange = axElement.textMarkerRangeForMarkers(preMarker, textMarker);
+        var currentCharacter = replaceAttachmentInString(axElement.stringForTextMarkerRange(markerRange));
         output += `Current character is: ${currentCharacter}\n`;
         
-        var range = obj.sentenceTextMarkerRangeForTextMarker(textMarker);
-        var sentence = replaceAttachmentInString(obj.stringForTextMarkerRange(range));
+        var range = axElement.sentenceTextMarkerRangeForTextMarker(textMarker);
+        var sentence = replaceAttachmentInString(axElement.stringForTextMarkerRange(range));
         output += `Current sentence is: ${sentence}\n`;
         
-        // FIXME: Add "Pre sentence start to next sentence end" to match original test once 
-        // previousSentenceStartTextMarkerForTextMarker and nextSentenceEndTextMarkerForTextMarker
-        // are implemented off the main thread.
+        var preStart = axElement.previousSentenceStartTextMarkerForTextMarker(textMarker);
+        var nextEnd = axElement.nextSentenceEndTextMarkerForTextMarker(textMarker);
+        var preAndNextSentenceRange = axElement.textMarkerRangeForMarkers(preStart, nextEnd);
+        var preAndNextSentence = replaceAttachmentInString(axElement.stringForTextMarkerRange(preAndNextSentenceRange));
+        output += `Pre sentence start to next sentence end: ${preAndNextSentence}\n`;
     }
+
+    function verifySentences(axElement, startMarker, sentenceCount) {
+        var current = startMarker;
+        var i = 0;
+        while(i < sentenceCount) {
+            current = axElement.nextSentenceEndTextMarkerForTextMarker(current);
+            var currRange = axElement.sentenceTextMarkerRangeForTextMarker(current);
+            var currSentence = axElement.stringForTextMarkerRange(currRange);
+            output += `Sentence: ${currSentence}\n`;
+            i++;
+        }
+
+        // Backwards.
+        i = 0;
+        while(i < sentenceCount) {
+            current = axElement.previousSentenceStartTextMarkerForTextMarker(current);
+            var next = axElement.nextTextMarker(current);
+            var currRange = axElement.sentenceTextMarkerRangeForTextMarker(next);
+            var currSentence = axElement.stringForTextMarkerRange(currRange);
+            output += `Sentence: ${currSentence}\n`;
+            i++;
+        }
+    }  
 }
 </script>
 

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -157,7 +157,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
 
         auto thisMarker = AXTextMarker { *this, 0 };
         AXTextMarkerRange range { thisMarker, thisMarker };
-        auto endMarker = thisMarker.findLastBefore(stopObject ? std::make_optional(stopObject->objectID()) : std::nullopt);
+        auto endMarker = thisMarker.findLastBefore(stopObject ? stopObject->objectID() : std::nullopt);
         if (endMarker.isValid() && endMarker.isInTextRun()) {
             // One or more of our descendants have text, so let's form a range from the first and last text positions.
             range = { thisMarker.toTextRunMarker(), WTFMove(endMarker) };

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3133,6 +3133,20 @@ enum class TextUnit {
 
 - (AXTextMarkerRef)textMarkerForTextMarker:(AXTextMarkerRef)textMarkerRef atUnit:(TextUnit)textUnit
 {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis()) {
+        AXTextMarker inputMarker { textMarkerRef };
+        switch (textUnit) {
+        case TextUnit::NextSentenceEnd:
+            return inputMarker.nextSentenceEnd().platformData().autorelease();
+        case TextUnit::PreviousSentenceStart:
+            return inputMarker.previousSentenceStart().platformData().autorelease();
+        default:
+            // TODO: Not implemented!
+            break;
+        }
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
     return Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRef>([textMarkerRef = retainPtr(textMarkerRef), &textUnit, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRef> {
         auto* backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)


### PR DESCRIPTION
#### ff546a4b6c04ed6c47dc1851f3f1268ac7e99a85
<pre>
AX: Implement NextSentenceEnd/PrevSentenceStart APIs off of the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=281541">https://bugs.webkit.org/show_bug.cgi?id=281541</a>
<a href="https://rdar.apple.com/138005738">rdar://138005738</a>

Reviewed by Tyler Wilcock and Andres Gonzalez.

Moving NextSentenceEnd and PreviousSentenceStart off of the main thread allows the rest
of text-marker-sentence-nav.html to be ported to ax-thread-text-apis/. This patch updates
how we handle `AXTextUnit::Sentence` to appropriately handle these APIs and match the
existing live tree behavior. This test fully passes when run with AX_THREAD_TEXT_APIS
enabled.

This also includes build fixes after 285102@main (Port AXID to ObjectIdentifier).

* LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt:
* LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):
(WebCore::AXTextMarker::findLastBefore const):
(WebCore::previousSentenceStartFromOffset):
(WebCore::nextSentenceEndFromOffset):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::sentenceRange const):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper textMarkerForTextMarker:atUnit:]):

Canonical link: <a href="https://commits.webkit.org/285413@main">https://commits.webkit.org/285413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412b8d6bce86c545317a7be0043d044c73156b61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78203 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6615 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->