### PR TITLE
[WGSL] shader,validation,shader_io,align:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -68,6 +68,7 @@ private:
     void validateBuiltinIO(const SourceSpan&, const Type*, ShaderStage, Builtin, Direction, Builtins&);
     void validateLocationIO(const SourceSpan&, const Type*, ShaderStage, unsigned, Locations&);
     void validateStructIO(ShaderStage, const Types::Struct&, Direction, Builtins&, Locations&);
+    void validateAlignment(const SourceSpan&, AddressSpace, const Type*);
 
     template<typename T>
     void update(const SourceSpan&, std::optional<T>&, const T&);
@@ -271,6 +272,52 @@ void AttributeValidator::visit(AST::Variable& variable)
 
     if (isResource && (!variable.m_group || !variable.m_binding))
         error(variable.span(), "resource variables require @group and @binding attributes"_s);
+
+    if (isResource && m_errors.isEmpty())
+        validateAlignment(variable.span(), *variable.addressSpace(), variable.storeType());
+}
+
+void AttributeValidator::validateAlignment(const SourceSpan& span, AddressSpace addressSpace, const Type* type)
+{
+    const auto& requiredAlignment = [&](const Type* type) {
+        auto alignment = type->alignment();
+        if (addressSpace == AddressSpace::Uniform && (std::holds_alternative<Types::Array>(*type) || std::holds_alternative<Types::Struct>(*type)))
+            alignment = WTF::roundUpToMultipleOf(16, alignment);
+        return alignment;
+    };
+
+    if (auto* arrayType = std::get_if<Types::Array>(type)) {
+        if (arrayType->stride() % requiredAlignment(arrayType->element))
+            error(span, "array must have a stride multiple of "_s, String::number(requiredAlignment(arrayType->element)), " bytes, but has a stride of "_s, String::number(arrayType->stride()), " bytes"_s);
+
+        if (addressSpace == AddressSpace::Uniform && (arrayType->stride() % 16))
+            error(span, "arrays in the uniform address space must have a stride multiple of 16 bytes, but has a stride of "_s, String::number(arrayType->stride()), " bytes"_s);
+
+        validateAlignment(span, addressSpace, arrayType->element);
+    }
+
+    if (auto* structType = std::get_if<Types::Struct>(type)) {
+        auto& structure = structType->structure;
+        auto memberCount = structure.members().size();
+        for (unsigned i = 0; i < memberCount; ++i) {
+            auto& member = structure.members()[i];
+            auto* type = member.type().inferredType();
+
+            validateAlignment(member.span(), addressSpace, type);
+
+            if (member.offset() % requiredAlignment(type))
+                error(member.span(), "offset of struct member "_s, structure.name(), "::"_s, member.name(), " must be a multiple of "_s, String::number(requiredAlignment(type)), " bytes, but its offset is "_s, String::number(member.offset()), " bytes"_s);
+
+            if (addressSpace == AddressSpace::Uniform && std::holds_alternative<Types::Struct>(*type) && (i + 1) < memberCount) {
+                auto& nextMember = structure.members()[i + 1];
+                auto spaceBetweenMembers = nextMember.offset() - member.offset();
+                auto minimumNumberOfBytes = WTF::roundUpToMultipleOf(16, type->size());
+                if (spaceBetweenMembers < minimumNumberOfBytes)
+                    error(member.span(), "uniform address space requires that the number of bytes between "_s, structure.name(), "::"_s, member.name(), " and "_s, structure.name(), "::"_s, nextMember.name(), " must be at least "_s, String::number(minimumNumberOfBytes), " bytes, but it is "_s, String::number(spaceBetweenMembers), " bytes"_s);
+            }
+        }
+
+    }
 }
 
 void AttributeValidator::visit(AST::Structure& structure)
@@ -401,9 +448,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
                 continue;
             }
 
-            // FIXME: validate that alignment is a multiple of RequiredAlignOf(T,C)
-            auto* type = member.type().inferredType();
-            update(attribute.span(), member.m_alignment, std::max<unsigned>(alignmentValue, type ? type->alignment() : 1u));
+            update<unsigned>(attribute.span(), member.m_alignment, alignmentValue);
             continue;
         }
 

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -38,6 +38,15 @@ namespace WGSL {
 
 using namespace Types;
 
+namespace Types {
+
+size_t Array::stride() const
+{
+    return WTF::roundUpToMultipleOf(element->alignment(), element->size());
+}
+
+} // namespace Types
+
 void Type::dump(PrintStream& out) const
 {
     WTF::switchOn(*this,

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -147,6 +147,8 @@ struct Array {
     bool isRuntimeSized() const { return std::holds_alternative<std::monostate>(size); }
     bool isCreationFixed() const { return std::holds_alternative<unsigned>(size); }
     bool isOverrideSized() const { return std::holds_alternative<AST::Expression*>(size); }
+
+    size_t stride() const;
 };
 
 struct Struct {

--- a/Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl
@@ -1,0 +1,31 @@
+// RUN: %not %wgslc | %check
+
+struct S1 {
+    // CHECK-L: arrays in the uniform address space must have a stride multiple of 16 bytes, but has a stride of 8 bytes
+    x: array<vec2<i32>, 2>,
+
+    x1: i32,
+    // CHECK-L: offset of struct member S1::y1 must be a multiple of 16 bytes, but its offset is 20 bytes
+    @align(4) y1: array<vec4<i32>, 2>,
+
+    @align(16) x2: i32,
+    // CHECK-L: offset of struct member S1::y2 must be a multiple of 32 bytes, but its offset is 80 bytes
+    @align(16) y2: U,
+
+    x3: i32,
+    y3: T,
+    // CHECK-L: uniform address space requires that the number of bytes between S1::y3 and S1::z3 must be at least 16 bytes, but it is 8 bytes
+    z3: i32,
+}
+
+struct T {
+    x: i32,
+    y: i32,
+};
+
+struct U {
+    x: i32,
+    @align(32) y: i32,
+};
+
+@group(0) @binding(1) var<uniform> x1: S1;


### PR DESCRIPTION
#### c5a93258333f65c7ffdff8de27d429d5e6eff40b
<pre>
[WGSL] shader,validation,shader_io,align:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=281588">https://bugs.webkit.org/show_bug.cgi?id=281588</a>
<a href="https://rdar.apple.com/135984013">rdar://135984013</a>

Reviewed by Mike Wyrzykowski.

Add validation for the &quot;required alignment&quot; according to the spec[1], which requires
validating the offset of struct members as well as array strides.

[1]: <a href="https://www.w3.org/TR/WGSL/#requiredalignof">https://www.w3.org/TR/WGSL/#requiredalignof</a>

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
(WGSL::AttributeValidator::validateAlignment):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Types::Array::stride const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/285327@main">https://commits.webkit.org/285327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04ce896b468a58db91af1e6e30b04078252a394c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43365 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65347 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6452 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47311 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->