### PR TITLE
Ensure InitializeWebKit2 is called before allocating API::Features in WebPreferencesFeatures.cpp

### DIFF
--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesFeatures.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesFeatures.cpp.erb
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "WebPreferences.h"
 
+#include "WebKit2Initialize.h"
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesKeys.h"
 #include <wtf/ExperimentalFeatureNames.h>
@@ -37,6 +38,7 @@ namespace WebKit {
 
 const Vector<RefPtr<API::Object>>& WebPreferences::features()
 {
+    InitializeWebKit2();
     static NeverDestroyed<Vector<RefPtr<API::Object>>> features(std::initializer_list<RefPtr<API::Object>> {
 <% for @pref in @exposedFeatures do -%>
 <%- if @pref.condition -%>

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "WebPreferencesStore.h"
 
+#include "WebKit2Initialize.h"
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesKeys.h"
 #include <variant>
@@ -45,7 +46,9 @@ using namespace WebCore;
 
 WebPreferencesStore::ValueMap& WebPreferencesStore::defaults()
 {
+    InitializeWebKit2();
     static NeverDestroyed<ValueMap> defaults;
+
     if (defaults.get().isEmpty()) {
 <%- for @pref in @exposedPreferences do -%>
 <%- if @pref.condition -%>


### PR DESCRIPTION
#### ae4bc135bbb4d8f8d5da23a31aeda69ec7d7552e
<pre>
Ensure InitializeWebKit2 is called before allocating API::Features in WebPreferencesFeatures.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=281537">https://bugs.webkit.org/show_bug.cgi?id=281537</a>
<a href="https://rdar.apple.com/138003594">rdar://138003594</a>

Reviewed by Mark Lam.

Changes the way we initialize the WebPreferences feature list to ensure
InitializeWebKit2() is called before constructing the API::Features,
or the defaults map in the Preferences store, since these functions are
potentially reachable before we do initialization elsewhere.

* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesFeatures.cpp.erb:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb:

Canonical link: <a href="https://commits.webkit.org/285293@main">https://commits.webkit.org/285293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f863bfd9f5d2c907ed2e5588b46c50ea595b9119

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24938 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62136 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/71657 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43401 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19140 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62159 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6478 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->