### PR TITLE
Make the return type as constexpr for CSSPropertyParserHelpers::LengthValidator::isValid().

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
@@ -30,7 +30,7 @@ namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
 struct LengthValidator {
-    static bool isValid(CSSUnitType unitType, CSSPropertyParserOptions options)
+    static constexpr bool isValid(CSSUnitType unitType, CSSPropertyParserOptions options)
     {
         switch (unitType) {
         case CSSUnitType::CSS_QUIRKY_EM:


### PR DESCRIPTION
#### 5148caa2836b61b2e681e7b81ae0bd54667e9f1a
<pre>
Make the return type as constexpr for CSSPropertyParserHelpers::LengthValidator::isValid().
<a href="https://bugs.webkit.org/show_bug.cgi?id=281564">https://bugs.webkit.org/show_bug.cgi?id=281564</a>

Reviewed by Sam Weinig.

To fix build error for gcc11/12 cases and to be in line with return types in other places.
As stated in the bug we have &quot;call to non-‘constexpr’&quot; error while calling
CSSPropertyParserHelpers::LengthValidator::isValid().
Some relevant restrictions of constextpr have been relaxed at [1] since gcc13.

[1] <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106649">https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106649</a>

* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h:
(WebCore::CSSPropertyParserHelpers::LengthPercentageValidator::isValid):

Canonical link: <a href="https://commits.webkit.org/285315@main">https://commits.webkit.org/285315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92758b18163efb3a1cb85d5d0cbf6f56063118f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15344 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19539 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77890 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6414 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2047 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->