### PR TITLE
Implement relaxed laneselect SIMD instructions

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test1") (result i32)
+        (i8x16.relaxed_laneselect (v128.const i8x16 0 127 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (v128.const i8x16 0 7 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+        (return (i8x16.extract_lane_u 1))
+    )
+    (func (export "test2") (result i32)
+        (i16x8.relaxed_laneselect (v128.const i16x8 0 32767 0 0 0 0 0 0) (v128.const i16x8 0 0 0 0 0 0 0 0) (v128.const i16x8 0 7 0 0 0 0 0 0))
+        (return (i16x8.extract_lane_u 1))
+    )
+    (func (export "test3") (result i32)
+        (i32x4.relaxed_laneselect (v128.const i32x4 0 2147483647 0 0) (v128.const i32x4 0 0 0 0) (v128.const i32x4 0 7 0 0))
+        (return (i32x4.extract_lane 1))
+    )
+    (func (export "test4") (result i64)
+        (i64x2.relaxed_laneselect (v128.const i64x2 0 9223372036854775807) (v128.const i64x2 0 0) (v128.const i64x2 0 7))
+        (return (i64x2.extract_lane 1))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { test1, test2, test3, test4 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test1(), 7);
+        assert.eq(test2(), 7);
+        assert.eq(test3(), 7);
+        assert.eq(test4(), 7n);
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4416,7 +4416,8 @@ private:
         case B3::VectorBitmask:
             emitSIMDUnaryOp(Air::VectorBitmask);
             return;
-        case B3::VectorBitwiseSelect: {
+        case B3::VectorBitwiseSelect:
+        case B3::VectorRelaxedLaneSelect: {
             SIMDValue* value = m_value->as<SIMDValue>();
             auto resultTmp = tmp(value);
             append(MoveVector, tmp(value->child(2)), resultTmp);

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -4636,7 +4636,8 @@ private:
         case B3::VectorBitmask:
             emitSIMDUnaryOp(Air::VectorBitmask);
             return;
-        case B3::VectorBitwiseSelect: {
+        case B3::VectorBitwiseSelect:
+        case B3::VectorRelaxedLaneSelect: {
             SIMDValue* value = m_value->as<SIMDValue>();
             auto resultTmp = tmp(value);
             append(MoveVector, tmp(value->child(2)), resultTmp);

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -555,6 +555,9 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorRelaxedNMAdd:
         out.print("VectorRelaxedNMAdd");
         return;
+    case VectorRelaxedLaneSelect:
+        out.print("VectorRelaxedLaneSelect");
+        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -428,6 +428,7 @@ enum Opcode : uint8_t {
     VectorRelaxedTruncSat,
     VectorRelaxedMAdd,
     VectorRelaxedNMAdd,
+    VectorRelaxedLaneSelect,
 
     // Currently only some architectures support this.
     // FIXME: Expand this to identical instructions for the other architectures as a macro.

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -101,6 +101,7 @@ public:
         case VectorRelaxedSwizzle:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
+        case VectorRelaxedLaneSelect:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -708,6 +708,20 @@ public:
                 VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
                 break;
 
+            case VectorRelaxedLaneSelect:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 3, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(2)->type() == V128, ("At ", *value));
+                VALIDATE((value->asSIMDValue()->simdLane() == SIMDLane::i8x16)
+                    || (value->asSIMDValue()->simdLane() == SIMDLane::i16x8)
+                    || (value->asSIMDValue()->simdLane() == SIMDLane::i32x4)
+                    || (value->asSIMDValue()->simdLane() == SIMDLane::i64x2), ("At ", *value));
+                VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
+                break;
+
             case CCall:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() >= 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -751,6 +751,7 @@ Effects Value::effects() const
     case VectorRelaxedSwizzle:
     case VectorRelaxedMAdd:
     case VectorRelaxedNMAdd:
+    case VectorRelaxedLaneSelect:
         break;
     case Div:
     case UDiv:
@@ -1012,6 +1013,7 @@ ValueKey Value::key() const
     case VectorRelaxedMAdd:
     case VectorRelaxedNMAdd:
     case VectorBitwiseSelect:
+    case VectorRelaxedLaneSelect:
         numChildrenForKind(kind(), 3);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), child(2));
     case VectorSwizzle:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -553,6 +553,7 @@ protected:
         case VectorBitwiseSelect:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
+        case VectorRelaxedLaneSelect:
             return 3 * sizeof(Value*);
         case CCall:
         case Check:
@@ -784,6 +785,7 @@ private:
         case VectorBitwiseSelect:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
+        case VectorRelaxedLaneSelect:
             if (UNLIKELY(numArgs != 3))
                 badKind(kind, numArgs);
             return Three;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -238,6 +238,7 @@ namespace JSC { namespace B3 {
     case VectorShiftByVector: \
     case VectorRelaxedMAdd: \
     case VectorRelaxedNMAdd: \
+    case VectorRelaxedLaneSelect: \
         return MACRO(SIMDValue); \
     default: \
         RELEASE_ASSERT_NOT_REACHED(); \

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1352,7 +1352,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         } else
             return pushUnreachable(Types::V128);
     }
-    case SIMDLaneOperation::BitwiseSelect: {
+    case SIMDLaneOperation::BitwiseSelect:
+    case SIMDLaneOperation::RelaxedLaneSelect: {
         if constexpr (!isReachable)
             return { };
 

--- a/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
+++ b/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
@@ -115,6 +115,7 @@ enum class SIMDLaneOperation : uint8_t {
     RelaxedTruncSat,
     RelaxedMAdd,
     RelaxedNMAdd,
+    RelaxedLaneSelect,
 };
 
 #define FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -365,7 +366,11 @@ macro(I32x4RelaxedTruncF64x2UZero, 0x104, RelaxedTruncSat,    SIMDLane::f64x2,  
 macro(F32x4RelaxedMAdd,           0x105, RelaxedMAdd,         SIMDLane::f32x4,  SIMDSignMode::None) \
 macro(F32x4RelaxedNMAdd,          0x106, RelaxedNMAdd,        SIMDLane::f32x4,  SIMDSignMode::None) \
 macro(F64x2RelaxedMAdd,           0x107, RelaxedMAdd,         SIMDLane::f64x2,  SIMDSignMode::None) \
-macro(F64x2RelaxedNMAdd,          0x108, RelaxedNMAdd,        SIMDLane::f64x2,  SIMDSignMode::None)
+macro(F64x2RelaxedNMAdd,          0x108, RelaxedNMAdd,        SIMDLane::f64x2,  SIMDSignMode::None) \
+macro(I8x16RelaxedLaneSelect,     0x109, RelaxedLaneSelect,   SIMDLane::i8x16,  SIMDSignMode::None) \
+macro(I16x8RelaxedLaneSelect,     0x10a, RelaxedLaneSelect,   SIMDLane::i16x8,  SIMDSignMode::None) \
+macro(I32x4RelaxedLaneSelect,     0x10b, RelaxedLaneSelect,   SIMDLane::i32x4,  SIMDSignMode::None) \
+macro(I64x2RelaxedLaneSelect,     0x10c, RelaxedLaneSelect,   SIMDLane::i64x2,  SIMDSignMode::None)
 
 #define FOR_EACH_WASM_EXT_SIMD_OP(macro) \
 FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -455,6 +460,7 @@ static void dumpSIMDLaneOperation(PrintStream& out, SIMDLaneOperation op)
     case SIMDLaneOperation::RelaxedTruncSat: out.print("RelaxedTruncSat"); break;
     case SIMDLaneOperation::RelaxedMAdd: out.print("RelaxedMAdd"); break;
     case SIMDLaneOperation::RelaxedNMAdd: out.print("RelaxedNMAdd"); break;
+    case SIMDLaneOperation::RelaxedLaneSelect: out.print("RelaxedLaneSelect"); break;
     }
 }
 MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperation);
@@ -468,6 +474,7 @@ inline bool isRelaxedSIMDOperation(SIMDLaneOperation op)
     case SIMDLaneOperation::RelaxedTruncSat:
     case SIMDLaneOperation::RelaxedMAdd:
     case SIMDLaneOperation::RelaxedNMAdd:
+    case SIMDLaneOperation::RelaxedLaneSelect:
         return true;
     default:
         return false;


### PR DESCRIPTION
#### 9affbf98e0099fe8f126bd9edba69f559d7fc33f
<pre>
Implement relaxed laneselect SIMD instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=281581">https://bugs.webkit.org/show_bug.cgi?id=281581</a>

Reviewed by Yusuke Suzuki.

The specification[1] notes that these instructions should behave as a
bitwise select SIMD instruction when the mask has either _all_ its bits
set or unset. When the mask is of any other value, it allows for
implementations to choose the behavior of the relaxed instruction based
on the backing architecture to be executed on.

The relaxed laneselect instructions are implemented for ARM64 as the
bitwise select (bsl) SIMD instruction since they are already natively
supported by the architecture.

For x86_64, CPUs without AVX support do not have an equivalent bsl
instruction. CPUs with SSE4.1 support feature an alternative set of
instructions (pblend) in which only the top bit of each lane within the
mask is examined. JSC requires AVX support for SIMD instructions, so
this is not applicable.

CPUs with AVX support have a similar instruction to ARM64&apos;s bsl, known
as vpblend. Note that this instruction is not currently used, and it is
instead emulated as v128.or(v128.and(v1, c), v128.and(v2, v128.not(c))).
This optimization can be deferred to future work. Nonetheless, we also
implement the relaxed laneselect instructions as a bitwise select for
x86_64 CPUs with AVX support.

[1] <a href="https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md#relaxed-laneselect">https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md#relaxed-laneselect</a>

* JSTests/wasm/stress/simd-const-relaxed-lane-select.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.i8x16.relaxed_laneselect.v128.const.i8x16.0.127.0.0.0.0.0.0.0.0.0.0.0.0.0.0.v128.const.i8x16.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.v128.const.i8x16.0.7.0.0.0.0.0.0.0.0.0.0.0.0.0.0.return.i8x16.extract_lane_u.1.func.export.string_appeared_here.result.i32.i16x8.relaxed_laneselect.v128.const.i16x8.0.32767.0.0.0.0.0.0.v128.const.i16x8.0.0.0.0.0.0.0.0.v128.const.i16x8.0.7.0.0.0.0.0.0.return.i16x8.extract_lane_u.1.func.export.string_appeared_here.result.i32.i32x4.relaxed_laneselect.v128.const.i32x4.0.2147483647.0.0.v128.const.i32x4.0.0.0.0.v128.const.i32x4.0.7.0.0.return.i32x4.extract_lane.1.func.export.string_appeared_here.result.i64.i64x2.relaxed_laneselect.v128.const.i64x2.0.9223372036854775807.v128.const.i64x2.0.0.v128.const.i64x2.0.7.return.i64x2.extract_lane.1.async test):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDBitwiseSelect):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h:
(JSC::dumpSIMDLaneOperation):
(JSC::isRelaxedSIMDOperation):

Canonical link: <a href="https://commits.webkit.org/286162@main">https://commits.webkit.org/286162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21ebfd588d61aaacfdf6c7971d27b860f9d18ecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23481 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15462 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62235 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37393 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43483 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 4 new passes 5 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21831 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78118 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71526 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64694 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12920 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6554 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93307 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11574 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47491 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20536 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->