### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make WebContextMenuListenerProxyClient ref-counted

### DIFF
--- a/Source/WebKit/UIProcess/WebContextMenuListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuListenerProxy.cpp
@@ -42,10 +42,8 @@ WebContextMenuListenerProxy::~WebContextMenuListenerProxy() = default;
 
 void WebContextMenuListenerProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& items)
 {
-    if (!m_client)
-        return;
-
-    m_client->useContextMenuItems(WTFMove(items));
+    if (RefPtr client = m_client.get())
+        client->useContextMenuItems(WTFMove(items));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebContextMenuListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuListenerProxy.h
@@ -28,24 +28,17 @@
 #if ENABLE(CONTEXT_MENUS)
 
 #include "APIObject.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-struct WebContextMenuListenerProxyClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebContextMenuListenerProxyClient> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebContextMenuItem;
 
-struct WebContextMenuListenerProxyClient : CanMakeWeakPtr<WebContextMenuListenerProxyClient> {
+struct WebContextMenuListenerProxyClient : AbstractRefCountedAndCanMakeWeakPtr<WebContextMenuListenerProxyClient> {
     virtual ~WebContextMenuListenerProxyClient() = default;
+
     virtual void useContextMenuItems(Vector<Ref<WebContextMenuItem>>&&) = 0;
 };
 

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -45,6 +45,9 @@ class WebContextMenuProxy : public RefCounted<WebContextMenuProxy>, public WebCo
 public:
     virtual ~WebContextMenuProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual void show();
 
     WebPageProxy* page() const { return m_page.get(); }


### PR DESCRIPTION
#### 2d61ca6cdb324fb7e5de0180473a7843f82428d7
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make WebContextMenuListenerProxyClient ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281557">https://bugs.webkit.org/show_bug.cgi?id=281557</a>
<a href="https://rdar.apple.com/138016028">rdar://138016028</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Remove IsDeprecatedWeakRefSmartPointerException] by making
WebContextMenuListenerProxyClient ref-counted. The sub-classes of
WebContextMenuListenerProxyClient are already ref-counted, so this
does not require any other refactoring.

* Source/WebKit/UIProcess/WebContextMenuListenerProxy.cpp:
(WebKit::WebContextMenuListenerProxy::useContextMenuItems):
* Source/WebKit/UIProcess/WebContextMenuListenerProxy.h:
* Source/WebKit/UIProcess/WebContextMenuProxy.h:

Canonical link: <a href="https://commits.webkit.org/285314@main">https://commits.webkit.org/285314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a5c92f284f420599f6f60be6335223685f9ca4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15398 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43381 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65353 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6465 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11087 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2132 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->