### PR TITLE
Unreviewed VisionOS build fix 285485@main

### DIFF
--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -38,20 +38,13 @@ Ref<DummyModelPlayer> DummyModelPlayer::create(ModelPlayerClient& client)
 
 DummyModelPlayer::DummyModelPlayer(ModelPlayerClient& client)
     : m_client { client }
-{
 #if ENABLE(MODEL_PROCESS)
-    m_id = ModelPlayerIdentifier::generate();
+    , m_id(ModelPlayerIdentifier::generate())
 #endif
+{
 }
 
 DummyModelPlayer::~DummyModelPlayer() = default;
-
-#if ENABLE(MODEL_PROCESS)
-ModelPlayerIdentifier DummyModelPlayer::identifier() const
-{
-    return m_id;
-}
-#endif
 
 void DummyModelPlayer::load(Model& model, LayoutSize)
 {

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -42,7 +42,7 @@ private:
 
     // ModelPlayer overrides.
 #if ENABLE(MODEL_PROCESS)
-    ModelPlayerIdentifier identifier() const final;
+    ModelPlayerIdentifier identifier() const final { return m_id; }
 #endif
     void load(Model&, LayoutSize) override;
     void sizeDidChange(LayoutSize) override;


### PR DESCRIPTION
#### b362f96a391da2c6a4b9cadf343d269a1e929ea7
<pre>
Unreviewed VisionOS build fix 285485@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=281584">https://bugs.webkit.org/show_bug.cgi?id=281584</a>
<a href="https://rdar.apple.com/138042262">rdar://138042262</a>

* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::DummyModelPlayer):
(WebCore::m_id):
(WebCore::DummyModelPlayer::identifier const): Deleted.
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/285270@main">https://commits.webkit.org/285270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3662d552f8c4ca976afca49641cb7d7bf518f601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72070 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24855 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75137 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11057 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47288 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49644 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->