### PR TITLE
[iOS] Remove unused code: WKRemoteView

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -207,7 +207,6 @@ static String allowListedClassToString(UIView *view)
         "WKCompositingView",
         "WKContentView",
         "WKModelView",
-        "WKRemoteView",
         "WKScrollView",
         "WKSeparatedModelView",
         "WKShapeView",

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -98,7 +98,7 @@ public:
     void setEventRegion(const WebCore::EventRegion&);
 
     // Non-ancestor scroller that controls positioning of the layer.
-    std::optional<WebCore::PlatformLayerIdentifier >actingScrollContainerID() const { return m_actingScrollContainerID.asOptional(); }
+    std::optional<WebCore::PlatformLayerIdentifier> actingScrollContainerID() const { return m_actingScrollContainerID.asOptional(); }
     // Ancestor scrollers that don't affect positioning of the layer.
     const Vector<WebCore::PlatformLayerIdentifier>& stationaryScrollContainerIDs() const { return m_stationaryScrollContainerIDs; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -62,12 +62,6 @@ class WebPageProxy;
 @interface WKShapeView : WKCompositingView
 @end
 
-@interface WKRemoteView : WKCompositingView
-
-- (instancetype)initWithFrame:(CGRect)frame contextID:(uint32_t)contextID;
-
-@end
-
 @interface WKUIRemoteView : _UIRemoteView <WKContentControlled>
 @end
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -377,31 +377,6 @@ static Class scrollViewScrollIndicatorClass()
 
 @end
 
-@implementation WKRemoteView
-
-- (instancetype)initWithFrame:(CGRect)frame contextID:(uint32_t)contextID
-{
-    if ((self = [super initWithFrame:frame])) {
-        CALayerHost *layer = (CALayerHost *)self.layer;
-        layer.contextId = contextID;
-#if PLATFORM(MACCATALYST)
-        // When running iOS apps on macOS, kCAContextIgnoresHitTest isn't respected; instead, we avoid
-        // hit-testing to the remote context by disabling hit-testing on its host layer. See
-        // <rdar://problem/40591107> for more details.
-        layer.allowsHitTesting = NO;
-#endif
-    }
-
-    return self;
-}
-
-+ (Class)layerClass
-{
-    return NSClassFromString(@"CALayerHost");
-}
-
-@end
-
 @implementation WKUIRemoteView
 
 - (instancetype)initWithFrame:(CGRect)frame pid:(pid_t)pid contextID:(uint32_t)contextID


### PR DESCRIPTION
#### edaf9b9e2928910e1fd9962e32e425c794704106
<pre>
[iOS] Remove unused code: WKRemoteView
<a href="https://bugs.webkit.org/show_bug.cgi?id=281582">https://bugs.webkit.org/show_bug.cgi?id=281582</a>

Reviewed by Abrar Rahman Protyasha.

Remove this unused `WKCompositingView` subclass. The only call site where this was instantiated had
been removed in 224271@main.

* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(allowListedClassToString):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(end::if): Deleted.
(+[WKRemoteView layerClass]): Deleted.
(-[WKUIRemoteView initWithFrame:pid:contextID:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/285275@main">https://commits.webkit.org/285275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed636cc407ff73db938f3c9198bbe80caebe7c3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15363 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75138 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62082 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43349 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19091 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62105 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6430 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47289 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->