### PR TITLE
[scroll-animations] Pass animation range value down into computeTimelineData

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Animation with animation-timeline:none holds current time at zero assert_equals: expected "100px" but got "0px"
-FAIL Animation with unknown timeline name holds current time at zero assert_equals: expected "100px" but got "101.9375px"
+FAIL Animation with unknown timeline name holds current time at zero assert_equals: expected "100px" but got "100.8125px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Scroll timeline with percentage range [JavaScript API] assert_approx_equals: expected 0.7 +/- 0.001 but got 0.6000000381469727
-FAIL Scroll timeline with px range [JavaScript API] assert_approx_equals: expected 0.8484848484848485 +/- 0.001 but got 0.6000000381469727
-FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected 0.7647058823529411 +/- 0.001 but got 0.6000000381469727
-FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected 0.6111111111111112 +/- 0.001 but got 0.6000000381469727
+PASS Scroll timeline with percentage range [JavaScript API]
+PASS Scroll timeline with px range [JavaScript API]
+FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected a number but got a "object"
+FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected a number but got a "object"
 FAIL Scroll timeline with percentage range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 FAIL Scroll timeline with px range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 FAIL Scroll timeline with calculated range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -14,5 +14,5 @@ FAIL Switching from one scroll timeline to another updates currentTime promise_t
 PASS Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS.
 PASS Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
 FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 0 +/- 0.125 but got 10
+FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: Timeline's currentTime aligns with the scroll position even when paused expected a number but got a "object"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Getting and setting the animation range assert_equals: Opacity with range set to [normal, normal] expected "0.5" but got "1"
+FAIL Getting and setting the animation range assert_equals: Initial value for rangeStart expected (string) "normal" but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -2,6 +2,6 @@
 FAIL View timeline with range as <name> <percent> pair. assert_equals: Effect at the start of the active phase: cover 0% to cover 100% expected "0.3" but got "0.7"
 FAIL View timeline with range and inferred name or offset. assert_equals: Effect at the start of the active phase: entry to exit expected "0.3" but got "0.7"
 FAIL View timeline with range as <name> <px> pair. assert_equals: Effect at the start of the active phase: cover 20% to cover 100% expected "0.3" but got "0.7"
-FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "0.7"
-FAIL View timeline with range as strings. assert_equals: Effect at the start of the active phase:  to  expected "0.3" but got "0.7"
+FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "1"
+FAIL View timeline with range as strings. assert_equals: Effect at the start of the active phase:  to  expected "0.3" but got "1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test view-timeline with document scrolling element. assert_equals: expected "1" but got "0.49927"
+FAIL Test view-timeline with document scrolling element. assert_equals: expected "1" but got "0"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with subject size change after the creation of the animation assert_equals: Effect at the start of the active phase expected "0.3" but got "0.609278"
+FAIL View timeline with subject size change after the creation of the animation assert_equals: Effect at the midpoint of the active range expected "0.5" but got "0.3"
 

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "TimelineRange.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
@@ -52,7 +53,7 @@ public:
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
 
-    virtual std::optional<WebAnimationTime> currentTime() { return m_currentTime; }
+    virtual std::optional<WebAnimationTime> currentTime(const TimelineRange& = { }) { return m_currentTime; }
     virtual std::optional<WebAnimationTime> duration() const { return m_duration; }
 
     virtual void detachFromDocument();
@@ -65,6 +66,8 @@ public:
     bool animationsAreSuspended() const;
 
     virtual AnimationTimelinesController* controller() const { return nullptr; }
+
+    virtual TimelineRange defaultRange() const { return { }; }
 
 protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -125,7 +125,7 @@ unsigned DocumentTimeline::numberOfActiveAnimationsForTesting() const
     return count;
 }
 
-std::optional<WebAnimationTime> DocumentTimeline::currentTime()
+std::optional<WebAnimationTime> DocumentTimeline::currentTime(const TimelineRange&)
 {
     if (auto* controller = this->controller()) {
         if (auto currentTime = controller->currentTime())

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -58,7 +58,7 @@ public:
 
     Document* document() const { return m_document.get(); }
 
-    std::optional<WebAnimationTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime(const TimelineRange& = { }) override;
     ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, std::optional<std::variant<double, CustomAnimationOptions>>&&);
 
     void animationTimingDidChange(WebAnimation&) override;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -189,10 +189,15 @@ float ScrollTimeline::floatValueForOffset(const Length& offset, float maxValue)
     return floatValueForLength(offset, maxValue);
 }
 
+TimelineRange ScrollTimeline::defaultRange() const
+{
+    return TimelineRange::defaultForScrollTimeline();
+}
+
 ScrollTimeline::Data ScrollTimeline::computeTimelineData(const TimelineRange& range) const
 {
-    ASSERT(range.start.name == SingleTimelineRange::Name::Normal || range.start.name == SingleTimelineRange::Name::Omitted);
-    ASSERT(range.end.name == SingleTimelineRange::Name::Normal || range.end.name == SingleTimelineRange::Name::Omitted);
+    if ((range.start.name != SingleTimelineRange::Name::Normal && range.start.name != SingleTimelineRange::Name::Omitted) || (range.end.name != SingleTimelineRange::Name::Normal && range.end.name != SingleTimelineRange::Name::Omitted))
+        return { };
 
     if (!m_source)
         return { };
@@ -209,15 +214,16 @@ ScrollTimeline::Data ScrollTimeline::computeTimelineData(const TimelineRange& ra
     if (maxScrollOffset > 0)
         scrollOffset = std::clamp(scrollOffset, 0.f, maxScrollOffset);
 
-    return { scrollOffset, floatValueForOffset(range.start.offset, maxScrollOffset), maxScrollOffset - floatValueForOffset(range.end.offset, maxScrollOffset) };
+    return { scrollOffset, floatValueForOffset(range.start.offset, maxScrollOffset), floatValueForOffset(range.end.offset, maxScrollOffset) };
 }
 
-std::optional<WebAnimationTime> ScrollTimeline::currentTime()
+std::optional<WebAnimationTime> ScrollTimeline::currentTime(const TimelineRange& timelineRange)
 {
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // Progress (the current time) for a scroll progress timeline is calculated as:
     // scroll offset ÷ (scrollable overflow size − scroll container size)
-    auto data = computeTimelineData();
+    auto timelineRangeOrDefault = timelineRange.isDefault() ? defaultRange() : timelineRange;
+    auto data = computeTimelineData(timelineRangeOrDefault);
     auto range = data.rangeEnd - data.rangeStart;
     if (!range)
         return std::nullopt;

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -28,7 +28,6 @@
 #include "AnimationTimeline.h"
 #include "ScrollAxis.h"
 #include "ScrollTimelineOptions.h"
-#include "TimelineRange.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
 
@@ -39,6 +38,8 @@ class CSSScrollValue;
 class Element;
 class RenderStyle;
 class ScrollableArea;
+
+struct TimelineRange;
 
 class ScrollTimeline : public AnimationTimeline {
 public:
@@ -63,7 +64,8 @@ public:
     AnimationTimelinesController* controller() const override;
     static ScrollableArea* scrollableAreaForSourceRenderer(RenderElement*, Ref<Document>);
 
-    std::optional<WebAnimationTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime(const TimelineRange&) override;
+    TimelineRange defaultRange() const override;
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
@@ -74,7 +76,7 @@ protected:
         float rangeEnd { 0 };
     };
     static float floatValueForOffset(const Length&, float);
-    virtual Data computeTimelineData(const TimelineRange& = { }) const;
+    virtual Data computeTimelineData(const TimelineRange&) const;
 
 private:
     enum class Scroller : uint8_t { Nearest, Root, Self };

--- a/Source/WebCore/animation/TimelineRange.h
+++ b/Source/WebCore/animation/TimelineRange.h
@@ -26,8 +26,15 @@
 #pragma once
 
 #include "Length.h"
+#include "WebAnimationTypes.h"
 
 namespace WebCore {
+
+namespace Style {
+class BuilderState;
+}
+
+class Element;
 
 struct SingleTimelineRange {
     enum class Name { Normal, Omitted, Cover, Contain, Entry, Exit, EntryCrossing, ExitCrossing };
@@ -40,16 +47,26 @@ struct SingleTimelineRange {
     enum class Type : bool { Start, End };
     static bool isDefault(const Length&, Type);
     static bool isDefault(const CSSPrimitiveValue&, Type);
+    static Length defaultValue(Type);
+    static Length lengthForCSSValue(RefPtr<const CSSPrimitiveValue>, RefPtr<Element>);
 
     static bool isOffsetValue(const CSSPrimitiveValue&);
 
     static Name timelineName(CSSValueID);
     static CSSValueID valueID(Name);
+
+    static SingleTimelineRange range(const CSSValue&, Type, const Style::BuilderState* = nullptr, RefPtr<Element> = nullptr);
+    static SingleTimelineRange parse(TimelineRangeValue&&, RefPtr<Element>, Type);
+    TimelineRangeValue serialize() const;
 };
 
 struct TimelineRange {
     SingleTimelineRange start;
     SingleTimelineRange end;
+
+    static TimelineRange defaultForScrollTimeline();
+    static TimelineRange defaultForViewTimeline();
+    bool isDefault() const { return start.name == SingleTimelineRange::Name::Normal && end.name == SingleTimelineRange::Name::Normal; }
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const SingleTimelineRange&);

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -27,7 +27,6 @@
 
 #include "CSSNumericValue.h"
 #include "ScrollTimeline.h"
-#include "TimelineRange.h"
 #include "ViewTimelineOptions.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
@@ -40,6 +39,8 @@ class BuilderState;
 
 class CSSViewValue;
 class Element;
+
+struct TimelineRange;
 
 struct ViewTimelineInsets {
     std::optional<Length> start;
@@ -67,9 +68,10 @@ public:
 
     RenderBox* sourceScrollerRenderer() const;
     Element* source() const override;
+    TimelineRange defaultRange() const final;
 
 private:
-    ScrollTimeline::Data computeTimelineData(const TimelineRange& = { }) const override;
+    ScrollTimeline::Data computeTimelineData(const TimelineRange&) const final;
 
     explicit ViewTimeline(ViewTimelineOptions&& = { });
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -473,11 +473,11 @@ std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respec
     //     2. the associated timeline is inactive, or
     //     3. the animation's start time is unresolved.
     // The current time is an unresolved time value.
-    if (!m_timeline || !m_timeline->currentTime() || !m_startTime)
+    if (!m_timeline || !m_timeline->currentTime(m_timelineRange) || !m_startTime)
         return std::nullopt;
 
     // Otherwise, current time = (timeline time - start time) * playback rate
-    return (*m_timeline->currentTime() - startTime.value_or(*m_startTime)) * m_playbackRate;
+    return (*m_timeline->currentTime(m_timelineRange) - startTime.value_or(*m_startTime)) * m_playbackRate;
 }
 
 ExceptionOr<void> WebAnimation::silentlySetCurrentTime(std::optional<WebAnimationTime> seekTime)
@@ -1845,5 +1845,18 @@ std::optional<double> WebAnimation::progress() const
     // Otherwise, progress = min(max(current time / animation’s associated effect end, 0), 1)
     return std::min(std::max(*currentTime / endTime, 0.0), 1.0);
 }
+
+void WebAnimation::setRangeStart(TimelineRangeValue&& rangeStart)
+{
+    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get()))
+        m_timelineRange.start = SingleTimelineRange::parse(WTFMove(rangeStart), keyframeEffect->target(), SingleTimelineRange::Type::Start);
+}
+
+void WebAnimation::setRangeEnd(TimelineRangeValue&& rangeEnd)
+{
+    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get()))
+        m_timelineRange.end = SingleTimelineRange::parse(WTFMove(rangeEnd), keyframeEffect->target(), SingleTimelineRange::Type::End);
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -140,10 +140,10 @@ public:
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);
     std::optional<FramesPerSecond> frameRate() const { return m_effectiveFrameRate; }
 
-    TimelineRangeValue rangeStart() const { return m_rangeStart; }
-    TimelineRangeValue rangeEnd() const { return m_rangeEnd; }
-    void setRangeStart(TimelineRangeValue&& rangeStart) { m_rangeStart = WTFMove(rangeStart); }
-    void setRangeEnd(TimelineRangeValue&& rangeEnd) { m_rangeEnd = WTFMove(rangeEnd); }
+    TimelineRangeValue rangeStart() const { return m_timelineRange.start.serialize(); }
+    TimelineRangeValue rangeEnd() const { return m_timelineRange.end.serialize();; }
+    void setRangeStart(TimelineRangeValue&&);
+    void setRangeEnd(TimelineRangeValue&&);
 
     bool needsTick() const;
     virtual void tick();
@@ -251,8 +251,7 @@ private:
     TimeToRunPendingTask m_timeToRunPendingPauseTask { TimeToRunPendingTask::NotScheduled };
     ReplaceState m_replaceState { ReplaceState::Active };
     uint64_t m_globalPosition { 0 };
-    TimelineRangeValue m_rangeStart { "normal"_s };
-    TimelineRangeValue m_rangeEnd { "normal"_s };
+    TimelineRange m_timelineRange;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -82,6 +82,7 @@
 #include "StyleTextEdge.h"
 #include "TabSize.h"
 #include "TextSpacing.h"
+#include "TimelineRange.h"
 #include "TouchAction.h"
 #include "TransformOperationsBuilder.h"
 #include "ViewTimeline.h"
@@ -243,7 +244,6 @@ public:
 
     static TimelineScope convertTimelineScope(const BuilderState&, const CSSValue&);
 
-    static SingleTimelineRange convertAnimationRange(const BuilderState&, const CSSValue&, SingleTimelineRange::Type);
     static SingleTimelineRange convertAnimationRangeStart(const BuilderState&, const CSSValue&);
     static SingleTimelineRange convertAnimationRangeEnd(const BuilderState&, const CSSValue&);
 
@@ -2215,35 +2215,14 @@ inline TimelineScope BuilderConverter::convertTimelineScope(const BuilderState&,
     }) };
 }
 
-inline SingleTimelineRange BuilderConverter::convertAnimationRange(const BuilderState& state, const CSSValue& value, SingleTimelineRange::Type type)
-{
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (SingleTimelineRange::isOffsetValue(*primitiveValue)) {
-            // <length-percentage>
-            return { SingleTimelineRange::Name::Omitted, convertLength(state, *primitiveValue) };
-        }
-        // <timeline-range-name> or Normal
-        return { SingleTimelineRange::timelineName(primitiveValue->valueID()), (type == SingleTimelineRange::Type::Start ? WebCore::Length(0, LengthType::Percent) : WebCore::Length(100, LengthType::Percent)) };
-    }
-    RefPtr pair = dynamicDowncast<CSSValuePair>(value);
-    if (!pair)
-        return { };
-
-    // <timeline-range-name> <length-percentage>
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(pair->second());
-    ASSERT(SingleTimelineRange::isOffsetValue(primitiveValue));
-
-    return { SingleTimelineRange::timelineName(pair->first().valueID()), convertLength(state, primitiveValue) };
-}
-
 inline SingleTimelineRange BuilderConverter::convertAnimationRangeStart(const BuilderState& state, const CSSValue& value)
 {
-    return convertAnimationRange(state, value, SingleTimelineRange::Type::Start);
+    return SingleTimelineRange::range(value, SingleTimelineRange::Type::Start, &state);
 }
 
 inline SingleTimelineRange BuilderConverter::convertAnimationRangeEnd(const BuilderState& state, const CSSValue& value)
 {
-    return convertAnimationRange(state, value, SingleTimelineRange::Type::End);
+    return SingleTimelineRange::range(value, SingleTimelineRange::Type::End, &state);
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 0aa547a211ad00f6c811fb509fd663b1c466cfba
<pre>
[scroll-animations] Pass animation range value down into computeTimelineData
<a href="https://bugs.webkit.org/show_bug.cgi?id=281543">https://bugs.webkit.org/show_bug.cgi?id=281543</a>
<a href="https://rdar.apple.com/138006146">rdar://138006146</a>

Reviewed by Tim Nguyen and Antoine Quint.

When calculating WebAnimation::currentTime, pass down any associated animation range down into
computeTimelineData. Also add parsing code for the JS api, reusing the parsing code for the CSS
portion. Also fix some various bugs about computing the timeline data using the animation range
value.

* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::currentTime):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::currentTime):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::computeTimelineData const):
(WebCore::ScrollTimeline::currentTime):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::currentTime):
(WebCore::ScrollTimeline::computeTimelineData):
* Source/WebCore/animation/TimelineRange.cpp:
(WebCore::SingleTimelineRange::defaultValue):
(WebCore::SingleTimelineRange::serialize const):
(WebCore::lengthFoCSSValue):
(WebCore::SingleTimelineRange::range):
(WebCore::SingleTimelineRange::parse):
(WebCore::TimelineRange::defaultForViewTimeline):
* Source/WebCore/animation/TimelineRange.h:
(WebCore::TimelineRange::isDefault const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::computeTimelineData const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::currentTime const):
(WebCore::WebAnimation::setRangeStart):
(WebCore::WebAnimation::setRangeEnd):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::rangeStart const):
(WebCore::WebAnimation::rangeEnd const):
(WebCore::WebAnimation::setRangeStart): Deleted.
(WebCore::WebAnimation::setRangeEnd): Deleted.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertAnimationRangeStart):
(WebCore::Style::BuilderConverter::convertAnimationRangeEnd):
(WebCore::Style::BuilderConverter::convertAnimationRange): Deleted.

Canonical link: <a href="https://commits.webkit.org/285533@main">https://commits.webkit.org/285533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c08f5b36447819d2a3e1fedfcb3dc5af8f1caeec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23952 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15813 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62748 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20231 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22473 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17148 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19716 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 20 flakes 3 failures; Uploaded test results; layout-tests running") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13359 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7016 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11225 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48125 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->