### PR TITLE
SystemPreviewController should be ref counted

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -220,13 +220,13 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 
 - (UIViewController *)presentingViewController
 {
-    if (!_previewController)
+    if (!_previewController || !_previewController->page())
         return nil;
 
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    return _previewController->page().uiClient().presentingViewController();
+    return _previewController->page()->uiClient().presentingViewController();
 }
 
 - (CGRect)previewController:(QLPreviewController *)controller frameForPreviewItem:(id <QLPreviewItem>)item inSourceView:(UIView * *)view
@@ -236,10 +236,14 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     if (!presentingViewController)
         return CGRectZero;
 
+    RefPtr page = _previewController->page();
+    if (!page)
+        return CGRectZero;
+
     *view = presentingViewController.view;
 
     if (!_previewController->previewInfo().previewRect.isEmpty())
-        return _previewController->page().syncRootViewToScreen(_previewController->previewInfo().previewRect);
+        return page->syncRootViewToScreen(_previewController->previewInfo().previewRect);
 
     CGRect frame;
     frame.size.width = (*view).frame.size.width / 2.0;
@@ -257,8 +261,8 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     if (presentingViewController) {
         if (_linkRect.isEmpty())
             *contentRect = {CGPointZero, {presentingViewController.view.frame.size.width / 2.0, presentingViewController.view.frame.size.height / 2.0}};
-        else {
-            WebCore::IntRect screenRect = _previewController->page().syncRootViewToScreen(_linkRect);
+        else if (RefPtr page = _previewController->page()) {
+            WebCore::IntRect screenRect = page->syncRootViewToScreen(_linkRect);
             *contentRect = { CGPointZero, { static_cast<CGFloat>(screenRect.width()), static_cast<CGFloat>(screenRect.height()) } };
         }
     }
@@ -390,10 +394,14 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
     if (m_qlPreviewController)
         return completionHandler();
 
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!webPageProxy)
+        return completionHandler();
+
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    RetainPtr<UIViewController> presentingViewController = m_webPageProxy->uiClient().presentingViewController();
+    RetainPtr<UIViewController> presentingViewController = webPageProxy->uiClient().presentingViewController();
 
     if (!presentingViewController)
         return completionHandler();
@@ -405,10 +413,13 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
             return completionHandler();
 
         auto protectedThis = weakThis.get();
+        RefPtr webPageProxy = protectedThis->m_webPageProxy.get();
+        if (!webPageProxy)
+            return completionHandler();
         RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier ? protectedThis->m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
         auto request = WebCore::ResourceRequest(url);
         bool shouldRunAtForegroundPriority = false;
-        protectedThis->m_webPageProxy->dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
+        webPageProxy->dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
             if (!weakThis)
                 return completionHandler();
 
@@ -565,7 +576,11 @@ void SystemPreviewController::takeActivityToken()
 #if USE(RUNNINGBOARD)
     RELEASE_LOG(ProcessSuspension, "%p - UIProcess is taking a background assertion because it is downloading a system preview", this);
     ASSERT(!m_activity);
-    m_activity = page().legacyMainFrameProcess().throttler().backgroundActivity("System preview download"_s);
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
+    m_activity = page->legacyMainFrameProcess().throttler().backgroundActivity("System preview download"_s);
 #endif
 }
 
@@ -588,14 +603,19 @@ void SystemPreviewController::triggerSystemPreviewAction()
 {
     RELEASE_LOG(SystemPreview, "SystemPreview action was triggered on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
 
-    page().systemPreviewActionTriggered(m_systemPreviewInfo, "_apple_ar_quicklook_button_tapped"_s);
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
+    page->systemPreviewActionTriggered(m_systemPreviewInfo, "_apple_ar_quicklook_button_tapped"_s);
 }
 
 void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uint64_t elementID, NSString* documentID, uint64_t pageID)
 {
     auto uuid = WTF::UUID::parseVersion4(String(documentID));
     ASSERT(uuid);
-    if (!uuid)
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!uuid || !webPageProxy)
         return;
 
     m_systemPreviewInfo.isPreview = true;
@@ -603,7 +623,7 @@ void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uin
         m_systemPreviewInfo.element.elementIdentifier = ObjectIdentifier<WebCore::ElementIdentifierType>(elementID);
     else
         m_systemPreviewInfo.element.elementIdentifier = std::nullopt;
-    m_systemPreviewInfo.element.documentIdentifier = WebCore::ScriptExecutionContextIdentifier { *uuid, m_webPageProxy->legacyMainFrameProcess().coreProcessIdentifier() };
+    m_systemPreviewInfo.element.documentIdentifier = WebCore::ScriptExecutionContextIdentifier { *uuid, webPageProxy->legacyMainFrameProcess().coreProcessIdentifier() };
     m_systemPreviewInfo.element.webPageIdentifier = ObjectIdentifier<WebCore::PageIdentifierType>(pageID);
     triggerSystemPreviewAction();
 }

--- a/Source/WebKit/UIProcess/SystemPreviewController.cpp
+++ b/Source/WebKit/UIProcess/SystemPreviewController.cpp
@@ -36,6 +36,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SystemPreviewController);
 
+Ref<SystemPreviewController> SystemPreviewController::create(WebPageProxy& webPageProxy)
+{
+    return adoptRef(*new SystemPreviewController(webPageProxy));
+}
+
 SystemPreviewController::SystemPreviewController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -32,6 +32,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceError.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
@@ -46,15 +47,6 @@ OBJC_CLASS _WKPreviewControllerDelegate;
 OBJC_CLASS _WKSystemPreviewDataTaskDelegate;
 #endif
 
-namespace WebKit {
-class SystemPreviewController;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SystemPreviewController> : std::true_type { };
-}
-
 namespace WebCore {
 class SecurityOriginData;
 }
@@ -63,10 +55,10 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class SystemPreviewController : public CanMakeWeakPtr<SystemPreviewController> {
+class SystemPreviewController : public RefCountedAndCanMakeWeakPtr<SystemPreviewController> {
     WTF_MAKE_TZONE_ALLOCATED(SystemPreviewController);
 public:
-    explicit SystemPreviewController(WebPageProxy&);
+    static Ref<SystemPreviewController> create(WebPageProxy&);
 
     bool canPreview(const String& mimeType) const;
 
@@ -77,7 +69,7 @@ public:
     void loadFailed();
     void end();
 
-    WebPageProxy& page() { return m_webPageProxy.get(); }
+    WebPageProxy* page() { return m_webPageProxy.get(); }
     const WebCore::SystemPreviewInfo& previewInfo() const { return m_systemPreviewInfo; }
 
     void triggerSystemPreviewAction();
@@ -86,6 +78,8 @@ public:
     void setCompletionHandlerForLoadTesting(CompletionHandler<void(bool)>&&);
 
 private:
+    explicit SystemPreviewController(WebPageProxy&);
+
     void takeActivityToken();
     void releaseActivityTokenIfNecessary();
 
@@ -100,7 +94,7 @@ private:
 
     State m_state { State::Initial };
 
-    WeakRef<WebPageProxy> m_webPageProxy;
+    WeakPtr<WebPageProxy> m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;
     URL m_downloadURL;
     URL m_localFileURL;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1501,7 +1501,7 @@ void WebPageProxy::didAttachToRunningProcess()
 
 #if USE(SYSTEM_PREVIEW)
     ASSERT(!m_systemPreviewController);
-    m_systemPreviewController = makeUnique<SystemPreviewController>(*this);
+    m_systemPreviewController = SystemPreviewController::create(*this);
 #endif
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
@@ -14983,15 +14983,16 @@ bool WebPageProxy::hasSleepDisabler() const
 #if USE(SYSTEM_PREVIEW)
 void WebPageProxy::beginSystemPreview(const URL& url, const SecurityOriginData& topOrigin, const SystemPreviewInfo& systemPreviewInfo, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_systemPreviewController)
+    RefPtr systemPreviewController = m_systemPreviewController;
+    if (!systemPreviewController)
         return completionHandler();
-    m_systemPreviewController->begin(url, topOrigin, systemPreviewInfo, WTFMove(completionHandler));
+    systemPreviewController->begin(url, topOrigin, systemPreviewInfo, WTFMove(completionHandler));
 }
 
 void WebPageProxy::setSystemPreviewCompletionHandlerForLoadTesting(CompletionHandler<void(bool)>&& handler)
 {
-    if (m_systemPreviewController)
-        m_systemPreviewController->setCompletionHandlerForLoadTesting(WTFMove(handler));
+    if (RefPtr systemPreviewController = m_systemPreviewController)
+        systemPreviewController->setCompletionHandlerForLoadTesting(WTFMove(handler));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3294,7 +3294,7 @@ private:
 #endif
 
 #if USE(SYSTEM_PREVIEW)
-    std::unique_ptr<SystemPreviewController> m_systemPreviewController;
+    RefPtr<SystemPreviewController> m_systemPreviewController;
 #endif
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)


### PR DESCRIPTION
#### a3e331da617996e0447846e773373650e739076c
<pre>
SystemPreviewController should be ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281547">https://bugs.webkit.org/show_bug.cgi?id=281547</a>

Reviewed by Chris Dumez and Geoffrey Garen.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/SystemPreviewController.cpp:
(WebKit::SystemPreviewController::create):
* Source/WebKit/UIProcess/SystemPreviewController.h:
(WebKit::SystemPreviewController::page):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::beginSystemPreview):
(WebKit::WebPageProxy::setSystemPreviewCompletionHandlerForLoadTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/285281@main">https://commits.webkit.org/285281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c61cfd5cd36e56594c1a60f5bcad1ccbcaccc3d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23223 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43297 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77856 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64550 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6385 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11063 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2016 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->