### PR TITLE
Use std::span in WebsocketFrame

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
@@ -47,10 +47,10 @@ bool WebSocketFrame::needsExtendedLengthField(size_t payloadLength)
     return payloadLength > maxPayloadLengthWithoutExtendedLengthField;
 }
 
-WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame& frame, const uint8_t*& frameEnd, String& errorString)
+WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(std::span<uint8_t> data, size_t dataLength, WebSocketFrame& frame, const uint8_t*& frameEnd, String& errorString)
 {
-    auto p = data;
-    const uint8_t* bufferEnd = data + dataLength;
+    auto p = data.data();
+    const uint8_t* bufferEnd = data.data() + dataLength;
 
     if (dataLength < 2)
         return FrameIncomplete;

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.h
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.h
@@ -56,7 +56,7 @@ struct WebSocketFrame {
     static bool isControlOpCode(OpCode opCode) { return opCode == OpCodeClose || opCode == OpCodePing || opCode == OpCodePong; }
     static bool isReservedOpCode(OpCode opCode) { return !isNonControlOpCode(opCode) && !isControlOpCode(opCode); }
     WEBCORE_EXPORT static bool needsExtendedLengthField(size_t payloadLength);
-    WEBCORE_EXPORT static ParseFrameResult parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame&, const uint8_t*& frameEnd, String& errorString); // May modify part of data to unmask the frame.
+    WEBCORE_EXPORT static ParseFrameResult parseFrame(std::span<uint8_t> data, size_t dataLength, WebSocketFrame&, const uint8_t*& frameEnd, String& errorString); // May modify part of data to unmask the frame.
 
     WEBCORE_EXPORT WebSocketFrame(OpCode = OpCodeInvalid, bool final = false, bool compress = false, bool masked = false, std::span<const uint8_t> payload = { });
     WEBCORE_EXPORT void makeFrameData(Vector<uint8_t>& frameData);

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -548,7 +548,7 @@ bool WebSocketChannel::processFrame()
     WebSocketFrame frame;
     const uint8_t* frameEnd;
     String errorString;
-    WebSocketFrame::ParseFrameResult result = WebSocketFrame::parseFrame(m_buffer.data(), m_buffer.size(), frame, frameEnd, errorString);
+    WebSocketFrame::ParseFrameResult result = WebSocketFrame::parseFrame(std::span<uint8_t>(m_buffer.data()), m_buffer.size(), frame, frameEnd, errorString);
     if (result == WebSocketFrame::FrameIncomplete)
         return false;
     if (result == WebSocketFrame::FrameError) {


### PR DESCRIPTION
#### f33e2800513e4aae83ee719bde27e5e5225665ba
<pre>
Use std::span in WebsocketFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=281560">https://bugs.webkit.org/show_bug.cgi?id=281560</a>

Reviewed by NOBODY (OOPS!).

Use std::span in WebsocketFrame instead of uint8_t*

* Source/WebCore/Modules/websockets/WebSocketFrame.cpp:
(WebCore::WebSocketFrame::parseFrame):
* Source/WebCore/Modules/websockets/WebSocketFrame.h:

* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f33e2800513e4aae83ee719bde27e5e5225665ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72466 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51887 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76648 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23675 "Hash f33e2800 for PR 35271 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74581 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59691 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23497 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57054 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/23675 "Hash f33e2800 for PR 35271 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75533 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/59691 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37488 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/59691 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22025 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/59691 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78316 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16707 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/23497 "Failed to compile WebKit") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65504 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16755 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64771 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/25254 "Hash f33e2800 for PR 35271 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47685 "Hash f33e2800 for PR 35271 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2470 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48754 "Hash f33e2800 for PR 35271 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50044 "Hash f33e2800 for PR 35271 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48497 "Hash f33e2800 for PR 35271 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->