### PR TITLE
Implement frame opener resetting between tests with site isolation

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -148,8 +148,10 @@ WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 
 void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
 {
-    if (auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame())
+    if (auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame()) {
+        RELEASE_ASSERT(!coreFrame->opener());
         coreFrame->disownOpener();
+    }
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)


### PR DESCRIPTION
#### d288a334e3f4594f927e68f995ceebfa0838df4d
<pre>
Implement frame opener resetting between tests with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=281574">https://bugs.webkit.org/show_bug.cgi?id=281574</a>

Reviewed by NOBODY (OOPS!).

This first version is just so EWS can tell me what tests to focus on.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameClearOpener):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d288a334e3f4594f927e68f995ceebfa0838df4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56843 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15346 "Found 4 new test failures: fast/dom/Window/window-open-self-from-other-frame.html fast/dom/Window/window-open-top.html fast/dom/Window/window-property-shadowing-onclick.html http/tests/navigation/window-open-cross-origin-then-navigated-back-same-origin.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75119 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46666 "Found 6 new test failures: fast/dom/Window/window-open-self-from-other-frame.html fast/dom/Window/window-open-top.html fast/dom/Window/window-property-shadowing-onclick.html http/tests/navigation/window-open-cross-origin-then-navigated-back-same-origin.html http/tests/security/contentSecurityPolicy/iframe-blank-url-programmatically-add-external-script.html http/tests/security/contentSecurityPolicy/iframe-blocked-when-loaded-via-javascript-url.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43329 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65254 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19907 "Found 6 new test failures: fast/dom/Window/window-open-self-from-other-frame.html fast/dom/Window/window-open-top.html fast/dom/Window/window-property-shadowing-onclick.html http/tests/navigation/window-open-cross-origin-then-navigated-back-same-origin.html http/tests/security/contentSecurityPolicy/iframe-blank-url-programmatically-add-external-script.html http/tests/security/contentSecurityPolicy/iframe-blocked-when-loaded-via-javascript-url.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19076 "Found 6 new test failures: fast/dom/Window/window-open-self-from-other-frame.html fast/dom/Window/window-open-top.html fast/dom/Window/window-property-shadowing-onclick.html http/tests/navigation/window-open-cross-origin-then-navigated-back-same-origin.html http/tests/security/contentSecurityPolicy/iframe-blank-url-programmatically-add-external-script.html http/tests/security/contentSecurityPolicy/iframe-blocked-when-loaded-via-javascript-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64575 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12772 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6422 "Found 6 new test failures: fast/dom/Window/window-open-self-from-other-frame.html fast/dom/Window/window-open-top.html fast/dom/Window/window-property-shadowing-onclick.html http/tests/navigation/window-open-cross-origin-then-navigated-back-same-origin.html http/tests/security/contentSecurityPolicy/iframe-blank-url-programmatically-add-external-script.html http/tests/security/contentSecurityPolicy/iframe-blocked-when-loaded-via-javascript-url.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2054 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->