### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for LegacyCustomProtocolManagerProxy

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -81,12 +81,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
 {
-    if (!_customProtocolManagerProxy)
+    RefPtr customProtocolManagerProxy = _customProtocolManagerProxy.get();
+    if (!customProtocolManagerProxy)
         return;
 
     WebCore::ResourceError coreError(error);
-    _customProtocolManagerProxy->didFailWithError(*_customProtocolID, coreError);
-    _customProtocolManagerProxy->stopLoading(*_customProtocolID);
+    customProtocolManagerProxy->didFailWithError(*_customProtocolID, coreError);
+    customProtocolManagerProxy->stopLoading(*_customProtocolID);
 }
 
 - (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse
@@ -98,28 +99,31 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
 {
-    if (!_customProtocolManagerProxy)
+    RefPtr customProtocolManagerProxy = _customProtocolManagerProxy.get();
+    if (!customProtocolManagerProxy)
         return;
 
     WebCore::ResourceResponse coreResponse(response);
-    _customProtocolManagerProxy->didReceiveResponse(*_customProtocolID, coreResponse, WebKit::toCacheStoragePolicy(_storagePolicy));
+    customProtocolManagerProxy->didReceiveResponse(*_customProtocolID, coreResponse, WebKit::toCacheStoragePolicy(_storagePolicy));
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
 {
-    if (!_customProtocolManagerProxy)
+    RefPtr customProtocolManagerProxy = _customProtocolManagerProxy.get();
+    if (!customProtocolManagerProxy)
         return;
 
-    _customProtocolManagerProxy->didLoadData(*_customProtocolID, span(data));
+    customProtocolManagerProxy->didLoadData(*_customProtocolID, span(data));
 }
 
 - (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse
 {
-    if (!_customProtocolManagerProxy)
+    RefPtr customProtocolManagerProxy = _customProtocolManagerProxy.get();
+    if (!customProtocolManagerProxy)
         return nil;
 
     if (redirectResponse) {
-        _customProtocolManagerProxy->wasRedirectedToRequest(*_customProtocolID, request, redirectResponse);
+        customProtocolManagerProxy->wasRedirectedToRequest(*_customProtocolID, request, redirectResponse);
         return nil;
     }
     return request;
@@ -127,11 +131,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
-    if (!_customProtocolManagerProxy)
+    RefPtr customProtocolManagerProxy = _customProtocolManagerProxy.get();
+    if (!customProtocolManagerProxy)
         return;
 
-    _customProtocolManagerProxy->didFinishLoading(*_customProtocolID);
-    _customProtocolManagerProxy->stopLoading(*_customProtocolID);
+    customProtocolManagerProxy->didFinishLoading(*_customProtocolID);
+    customProtocolManagerProxy->stopLoading(*_customProtocolID);
 }
 
 @end

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
@@ -37,6 +37,16 @@ LegacyCustomProtocolManagerProxy::LegacyCustomProtocolManagerProxy(NetworkProces
     networkProcessProxy.addMessageReceiver(Messages::LegacyCustomProtocolManagerProxy::messageReceiverName(), *this);
 }
 
+void LegacyCustomProtocolManagerProxy::ref() const
+{
+    m_networkProcessProxy->ref();
+}
+
+void LegacyCustomProtocolManagerProxy::deref() const
+{
+    m_networkProcessProxy->deref();
+}
+
 Ref<NetworkProcessProxy> LegacyCustomProtocolManagerProxy::protectedProcess()
 {
     return m_networkProcessProxy.get();

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -36,15 +36,6 @@
 OBJC_CLASS WKCustomProtocolLoader;
 #endif
 
-namespace WebKit {
-class LegacyCustomProtocolManagerProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::LegacyCustomProtocolManagerProxy> : std::true_type { };
-}
-
 namespace WebCore {
 class ResourceError;
 class ResourceRequest;
@@ -56,9 +47,9 @@ namespace WebKit {
 enum class CacheStoragePolicy : uint8_t;
 class NetworkProcessProxy;
 
-class LegacyCustomProtocolManagerProxy : public IPC::MessageReceiver {
+class LegacyCustomProtocolManagerProxy final : public IPC::MessageReceiver {
 public:
-    LegacyCustomProtocolManagerProxy(NetworkProcessProxy&);
+    explicit LegacyCustomProtocolManagerProxy(NetworkProcessProxy&);
     ~LegacyCustomProtocolManagerProxy();
 
     void startLoading(LegacyCustomProtocolID, const WebCore::ResourceRequest&);
@@ -71,6 +62,9 @@ public:
     void didLoadData(LegacyCustomProtocolID, std::span<const uint8_t>);
     void didFailWithError(LegacyCustomProtocolID, const WebCore::ResourceError&);
     void didFinishLoading(LegacyCustomProtocolID);
+
+    void ref() const;
+    void deref() const;
 
 private:
     Ref<NetworkProcessProxy> protectedProcess();


### PR DESCRIPTION
#### 46b77e53c88f0c107ae6288e16a57c1c31913a03
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for LegacyCustomProtocolManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281602">https://bugs.webkit.org/show_bug.cgi?id=281602</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp:
(WebKit::LegacyCustomProtocolManagerProxy::ref const):
(WebKit::LegacyCustomProtocolManagerProxy::deref const):
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/285335@main">https://commits.webkit.org/285335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9798c3e4d79ace9b2fc815cacb095a76dc46773c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23451 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23273 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62213 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43462 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78087 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71496 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65406 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64669 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6539 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11092 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47461 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2245 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->