### PR TITLE
[Navigation] Improve cross-document traversals

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange does not fire for cross-document navigation.back() and navigation.forward() assert_equals: expected 2 but got 1
+PASS currententrychange does not fire for cross-document navigation.back() and navigation.forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS navigate event destination after iframe detach
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+PASS navigate event for navigation.back() - same-document in an iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+FAIL navigation.traverseTo() in an iframe with same-document preventDefault in its parent assert_unreached: navigate event should not fire in the iframe, because the traversal was cancelled in the top window Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after replace assert_equals: expected 1 but got 2
+PASS navigation.activation after replace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after traverse assert_equals: expected 2 but got 1
+PASS navigation.activation after traverse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
@@ -1,4 +1,2 @@
-
-
-PASS navigation.activation - traverse from a non-contiguous same-origin url
+FAIL: Timed out waiting for notifyDone to be called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-then-clobber-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-then-clobber-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation - traverse, then push same-document assert_equals: expected 2 but got 1
+PASS navigation.activation - traverse, then push same-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT entries() in an iframe must be updated after navigating back to a bfcached page Test timed out
+NOTRUN entries() in an iframe must be updated after navigating back to a bfcached page Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-cross-document-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Error: assert_equals: expected 2 but got 1
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT NavigationHistoryEntry's key and id on cross-document back navigation Test timed out
+PASS NavigationHistoryEntry's key and id on cross-document back navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.sameDocument is properly restored after cross-document back assert_equals: expected 3 but got 1
+PASS entry.sameDocument is properly restored after cross-document back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() is properly restored after cross-document back assert_equals: expected 3 but got 1
+PASS entry.getState() is properly restored after cross-document back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
@@ -1,3 +1,6 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigation.back() and navigation.forward() can navigate multiple frames Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS navigate() to the current URL with history: 'push' and allow it to go cross document
+FAIL navigate() to the current URL with history: 'push' and allow it to go cross document assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL back() promises to 204s never settle assert_unreached: committed must not reject Reached unreachable code
-FAIL back() promises to 205s never settle assert_unreached: committed must not reject Reached unreachable code
-FAIL back() promises to Content-Disposition: attachment responses never settle assert_unreached: committed must not reject Reached unreachable code
+PASS back() promises to 204s never settle
+PASS back() promises to 205s never settle
+PASS back() promises to Content-Disposition: attachment responses never settle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-already-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-already-detached-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT forward() in a detached window Test timed out
+PASS forward() in a detached window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL traverseTo() promise never settle when preventDefault()ing the navigate event (cross-document) assert_equals: expected 2 but got 1
+PASS traverseTo() promise never settle when preventDefault()ing the navigate event (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL traverseTo() promise rejections when detaching an iframe inside onnavigate (cross-document) assert_equals: expected 2 but got 1
+PASS traverseTo() promise rejections when detaching an iframe inside onnavigate (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe cannot navigate its parent via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
+FAIL A sandboxed iframe cannot navigate its parent via its own navigation object by using back() assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Cannot go back" that is not a DOMException SecurityError: property "code" is equal to 11, expected 18
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe cannot navigate its sibling via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
+FAIL A sandboxed iframe cannot navigate its sibling via its own navigation object by using back() assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Cannot go back" that is not a DOMException SecurityError: property "code" is equal to 11, expected 18
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL cross-document traverseTo(), back(), and forward() assert_equals: expected 2 but got 1
+PASS cross-document traverseTo(), back(), and forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL entries() should be correct after a traversal that navigates multiple browsing contexts assert_equals: expected 2 but got 1
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT entries() should be correct after a traversal that navigates multiple browsing contexts Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT back() event ordering for cross-document traversal Test timed out
+PASS back() event ordering for cross-document traversal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
@@ -1,10 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS cross-document reload() must leave transition null
 PASS cross-document navigate() must leave transition null
-TIMEOUT cross-document back() must leave transition null Test timed out
+PASS cross-document back() must leave transition null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-cross-document-expected.txt
@@ -1,8 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Invalid key
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Invalid key
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT No dispose events are fired due to cross-document forward pruning Test timed out
+PASS No dispose events are fired due to cross-document forward pruning
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after navigating away and back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS entry.getState() still works for a non-current cross-document entry
+FAIL entry.getState() still works for a non-current cross-document entry assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS Default behavior for entry.getState() for a non-current cross-document entry
+FAIL Default behavior for entry.getState() for a non-current cross-document entry assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS entry.getState() behavior after cross-document location API navigation
+FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after navigating away and back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS entry.getState() behavior after cross-document location API navigation
+FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 1 but got 0
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
@@ -1,3 +1,0 @@
-
-PASS Basic tests for navigation.currentEntry
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL navigation.entries() behavior when multiple windows navigate. assert_equals: expected 2 but got 1
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
@@ -1,3 +1,0 @@
-
-PASS NavigationHistoryEntry properties after detach
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
@@ -1,4 +1,0 @@
-
-
-PASS A sandboxed iframe can use its sibling's navigation object to call navigate(), as long as allow-same-origin is present
-

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -323,6 +323,23 @@ void HistoryItem::setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&& ob
     m_navigationAPIStateObject = WTFMove(object);
 }
 
+bool HistoryItem::recursiveReplaceChildItem(HistoryItem& child)
+{
+    ASSERT(child.frameID());
+
+    for (size_t i = 0; i < m_children.size(); i++) {
+        Ref existingChild = m_children[i];
+        if (existingChild->frameID() == child.frameID()) {
+            m_children[i] = child;
+            return true;
+        }
+        if (existingChild->recursiveReplaceChildItem(child))
+            return true;
+    }
+
+    return false;
+}
+
 void HistoryItem::addChildItem(Ref<HistoryItem>&& child)
 {
     ASSERT(!child->frameID() || !childItemWithFrameID(*child->frameID()));
@@ -480,7 +497,7 @@ int HistoryItem::showTreeWithIndent(unsigned indentLevel) const
         prefix.append("  "_span);
     prefix.append('\0');
 
-    fprintf(stderr, "%s+-%s (%p)\n", prefix.data(), m_urlString.utf8().data(), this);
+    fprintf(stderr, "%s+-%s (%p) (id=%s) (frame=%s) (item=%ld)\n", prefix.data(), m_urlString.utf8().data(), this, m_identifier.toString().utf8().data(), m_frameID->toString().utf8().data(), m_itemSequenceNumber);
     
     int totalSubItems = 0;
     for (unsigned i = 0; i < m_children.size(); ++i)

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -165,6 +165,7 @@ public:
     WEBCORE_EXPORT HistoryItem* childItemWithFrameID(FrameIdentifier);
     HistoryItem* childItemWithDocumentSequenceNumber(long long number);
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& children() const;
+    bool recursiveReplaceChildItem(HistoryItem&);
     void clearChildren();
     
     bool shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;


### PR DESCRIPTION
#### 0a6c6c13f1bad73e64ad2db1800fa70cbbf24b4e
<pre>
[Navigation] Improve cross-document traversals

page-&gt;goToItem() does not take an arbitary HistoryItem it requires a full HistoryItem tree for the mainFrame so we now make one. Previously the wrong Frame would try to load the item.

Now that the right frame loads the item we also now handle the new entry list for cross-document traverals.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6c6c13f1bad73e64ad2db1800fa70cbbf24b4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59293 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23101 "Hash 0a6c6c13 for PR 35286 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56858 "Found 11 new test failures: fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/forward-and-cancel.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html imported/blink/svg/as-object/history-navigation.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15366 "7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75139 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46701 "Found 10 new test failures: fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html http/tests/security/cross-origin-session-storage-third-party-partitioned.html imported/blink/svg/as-object/history-navigation.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37296 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43348 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-navigated-history-popup.https.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19563 "Found 10 new test failures: fast/history/history-back-initial-vs-final-url.html fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html http/tests/security/cross-origin-session-storage-third-party-partitioned.html imported/blink/svg/as-object/history-navigation.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65252 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19923 "Found 12 new test failures: fast/history/history-back-initial-vs-final-url.html fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html http/tests/security/cross-origin-session-storage-third-party-partitioned.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16312 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/23101 "Hash 0a6c6c13 for PR 35286 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65330 "Found 13 new test failures: fast/history/history-back-initial-vs-final-url.html fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/forward-and-cancel.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12789 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6436 "Found 12 new test failures: fast/history/history-back-initial-vs-final-url.html fast/loader/form-state-restore-with-frames.html fast/loader/stateobjects/replacestate-in-iframe.html http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-to-slow-frame.html http/tests/navigation/post-frames-goback1.html http/tests/navigation/postredirect-frames-goback1.html http/tests/security/cross-origin-session-storage-third-party-partitioned.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->