### PR TITLE
Implement Observable#first

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL first(): Promise resolves with the first value from the source Observable promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
-FAIL first(): Promise rejects with the error emitted from the source Observable assert_equals: Promise rejects with source Observable error expected object "Error: error from source" but got object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
-FAIL first(): Promise rejects with RangeError when source Observable completes without emitting any values assert_true: Upon complete(), first() Promise rejects with RangeError expected true got false
-FAIL first(): Aborting a signal rejects the Promise with an AbortError DOMException promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first({ signal: controller.signal })', 'source.first' is undefined)"
-FAIL first(): Lifecycle promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
+PASS first(): Promise resolves with the first value from the source Observable
+PASS first(): Promise rejects with the error emitted from the source Observable
+PASS first(): Promise rejects with RangeError when source Observable completes without emitting any values
+PASS first(): Aborting a signal rejects the Promise with an AbortError DOMException
+PASS first(): Lifecycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.js
@@ -19,41 +19,25 @@ promise_test(async () => {
       "Promise resolves with the first value from the source Observable");
 }, "first(): Promise resolves with the first value from the source Observable");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const error = new Error("error from source");
   const source = new Observable(subscriber => {
     subscriber.error(error);
   });
 
-  let rejection;
-  try {
-    await source.first();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_equals(rejection, error, "Promise rejects with source Observable error");
+  return promise_rejects_exactly(t, error, source.first(), "Promise rejects with source Observable error");
 }, "first(): Promise rejects with the error emitted from the source Observable");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {
     subscriber.complete();
   });
 
-  let rejection;
-  try {
-    await source.first();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof RangeError,
-      "Upon complete(), first() Promise rejects with RangeError");
-  assert_equals(rejection.message, "No values in Observable");
+  return promise_rejects_js(t, RangeError, source.first(), "Upon complete(), first() Promise rejects with RangeError");
 }, "first(): Promise rejects with RangeError when source Observable " +
    "completes without emitting any values");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {});
 
   const controller = new AbortController();
@@ -61,18 +45,7 @@ promise_test(async () => {
 
   controller.abort();
 
-  let rejection;
-  try {
-    await promise;
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof DOMException,
-      "Promise rejects with a DOMException for abortion");
-  assert_equals(rejection.name, "AbortError",
-      "Rejected with 'AbortError' DOMException");
-  assert_equals(rejection.message, "signal is aborted without reason");
+  return promise_rejects_dom(t, "AbortError", promise, "Promise rejects with a DOMException for abortion");
 }, "first(): Aborting a signal rejects the Promise with an AbortError DOMException");
 
 promise_test(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL first(): Promise resolves with the first value from the source Observable promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
-FAIL first(): Promise rejects with the error emitted from the source Observable assert_equals: Promise rejects with source Observable error expected object "Error: error from source" but got object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
-FAIL first(): Promise rejects with RangeError when source Observable completes without emitting any values assert_true: Upon complete(), first() Promise rejects with RangeError expected true got false
-FAIL first(): Aborting a signal rejects the Promise with an AbortError DOMException promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first({ signal: controller.signal })', 'source.first' is undefined)"
-FAIL first(): Lifecycle promise_test: Unhandled rejection with value: object "TypeError: source.first is not a function. (In 'source.first()', 'source.first' is undefined)"
+PASS first(): Promise resolves with the first value from the source Observable
+PASS first(): Promise rejects with the error emitted from the source Observable
+PASS first(): Promise rejects with RangeError when source Observable completes without emitting any values
+PASS first(): Aborting a signal rejects the Promise with an AbortError DOMException
+PASS first(): Lifecycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js
@@ -12,41 +12,25 @@ promise_test(async () => {
   assert_equals(value, 2);
 }, "last(): Promise resolves to last value");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const error = new Error("error from source");
   const source = new Observable(subscriber => {
     subscriber.error(error);
   });
 
-  let rejection = null;
-  try {
-    await source.last();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_equals(rejection, error);
+  return promise_rejects_exactly(t, error, source.last());
 }, "last(): Promise rejects with emitted error");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {
     subscriber.complete();
   });
 
-  let rejection = null;
-  try {
-    await source.last();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof RangeError,
-      "Promise rejects with RangeError");
-  assert_equals(rejection.message, "No values in Observable");
+  return promise_rejects_js(t, RangeError, source.last());
 }, "last(): Promise rejects with RangeError when source Observable " +
    "completes without emitting any values");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {});
 
   const controller = new AbortController();
@@ -54,17 +38,7 @@ promise_test(async () => {
 
   controller.abort();
 
-  let rejection = null;
-  try {
-    await promise;
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof DOMException,
-      "Promise rejects with a DOMException for abortion");
-  assert_equals(rejection.name, "AbortError",
-      "Rejected with 'AbortError' DOMException");
+  return promise_rejects_dom(t, "AbortError", promise, "Promise rejects with a DOMException for abortion");
 }, "last(): Aborting a signal rejects the Promise with an AbortError DOMException");
 
 promise_test(async () => {

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1228,6 +1228,7 @@ dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverDrop.cpp
 dom/InternalObserverFilter.cpp
+dom/InternalObserverFirst.cpp
 dom/InternalObserverFromScript.cpp
 dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -1,0 +1,114 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverFirst.h"
+
+#include "AbortController.h"
+#include "AbortSignal.h"
+#include "Exception.h"
+#include "ExceptionCode.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverFirst final : public InternalObserver {
+public:
+    static Ref<InternalObserverFirst> create(ScriptExecutionContext& context, Ref<AbortController>&& controller, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverFirst(context, WTFMove(controller), WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref { m_promise }->resolve<IDLAny>(value);
+        Ref { m_controller }->abort(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), JSC::jsUndefined());
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        Ref { m_promise }->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        Ref { m_promise }->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
+    {
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor&) const final
+    {
+    }
+
+    InternalObserverFirst(ScriptExecutionContext& context, Ref<AbortController>&& controller, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_controller(WTFMove(controller))
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    Ref<AbortController> m_controller;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorFirst(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref controller = AbortController::create(context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { controller->protectedSignal() };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverFirst::create(context, WTFMove(controller), WTFMove(promise));
+
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFirst.h
+++ b/Source/WebCore/dom/InternalObserverFirst.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorFirst(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverLast.h
+++ b/Source/WebCore/dom/InternalObserverLast.h
@@ -34,6 +34,6 @@ class Observable;
 class ScriptExecutionContext;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorLast(ScriptExecutionContext&, Ref<Observable>, SubscribeOptions, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorLast(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -52,7 +52,7 @@ public:
     explicit Observable(Ref<SubscriberCallback>);
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
-    void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>, SubscribeOptions);
+    void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);
 
     Ref<Observable> map(ScriptExecutionContext&, MapperCallback&);
 
@@ -64,7 +64,8 @@ public:
 
     // Promise-returning operators.
 
-    void last(ScriptExecutionContext&, SubscribeOptions, Ref<DeferredPromise>&&);
+    void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -44,5 +44,6 @@ interface Observable {
 
   // Promise-returning operators.
 
+  [CallWith=CurrentScriptExecutionContext] Promise<any> first(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
 };

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -36,17 +36,20 @@
 
 namespace WebCore {
 
-Ref<Subscriber> Subscriber::create(ScriptExecutionContext& context, Ref<InternalObserver> observer)
+Ref<Subscriber> Subscriber::create(ScriptExecutionContext& context, Ref<InternalObserver>&& observer, const SubscribeOptions& options)
 {
-    return adoptRef(*new Subscriber(context, observer));
+    return adoptRef(*new Subscriber(context, WTFMove(observer), options));
 }
 
-Subscriber::Subscriber(ScriptExecutionContext& context, Ref<InternalObserver> observer)
+Subscriber::Subscriber(ScriptExecutionContext& context, Ref<InternalObserver>&& observer, const SubscribeOptions& options)
     : ActiveDOMObject(&context)
     , m_abortController(AbortController::create(context))
     , m_observer(observer)
+    , m_options(options)
 {
     followSignal(m_abortController->signal());
+    if (RefPtr signal = options.signal)
+        followSignal(*signal);
     suspendIfNeeded();
 }
 


### PR DESCRIPTION
#### f3f3afde18272fdabcd5901b755b47bef3b77da2
<pre>
Implement Observable#first
<a href="https://bugs.webkit.org/show_bug.cgi?id=277509">https://bugs.webkit.org/show_bug.cgi?id=277509</a>

Reviewed by Chris Dumez and Darin Adler.

This change introduces the `.first` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-first">https://wicg.github.io/observable/#dom-observable-first</a>

Because promise-returning operators subscribe immediatly in the runtime,
as opposed to user-land. We made a change to the Subscriber class to
now hold a reference to it&apos;s options, specifically any AbortSignals.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.js:
  AbortErrors&apos; description text is not normative,
   as such do not assert against it.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::first): Added.
(WebCore::Observable::subscribeInternal):
  Move the abort signal following logic inside the Subscriber class.
* Source/WebCore/dom/Observable.idl:
  Exposes `Promise&lt;any&gt; first(options)` as a promise-returning operator.
* Source/WebCore/dom/Subscriber.h:
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::create):
(WebCore::Subscriber::Subscriber):
  When a subscriber is created, it should own the options for the
  lifetime of the subscriber.
* Source/WebCore/dom/InternalObserverLast.cpp:
  Addressed diff feedback for `.first` in here as well.
* Source/WebCore/dom/InternalObserverLast.h:
* Source/WebCore/dom/InternalObserverFirst.cpp: Added.
(WebCore::createInternalObserverOperatorFirst):
* Source/WebCore/dom/InternalObserverFirst.h: Added.

Canonical link: <a href="https://commits.webkit.org/285650@main">https://commits.webkit.org/285650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8261a85c17bcd5fbbc3f55575b19766f869db7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75498 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/61971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16103 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76450 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/61971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38062 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/61971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22950 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/61971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/698 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/201 "Found 1 new test failure: http/tests/paymentrequest/payment-response-payerPhone-attribute.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7366 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3399 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->