### PR TITLE
Crash under ValidationBubble::showRelativeTo() when the view doesn't have a window

### DIFF
--- a/Source/WebCore/platform/mac/ValidationBubbleMac.mm
+++ b/Source/WebCore/platform/mac/ValidationBubbleMac.mm
@@ -86,6 +86,10 @@ ValidationBubble::~ValidationBubble()
 
 void ValidationBubble::showRelativeTo(const IntRect& anchorRect)
 {
+    // Passing an unparented view to [m_popover showRelativeToRect:ofView:preferredEdge:] crashes.
+    if (![m_view window])
+        return;
+
     NSRect rect = NSMakeRect(anchorRect.x(), anchorRect.y(), anchorRect.width(), anchorRect.height());
     [m_popover showRelativeToRect:rect ofView:m_view preferredEdge:NSMinYEdge];
 }

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -157,6 +157,7 @@ struct AutocorrectionContext {
 - (void)collapseToStart;
 - (void)collapseToEnd;
 - (void)addToTestWindow;
+- (void)removeFromTestWindow;
 - (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end;
 - (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end inFrame:(WKFrameInfo *)frameInfo;
 - (void)clickOnElementID:(NSString *)elementID;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -924,6 +924,12 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 #endif
 }
 
+- (void)removeFromTestWindow
+{
+    if (_hostWindow)
+        [self removeFromSuperview];
+}
+
 - (void)clearMessageHandlers:(NSArray *)messageNames
 {
     for (NSString *messageName in messageNames)


### PR DESCRIPTION
#### c78fd3d92bca9e0ec3db940fac259fbfc660c230
<pre>
Crash under ValidationBubble::showRelativeTo() when the view doesn&apos;t have a window
<a href="https://bugs.webkit.org/show_bug.cgi?id=281551">https://bugs.webkit.org/show_bug.cgi?id=281551</a>
<a href="https://rdar.apple.com/137514579">rdar://137514579</a>

Reviewed by Wenson Hsieh.

Passing a view that isn&apos;t part of a window to `[NSPopover showRelativeTo:]` crashes.
However, this can happen if the user quickly switches to another tab as form validation
is happening. We now early return if the view no longer has a window when
ValidationBubble::showRelativeTo() gets called.

* Source/WebCore/platform/mac/ValidationBubbleMac.mm:
(WebCore::ValidationBubble::showRelativeTo):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm:
(TEST(FormValidation, PresentingFormValidationUIWithoutViewControllerDoesNotCrash)):
(TEST(FormValidation, FormValidationOnUnparentedWindowDoesNotCrash)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView removeFromTestWindow]):

Canonical link: <a href="https://commits.webkit.org/285264@main">https://commits.webkit.org/285264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a81381dbd29c8f177df30ed7eb16222947c022

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15291 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65279 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64528 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6358 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1980 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->