### PR TITLE
Make Style::BuilderState 'const' in more places

### DIFF
--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -55,7 +55,7 @@ Ref<ViewTimeline> ViewTimeline::create(const AtomString& name, ScrollAxis axis, 
     return adoptRef(*new ViewTimeline(name, axis, WTFMove(insets)));
 }
 
-Ref<ViewTimeline> ViewTimeline::createFromCSSValue(Style::BuilderState& builderState, const CSSViewValue& cssViewValue)
+Ref<ViewTimeline> ViewTimeline::createFromCSSValue(const Style::BuilderState& builderState, const CSSViewValue& cssViewValue)
 {
     auto axisValue = cssViewValue.axis();
     auto axis = axisValue ? fromCSSValueID<ScrollAxis>(axisValue->valueID()) : ScrollAxis::Block;

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -51,7 +51,7 @@ class ViewTimeline final : public ScrollTimeline {
 public:
     static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
-    static Ref<ViewTimeline> createFromCSSValue(Style::BuilderState&, const CSSViewValue&);
+    static Ref<ViewTimeline> createFromCSSValue(const Style::BuilderState&, const CSSViewValue&);
 
     Element* subject() const { return m_subject.get(); }
     const CSSNumericValue& startOffset();

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -49,7 +49,7 @@ bool CSSCanvasValue::equals(const CSSCanvasValue& other) const
     return m_name == other.m_name;
 }
 
-RefPtr<StyleImage> CSSCanvasValue::createStyleImage(Style::BuilderState&) const
+RefPtr<StyleImage> CSSCanvasValue::createStyleImage(const Style::BuilderState&) const
 {
     if (m_cachedStyleImage)
         return m_cachedStyleImage;

--- a/Source/WebCore/css/CSSCanvasValue.h
+++ b/Source/WebCore/css/CSSCanvasValue.h
@@ -44,7 +44,7 @@ public:
     String customCSSText() const;
     bool equals(const CSSCanvasValue&) const;
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
     explicit CSSCanvasValue(String&&);

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -64,7 +64,7 @@ String CSSCrossfadeValue::customCSSText() const
     return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(), ", "_s, m_toValueOrNone->cssText(), ", "_s, m_percentageValue->cssText(), ')');
 }
 
-RefPtr<StyleImage> CSSCrossfadeValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleImage> CSSCrossfadeValue::createStyleImage(const Style::BuilderState& state) const
 {
     return StyleCrossfadeImage::create(
         state.createStyleImage(m_fromValueOrNone),

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -49,7 +49,7 @@ public:
     String customCSSText() const;
     bool isPrefixed() const { return m_isPrefixed; }
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -74,7 +74,7 @@ bool CSSCursorImageValue::equals(const CSSCursorImageValue& other) const
         && compareCSSValuePtr(m_hotSpot, other.m_hotSpot);
 }
 
-RefPtr<StyleCursorImage> CSSCursorImageValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleCursorImage> CSSCursorImageValue::createStyleImage(const Style::BuilderState& state) const
 {
     auto styleImage = state.createStyleImage(m_imageValue.get());
     if (!styleImage)

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -50,7 +50,7 @@ public:
         return func(m_imageValue.get());
     }
 
-    RefPtr<StyleCursorImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleCursorImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
     CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, URL, LoadedFromOpaqueSource);

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -58,7 +58,7 @@ String CSSFilterImageValue::customCSSText() const
     return makeString("filter("_s, m_imageValueOrNone->cssText(), ", "_s, m_filterValue->cssText(), ')');
 }
 
-RefPtr<StyleImage> CSSFilterImageValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleImage> CSSFilterImageValue::createStyleImage(const Style::BuilderState& state) const
 {
     return StyleFilterImage::create(state.createStyleImage(m_imageValueOrNone), state.createFilterOperations(m_filterValue));
 }

--- a/Source/WebCore/css/CSSFilterImageValue.h
+++ b/Source/WebCore/css/CSSFilterImageValue.h
@@ -51,7 +51,7 @@ public:
 
     String customCSSText() const;
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -131,7 +131,7 @@ template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct StyleImag
 
 // MARK: -
 
-RefPtr<StyleImage> CSSGradientValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleImage> CSSGradientValue::createStyleImage(const Style::BuilderState& state) const
 {
     if (m_cachedStyleImage)
         return m_cachedStyleImage;

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -43,7 +43,7 @@ public:
 
     String customCSSText() const;
     bool equals(const CSSGradientValue&) const;
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -60,7 +60,7 @@ String CSSImageSetValue::customCSSText() const
     return result.toString();
 }
 
-RefPtr<StyleImage> CSSImageSetValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleImage> CSSImageSetValue::createStyleImage(const Style::BuilderState& state) const
 {
     size_t length = this->length();
 

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -42,7 +42,7 @@ public:
     String customCSSText() const;
     bool equals(const CSSImageSetValue& other) const { return itemsEqual(other); }
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
     explicit CSSImageSetValue(CSSValueListBuilder);

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -85,7 +85,7 @@ URL CSSImageValue::reresolvedURL(const Document& document) const
     return document.completeURL(m_location.resolvedURL.string());
 }
 
-RefPtr<StyleImage> CSSImageValue::createStyleImage(Style::BuilderState& state) const
+RefPtr<StyleImage> CSSImageValue::createStyleImage(const Style::BuilderState& state) const
 {
     auto location = makeResolvedURL(reresolvedURL(state.document()));
     if (m_location == location)

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -69,7 +69,7 @@ public:
 
     bool knownToBeOpaque(const RenderElement&) const;
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
     bool isLoadedFromOpaqueSource() const { return m_loadedFromOpaqueSource == LoadedFromOpaqueSource::Yes; }
 

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -49,7 +49,7 @@ bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const
     return m_name == other.m_name;
 }
 
-RefPtr<StyleImage> CSSNamedImageValue::createStyleImage(Style::BuilderState&) const
+RefPtr<StyleImage> CSSNamedImageValue::createStyleImage(const Style::BuilderState&) const
 {
     if (m_cachedStyleImage)
         return m_cachedStyleImage;

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -47,7 +47,7 @@ public:
     String customCSSText() const;
     bool equals(const CSSNamedImageValue&) const;
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
     explicit CSSNamedImageValue(String&&);

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -49,7 +49,7 @@ String CSSPaintImageValue::customCSSText() const
     return makeString("paint("_s, m_name, ')');
 }
 
-RefPtr<StyleImage> CSSPaintImageValue::createStyleImage(Style::BuilderState&) const
+RefPtr<StyleImage> CSSPaintImageValue::createStyleImage(const Style::BuilderState&) const
 {
     return StylePaintImage::create(m_name, m_arguments);
 }

--- a/Source/WebCore/css/CSSPaintImageValue.h
+++ b/Source/WebCore/css/CSSPaintImageValue.h
@@ -51,7 +51,7 @@ public:
     bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
     String customCSSText() const;
 
-    RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+    RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
     explicit CSSPaintImageValue(String&&, Ref<CSSVariableData>&&);

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -64,17 +64,12 @@ static bool treatAsInitialValue(const CSSValue& value, CSSPropertyID propertyID)
     }
 }
 
-CSSToStyleMap::CSSToStyleMap(Style::BuilderState& builderState)
+CSSToStyleMap::CSSToStyleMap(const Style::BuilderState& builderState)
     : m_builderState(builderState)
 {
 }
 
-RenderStyle* CSSToStyleMap::style() const
-{
-    return &m_builderState.style();
-}
-
-RefPtr<StyleImage> CSSToStyleMap::styleImage(const CSSValue& value)
+RefPtr<StyleImage> CSSToStyleMap::styleImage(const CSSValue& value) const
 {
     return m_builderState.createStyleImage(value);
 }
@@ -156,7 +151,7 @@ void CSSToStyleMap::mapFillOrigin(CSSPropertyID propertyID, FillLayer& layer, co
     layer.setOrigin(fromCSSValue<FillBox>(value));
 }
 
-void CSSToStyleMap::mapFillImage(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
+void CSSToStyleMap::mapFillImage(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, propertyID)) {
         layer.setImage(FillLayer::initialFillImage(layer.type()));
@@ -192,7 +187,7 @@ static inline bool convertToLengthSize(const CSSValue& value, const CSSToLengthC
     return !size.width.isUndefined() && !size.height.isUndefined();
 }
 
-void CSSToStyleMap::mapFillSize(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
+void CSSToStyleMap::mapFillSize(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, propertyID)) {
         layer.setSize(FillLayer::initialFillSize(layer.type()));
@@ -216,7 +211,7 @@ void CSSToStyleMap::mapFillSize(CSSPropertyID propertyID, FillLayer& layer, cons
     layer.setSize(fillSize);
 }
 
-void CSSToStyleMap::mapFillXPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
+void CSSToStyleMap::mapFillXPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, propertyID)) {
         layer.setXPosition(FillLayer::initialFillXPosition(layer.type()));
@@ -235,7 +230,7 @@ void CSSToStyleMap::mapFillXPosition(CSSPropertyID propertyID, FillLayer& layer,
         layer.setBackgroundXOrigin(fromCSSValue<Edge>(value.first()));
 }
 
-void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
+void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, propertyID)) {
         layer.setYPosition(FillLayer::initialFillYPosition(layer.type()));
@@ -285,7 +280,7 @@ void CSSToStyleMap::mapFillMaskMode(CSSPropertyID propertyID, FillLayer& layer, 
     layer.setMaskMode(maskMode);
 }
 
-void CSSToStyleMap::mapAnimationDelay(Animation& animation, const CSSValue& value)
+void CSSToStyleMap::mapAnimationDelay(Animation& animation, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationDelay)) {
         animation.setDelay(Animation::initialDelay());
@@ -327,7 +322,7 @@ void CSSToStyleMap::mapAnimationDirection(Animation& layer, const CSSValue& valu
     }
 }
 
-void CSSToStyleMap::mapAnimationDuration(Animation& animation, const CSSValue& value)
+void CSSToStyleMap::mapAnimationDuration(Animation& animation, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationDuration)) {
         animation.setDuration(Animation::initialDuration());
@@ -375,7 +370,7 @@ void CSSToStyleMap::mapAnimationFillMode(Animation& layer, const CSSValue& value
     }
 }
 
-void CSSToStyleMap::mapAnimationIterationCount(Animation& animation, const CSSValue& value)
+void CSSToStyleMap::mapAnimationIterationCount(Animation& animation, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationIterationCount)) {
         animation.setIterationCount(Animation::initialIterationCount());
@@ -392,7 +387,7 @@ void CSSToStyleMap::mapAnimationIterationCount(Animation& animation, const CSSVa
         animation.setIterationCount(primitiveValue->resolveAsNumber<float>(m_builderState.cssToLengthConversionData()));
 }
 
-void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value)
+void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationName)) {
         layer.setName(Animation::initialName());
@@ -452,7 +447,7 @@ void CSSToStyleMap::mapAnimationProperty(Animation& animation, const CSSValue& v
     animation.setProperty({ Animation::TransitionMode::SingleProperty, primitiveValue->propertyID() });
 }
 
-void CSSToStyleMap::mapAnimationTimeline(Animation& animation, const CSSValue& value)
+void CSSToStyleMap::mapAnimationTimeline(Animation& animation, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationTimeline))
         animation.setTimeline(Animation::initialTimeline());
@@ -477,7 +472,7 @@ void CSSToStyleMap::mapAnimationTimeline(Animation& animation, const CSSValue& v
     }
 }
 
-void CSSToStyleMap::mapAnimationTimingFunction(Animation& animation, const CSSValue& value)
+void CSSToStyleMap::mapAnimationTimingFunction(Animation& animation, const CSSValue& value) const
 {
     if (treatAsInitialValue(value, CSSPropertyAnimationTimingFunction))
         animation.setTimingFunction(Animation::initialTimingFunction());
@@ -501,7 +496,7 @@ void CSSToStyleMap::mapAnimationAllowsDiscreteTransitions(Animation& layer, cons
         layer.setAllowsDiscreteTransitions(value.valueID() == CSSValueAllowDiscrete);
 }
 
-void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& image)
+void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& image) const
 {
     // If we're not a value list, then we are "none" and don't need to alter the empty image at all.
     auto* borderImage = dynamicDowncast<CSSValueList>(value);
@@ -533,13 +528,13 @@ void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& ima
     }
 }
 
-void CSSToStyleMap::mapNinePieceImageSlice(const CSSValue& value, NinePieceImage& image)
+void CSSToStyleMap::mapNinePieceImageSlice(const CSSValue& value, NinePieceImage& image) const
 {
     if (auto* sliceValue = dynamicDowncast<CSSBorderImageSliceValue>(value))
         mapNinePieceImageSlice(*sliceValue, image);
 }
 
-void CSSToStyleMap::mapNinePieceImageSlice(const CSSBorderImageSliceValue& value, NinePieceImage& image)
+void CSSToStyleMap::mapNinePieceImageSlice(const CSSBorderImageSliceValue& value, NinePieceImage& image) const
 {
     // Set up a length box to represent our image slices.
     auto& conversionData = m_builderState.cssToLengthConversionData();
@@ -560,13 +555,13 @@ void CSSToStyleMap::mapNinePieceImageSlice(const CSSBorderImageSliceValue& value
     image.setFill(value.fill());
 }
 
-void CSSToStyleMap::mapNinePieceImageWidth(const CSSValue& value, NinePieceImage& image)
+void CSSToStyleMap::mapNinePieceImageWidth(const CSSValue& value, NinePieceImage& image) const
 {
     if (auto* widthValue = dynamicDowncast<CSSBorderImageWidthValue>(value))
         mapNinePieceImageWidth(*widthValue, image);
 }
 
-void CSSToStyleMap::mapNinePieceImageWidth(const CSSBorderImageWidthValue& value, NinePieceImage& image)
+void CSSToStyleMap::mapNinePieceImageWidth(const CSSBorderImageWidthValue& value, NinePieceImage& image) const
 {
     if (!is<CSSBorderImageWidthValue>(value))
         return;
@@ -575,7 +570,7 @@ void CSSToStyleMap::mapNinePieceImageWidth(const CSSBorderImageWidthValue& value
     image.setOverridesBorderWidths(value.overridesBorderWidths());
 }
 
-LengthBox CSSToStyleMap::mapNinePieceImageQuad(const CSSValue& value)
+LengthBox CSSToStyleMap::mapNinePieceImageQuad(const CSSValue& value) const
 {
     if (LIKELY(value.isQuad()))
         return mapNinePieceImageQuad(value.quad());
@@ -590,7 +585,7 @@ LengthBox CSSToStyleMap::mapNinePieceImageQuad(const CSSValue& value)
     return { Length { side }, Length { side }, Length { side }, Length { side } };
 }
 
-Length CSSToStyleMap::mapNinePieceImageSide(const CSSValue& side)
+Length CSSToStyleMap::mapNinePieceImageSide(const CSSValue& side) const
 {
     auto& value = downcast<CSSPrimitiveValue>(side);
     if (value.valueID() == CSSValueAuto)
@@ -605,7 +600,7 @@ Length CSSToStyleMap::mapNinePieceImageSide(const CSSValue& side)
     return { value.resolveAsLength<Length>(conversionData) };
 }
 
-LengthBox CSSToStyleMap::mapNinePieceImageQuad(const Quad& quad)
+LengthBox CSSToStyleMap::mapNinePieceImageQuad(const Quad& quad) const
 {
     auto side = [&](const CSSValue& value) {
         return mapNinePieceImageSide(value);

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -46,48 +46,47 @@ class BuilderState;
 
 class CSSToStyleMap {
 public:
-    explicit CSSToStyleMap(Style::BuilderState&);
+    explicit CSSToStyleMap(const Style::BuilderState&);
 
     static void mapFillAttachment(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillClip(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillComposite(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillBlendMode(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillOrigin(CSSPropertyID, FillLayer&, const CSSValue&);
-    void mapFillImage(CSSPropertyID, FillLayer&, const CSSValue&);
+    void mapFillImage(CSSPropertyID, FillLayer&, const CSSValue&) const;
     static void mapFillRepeat(CSSPropertyID, FillLayer&, const CSSValue&);
-    void mapFillSize(CSSPropertyID, FillLayer&, const CSSValue&);
-    void mapFillXPosition(CSSPropertyID, FillLayer&, const CSSValue&);
-    void mapFillYPosition(CSSPropertyID, FillLayer&, const CSSValue&);
+    void mapFillSize(CSSPropertyID, FillLayer&, const CSSValue&) const;
+    void mapFillXPosition(CSSPropertyID, FillLayer&, const CSSValue&) const;
+    void mapFillYPosition(CSSPropertyID, FillLayer&, const CSSValue&) const;
     static void mapFillMaskMode(CSSPropertyID, FillLayer&, const CSSValue&);
 
-    void mapAnimationDelay(Animation&, const CSSValue&);
+    void mapAnimationDelay(Animation&, const CSSValue&) const;
     static void mapAnimationDirection(Animation&, const CSSValue&);
-    void mapAnimationDuration(Animation&, const CSSValue&);
+    void mapAnimationDuration(Animation&, const CSSValue&) const;
     static void mapAnimationFillMode(Animation&, const CSSValue&);
-    void mapAnimationIterationCount(Animation&, const CSSValue&);
-    void mapAnimationName(Animation&, const CSSValue&);
+    void mapAnimationIterationCount(Animation&, const CSSValue&) const;
+    void mapAnimationName(Animation&, const CSSValue&) const;
     static void mapAnimationPlayState(Animation&, const CSSValue&);
     static void mapAnimationProperty(Animation&, const CSSValue&);
-    void mapAnimationTimeline(Animation&, const CSSValue&);
-    void mapAnimationTimingFunction(Animation&, const CSSValue&);
+    void mapAnimationTimeline(Animation&, const CSSValue&) const;
+    void mapAnimationTimingFunction(Animation&, const CSSValue&) const;
     static void mapAnimationCompositeOperation(Animation&, const CSSValue&);
     static void mapAnimationAllowsDiscreteTransitions(Animation&, const CSSValue&);
 
-    void mapNinePieceImage(const CSSValue*, NinePieceImage&);
-    void mapNinePieceImageSlice(const CSSValue&, NinePieceImage&);
-    void mapNinePieceImageSlice(const CSSBorderImageSliceValue&, NinePieceImage&);
-    void mapNinePieceImageWidth(const CSSValue&, NinePieceImage&);
-    void mapNinePieceImageWidth(const CSSBorderImageWidthValue&, NinePieceImage&);
-    LengthBox mapNinePieceImageQuad(const CSSValue&);
+    void mapNinePieceImage(const CSSValue*, NinePieceImage&) const;
+    void mapNinePieceImageSlice(const CSSValue&, NinePieceImage&) const;
+    void mapNinePieceImageSlice(const CSSBorderImageSliceValue&, NinePieceImage&) const;
+    void mapNinePieceImageWidth(const CSSValue&, NinePieceImage&) const;
+    void mapNinePieceImageWidth(const CSSBorderImageWidthValue&, NinePieceImage&) const;
+    LengthBox mapNinePieceImageQuad(const CSSValue&) const;
     static void mapNinePieceImageRepeat(const CSSValue&, NinePieceImage&);
 
 private:
-    RenderStyle* style() const;
-    RefPtr<StyleImage> styleImage(const CSSValue&);
-    LengthBox mapNinePieceImageQuad(const Quad&);
-    Length mapNinePieceImageSide(const CSSValue&);
+    RefPtr<StyleImage> styleImage(const CSSValue&) const;
+    LengthBox mapNinePieceImageQuad(const Quad&) const;
+    Length mapNinePieceImageSide(const CSSValue&) const;
 
-    Style::BuilderState& m_builderState;
+    const Style::BuilderState& m_builderState;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -101,168 +101,168 @@ public:
     static WebCore::Length convertLengthSizing(const BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthMaxSizing(const BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthAllowingNumber(const BuilderState&, const CSSValue&); // Assumes unit is 'px' if input is a number.
-    static WebCore::Length convertTextLengthOrNormal(BuilderState&, const CSSValue&); // Converts length by text zoom factor, normal to zero
+    static WebCore::Length convertTextLengthOrNormal(const BuilderState&, const CSSValue&); // Converts length by text zoom factor, normal to zero
     static TabSize convertTabSize(const BuilderState&, const CSSValue&);
-    template<typename T> static T convertComputedLength(BuilderState&, const CSSValue&);
-    template<typename T> static T convertLineWidth(BuilderState&, const CSSValue&);
-    static LengthSize convertRadius(BuilderState&, const CSSValue&);
-    static LengthPoint convertPosition(BuilderState&, const CSSValue&);
-    static LengthPoint convertPositionOrAuto(BuilderState&, const CSSValue&);
-    static LengthPoint convertPositionOrAutoOrNormal(BuilderState&, const CSSValue&);
-    static OptionSet<TextDecorationLine> convertTextDecorationLine(BuilderState&, const CSSValue&);
-    static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
-    template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
-    template<typename T> static T convertNumberOrAuto(BuilderState&, const CSSValue&);
-    static short convertWebkitHyphenateLimitLines(BuilderState&, const CSSValue&);
-    template<CSSPropertyID> static RefPtr<StyleImage> convertStyleImage(BuilderState&, CSSValue&);
-    static ImageOrientation convertImageOrientation(BuilderState&, const CSSValue&);
-    static TransformOperations convertTransform(BuilderState&, const CSSValue&);
-    static RefPtr<RotateTransformOperation> convertRotate(BuilderState&, const CSSValue&);
-    static RefPtr<ScaleTransformOperation> convertScale(BuilderState&, const CSSValue&);
-    static RefPtr<TranslateTransformOperation> convertTranslate(BuilderState&, const CSSValue&);
+    template<typename T> static T convertComputedLength(const BuilderState&, const CSSValue&);
+    template<typename T> static T convertLineWidth(const BuilderState&, const CSSValue&);
+    static LengthSize convertRadius(const BuilderState&, const CSSValue&);
+    static LengthPoint convertPosition(const BuilderState&, const CSSValue&);
+    static LengthPoint convertPositionOrAuto(const BuilderState&, const CSSValue&);
+    static LengthPoint convertPositionOrAutoOrNormal(const BuilderState&, const CSSValue&);
+    static OptionSet<TextDecorationLine> convertTextDecorationLine(const BuilderState&, const CSSValue&);
+    static OptionSet<TextTransform> convertTextTransform(const BuilderState&, const CSSValue&);
+    template<typename T> static T convertNumber(const BuilderState&, const CSSValue&);
+    template<typename T> static T convertNumberOrAuto(const BuilderState&, const CSSValue&);
+    static short convertWebkitHyphenateLimitLines(const BuilderState&, const CSSValue&);
+    template<CSSPropertyID> static RefPtr<StyleImage> convertStyleImage(const BuilderState&, CSSValue&);
+    static ImageOrientation convertImageOrientation(const BuilderState&, const CSSValue&);
+    static TransformOperations convertTransform(const BuilderState&, const CSSValue&);
+    static RefPtr<RotateTransformOperation> convertRotate(const BuilderState&, const CSSValue&);
+    static RefPtr<ScaleTransformOperation> convertScale(const BuilderState&, const CSSValue&);
+    static RefPtr<TranslateTransformOperation> convertTranslate(const BuilderState&, const CSSValue&);
 #if ENABLE(DARK_MODE_CSS)
-    static StyleColorScheme convertColorScheme(BuilderState&, const CSSValue&);
+    static StyleColorScheme convertColorScheme(const BuilderState&, const CSSValue&);
 #endif
-    static String convertString(BuilderState&, const CSSValue&);
-    static String convertStringOrAuto(BuilderState&, const CSSValue&);
-    static AtomString convertStringOrAutoAtom(BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrAuto(state, value) }; }
-    static String convertStringOrNone(BuilderState&, const CSSValue&);
-    static AtomString convertStringOrNoneAtom(BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrNone(state, value) }; }
-    static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(BuilderState&, const CSSValue&);
-    static TextAlignMode convertTextAlign(BuilderState&, const CSSValue&);
-    static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
-    static RefPtr<BasicShapePath> convertSVGPath(BuilderState&, const CSSValue&);
-    static RefPtr<PathOperation> convertPathOperation(BuilderState&, const CSSValue&);
-    static RefPtr<PathOperation> convertRayPathOperation(BuilderState&, const CSSValue&);
-    static Resize convertResize(BuilderState&, const CSSValue&);
-    static int convertMarqueeRepetition(BuilderState&, const CSSValue&);
-    static int convertMarqueeSpeed(BuilderState&, const CSSValue&);
-    static RefPtr<QuotesData> convertQuotes(BuilderState&, const CSSValue&);
-    static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
-    static TextUnderlineOffset convertTextUnderlineOffset(BuilderState&, const CSSValue&);
-    static TextDecorationThickness convertTextDecorationThickness(BuilderState&, const CSSValue&);
-    static RefPtr<StyleReflection> convertReflection(BuilderState&, const CSSValue&);
-    static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
-    static IntSize convertInitialLetter(BuilderState&, const CSSValue&);
-    static float convertTextStrokeWidth(BuilderState&, const CSSValue&);
-    static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
-    static RefPtr<ShapeValue> convertShapeValue(BuilderState&, CSSValue&);
-    static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
-    static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
-    static ScrollSnapStop convertScrollSnapStop(BuilderState&, const CSSValue&);
-    static std::optional<ScrollbarColor> convertScrollbarColor(BuilderState&, const CSSValue&);
-    static ScrollbarGutter convertScrollbarGutter(BuilderState&, const CSSValue&);
-    static GridTrackSize convertGridTrackSize(BuilderState&, const CSSValue&);
-    static Vector<GridTrackSize> convertGridTrackSizeList(BuilderState&, const CSSValue&);
-    static std::optional<GridTrackList> convertGridTrackList(BuilderState&, const CSSValue&);
-    static GridPosition convertGridPosition(BuilderState&, const CSSValue&);
-    static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
-    static Vector<StyleContentAlignmentData> convertContentAlignmentDataList(BuilderState&, const CSSValue&);
-    static MasonryAutoFlow convertMasonryAutoFlow(BuilderState&, const CSSValue&);
-    static std::optional<float> convertPerspective(BuilderState&, const CSSValue&);
-    static std::optional<WebCore::Length> convertMarqueeIncrement(BuilderState&, const CSSValue&);
-    static FilterOperations convertFilterOperations(BuilderState&, const CSSValue&);
+    static String convertString(const BuilderState&, const CSSValue&);
+    static String convertStringOrAuto(const BuilderState&, const CSSValue&);
+    static AtomString convertStringOrAutoAtom(const BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrAuto(state, value) }; }
+    static String convertStringOrNone(const BuilderState&, const CSSValue&);
+    static AtomString convertStringOrNoneAtom(const BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrNone(state, value) }; }
+    static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(const BuilderState&, const CSSValue&);
+    static TextAlignMode convertTextAlign(const BuilderState&, const CSSValue&);
+    static TextAlignLast convertTextAlignLast(const BuilderState&, const CSSValue&);
+    static RefPtr<BasicShapePath> convertSVGPath(const BuilderState&, const CSSValue&);
+    static RefPtr<PathOperation> convertPathOperation(const BuilderState&, const CSSValue&);
+    static RefPtr<PathOperation> convertRayPathOperation(const BuilderState&, const CSSValue&);
+    static Resize convertResize(const BuilderState&, const CSSValue&);
+    static int convertMarqueeRepetition(const BuilderState&, const CSSValue&);
+    static int convertMarqueeSpeed(const BuilderState&, const CSSValue&);
+    static RefPtr<QuotesData> convertQuotes(const BuilderState&, const CSSValue&);
+    static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(const BuilderState&, const CSSValue&);
+    static TextUnderlineOffset convertTextUnderlineOffset(const BuilderState&, const CSSValue&);
+    static TextDecorationThickness convertTextDecorationThickness(const BuilderState&, const CSSValue&);
+    static RefPtr<StyleReflection> convertReflection(const BuilderState&, const CSSValue&);
+    static TextEdge convertTextEdge(const BuilderState&, const CSSValue&);
+    static IntSize convertInitialLetter(const BuilderState&, const CSSValue&);
+    static float convertTextStrokeWidth(const BuilderState&, const CSSValue&);
+    static OptionSet<LineBoxContain> convertLineBoxContain(const BuilderState&, const CSSValue&);
+    static RefPtr<ShapeValue> convertShapeValue(const BuilderState&, CSSValue&);
+    static ScrollSnapType convertScrollSnapType(const BuilderState&, const CSSValue&);
+    static ScrollSnapAlign convertScrollSnapAlign(const BuilderState&, const CSSValue&);
+    static ScrollSnapStop convertScrollSnapStop(const BuilderState&, const CSSValue&);
+    static std::optional<ScrollbarColor> convertScrollbarColor(const BuilderState&, const CSSValue&);
+    static ScrollbarGutter convertScrollbarGutter(const BuilderState&, const CSSValue&);
+    static GridTrackSize convertGridTrackSize(const BuilderState&, const CSSValue&);
+    static Vector<GridTrackSize> convertGridTrackSizeList(const BuilderState&, const CSSValue&);
+    static std::optional<GridTrackList> convertGridTrackList(const BuilderState&, const CSSValue&);
+    static GridPosition convertGridPosition(const BuilderState&, const CSSValue&);
+    static GridAutoFlow convertGridAutoFlow(const BuilderState&, const CSSValue&);
+    static Vector<StyleContentAlignmentData> convertContentAlignmentDataList(const BuilderState&, const CSSValue&);
+    static MasonryAutoFlow convertMasonryAutoFlow(const BuilderState&, const CSSValue&);
+    static std::optional<float> convertPerspective(const BuilderState&, const CSSValue&);
+    static std::optional<WebCore::Length> convertMarqueeIncrement(const BuilderState&, const CSSValue&);
+    static FilterOperations convertFilterOperations(const BuilderState&, const CSSValue&);
     static ListStyleType convertListStyleType(const BuilderState&, const CSSValue&);
 #if PLATFORM(IOS_FAMILY)
-    static bool convertTouchCallout(BuilderState&, const CSSValue&);
+    static bool convertTouchCallout(const BuilderState&, const CSSValue&);
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    static StyleColor convertTapHighlightColor(BuilderState&, const CSSValue&);
+    static StyleColor convertTapHighlightColor(const BuilderState&, const CSSValue&);
 #endif
-    static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
+    static OptionSet<TouchAction> convertTouchAction(const BuilderState&, const CSSValue&);
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
-    static bool convertOverflowScrolling(BuilderState&, const CSSValue&);
+    static bool convertOverflowScrolling(const BuilderState&, const CSSValue&);
 #endif
-    static bool convertSmoothScrolling(BuilderState&, const CSSValue&);
+    static bool convertSmoothScrolling(const BuilderState&, const CSSValue&);
 
-    static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
-    static std::optional<FontSelectionValue> convertFontStyleFromValue(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontWeight(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontStretch(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontStyle(BuilderState&, const CSSValue&);
-    static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
-    static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
-    static SVGLengthValue convertSVGLengthValue(BuilderState&, const CSSValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
-    static Vector<SVGLengthValue> convertSVGLengthVector(BuilderState&, const CSSValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
-    static Vector<SVGLengthValue> convertStrokeDashArray(BuilderState&, const CSSValue&);
-    static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
-    static float convertOpacity(BuilderState&, const CSSValue&);
-    static String convertSVGURIReference(BuilderState&, const CSSValue&);
-    static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue&);
-    static StyleContentAlignmentData convertContentAlignmentData(BuilderState&, const CSSValue&);
-    static GlyphOrientation convertGlyphOrientation(BuilderState&, const CSSValue&);
-    static GlyphOrientation convertGlyphOrientationOrAuto(BuilderState&, const CSSValue&);
-    static WebCore::Length convertLineHeight(BuilderState&, const CSSValue&, float multiplier = 1.f);
-    static FontPalette convertFontPalette(BuilderState&, const CSSValue&);
+    static FontSizeAdjust convertFontSizeAdjust(const BuilderState&, const CSSValue&);
+    static std::optional<FontSelectionValue> convertFontStyleFromValue(const BuilderState&, const CSSValue&);
+    static FontSelectionValue convertFontWeight(const BuilderState&, const CSSValue&);
+    static FontSelectionValue convertFontStretch(const BuilderState&, const CSSValue&);
+    static FontSelectionValue convertFontStyle(const BuilderState&, const CSSValue&);
+    static FontFeatureSettings convertFontFeatureSettings(const BuilderState&, const CSSValue&);
+    static FontVariationSettings convertFontVariationSettings(const BuilderState&, const CSSValue&);
+    static SVGLengthValue convertSVGLengthValue(const BuilderState&, const CSSValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
+    static Vector<SVGLengthValue> convertSVGLengthVector(const BuilderState&, const CSSValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
+    static Vector<SVGLengthValue> convertStrokeDashArray(const BuilderState&, const CSSValue&);
+    static PaintOrder convertPaintOrder(const BuilderState&, const CSSValue&);
+    static float convertOpacity(const BuilderState&, const CSSValue&);
+    static String convertSVGURIReference(const BuilderState&, const CSSValue&);
+    static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(const BuilderState&, const CSSValue&);
+    static StyleContentAlignmentData convertContentAlignmentData(const BuilderState&, const CSSValue&);
+    static GlyphOrientation convertGlyphOrientation(const BuilderState&, const CSSValue&);
+    static GlyphOrientation convertGlyphOrientationOrAuto(const BuilderState&, const CSSValue&);
+    static WebCore::Length convertLineHeight(const BuilderState&, const CSSValue&, float multiplier = 1.f);
+    static FontPalette convertFontPalette(const BuilderState&, const CSSValue&);
     
-    static BreakBetween convertPageBreakBetween(BuilderState&, const CSSValue&);
-    static BreakInside convertPageBreakInside(BuilderState&, const CSSValue&);
-    static BreakBetween convertColumnBreakBetween(BuilderState&, const CSSValue&);
-    static BreakInside convertColumnBreakInside(BuilderState&, const CSSValue&);
+    static BreakBetween convertPageBreakBetween(const BuilderState&, const CSSValue&);
+    static BreakInside convertPageBreakInside(const BuilderState&, const CSSValue&);
+    static BreakBetween convertColumnBreakBetween(const BuilderState&, const CSSValue&);
+    static BreakInside convertColumnBreakInside(const BuilderState&, const CSSValue&);
 
-    static OptionSet<HangingPunctuation> convertHangingPunctuation(BuilderState&, const CSSValue&);
+    static OptionSet<HangingPunctuation> convertHangingPunctuation(const BuilderState&, const CSSValue&);
 
-    static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
+    static OptionSet<SpeakAs> convertSpeakAs(const BuilderState&, const CSSValue&);
 
-    static WebCore::Length convertPositionComponentX(BuilderState&, const CSSValue&);
-    static WebCore::Length convertPositionComponentY(BuilderState&, const CSSValue&);
+    static WebCore::Length convertPositionComponentX(const BuilderState&, const CSSValue&);
+    static WebCore::Length convertPositionComponentY(const BuilderState&, const CSSValue&);
 
-    static GapLength convertGapLength(BuilderState&, const CSSValue&);
+    static GapLength convertGapLength(const BuilderState&, const CSSValue&);
 
-    static OffsetRotation convertOffsetRotate(BuilderState&, const CSSValue&);
+    static OffsetRotation convertOffsetRotate(const BuilderState&, const CSSValue&);
 
-    static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
-    static Vector<Style::ScopedName> convertContainerName(BuilderState&, const CSSValue&);
+    static OptionSet<Containment> convertContain(const BuilderState&, const CSSValue&);
+    static Vector<Style::ScopedName> convertContainerName(const BuilderState&, const CSSValue&);
 
-    static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
+    static OptionSet<MarginTrimType> convertMarginTrim(const BuilderState&, const CSSValue&);
 
-    static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
-    static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
+    static TextSpacingTrim convertTextSpacingTrim(const BuilderState&, const CSSValue&);
+    static TextAutospace convertTextAutospace(const BuilderState&, const CSSValue&);
 
-    static std::optional<WebCore::Length> convertBlockStepSize(BuilderState&, const CSSValue&);
+    static std::optional<WebCore::Length> convertBlockStepSize(const BuilderState&, const CSSValue&);
 
-    static Vector<Style::ScopedName> convertViewTransitionClass(BuilderState&, const CSSValue&);
-    static Style::ViewTransitionName convertViewTransitionName(BuilderState&, const CSSValue&);
-    static RefPtr<WillChangeData> convertWillChange(BuilderState&, const CSSValue&);
+    static Vector<Style::ScopedName> convertViewTransitionClass(const BuilderState&, const CSSValue&);
+    static Style::ViewTransitionName convertViewTransitionName(const BuilderState&, const CSSValue&);
+    static RefPtr<WillChangeData> convertWillChange(const BuilderState&, const CSSValue&);
     
-    static Vector<AtomString> convertScrollTimelineName(BuilderState&, const CSSValue&);
-    static Vector<ScrollAxis> convertScrollTimelineAxis(BuilderState&, const CSSValue&);
-    static Vector<ViewTimelineInsets> convertViewTimelineInset(BuilderState&, const CSSValue&);
+    static Vector<AtomString> convertScrollTimelineName(const BuilderState&, const CSSValue&);
+    static Vector<ScrollAxis> convertScrollTimelineAxis(const BuilderState&, const CSSValue&);
+    static Vector<ViewTimelineInsets> convertViewTimelineInset(const BuilderState&, const CSSValue&);
 
-    static Vector<AtomString> convertAnchorName(BuilderState&, const CSSValue&);
+    static Vector<AtomString> convertAnchorName(const BuilderState&, const CSSValue&);
 
-    static BlockEllipsis convertBlockEllipsis(BuilderState&, const CSSValue&);
-    static size_t convertMaxLines(BuilderState&, const CSSValue&);
+    static BlockEllipsis convertBlockEllipsis(const BuilderState&, const CSSValue&);
+    static size_t convertMaxLines(const BuilderState&, const CSSValue&);
 
-    static LineClampValue convertLineClamp(BuilderState&, const CSSValue&);
+    static LineClampValue convertLineClamp(const BuilderState&, const CSSValue&);
 
-    static RefPtr<TimingFunction> convertTimingFunction(BuilderState&, const CSSValue&);
+    static RefPtr<TimingFunction> convertTimingFunction(const BuilderState&, const CSSValue&);
 
-    static TimelineScope convertTimelineScope(BuilderState&, const CSSValue&);
+    static TimelineScope convertTimelineScope(const BuilderState&, const CSSValue&);
 
-    static SingleTimelineRange convertAnimationRange(BuilderState&, const CSSValue&, SingleTimelineRange::Type);
-    static SingleTimelineRange convertAnimationRangeStart(BuilderState&, const CSSValue&);
-    static SingleTimelineRange convertAnimationRangeEnd(BuilderState&, const CSSValue&);
+    static SingleTimelineRange convertAnimationRange(const BuilderState&, const CSSValue&, SingleTimelineRange::Type);
+    static SingleTimelineRange convertAnimationRangeStart(const BuilderState&, const CSSValue&);
+    static SingleTimelineRange convertAnimationRangeEnd(const BuilderState&, const CSSValue&);
 
 private:
     friend class BuilderCustom;
 
-    static WebCore::Length convertToRadiusLength(BuilderState&, const CSSPrimitiveValue&);
-    static WebCore::Length parseSnapCoordinate(BuilderState&, const CSSValue&);
+    static WebCore::Length convertToRadiusLength(const BuilderState&, const CSSPrimitiveValue&);
+    static WebCore::Length parseSnapCoordinate(const BuilderState&, const CSSValue&);
 
 #if ENABLE(DARK_MODE_CSS)
     static void updateColorScheme(const CSSPrimitiveValue&, StyleColorScheme&);
 #endif
 
-    template<CSSValueID, CSSValueID> static WebCore::Length convertPositionComponent(BuilderState&, const CSSValue&);
+    template<CSSValueID, CSSValueID> static WebCore::Length convertPositionComponent(const BuilderState&, const CSSValue&);
 
-    static GridLength createGridTrackBreadth(BuilderState&, const CSSPrimitiveValue&);
-    static GridTrackSize createGridTrackSize(BuilderState&, const CSSValue&);
-    static std::optional<GridTrackList> createGridTrackList(BuilderState&, const CSSValue&);
-    static GridPosition createGridPosition(BuilderState&, const CSSValue&);
-    static NamedGridLinesMap createImplicitNamedGridLinesFromGridArea(BuilderState&, const NamedGridAreaMap&, GridTrackSizingDirection);
+    static GridLength createGridTrackBreadth(const BuilderState&, const CSSPrimitiveValue&);
+    static GridTrackSize createGridTrackSize(const BuilderState&, const CSSValue&);
+    static std::optional<GridTrackList> createGridTrackList(const BuilderState&, const CSSValue&);
+    static GridPosition createGridPosition(const BuilderState&, const CSSValue&);
+    static NamedGridLinesMap createImplicitNamedGridLinesFromGridArea(const BuilderState&, const NamedGridAreaMap&, GridTrackSizingDirection);
 
-    static CSSToLengthConversionData cssToLengthConversionDataWithTextZoomFactor(BuilderState&);
+    static CSSToLengthConversionData cssToLengthConversionDataWithTextZoomFactor(const BuilderState&);
 };
 
 inline WebCore::Length BuilderConverter::convertLength(const BuilderState& builderState, const CSSValue& value)
@@ -372,13 +372,13 @@ inline TabSize BuilderConverter::convertTabSize(const BuilderState& builderState
 }
 
 template<typename T>
-inline T BuilderConverter::convertComputedLength(BuilderState& builderState, const CSSValue& value)
+inline T BuilderConverter::convertComputedLength(const BuilderState& builderState, const CSSValue& value)
 {
     return downcast<CSSPrimitiveValue>(value).resolveAsLength<T>(builderState.cssToLengthConversionData());
 }
 
 template<typename T>
-inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CSSValue& value)
+inline T BuilderConverter::convertLineWidth(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     switch (primitiveValue.valueID()) {
@@ -408,7 +408,7 @@ inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CS
     }
 }
 
-inline WebCore::Length BuilderConverter::convertToRadiusLength(BuilderState& builderState, const CSSPrimitiveValue& value)
+inline WebCore::Length BuilderConverter::convertToRadiusLength(const BuilderState& builderState, const CSSPrimitiveValue& value)
 {
     auto& conversionData = builderState.cssToLengthConversionData();
     if (value.isPercentage())
@@ -421,7 +421,7 @@ inline WebCore::Length BuilderConverter::convertToRadiusLength(BuilderState& bui
     return length;
 }
 
-inline LengthSize BuilderConverter::convertRadius(BuilderState& builderState, const CSSValue& value)
+inline LengthSize BuilderConverter::convertRadius(const BuilderState& builderState, const CSSValue& value)
 {
     if (!value.isPair())
         return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } };
@@ -436,18 +436,18 @@ inline LengthSize BuilderConverter::convertRadius(BuilderState& builderState, co
     return radius;
 }
 
-inline WebCore::Length BuilderConverter::convertPositionComponentX(BuilderState& builderState, const CSSValue& value)
+inline WebCore::Length BuilderConverter::convertPositionComponentX(const BuilderState& builderState, const CSSValue& value)
 {
     return convertPositionComponent<CSSValueLeft, CSSValueRight>(builderState, value);
 }
 
-inline WebCore::Length BuilderConverter::convertPositionComponentY(BuilderState& builderState, const CSSValue& value)
+inline WebCore::Length BuilderConverter::convertPositionComponentY(const BuilderState& builderState, const CSSValue& value)
 {
     return convertPositionComponent<CSSValueTop, CSSValueBottom>(builderState, value);
 }
 
 template<CSSValueID cssValueFor0, CSSValueID cssValueFor100>
-inline WebCore::Length BuilderConverter::convertPositionComponent(BuilderState& builderState, const CSSValue& value)
+inline WebCore::Length BuilderConverter::convertPositionComponent(const BuilderState& builderState, const CSSValue& value)
 {
     WebCore::Length length;
 
@@ -482,7 +482,7 @@ inline WebCore::Length BuilderConverter::convertPositionComponent(BuilderState& 
     return length;
 }
 
-inline LengthPoint BuilderConverter::convertPosition(BuilderState& builderState, const CSSValue& value)
+inline LengthPoint BuilderConverter::convertPosition(const BuilderState& builderState, const CSSValue& value)
 {
     if (!value.isPair())
         return RenderStyle::initialObjectPosition();
@@ -493,7 +493,7 @@ inline LengthPoint BuilderConverter::convertPosition(BuilderState& builderState,
     return LengthPoint(lengthX, lengthY);
 }
 
-inline LengthPoint BuilderConverter::convertPositionOrAutoOrNormal(BuilderState& builderState, const CSSValue& value)
+inline LengthPoint BuilderConverter::convertPositionOrAutoOrNormal(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.isPair())
         return convertPosition(builderState, value);
@@ -502,14 +502,14 @@ inline LengthPoint BuilderConverter::convertPositionOrAutoOrNormal(BuilderState&
     return { };
 }
 
-inline LengthPoint BuilderConverter::convertPositionOrAuto(BuilderState& builderState, const CSSValue& value)
+inline LengthPoint BuilderConverter::convertPositionOrAuto(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.isPair())
         return convertPosition(builderState, value);
     return { };
 }
 
-inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine(BuilderState&, const CSSValue& value)
+inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine(const BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialTextDecorationLine();
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
@@ -519,7 +519,7 @@ inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine
     return result;
 }
 
-inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderState&, const CSSValue& value)
+inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(const BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialTextTransform();
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
@@ -530,20 +530,20 @@ inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderSt
 }
 
 template<typename T>
-inline T BuilderConverter::convertNumber(BuilderState& builderState, const CSSValue& value)
+inline T BuilderConverter::convertNumber(const BuilderState& builderState, const CSSValue& value)
 {
     return downcast<CSSPrimitiveValue>(value).resolveAsNumber<T>(builderState.cssToLengthConversionData());
 }
 
 template<typename T>
-inline T BuilderConverter::convertNumberOrAuto(BuilderState& builderState, const CSSValue& value)
+inline T BuilderConverter::convertNumberOrAuto(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueAuto)
         return -1;
     return convertNumber<T>(builderState, value);
 }
 
-inline short BuilderConverter::convertWebkitHyphenateLimitLines(BuilderState& builderState, const CSSValue& value)
+inline short BuilderConverter::convertWebkitHyphenateLimitLines(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueNoLimit)
@@ -552,12 +552,12 @@ inline short BuilderConverter::convertWebkitHyphenateLimitLines(BuilderState& bu
 }
 
 template<CSSPropertyID>
-inline RefPtr<StyleImage> BuilderConverter::convertStyleImage(BuilderState& builderState, CSSValue& value)
+inline RefPtr<StyleImage> BuilderConverter::convertStyleImage(const BuilderState& builderState, CSSValue& value)
 {
     return builderState.createStyleImage(value);
 }
 
-inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState&, const CSSValue& value)
+inline ImageOrientation BuilderConverter::convertImageOrientation(const BuilderState&, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueFromImage)
@@ -565,7 +565,7 @@ inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState&,
     return ImageOrientation::Orientation::None;
 }
 
-inline TransformOperations BuilderConverter::convertTransform(BuilderState& builderState, const CSSValue& value)
+inline TransformOperations BuilderConverter::convertTransform(const BuilderState& builderState, const CSSValue& value)
 {
     CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
@@ -573,7 +573,7 @@ inline TransformOperations BuilderConverter::convertTransform(BuilderState& buil
     return createTransformOperations(value, conversionData);
 }
 
-inline RefPtr<TranslateTransformOperation> BuilderConverter::convertTranslate(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<TranslateTransformOperation> BuilderConverter::convertTranslate(const BuilderState& builderState, const CSSValue& value)
 {
     CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
@@ -581,7 +581,7 @@ inline RefPtr<TranslateTransformOperation> BuilderConverter::convertTranslate(Bu
     return createTranslate(value, conversionData);
 }
 
-inline RefPtr<RotateTransformOperation> BuilderConverter::convertRotate(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<RotateTransformOperation> BuilderConverter::convertRotate(const BuilderState& builderState, const CSSValue& value)
 {
     CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
@@ -589,7 +589,7 @@ inline RefPtr<RotateTransformOperation> BuilderConverter::convertRotate(BuilderS
     return createRotate(value, conversionData);
 }
 
-inline RefPtr<ScaleTransformOperation> BuilderConverter::convertScale(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<ScaleTransformOperation> BuilderConverter::convertScale(const BuilderState& builderState, const CSSValue& value)
 {
     CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
@@ -621,7 +621,7 @@ inline void BuilderConverter::updateColorScheme(const CSSPrimitiveValue& primiti
     }
 }
 
-inline StyleColorScheme BuilderConverter::convertColorScheme(BuilderState&, const CSSValue& value)
+inline StyleColorScheme BuilderConverter::convertColorScheme(const BuilderState&, const CSSValue& value)
 {
     StyleColorScheme colorScheme;
 
@@ -639,19 +639,19 @@ inline StyleColorScheme BuilderConverter::convertColorScheme(BuilderState&, cons
 }
 #endif
 
-inline String BuilderConverter::convertString(BuilderState&, const CSSValue& value)
+inline String BuilderConverter::convertString(const BuilderState&, const CSSValue& value)
 {
     return downcast<CSSPrimitiveValue>(value).stringValue();
 }
 
-inline String BuilderConverter::convertStringOrAuto(BuilderState& builderState, const CSSValue& value)
+inline String BuilderConverter::convertStringOrAuto(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueAuto)
         return nullAtom();
     return convertString(builderState, value);
 }
 
-inline String BuilderConverter::convertStringOrNone(BuilderState& builderState, const CSSValue& value)
+inline String BuilderConverter::convertStringOrNone(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueNone)
         return nullAtom();
@@ -679,7 +679,7 @@ inline static OptionSet<TextEmphasisPosition> valueToEmphasisPosition(const CSSP
     return RenderStyle::initialTextEmphasisPosition();
 }
 
-inline OptionSet<TextEmphasisPosition> BuilderConverter::convertTextEmphasisPosition(BuilderState&, const CSSValue& value)
+inline OptionSet<TextEmphasisPosition> BuilderConverter::convertTextEmphasisPosition(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
         return valueToEmphasisPosition(*primitiveValue);
@@ -690,7 +690,7 @@ inline OptionSet<TextEmphasisPosition> BuilderConverter::convertTextEmphasisPosi
     return position;
 }
 
-inline TextAlignMode BuilderConverter::convertTextAlign(BuilderState& builderState, const CSSValue& value)
+inline TextAlignMode BuilderConverter::convertTextAlign(const BuilderState& builderState, const CSSValue& value)
 {
     const auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     ASSERT(primitiveValue.isValueID());
@@ -723,7 +723,7 @@ inline TextAlignMode BuilderConverter::convertTextAlign(BuilderState& builderSta
     return fromCSSValue<TextAlignMode>(value);
 }
 
-inline TextAlignLast BuilderConverter::convertTextAlignLast(BuilderState& builderState, const CSSValue& value)
+inline TextAlignLast BuilderConverter::convertTextAlignLast(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     ASSERT(primitiveValue.isValueID());
@@ -739,7 +739,7 @@ inline TextAlignLast BuilderConverter::convertTextAlignLast(BuilderState& builde
     return parentStyle.textAlignLast();
 }
 
-inline RefPtr<PathOperation> BuilderConverter::convertRayPathOperation(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<PathOperation> BuilderConverter::convertRayPathOperation(const BuilderState& builderState, const CSSValue& value)
 {
     auto& rayValue = downcast<CSSRayValue>(value);
 
@@ -772,7 +772,7 @@ inline RefPtr<PathOperation> BuilderConverter::convertRayPathOperation(BuilderSt
     return RayPathOperation::create(rayValue.angle()->resolveAsAngle(builderState.cssToLengthConversionData()), size, rayValue.isContaining());
 }
 
-inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(const BuilderState& builderState, const CSSValue& value)
 {
     if (auto* pathValue = dynamicDowncast<CSSPathValue>(value))
         return basicShapePathForValue(*pathValue, builderState, 1);
@@ -782,7 +782,7 @@ inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState& bui
     return nullptr;
 }
 
-inline RefPtr<PathOperation> BuilderConverter::convertPathOperation(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<PathOperation> BuilderConverter::convertPathOperation(const BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->isURI()) {
@@ -832,7 +832,7 @@ inline RefPtr<PathOperation> BuilderConverter::convertPathOperation(BuilderState
     return operation;
 }
 
-inline Resize BuilderConverter::convertResize(BuilderState& builderState, const CSSValue& value)
+inline Resize BuilderConverter::convertResize(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
@@ -845,7 +845,7 @@ inline Resize BuilderConverter::convertResize(BuilderState& builderState, const 
     return resize;
 }
 
-inline int BuilderConverter::convertMarqueeRepetition(BuilderState& builderState, const CSSValue& value)
+inline int BuilderConverter::convertMarqueeRepetition(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueInfinite)
@@ -855,7 +855,7 @@ inline int BuilderConverter::convertMarqueeRepetition(BuilderState& builderState
     return primitiveValue.resolveAsNumber<int>(builderState.cssToLengthConversionData());
 }
 
-inline int BuilderConverter::convertMarqueeSpeed(BuilderState& builderState, const CSSValue& value)
+inline int BuilderConverter::convertMarqueeSpeed(const BuilderState& builderState, const CSSValue& value)
 {
     auto& conversionData = builderState.cssToLengthConversionData();
 
@@ -868,7 +868,7 @@ inline int BuilderConverter::convertMarqueeSpeed(BuilderState& builderState, con
     return primitiveValue.resolveAsNumber<int>(conversionData);
 }
 
-inline RefPtr<QuotesData> BuilderConverter::convertQuotes(BuilderState&, const CSSValue& value)
+inline RefPtr<QuotesData> BuilderConverter::convertQuotes(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueNone)
@@ -916,7 +916,7 @@ inline static OptionSet<TextUnderlinePosition> valueToUnderlinePosition(const CS
     return RenderStyle::initialTextUnderlinePosition();
 }
 
-inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePosition(BuilderState&, const CSSValue& value)
+inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePosition(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
         return valueToUnderlinePosition(*primitiveValue);
@@ -930,12 +930,12 @@ inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePo
     return position;
 }
 
-inline TextUnderlineOffset BuilderConverter::convertTextUnderlineOffset(BuilderState& builderState, const CSSValue& value)
+inline TextUnderlineOffset BuilderConverter::convertTextUnderlineOffset(const BuilderState& builderState, const CSSValue& value)
 {
     return TextUnderlineOffset::createWithLength(BuilderConverter::convertLengthOrAuto(builderState, value));
 }
 
-inline TextDecorationThickness BuilderConverter::convertTextDecorationThickness(BuilderState& builderState, const CSSValue& value)
+inline TextDecorationThickness BuilderConverter::convertTextDecorationThickness(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     switch (primitiveValue.valueID()) {
@@ -958,7 +958,7 @@ inline TextDecorationThickness BuilderConverter::convertTextDecorationThickness(
     }
 }
 
-inline RefPtr<StyleReflection> BuilderConverter::convertReflection(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<StyleReflection> BuilderConverter::convertReflection(const BuilderState& builderState, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNone);
@@ -979,7 +979,7 @@ inline RefPtr<StyleReflection> BuilderConverter::convertReflection(BuilderState&
     return reflection;
 }
 
-inline TextEdge BuilderConverter::convertTextEdge(BuilderState&, const CSSValue& value)
+inline TextEdge BuilderConverter::convertTextEdge(const BuilderState&, const CSSValue& value)
 {
     auto overValue = [&](CSSValueID valueID) {
         switch (valueID) {
@@ -1040,7 +1040,7 @@ inline TextEdge BuilderConverter::convertTextEdge(BuilderState&, const CSSValue&
     };
 }
 
-inline IntSize BuilderConverter::convertInitialLetter(BuilderState& builderState, const CSSValue& value)
+inline IntSize BuilderConverter::convertInitialLetter(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueNormal)
         return IntSize();
@@ -1052,7 +1052,7 @@ inline IntSize BuilderConverter::convertInitialLetter(BuilderState& builderState
     };
 }
 
-inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState, const CSSValue& value)
+inline float BuilderConverter::convertTextStrokeWidth(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
@@ -1082,7 +1082,7 @@ inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState
     return width;
 }
 
-inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(BuilderState&, const CSSValue& value)
+inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(const BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNone);
@@ -1092,7 +1092,7 @@ inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(Builder
     return downcast<CSSLineBoxContainValue>(value).value();
 }
 
-inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& builderState, CSSValue& value)
+inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(const BuilderState& builderState, CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNone);
@@ -1127,7 +1127,7 @@ inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& buil
     return nullptr;
 }
 
-inline ScrollSnapType BuilderConverter::convertScrollSnapType(BuilderState&, const CSSValue& value)
+inline ScrollSnapType BuilderConverter::convertScrollSnapType(const BuilderState&, const CSSValue& value)
 {
     ScrollSnapType type;
     auto& values = downcast<CSSValueList>(value);
@@ -1144,7 +1144,7 @@ inline ScrollSnapType BuilderConverter::convertScrollSnapType(BuilderState&, con
     return type;
 }
 
-inline ScrollSnapAlign BuilderConverter::convertScrollSnapAlign(BuilderState&, const CSSValue& value)
+inline ScrollSnapAlign BuilderConverter::convertScrollSnapAlign(const BuilderState&, const CSSValue& value)
 {
     auto& values = downcast<CSSValueList>(value);
     ScrollSnapAlign alignment;
@@ -1156,12 +1156,12 @@ inline ScrollSnapAlign BuilderConverter::convertScrollSnapAlign(BuilderState&, c
     return alignment;
 }
 
-inline ScrollSnapStop BuilderConverter::convertScrollSnapStop(BuilderState&, const CSSValue& value)
+inline ScrollSnapStop BuilderConverter::convertScrollSnapStop(const BuilderState&, const CSSValue& value)
 {
     return fromCSSValue<ScrollSnapStop>(value);
 }
 
-inline std::optional<ScrollbarColor> BuilderConverter::convertScrollbarColor(BuilderState& builderState, const CSSValue& value)
+inline std::optional<ScrollbarColor> BuilderConverter::convertScrollbarColor(const BuilderState& builderState, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueAuto);
@@ -1176,7 +1176,7 @@ inline std::optional<ScrollbarColor> BuilderConverter::convertScrollbarColor(Bui
     };
 }
 
-inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(BuilderState&, const CSSValue& value)
+inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(const BuilderState&, const CSSValue& value)
 {
     ScrollbarGutter gutter;
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
@@ -1193,7 +1193,7 @@ inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(BuilderState&, c
     return gutter;
 }
 
-inline GridLength BuilderConverter::createGridTrackBreadth(BuilderState& builderState, const CSSPrimitiveValue& primitiveValue)
+inline GridLength BuilderConverter::createGridTrackBreadth(const BuilderState& builderState, const CSSPrimitiveValue& primitiveValue)
 {
     if (primitiveValue.valueID() == CSSValueMinContent || primitiveValue.valueID() == CSSValueWebkitMinContent)
         return WebCore::Length(LengthType::MinContent);
@@ -1213,7 +1213,7 @@ inline GridLength BuilderConverter::createGridTrackBreadth(BuilderState& builder
     return WebCore::Length(0.0, LengthType::Fixed);
 }
 
-inline GridTrackSize BuilderConverter::createGridTrackSize(BuilderState& builderState, const CSSValue& value)
+inline GridTrackSize BuilderConverter::createGridTrackSize(const BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
         return GridTrackSize(createGridTrackBreadth(builderState, *primitiveValue));
@@ -1231,7 +1231,7 @@ inline GridTrackSize BuilderConverter::createGridTrackSize(BuilderState& builder
     return GridTrackSize(minTrackBreadth, maxTrackBreadth);
 }
 
-inline std::optional<GridTrackList> BuilderConverter::createGridTrackList(BuilderState& builderState, const CSSValue& value)
+inline std::optional<GridTrackList> BuilderConverter::createGridTrackList(const BuilderState& builderState, const CSSValue& value)
 {
     RefPtr<const CSSValueContainingVector> valueList;
 
@@ -1319,7 +1319,7 @@ inline std::optional<GridTrackList> BuilderConverter::createGridTrackList(Builde
     return { WTFMove(trackList) };
 }
 
-inline GridPosition BuilderConverter::createGridPosition(BuilderState& builderState, const CSSValue& value)
+inline GridPosition BuilderConverter::createGridPosition(const BuilderState& builderState, const CSSValue& value)
 {
     GridPosition position;
 
@@ -1351,7 +1351,7 @@ inline GridPosition BuilderConverter::createGridPosition(BuilderState& builderSt
     return position;
 }
 
-inline NamedGridLinesMap BuilderConverter::createImplicitNamedGridLinesFromGridArea(BuilderState&, const NamedGridAreaMap& namedGridAreas, GridTrackSizingDirection direction)
+inline NamedGridLinesMap BuilderConverter::createImplicitNamedGridLinesFromGridArea(const BuilderState&, const NamedGridAreaMap& namedGridAreas, GridTrackSizingDirection direction)
 {
     NamedGridLinesMap namedGridLines;
 
@@ -1373,7 +1373,7 @@ inline NamedGridLinesMap BuilderConverter::createImplicitNamedGridLinesFromGridA
     return namedGridLines;
 }
 
-inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderState& builderState, const CSSValue& value)
+inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(const BuilderState& builderState, const CSSValue& value)
 {
     auto validateValue = [](const CSSValue& value) {
         ASSERT_UNUSED(value, !value.isGridLineNamesValue());
@@ -1401,22 +1401,22 @@ inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderS
     return Vector<GridTrackSize>({ convertGridTrackSize(builderState, value) });
 }
 
-inline GridTrackSize BuilderConverter::convertGridTrackSize(BuilderState& builderState, const CSSValue& value)
+inline GridTrackSize BuilderConverter::convertGridTrackSize(const BuilderState& builderState, const CSSValue& value)
 {
     return createGridTrackSize(builderState, value);
 }
 
-inline std::optional<GridTrackList> BuilderConverter::convertGridTrackList(BuilderState& builderState, const CSSValue& value)
+inline std::optional<GridTrackList> BuilderConverter::convertGridTrackList(const BuilderState& builderState, const CSSValue& value)
 {
     return createGridTrackList(builderState, value);
 }
 
-inline GridPosition BuilderConverter::convertGridPosition(BuilderState& builderState, const CSSValue& value)
+inline GridPosition BuilderConverter::convertGridPosition(const BuilderState& builderState, const CSSValue& value)
 {
     return createGridPosition(builderState, value);
 }
 
-inline GridAutoFlow BuilderConverter::convertGridAutoFlow(BuilderState&, const CSSValue& value)
+inline GridAutoFlow BuilderConverter::convertGridAutoFlow(const BuilderState&, const CSSValue& value)
 {
     ASSERT(!is<CSSPrimitiveValue>(value) || downcast<CSSPrimitiveValue>(value).isValueID());
 
@@ -1456,7 +1456,7 @@ inline GridAutoFlow BuilderConverter::convertGridAutoFlow(BuilderState&, const C
     return autoFlow;
 }
 
-inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignmentDataList(BuilderState& builder, const CSSValue& value)
+inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignmentDataList(const BuilderState& builder, const CSSValue& value)
 {
     auto& list = downcast<CSSValueList>(value);
     return WTF::map(list, [&](auto& value) {
@@ -1464,7 +1464,7 @@ inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignme
     });
 }
 
-inline MasonryAutoFlow BuilderConverter::convertMasonryAutoFlow(BuilderState&, const CSSValue& value)
+inline MasonryAutoFlow BuilderConverter::convertMasonryAutoFlow(const BuilderState&, const CSSValue& value)
 {
     auto& valueList = downcast<CSSValueList>(value);
     ASSERT(valueList.size() == 1 || valueList.size() == 2);
@@ -1500,7 +1500,7 @@ inline MasonryAutoFlow BuilderConverter::convertMasonryAutoFlow(BuilderState&, c
     return masonryAutoFlow;
 }
 
-inline float zoomWithTextZoomFactor(BuilderState& builderState)
+inline float zoomWithTextZoomFactor(const BuilderState& builderState)
 {
     if (auto* frame = builderState.document().frame()) {
         float textZoomFactor = builderState.style().textZoom() != TextZoom::Reset ? frame->textZoomFactor() : 1.0f;
@@ -1509,7 +1509,7 @@ inline float zoomWithTextZoomFactor(BuilderState& builderState)
     return builderState.cssToLengthConversionData().zoom();
 }
 
-inline CSSToLengthConversionData BuilderConverter::cssToLengthConversionDataWithTextZoomFactor(BuilderState& builderState)
+inline CSSToLengthConversionData BuilderConverter::cssToLengthConversionDataWithTextZoomFactor(const BuilderState& builderState)
 {
     float zoom = zoomWithTextZoomFactor(builderState);
     if (zoom == builderState.cssToLengthConversionData().zoom())
@@ -1518,7 +1518,7 @@ inline CSSToLengthConversionData BuilderConverter::cssToLengthConversionDataWith
     return builderState.cssToLengthConversionData().copyWithAdjustedZoom(zoom);
 }
 
-inline WebCore::Length BuilderConverter::convertTextLengthOrNormal(BuilderState& builderState, const CSSValue& value)
+inline WebCore::Length BuilderConverter::convertTextLengthOrNormal(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     auto conversionData = (builderState.useSVGZoomRulesForLength())
@@ -1539,7 +1539,7 @@ inline WebCore::Length BuilderConverter::convertTextLengthOrNormal(BuilderState&
     return RenderStyle::zeroLength();
 }
 
-inline std::optional<float> BuilderConverter::convertPerspective(BuilderState& builderState, const CSSValue& value)
+inline std::optional<float> BuilderConverter::convertPerspective(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueNone)
@@ -1558,7 +1558,7 @@ inline std::optional<float> BuilderConverter::convertPerspective(BuilderState& b
     return perspective < 0 ? std::optional<float>(std::nullopt) : std::optional<float>(perspective);
 }
 
-inline std::optional<WebCore::Length> BuilderConverter::convertMarqueeIncrement(BuilderState& builderState, const CSSValue& value)
+inline std::optional<WebCore::Length> BuilderConverter::convertMarqueeIncrement(const BuilderState& builderState, const CSSValue& value)
 {
     auto length = downcast<CSSPrimitiveValue>(value).convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
     if (length.isUndefined())
@@ -1566,57 +1566,57 @@ inline std::optional<WebCore::Length> BuilderConverter::convertMarqueeIncrement(
     return length;
 }
 
-inline FilterOperations BuilderConverter::convertFilterOperations(BuilderState& builderState, const CSSValue& value)
+inline FilterOperations BuilderConverter::convertFilterOperations(const BuilderState& builderState, const CSSValue& value)
 {
     return builderState.createFilterOperations(value);
 }
 
 // The input value needs to parsed and valid, this function returns std::nullopt if the input was "normal".
-inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromValue(BuilderState& builderState, const CSSValue& value)
+inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromValue(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontStyleFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
-inline FontSelectionValue BuilderConverter::convertFontWeight(BuilderState& builderState, const CSSValue& value)
+inline FontSelectionValue BuilderConverter::convertFontWeight(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontWeightFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
-inline FontSelectionValue BuilderConverter::convertFontStretch(BuilderState& builderState, const CSSValue& value)
+inline FontSelectionValue BuilderConverter::convertFontStretch(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontStretchFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
-inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState& builderState, const CSSValue& value)
+inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontFeatureSettingsFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
-inline FontVariationSettings BuilderConverter::convertFontVariationSettings(BuilderState& builderState, const CSSValue& value)
+inline FontVariationSettings BuilderConverter::convertFontVariationSettings(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontVariationSettingsFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
-inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& builderState, const CSSValue& value)
+inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(const BuilderState& builderState, const CSSValue& value)
 {
     return Style::fontSizeAdjustFromCSSValue(value, builderState.cssToLengthConversionData());
 }
 
 #if PLATFORM(IOS_FAMILY)
-inline bool BuilderConverter::convertTouchCallout(BuilderState&, const CSSValue& value)
+inline bool BuilderConverter::convertTouchCallout(const BuilderState&, const CSSValue& value)
 {
     return !equalLettersIgnoringASCIICase(downcast<CSSPrimitiveValue>(value).stringValue(), "none"_s);
 }
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
-inline StyleColor BuilderConverter::convertTapHighlightColor(BuilderState& builderState, const CSSValue& value)
+inline StyleColor BuilderConverter::convertTapHighlightColor(const BuilderState& builderState, const CSSValue& value)
 {
     return builderState.colorFromPrimitiveValue(downcast<CSSPrimitiveValue>(value));
 }
 #endif
 
-inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&, const CSSValue& value)
+inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(const BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value))
         return fromCSSValue<TouchAction>(value);
@@ -1636,23 +1636,23 @@ inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&
 }
 
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
-inline bool BuilderConverter::convertOverflowScrolling(BuilderState&, const CSSValue& value)
+inline bool BuilderConverter::convertOverflowScrolling(const BuilderState&, const CSSValue& value)
 {
     return value.valueID() == CSSValueTouch;
 }
 #endif
 
-inline bool BuilderConverter::convertSmoothScrolling(BuilderState&, const CSSValue& value)
+inline bool BuilderConverter::convertSmoothScrolling(const BuilderState&, const CSSValue& value)
 {
     return value.valueID() == CSSValueSmooth;
 }
 
-inline SVGLengthValue BuilderConverter::convertSVGLengthValue(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
+inline SVGLengthValue BuilderConverter::convertSVGLengthValue(const BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
     return SVGLengthValue::fromCSSPrimitiveValue(downcast<CSSPrimitiveValue>(value), builderState.cssToLengthConversionData(), shouldConvertNumberToPxLength);
 }
 
-inline Vector<SVGLengthValue> BuilderConverter::convertSVGLengthVector(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
+inline Vector<SVGLengthValue> BuilderConverter::convertSVGLengthVector(const BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
     auto& valueList = downcast<CSSValueList>(value);
     return WTF::map(valueList, [&](auto& item) {
@@ -1660,7 +1660,7 @@ inline Vector<SVGLengthValue> BuilderConverter::convertSVGLengthVector(BuilderSt
     });
 }
 
-inline Vector<SVGLengthValue> BuilderConverter::convertStrokeDashArray(BuilderState& builderState, const CSSValue& value)
+inline Vector<SVGLengthValue> BuilderConverter::convertStrokeDashArray(const BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueNone)
@@ -1673,7 +1673,7 @@ inline Vector<SVGLengthValue> BuilderConverter::convertStrokeDashArray(BuilderSt
     return convertSVGLengthVector(builderState, value, ShouldConvertNumberToPxLength::Yes);
 }
 
-inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState&, const CSSValue& value)
+inline PaintOrder BuilderConverter::convertPaintOrder(const BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNormal);
@@ -1694,14 +1694,14 @@ inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState&, const CSSVa
     }
 }
 
-inline float BuilderConverter::convertOpacity(BuilderState& builderState, const CSSValue& value)
+inline float BuilderConverter::convertOpacity(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     float opacity = primitiveValue.valueDividingBy100IfPercentage(builderState.cssToLengthConversionData());
     return std::max(0.0f, std::min(1.0f, opacity));
 }
 
-inline String BuilderConverter::convertSVGURIReference(BuilderState&, const CSSValue& value)
+inline String BuilderConverter::convertSVGURIReference(const BuilderState&, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.isURI())
@@ -1709,7 +1709,7 @@ inline String BuilderConverter::convertSVGURIReference(BuilderState&, const CSSV
     return emptyString();
 }
 
-inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue& value)
+inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(const BuilderState&, const CSSValue& value)
 {
     auto alignmentData = RenderStyle::initialSelfAlignment();
     if (value.isPair()) {
@@ -1729,7 +1729,7 @@ inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentDat
     return alignmentData;
 }
 
-inline StyleContentAlignmentData BuilderConverter::convertContentAlignmentData(BuilderState&, const CSSValue& value)
+inline StyleContentAlignmentData BuilderConverter::convertContentAlignmentData(const BuilderState&, const CSSValue& value)
 {
     StyleContentAlignmentData alignmentData = RenderStyle::initialContentAlignment();
     auto* contentValue = dynamicDowncast<CSSContentDistributionValue>(value);
@@ -1744,7 +1744,7 @@ inline StyleContentAlignmentData BuilderConverter::convertContentAlignmentData(B
     return alignmentData;
 }
 
-inline GlyphOrientation BuilderConverter::convertGlyphOrientation(BuilderState& builderState, const CSSValue& value)
+inline GlyphOrientation BuilderConverter::convertGlyphOrientation(const BuilderState& builderState, const CSSValue& value)
 {
     float angle = std::abs(fmodf(downcast<CSSPrimitiveValue>(value).resolveAsAngle(builderState.cssToLengthConversionData()), 360.0f));
     if (angle <= 45.0f || angle > 315.0f)
@@ -1756,14 +1756,14 @@ inline GlyphOrientation BuilderConverter::convertGlyphOrientation(BuilderState& 
     return GlyphOrientation::Degrees270;
 }
 
-inline GlyphOrientation BuilderConverter::convertGlyphOrientationOrAuto(BuilderState& builderState, const CSSValue& value)
+inline GlyphOrientation BuilderConverter::convertGlyphOrientationOrAuto(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueAuto)
         return GlyphOrientation::Auto;
     return convertGlyphOrientation(builderState, value);
 }
 
-inline WebCore::Length BuilderConverter::convertLineHeight(BuilderState& builderState, const CSSValue& value, float multiplier)
+inline WebCore::Length BuilderConverter::convertLineHeight(const BuilderState& builderState, const CSSValue& value, float multiplier)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     auto valueID = primitiveValue.valueID();
@@ -1803,7 +1803,7 @@ inline WebCore::Length BuilderConverter::convertLineHeight(BuilderState& builder
     return WebCore::Length(primitiveValue.resolveAsNumber(conversionData) * 100.0, LengthType::Percent);
 }
 
-inline FontPalette BuilderConverter::convertFontPalette(BuilderState&, const CSSValue& value)
+inline FontPalette BuilderConverter::convertFontPalette(const BuilderState&, const CSSValue& value)
 {
     const auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     switch (primitiveValue.valueID()) {
@@ -1820,7 +1820,7 @@ inline FontPalette BuilderConverter::convertFontPalette(BuilderState&, const CSS
     }
 }
     
-inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const CSSValue& value)
+inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(const BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialSpeakAs();
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
@@ -1832,7 +1832,7 @@ inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const 
     return result;
 }
 
-inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation(BuilderState&, const CSSValue& value)
+inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation(const BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialHangingPunctuation();
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
@@ -1842,12 +1842,12 @@ inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation
     return result;
 }
 
-inline GapLength BuilderConverter::convertGapLength(BuilderState& builderState, const CSSValue& value)
+inline GapLength BuilderConverter::convertGapLength(const BuilderState& builderState, const CSSValue& value)
 {
     return (value.valueID() == CSSValueNormal) ? GapLength() : GapLength(convertLength(builderState, value));
 }
 
-inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState& builderState, const CSSValue& value)
+inline OffsetRotation BuilderConverter::convertOffsetRotate(const BuilderState& builderState, const CSSValue& value)
 {
     RefPtr<const CSSPrimitiveValue> modifierValue;
     RefPtr<const CSSPrimitiveValue> angleValue;
@@ -1886,7 +1886,7 @@ inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState& builde
     return OffsetRotation(hasAuto, angleInDegrees);
 }
 
-inline Vector<Style::ScopedName> BuilderConverter::convertContainerName(BuilderState& state, const CSSValue& value)
+inline Vector<Style::ScopedName> BuilderConverter::convertContainerName(const BuilderState& state, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNone);
@@ -1901,7 +1901,7 @@ inline Vector<Style::ScopedName> BuilderConverter::convertContainerName(BuilderS
     });
 }
 
-inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderState&, const CSSValue& value)
+inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(const BuilderState&, const CSSValue& value)
 {
     // See if value is "block" or "inline" before trying to parse a list
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
@@ -1928,7 +1928,7 @@ inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderStat
     return marginTrim;
 }
 
-inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, const CSSValue& value)
+inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueAuto)
@@ -1937,7 +1937,7 @@ inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, c
     return { };
 }
 
-inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState&, const CSSValue& value)
+inline TextAutospace BuilderConverter::convertTextAutospace(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueNoAutospace)
@@ -1966,14 +1966,14 @@ inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState&, const
     return options;
 }
 
-inline std::optional<WebCore::Length> BuilderConverter::convertBlockStepSize(BuilderState& builderState, const CSSValue& value)
+inline std::optional<WebCore::Length> BuilderConverter::convertBlockStepSize(const BuilderState& builderState, const CSSValue& value)
 {
     if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
         return { };
     return convertLength(builderState, value);
 }
 
-inline OptionSet<Containment> BuilderConverter::convertContain(BuilderState&, const CSSValue& value)
+inline OptionSet<Containment> BuilderConverter::convertContain(const BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
@@ -2010,7 +2010,7 @@ inline OptionSet<Containment> BuilderConverter::convertContain(BuilderState&, co
     return containment;
 }
 
-inline Vector<Style::ScopedName> BuilderConverter::convertViewTransitionClass(BuilderState& state, const CSSValue& value)
+inline Vector<Style::ScopedName> BuilderConverter::convertViewTransitionClass(const BuilderState& state, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
@@ -2026,7 +2026,7 @@ inline Vector<Style::ScopedName> BuilderConverter::convertViewTransitionClass(Bu
     });
 }
 
-inline Style::ViewTransitionName BuilderConverter::convertViewTransitionName(BuilderState& state, const CSSValue& value)
+inline Style::ViewTransitionName BuilderConverter::convertViewTransitionName(const BuilderState& state, const CSSValue& value)
 {
     auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
     if (!primitiveValue)
@@ -2041,7 +2041,7 @@ inline Style::ViewTransitionName BuilderConverter::convertViewTransitionName(Bui
     return Style::ViewTransitionName::createWithCustomIdent(state.styleScopeOrdinal(), AtomString { primitiveValue->stringValue() });
 }
 
-inline RefPtr<WillChangeData> BuilderConverter::convertWillChange(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<WillChangeData> BuilderConverter::convertWillChange(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueAuto)
         return nullptr;
@@ -2075,7 +2075,7 @@ inline RefPtr<WillChangeData> BuilderConverter::convertWillChange(BuilderState& 
     return willChange;
 }
 
-inline Vector<AtomString> BuilderConverter::convertScrollTimelineName(BuilderState&, const CSSValue& value)
+inline Vector<AtomString> BuilderConverter::convertScrollTimelineName(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
@@ -2092,7 +2092,7 @@ inline Vector<AtomString> BuilderConverter::convertScrollTimelineName(BuilderSta
     });
 }
 
-inline Vector<ScrollAxis> BuilderConverter::convertScrollTimelineAxis(BuilderState&, const CSSValue& value)
+inline Vector<ScrollAxis> BuilderConverter::convertScrollTimelineAxis(const BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value))
         return { fromCSSValueID<ScrollAxis>(value.valueID()) };
@@ -2102,7 +2102,7 @@ inline Vector<ScrollAxis> BuilderConverter::convertScrollTimelineAxis(BuilderSta
     });
 }
 
-inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInset(BuilderState& state, const CSSValue& value)
+inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInset(const BuilderState& state, const CSSValue& value)
 {
     // While parsing, consumeViewTimelineInset() and consumeViewTimelineShorthand() yield a CSSValueList exclusively.
     auto* list = dynamicDowncast<CSSValueList>(value);
@@ -2119,7 +2119,7 @@ inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInset(Bui
     });
 }
 
-inline Vector<AtomString> BuilderConverter::convertAnchorName(BuilderState&, const CSSValue& value)
+inline Vector<AtomString> BuilderConverter::convertAnchorName(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
@@ -2136,7 +2136,7 @@ inline Vector<AtomString> BuilderConverter::convertAnchorName(BuilderState&, con
     });
 }
 
-inline BlockEllipsis BuilderConverter::convertBlockEllipsis(BuilderState& builderState, const CSSValue& value)
+inline BlockEllipsis BuilderConverter::convertBlockEllipsis(const BuilderState& builderState, const CSSValue& value)
 {
     if (value.valueID() == CSSValueNone)
         return { };
@@ -2146,14 +2146,14 @@ inline BlockEllipsis BuilderConverter::convertBlockEllipsis(BuilderState& builde
 
 }
 
-inline size_t BuilderConverter::convertMaxLines(BuilderState& builderState, const CSSValue& value)
+inline size_t BuilderConverter::convertMaxLines(const BuilderState& builderState, const CSSValue& value)
 {
     if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
         return 0;
     return convertNumber<size_t>(builderState, value);
 }
 
-inline LineClampValue BuilderConverter::convertLineClamp(BuilderState& builderState, const CSSValue& value)
+inline LineClampValue BuilderConverter::convertLineClamp(const BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
@@ -2167,12 +2167,12 @@ inline LineClampValue BuilderConverter::convertLineClamp(BuilderState& builderSt
     return LineClampValue();
 }
 
-inline RefPtr<TimingFunction> BuilderConverter::convertTimingFunction(BuilderState&, const CSSValue& value)
+inline RefPtr<TimingFunction> BuilderConverter::convertTimingFunction(const BuilderState&, const CSSValue& value)
 {
     return createTimingFunction(value);
 }
 
-inline TimelineScope BuilderConverter::convertTimelineScope(BuilderState&, const CSSValue& value)
+inline TimelineScope BuilderConverter::convertTimelineScope(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         switch (primitiveValue->valueID()) {
@@ -2194,7 +2194,7 @@ inline TimelineScope BuilderConverter::convertTimelineScope(BuilderState&, const
     }) };
 }
 
-inline SingleTimelineRange BuilderConverter::convertAnimationRange(BuilderState& state, const CSSValue& value, SingleTimelineRange::Type type)
+inline SingleTimelineRange BuilderConverter::convertAnimationRange(const BuilderState& state, const CSSValue& value, SingleTimelineRange::Type type)
 {
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (SingleTimelineRange::isOffsetValue(*primitiveValue)) {
@@ -2215,12 +2215,12 @@ inline SingleTimelineRange BuilderConverter::convertAnimationRange(BuilderState&
     return { SingleTimelineRange::timelineName(pair->first().valueID()), convertLength(state, primitiveValue) };
 }
 
-inline SingleTimelineRange BuilderConverter::convertAnimationRangeStart(BuilderState& state, const CSSValue& value)
+inline SingleTimelineRange BuilderConverter::convertAnimationRangeStart(const BuilderState& state, const CSSValue& value)
 {
     return convertAnimationRange(state, value, SingleTimelineRange::Type::Start);
 }
 
-inline SingleTimelineRange BuilderConverter::convertAnimationRangeEnd(BuilderState& state, const CSSValue& value)
+inline SingleTimelineRange BuilderConverter::convertAnimationRangeEnd(const BuilderState& state, const CSSValue& value)
 {
     return convertAnimationRange(state, value, SingleTimelineRange::Type::End);
 }

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -98,7 +98,7 @@ bool BuilderState::useSVGZoomRulesForLength() const
     return is<SVGElement>(element()) && !(is<SVGSVGElement>(*element()) && element()->parentNode());
 }
 
-RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value)
+RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value) const
 {
     if (auto* imageValue = dynamicDowncast<CSSImageValue>(value))
         return imageValue->createStyleImage(*this);
@@ -121,7 +121,7 @@ RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value)
     return nullptr;
 }
 
-FilterOperations BuilderState::createFilterOperations(const CSSValue& inValue)
+FilterOperations BuilderState::createFilterOperations(const CSSValue& inValue) const
 {
     return WebCore::Style::createFilterOperations(document(), m_style, m_cssToLengthConversionData, inValue);
 }

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -94,8 +94,8 @@ public:
     bool useSVGZoomRulesForLength() const;
     ScopeOrdinal styleScopeOrdinal() const { return m_currentProperty->styleScopeOrdinal; }
 
-    RefPtr<StyleImage> createStyleImage(const CSSValue&);
-    FilterOperations createFilterOperations(const CSSValue&);
+    RefPtr<StyleImage> createStyleImage(const CSSValue&) const;
+    FilterOperations createFilterOperations(const CSSValue&) const;
 
     static bool isColorFromPrimitiveValueDerivedFromElement(const CSSPrimitiveValue&);
     StyleColor colorFromPrimitiveValue(const CSSPrimitiveValue&, ForVisitedLink = ForVisitedLink::No) const;
@@ -104,7 +104,7 @@ public:
     void registerContentAttribute(const AtomString& attributeLocalName);
 
     const CSSToLengthConversionData& cssToLengthConversionData() const { return m_cssToLengthConversionData; }
-    CSSToStyleMap& styleMap() { return m_styleMap; }
+    const CSSToStyleMap& styleMap() const { return m_styleMap; }
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
 

--- a/Source/WebCore/style/values/StyleGradient.cpp
+++ b/Source/WebCore/style/values/StyleGradient.cpp
@@ -101,24 +101,24 @@ auto ToCSS<GradientDeprecatedColorStop>::operator()(const GradientDeprecatedColo
 
 // MARK: - Conversion: CSS -> Style
 
-static auto toStyleStopColor(const RefPtr<CSSPrimitiveValue>& color, BuilderState& state, const CSSCalcSymbolTable&) -> std::optional<StyleColor>
+static auto toStyleStopColor(const RefPtr<CSSPrimitiveValue>& color, const BuilderState& state, const CSSCalcSymbolTable&) -> std::optional<StyleColor>
 {
     if (!color)
         return std::nullopt;
     return state.colorFromPrimitiveValue(*color);
 }
 
-static auto toStyleStopPosition(const CSS::GradientLinearColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStopPosition
+static auto toStyleStopPosition(const CSS::GradientLinearColorStopPosition& position, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStopPosition
 {
     return toStyle(position, state, symbolTable);
 }
 
-static auto toStyleStopPosition(const CSS::GradientAngularColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStopPosition
+static auto toStyleStopPosition(const CSS::GradientAngularColorStopPosition& position, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStopPosition
 {
     return toStyle(position, state, symbolTable);
 }
 
-static auto toStyleStopPosition(const CSS::GradientDeprecatedColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStopPosition
+static auto toStyleStopPosition(const CSS::GradientDeprecatedColorStopPosition& position, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStopPosition
 {
     return WTF::switchOn(position,
         [&](const CSS::Number<>& number) {
@@ -130,7 +130,7 @@ static auto toStyleStopPosition(const CSS::GradientDeprecatedColorStopPosition& 
     );
 }
 
-template<typename T> decltype(auto) toStyleColorStop(const T& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+template<typename T> decltype(auto) toStyleColorStop(const T& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable)
 {
     return GradientColorStop {
         toStyleStopColor(stop.color, state, symbolTable),
@@ -138,17 +138,17 @@ template<typename T> decltype(auto) toStyleColorStop(const T& stop, BuilderState
     };
 }
 
-auto ToStyle<CSS::GradientAngularColorStop>::operator()(const CSS::GradientAngularColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStop
+auto ToStyle<CSS::GradientAngularColorStop>::operator()(const CSS::GradientAngularColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStop
 {
     return toStyleColorStop(stop, state, symbolTable);
 }
 
-auto ToStyle<CSS::GradientLinearColorStop>::operator()(const CSS::GradientLinearColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStop
+auto ToStyle<CSS::GradientLinearColorStop>::operator()(const CSS::GradientLinearColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStop
 {
     return toStyleColorStop(stop, state, symbolTable);
 }
 
-auto ToStyle<CSS::GradientDeprecatedColorStop>::operator()(const CSS::GradientDeprecatedColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStop
+auto ToStyle<CSS::GradientDeprecatedColorStop>::operator()(const CSS::GradientDeprecatedColorStop& stop, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStop
 {
     return toStyleColorStop(stop, state, symbolTable);
 }

--- a/Source/WebCore/style/values/StyleGradient.h
+++ b/Source/WebCore/style/values/StyleGradient.h
@@ -90,9 +90,9 @@ template<> struct ToCSS<GradientAngularColorStop> { auto operator()(const Gradie
 template<> struct ToCSS<GradientLinearColorStop> { auto operator()(const GradientLinearColorStop&, const RenderStyle&) -> CSS::GradientLinearColorStop; };
 template<> struct ToCSS<GradientDeprecatedColorStop> { auto operator()(const GradientDeprecatedColorStop&, const RenderStyle&) -> CSS::GradientDeprecatedColorStop; };
 
-template<> struct ToStyle<CSS::GradientAngularColorStop> { auto operator()(const CSS::GradientAngularColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientAngularColorStop; };
-template<> struct ToStyle<CSS::GradientLinearColorStop> { auto operator()(const CSS::GradientLinearColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientLinearColorStop; };
-template<> struct ToStyle<CSS::GradientDeprecatedColorStop> { auto operator()(const CSS::GradientDeprecatedColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientDeprecatedColorStop; };
+template<> struct ToStyle<CSS::GradientAngularColorStop> { auto operator()(const CSS::GradientAngularColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientAngularColorStop; };
+template<> struct ToStyle<CSS::GradientLinearColorStop> { auto operator()(const CSS::GradientLinearColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientLinearColorStop; };
+template<> struct ToStyle<CSS::GradientDeprecatedColorStop> { auto operator()(const CSS::GradientDeprecatedColorStop&, const BuilderState&, const CSSCalcSymbolTable&) -> GradientDeprecatedColorStop; };
 
 // MARK: - LinearGradient
 

--- a/Source/WebCore/style/values/StylePosition.cpp
+++ b/Source/WebCore/style/values/StylePosition.cpp
@@ -50,7 +50,7 @@ static LengthPercentage<> makeLengthPercentageForRoot(Calculation::Child&& root)
     };
 }
 
-auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Position
+auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> Position
 {
     auto convertTo100PercentMinus = [](LengthPercentage<> value) -> LengthPercentage<> {
         return value.value.switchOn(

--- a/Source/WebCore/style/values/StylePosition.h
+++ b/Source/WebCore/style/values/StylePosition.h
@@ -58,7 +58,7 @@ template<size_t I> const auto& get(const Position& position)
 }
 
 template<> struct ToCSS<Position> { auto operator()(const Position&, const RenderStyle&) -> CSS::Position; };
-template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, BuilderState&, const CSSCalcSymbolTable&) -> Position; };
+template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, const BuilderState&, const CSSCalcSymbolTable&) -> Position; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.h
@@ -34,14 +34,14 @@ namespace Style {
 // MARK: - Conversion Data specialization
 
 template<typename T> struct ConversionDataSpecializer {
-    static CSSToLengthConversionData conversionData(BuilderState& state)
+    static CSSToLengthConversionData conversionData(const BuilderState& state)
     {
         return state.cssToLengthConversionData();
     }
 };
 
 template<auto R> struct ConversionDataSpecializer<CSS::LengthRaw<R>> {
-    static CSSToLengthConversionData conversionData(BuilderState& state)
+    static CSSToLengthConversionData conversionData(const BuilderState& state)
     {
         return state.useSVGZoomRulesForLength()
              ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
@@ -49,7 +49,7 @@ template<auto R> struct ConversionDataSpecializer<CSS::LengthRaw<R>> {
     }
 };
 
-template<typename T> CSSToLengthConversionData conversionData(BuilderState& state)
+template<typename T> CSSToLengthConversionData conversionData(const BuilderState& state)
 {
     return ConversionDataSpecializer<T>::conversionData(state);
 }
@@ -135,15 +135,15 @@ template<auto R> struct ToStyle<CSS::AnglePercentage<R>> {
         return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
-    auto operator()(const typename From::Raw& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
-    auto operator()(const typename From::Calc& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Calc& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
-    auto operator()(const From& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const From& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
@@ -194,15 +194,15 @@ template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
         return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
-    auto operator()(const typename From::Raw& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
-    auto operator()(const typename From::Calc& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Calc& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
-    auto operator()(const From& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const From& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
@@ -247,15 +247,15 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
         return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
-    auto operator()(const typename From::Raw& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<RawType>(state), symbolTable);
     }
-    auto operator()(const typename From::Calc& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const typename From::Calc& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<RawType>(state), symbolTable);
     }
-    auto operator()(const CSS::PrimitiveNumeric<RawType>& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const CSS::PrimitiveNumeric<RawType>& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
         return (*this)(value, conversionData<RawType>(state), symbolTable);
     }
@@ -277,7 +277,7 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
 // None just needs its trivial implementation.
 template<> struct ToStyle<CSS::None> {
     auto operator()(const CSS::None&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&) -> None { return { }; }
-    auto operator()(const CSS::None&, BuilderState&, const CSSCalcSymbolTable&) -> None { return { }; }
+    auto operator()(const CSS::None&, const BuilderState&, const CSSCalcSymbolTable&) -> None { return { }; }
     auto operator()(const CSS::None&, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> None { return { }; }
 };
 


### PR DESCRIPTION
#### f607bbdba4df616b144d16367b4f4fa3ee329a02
<pre>
Make Style::BuilderState &apos;const&apos; in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=281553">https://bugs.webkit.org/show_bug.cgi?id=281553</a>
<a href="https://rdar.apple.com/138013855">rdar://138013855</a>

Reviewed by Antti Koivisto.

Most of the code paths that use `Style::BuilderState` do so for cssToLengthConversionData(), which doesn&apos;t mutate
the state. So pass it around in more places as a const reference.

Many functions on CSSToStyleMap can also be &apos;const&apos;. CSSToStyleMap::style() is unused, and can be removed.

* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::createFromCSSValue):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/css/CSSCanvasValue.cpp:
(WebCore::CSSCanvasValue::createStyleImage const):
* Source/WebCore/css/CSSCanvasValue.h:
* Source/WebCore/css/CSSCrossfadeValue.cpp:
(WebCore::CSSCrossfadeValue::createStyleImage const):
* Source/WebCore/css/CSSCrossfadeValue.h:
* Source/WebCore/css/CSSCursorImageValue.cpp:
(WebCore::CSSCursorImageValue::createStyleImage const):
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSFilterImageValue.cpp:
(WebCore::CSSFilterImageValue::createStyleImage const):
* Source/WebCore/css/CSSFilterImageValue.h:
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::CSSGradientValue::createStyleImage const):
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::createStyleImage const):
* Source/WebCore/css/CSSImageSetValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::createStyleImage const):
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSNamedImageValue.cpp:
(WebCore::CSSNamedImageValue::createStyleImage const):
* Source/WebCore/css/CSSNamedImageValue.h:
* Source/WebCore/css/CSSPaintImageValue.cpp:
(WebCore::CSSPaintImageValue::createStyleImage const):
* Source/WebCore/css/CSSPaintImageValue.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::CSSToStyleMap):
(WebCore::CSSToStyleMap::styleImage const):
(WebCore::CSSToStyleMap::mapFillImage const):
(WebCore::CSSToStyleMap::mapFillSize const):
(WebCore::CSSToStyleMap::mapFillXPosition const):
(WebCore::CSSToStyleMap::mapFillYPosition const):
(WebCore::CSSToStyleMap::mapAnimationDelay const):
(WebCore::CSSToStyleMap::mapAnimationDuration const):
(WebCore::CSSToStyleMap::mapAnimationIterationCount const):
(WebCore::CSSToStyleMap::mapAnimationName const):
(WebCore::CSSToStyleMap::mapAnimationTimeline const):
(WebCore::CSSToStyleMap::mapAnimationTimingFunction const):
(WebCore::CSSToStyleMap::mapNinePieceImage const):
(WebCore::CSSToStyleMap::mapNinePieceImageSlice const):
(WebCore::CSSToStyleMap::mapNinePieceImageWidth const):
(WebCore::CSSToStyleMap::mapNinePieceImageQuad const):
(WebCore::CSSToStyleMap::mapNinePieceImageSide const):
(WebCore::CSSToStyleMap::style const): Deleted.
(WebCore::CSSToStyleMap::styleImage): Deleted.
(WebCore::CSSToStyleMap::mapFillImage): Deleted.
(WebCore::CSSToStyleMap::mapFillSize): Deleted.
(WebCore::CSSToStyleMap::mapFillXPosition): Deleted.
(WebCore::CSSToStyleMap::mapFillYPosition): Deleted.
(WebCore::CSSToStyleMap::mapAnimationDelay): Deleted.
(WebCore::CSSToStyleMap::mapAnimationDuration): Deleted.
(WebCore::CSSToStyleMap::mapAnimationIterationCount): Deleted.
(WebCore::CSSToStyleMap::mapAnimationName): Deleted.
(WebCore::CSSToStyleMap::mapAnimationTimeline): Deleted.
(WebCore::CSSToStyleMap::mapAnimationTimingFunction): Deleted.
(WebCore::CSSToStyleMap::mapNinePieceImage): Deleted.
(WebCore::CSSToStyleMap::mapNinePieceImageSlice): Deleted.
(WebCore::CSSToStyleMap::mapNinePieceImageWidth): Deleted.
(WebCore::CSSToStyleMap::mapNinePieceImageQuad): Deleted.
(WebCore::CSSToStyleMap::mapNinePieceImageSide): Deleted.
* Source/WebCore/css/CSSToStyleMap.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertStringOrAutoAtom):
(WebCore::Style::BuilderConverter::convertStringOrNoneAtom):
(WebCore::Style::BuilderConverter::convertComputedLength):
(WebCore::Style::BuilderConverter::convertLineWidth):
(WebCore::Style::BuilderConverter::convertToRadiusLength):
(WebCore::Style::BuilderConverter::convertRadius):
(WebCore::Style::BuilderConverter::convertPositionComponentX):
(WebCore::Style::BuilderConverter::convertPositionComponentY):
(WebCore::Style::BuilderConverter::convertPositionComponent):
(WebCore::Style::BuilderConverter::convertPosition):
(WebCore::Style::BuilderConverter::convertPositionOrAutoOrNormal):
(WebCore::Style::BuilderConverter::convertPositionOrAuto):
(WebCore::Style::BuilderConverter::convertTextDecorationLine):
(WebCore::Style::BuilderConverter::convertTextTransform):
(WebCore::Style::BuilderConverter::convertNumber):
(WebCore::Style::BuilderConverter::convertNumberOrAuto):
(WebCore::Style::BuilderConverter::convertWebkitHyphenateLimitLines):
(WebCore::Style::BuilderConverter::convertStyleImage):
(WebCore::Style::BuilderConverter::convertImageOrientation):
(WebCore::Style::BuilderConverter::convertTransform):
(WebCore::Style::BuilderConverter::convertTranslate):
(WebCore::Style::BuilderConverter::convertRotate):
(WebCore::Style::BuilderConverter::convertScale):
(WebCore::Style::BuilderConverter::convertColorScheme):
(WebCore::Style::BuilderConverter::convertString):
(WebCore::Style::BuilderConverter::convertStringOrAuto):
(WebCore::Style::BuilderConverter::convertStringOrNone):
(WebCore::Style::BuilderConverter::convertTextEmphasisPosition):
(WebCore::Style::BuilderConverter::convertTextAlign):
(WebCore::Style::BuilderConverter::convertTextAlignLast):
(WebCore::Style::BuilderConverter::convertRayPathOperation):
(WebCore::Style::BuilderConverter::convertSVGPath):
(WebCore::Style::BuilderConverter::convertPathOperation):
(WebCore::Style::BuilderConverter::convertResize):
(WebCore::Style::BuilderConverter::convertMarqueeRepetition):
(WebCore::Style::BuilderConverter::convertMarqueeSpeed):
(WebCore::Style::BuilderConverter::convertQuotes):
(WebCore::Style::BuilderConverter::convertTextUnderlinePosition):
(WebCore::Style::BuilderConverter::convertTextUnderlineOffset):
(WebCore::Style::BuilderConverter::convertTextDecorationThickness):
(WebCore::Style::BuilderConverter::convertReflection):
(WebCore::Style::BuilderConverter::convertTextEdge):
(WebCore::Style::BuilderConverter::convertInitialLetter):
(WebCore::Style::BuilderConverter::convertTextStrokeWidth):
(WebCore::Style::BuilderConverter::convertLineBoxContain):
(WebCore::Style::BuilderConverter::convertShapeValue):
(WebCore::Style::BuilderConverter::convertScrollSnapType):
(WebCore::Style::BuilderConverter::convertScrollSnapAlign):
(WebCore::Style::BuilderConverter::convertScrollSnapStop):
(WebCore::Style::BuilderConverter::convertScrollbarColor):
(WebCore::Style::BuilderConverter::convertScrollbarGutter):
(WebCore::Style::BuilderConverter::createGridTrackBreadth):
(WebCore::Style::BuilderConverter::createGridTrackSize):
(WebCore::Style::BuilderConverter::createGridTrackList):
(WebCore::Style::BuilderConverter::createGridPosition):
(WebCore::Style::BuilderConverter::createImplicitNamedGridLinesFromGridArea):
(WebCore::Style::BuilderConverter::convertGridTrackSizeList):
(WebCore::Style::BuilderConverter::convertGridTrackSize):
(WebCore::Style::BuilderConverter::convertGridTrackList):
(WebCore::Style::BuilderConverter::convertGridPosition):
(WebCore::Style::BuilderConverter::convertGridAutoFlow):
(WebCore::Style::BuilderConverter::convertContentAlignmentDataList):
(WebCore::Style::BuilderConverter::convertMasonryAutoFlow):
(WebCore::Style::zoomWithTextZoomFactor):
(WebCore::Style::BuilderConverter::cssToLengthConversionDataWithTextZoomFactor):
(WebCore::Style::BuilderConverter::convertTextLengthOrNormal):
(WebCore::Style::BuilderConverter::convertPerspective):
(WebCore::Style::BuilderConverter::convertMarqueeIncrement):
(WebCore::Style::BuilderConverter::convertFilterOperations):
(WebCore::Style::BuilderConverter::convertFontStyleFromValue):
(WebCore::Style::BuilderConverter::convertFontWeight):
(WebCore::Style::BuilderConverter::convertFontStretch):
(WebCore::Style::BuilderConverter::convertFontFeatureSettings):
(WebCore::Style::BuilderConverter::convertFontVariationSettings):
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
(WebCore::Style::BuilderConverter::convertTouchCallout):
(WebCore::Style::BuilderConverter::convertTapHighlightColor):
(WebCore::Style::BuilderConverter::convertTouchAction):
(WebCore::Style::BuilderConverter::convertOverflowScrolling):
(WebCore::Style::BuilderConverter::convertSmoothScrolling):
(WebCore::Style::BuilderConverter::convertSVGLengthValue):
(WebCore::Style::BuilderConverter::convertSVGLengthVector):
(WebCore::Style::BuilderConverter::convertStrokeDashArray):
(WebCore::Style::BuilderConverter::convertPaintOrder):
(WebCore::Style::BuilderConverter::convertOpacity):
(WebCore::Style::BuilderConverter::convertSVGURIReference):
(WebCore::Style::BuilderConverter::convertSelfOrDefaultAlignmentData):
(WebCore::Style::BuilderConverter::convertContentAlignmentData):
(WebCore::Style::BuilderConverter::convertGlyphOrientation):
(WebCore::Style::BuilderConverter::convertGlyphOrientationOrAuto):
(WebCore::Style::BuilderConverter::convertLineHeight):
(WebCore::Style::BuilderConverter::convertFontPalette):
(WebCore::Style::BuilderConverter::convertSpeakAs):
(WebCore::Style::BuilderConverter::convertHangingPunctuation):
(WebCore::Style::BuilderConverter::convertGapLength):
(WebCore::Style::BuilderConverter::convertOffsetRotate):
(WebCore::Style::BuilderConverter::convertContainerName):
(WebCore::Style::BuilderConverter::convertMarginTrim):
(WebCore::Style::BuilderConverter::convertTextSpacingTrim):
(WebCore::Style::BuilderConverter::convertTextAutospace):
(WebCore::Style::BuilderConverter::convertBlockStepSize):
(WebCore::Style::BuilderConverter::convertContain):
(WebCore::Style::BuilderConverter::convertViewTransitionClass):
(WebCore::Style::BuilderConverter::convertViewTransitionName):
(WebCore::Style::BuilderConverter::convertWillChange):
(WebCore::Style::BuilderConverter::convertScrollTimelineName):
(WebCore::Style::BuilderConverter::convertScrollTimelineAxis):
(WebCore::Style::BuilderConverter::convertViewTimelineInset):
(WebCore::Style::BuilderConverter::convertAnchorName):
(WebCore::Style::BuilderConverter::convertBlockEllipsis):
(WebCore::Style::BuilderConverter::convertMaxLines):
(WebCore::Style::BuilderConverter::convertLineClamp):
(WebCore::Style::BuilderConverter::convertTimingFunction):
(WebCore::Style::BuilderConverter::convertTimelineScope):
(WebCore::Style::BuilderConverter::convertAnimationRange):
(WebCore::Style::BuilderConverter::convertAnimationRangeStart):
(WebCore::Style::BuilderConverter::convertAnimationRangeEnd):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createStyleImage const):
(WebCore::Style::BuilderState::createFilterOperations const):
(WebCore::Style::BuilderState::createStyleImage): Deleted.
(WebCore::Style::BuilderState::createFilterOperations): Deleted.
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::styleMap const):
(WebCore::Style::BuilderState::styleMap): Deleted.
* Source/WebCore/style/values/StyleGradient.cpp:
(WebCore::Style::toStyleStopColor):
(WebCore::Style::toStyleStopPosition):
(WebCore::Style::toStyleColorStop):
(WebCore::Style::ToStyle&lt;CSS::GradientAngularColorStop&gt;::operator):
(WebCore::Style::ToStyle&lt;CSS::GradientLinearColorStop&gt;::operator):
(WebCore::Style::ToStyle&lt;CSS::GradientDeprecatedColorStop&gt;::operator):
* Source/WebCore/style/values/StyleGradient.h:
* Source/WebCore/style/values/StylePosition.cpp:
(WebCore::Style::ToStyle&lt;CSS::Position&gt;::operator):
* Source/WebCore/style/values/StylePosition.h:
* Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.h:
(WebCore::Style::ConversionDataSpecializer::conversionData):
(WebCore::Style::ConversionDataSpecializer&lt;CSS::LengthRaw&lt;R&gt;&gt;::conversionData):
(WebCore::Style::conversionData):
(WebCore::Style::ToStyle&lt;CSS::AnglePercentage&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::LengthPercentage&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::None&gt;::operator()):
* Source/WebCore/style/values/StyleValueTypes.h:
(WebCore::Style::toStyle):
(WebCore::Style::ToStyle&lt;CSSType&gt;::operator()):
(WebCore::Style::ToStyle&lt;std::optional&lt;CSSType&gt;&gt;::operator()):

Canonical link: <a href="https://commits.webkit.org/285269@main">https://commits.webkit.org/285269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dbe1df434f1bfd3917ac436fc7019ed43370440

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71988 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23017 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56794 "Found 2 new test failures: webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgba4-rgba-unsigned_byte.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgb565-rgb-unsigned_byte.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15300 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77828 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65280 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12721 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6365 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1990 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->