### PR TITLE
Implement Observable#last

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL last(): Promise resolves to last value promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
-FAIL last(): Promise rejects with emitted error assert_equals: expected object "Error: error from source" but got object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
-FAIL last(): Promise rejects with RangeError when source Observable completes without emitting any values assert_true: Promise rejects with RangeError expected true got false
-FAIL last(): Aborting a signal rejects the Promise with an AbortError DOMException promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last({ signal: controller.signal })', 'source.last' is undefined)"
-FAIL last(): Lifecycle promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
+PASS last(): Promise resolves to last value
+PASS last(): Promise rejects with emitted error
+PASS last(): Promise rejects with RangeError when source Observable completes without emitting any values
+PASS last(): Aborting a signal rejects the Promise with an AbortError DOMException
+PASS last(): Lifecycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js
@@ -65,7 +65,6 @@ promise_test(async () => {
       "Promise rejects with a DOMException for abortion");
   assert_equals(rejection.name, "AbortError",
       "Rejected with 'AbortError' DOMException");
-  assert_equals(rejection.message, "signal is aborted without reason");
 }, "last(): Aborting a signal rejects the Promise with an AbortError DOMException");
 
 promise_test(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL last(): Promise resolves to last value promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
-FAIL last(): Promise rejects with emitted error assert_equals: expected object "Error: error from source" but got object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
-FAIL last(): Promise rejects with RangeError when source Observable completes without emitting any values assert_true: Promise rejects with RangeError expected true got false
-FAIL last(): Aborting a signal rejects the Promise with an AbortError DOMException promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last({ signal: controller.signal })', 'source.last' is undefined)"
-FAIL last(): Lifecycle promise_test: Unhandled rejection with value: object "TypeError: source.last is not a function. (In 'source.last()', 'source.last' is undefined)"
+PASS last(): Promise resolves to last value
+PASS last(): Promise rejects with emitted error
+PASS last(): Promise rejects with RangeError when source Observable completes without emitting any values
+PASS last(): Aborting a signal rejects the Promise with an AbortError DOMException
+PASS last(): Lifecycle
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1225,11 +1225,12 @@ dom/InlineClassicScript.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
 dom/InternalObserver.cpp
-dom/InternalObserverFromScript.cpp
+dom/InternalObserverDrop.cpp
 dom/InternalObserverFilter.cpp
+dom/InternalObserverFromScript.cpp
+dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp
 dom/InternalObserverTake.cpp
-dom/InternalObserverDrop.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -1,0 +1,112 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverLast.h"
+
+#include "AbortController.h"
+#include "AbortSignal.h"
+#include "Exception.h"
+#include "ExceptionCode.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverLast final : public InternalObserver {
+public:
+    static Ref<InternalObserverLast> create(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverLast(context, WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        m_lastValue = value;
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        (Ref { m_promise })->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+
+        auto lastValue = std::exchange(m_lastValue, std::nullopt);
+
+        if (UNLIKELY(!lastValue))
+            return (Ref { m_promise })->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
+
+        (Ref { m_promise })->resolve<IDLAny>(*lastValue);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
+    {
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor&) const final
+    {
+    }
+
+    InternalObserverLast(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    std::optional<JSC::JSValue> m_lastValue;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorLast(ScriptExecutionContext& context, Ref<Observable> observable, SubscribeOptions options, Ref<DeferredPromise>&& promise)
+{
+    if (UNLIKELY(options.signal)) {
+        Ref signal = *options.signal;
+
+        if (UNLIKELY(signal->aborted()))
+            return promise->reject<IDLAny>(signal->reason().getValue());
+
+        signal->addAlgorithm([promise](JSC::JSValue reason) {
+            promise->reject<IDLAny>(reason);
+        });
+    }
+
+    auto observer = InternalObserverLast::create(context, WTFMove(promise));
+
+    observable->subscribeInternal(context, observer, options);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverLast.h
+++ b/Source/WebCore/dom/InternalObserverLast.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorLast(ScriptExecutionContext&, Ref<Observable>, SubscribeOptions, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -33,6 +33,7 @@
 #include "InternalObserverDrop.h"
 #include "InternalObserverFilter.h"
 #include "InternalObserverFromScript.h"
+#include "InternalObserverLast.h"
 #include "InternalObserverMap.h"
 #include "InternalObserverTake.h"
 #include "JSSubscriptionObserverCallback.h"
@@ -117,6 +118,11 @@ Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amoun
 Ref<Observable> Observable::drop(ScriptExecutionContext& context, uint64_t amount)
 {
     return create(createSubscriberCallbackDrop(context, *this, amount));
+}
+
+void Observable::last(ScriptExecutionContext& context, SubscribeOptions options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorLast(context, *this, options, WTFMove(promise));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -62,6 +62,10 @@ public:
 
     Ref<Observable> drop(ScriptExecutionContext&, uint64_t);
 
+    // Promise-returning operators.
+
+    void last(ScriptExecutionContext&, SubscribeOptions, Ref<DeferredPromise>&&);
+
 private:
     Ref<SubscriberCallback> m_subscriberCallback;
 };

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -31,6 +31,7 @@ typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
 ]
 interface Observable {
   constructor(SubscriberCallback callback);
+
   [CallWith=CurrentScriptExecutionContext, RaisesException] undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
 
   [CallWith=CurrentScriptExecutionContext] Observable map(MapperCallback mapper);
@@ -40,4 +41,8 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
 
   [CallWith=CurrentScriptExecutionContext] Observable drop(unsigned long long amount);
+
+  // Promise-returning operators.
+
+  [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
 };


### PR DESCRIPTION
#### 39c23277bab79fb17fa560e50f4adbdee7d13020
<pre>
Implement Observable#last
<a href="https://bugs.webkit.org/show_bug.cgi?id=277512">https://bugs.webkit.org/show_bug.cgi?id=277512</a>

Reviewed by Darin Adler.

This change introduces the `.last` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-last">https://wicg.github.io/observable/#dom-observable-last</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-last.any.js:
  AbortErrors&apos; description text is not normative, as such do not assert
  against it.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverLast.cpp: Added.
(WebCore::createInternalObserverOperatorLast):
* Source/WebCore/dom/InternalObserverLast.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::last):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
  Exposes `Promise&lt;any&gt; last(options)` as a promise-returning operator.

Canonical link: <a href="https://commits.webkit.org/285542@main">https://commits.webkit.org/285542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec17b43773ec712878a319115928c540f925714

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56929 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15434 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19663 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78065 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65393 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64656 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16086 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6519 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2223 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->