### PR TITLE
The try_table catch targets should be validated against the control stack size.

### DIFF
--- a/JSTests/wasm/stress/try-table-malformed-catch-label.js
+++ b/JSTests/wasm/stress/try-table-malformed-catch-label.js
@@ -1,0 +1,15 @@
+var exception;
+try {
+    new WebAssembly.Module(new Uint8Array([
+        , 97, 115, 109, 1, , , , 1, 7, 1, 96, 3, 127, 127, 127, , 2, 12, 1, 2, , ,
+        3, , , , 2, 1, , , 3, 2, 1, , , 1, , , 13, , , , , , , , , , , , , , 10,
+        57, 1, 55, 1, 1, 127, 65, , 33, , 3, 64, 2, 64, 32, , 32, , 70, -61139, 0,
+        , 1, 65, 4, 108, 32, 3, 65, 0, 108, 106, 31, 0, 32, 3, , 4, 1, 1, 40, 0, 0,
+        , 0, 0, 32, 3, 65, 1, 1, 33, 7, , 1, 11, , 1
+    ]));
+} catch (e) {
+    exception = e;
+}
+
+if (!exception || !exception.toString().startsWith("CompileError: WebAssembly.Module doesn't parse at byte 55: try_table's catch target 65 exceeds control stack size 3, in function at index 0"))
+    throw "FAILED";

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -3452,8 +3452,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
                 return { };
             }
 
+            if (exceptionLabel >= m_controlStack.size()) {
+                errorMessage = WTF::makeString("try_table's catch target "_s, exceptionLabel, " exceeds control stack size "_s, m_controlStack.size());
+                return { };
+            }
             // Type checking
-
             return {
                 static_cast<CatchKind>(catchOpcode),
                 exceptionTag,


### PR DESCRIPTION
#### c28107072dbb85310d2f7fa07cc9f60131edb766
<pre>
The try_table catch targets should be validated against the control stack size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281546">https://bugs.webkit.org/show_bug.cgi?id=281546</a>
<a href="https://rdar.apple.com/137600598">rdar://137600598</a>

Reviewed by David Degazio.

This is needed for handling malformed Wasm payloads.  This check was missed in the implementation
of the new Wasm exception spec in 283954@main.

* JSTests/wasm/stress/try-table-malformed-catch-label.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):

Canonical link: <a href="https://commits.webkit.org/285256@main">https://commits.webkit.org/285256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af0ff63ca33e34ec1e2028196359a51777e41f99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21520 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65094 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77806 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71218 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64516 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6352 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93001 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11052 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47184 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20488 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->