### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Remove exception from RemoteRenderingBackendProxy

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -53,15 +53,6 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
 
-namespace WebKit {
-class TimerAlignment;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteRenderingBackendProxy> : std::true_type { };
-}
-
 namespace WebCore {
 
 class DestinationColorSpace;


### PR DESCRIPTION
#### 06d849415c31fc9b3d9b32eded8b601692390e4a
<pre>
[IsDeprecatedWeakRefSmartPointerException] Remove exception from RemoteRenderingBackendProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281558">https://bugs.webkit.org/show_bug.cgi?id=281558</a>
<a href="https://rdar.apple.com/138016364">rdar://138016364</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Since RemoteRenderingBackendProxy does not inherit from `CanMakeWeakPtr`,
it does not need IsDeprecatedWeakRefSmartPointerException.

* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/285283@main">https://commits.webkit.org/285283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f090e598936aef1de515077a8d046ff7dfb11e75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23215 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56814 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43293 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65294 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64544 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6379 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2008 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48293 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->