### PR TITLE
Make `TextCheckerState` an OptionSet

### DIFF
--- a/Source/WebKit/Shared/TextCheckerState.h
+++ b/Source/WebKit/Shared/TextCheckerState.h
@@ -25,20 +25,17 @@
 
 #pragma once
 
-#include "ArgumentCoders.h"
-
 namespace WebKit {
 
-struct TextCheckerState {
-    bool isContinuousSpellCheckingEnabled { false };
-    bool isGrammarCheckingEnabled { false };
-
+enum class TextCheckerState : uint8_t {
+    ContinuousSpellCheckingEnabled = 1 << 0,
+    GrammarCheckingEnabled = 1 << 1,
 #if USE(APPKIT)
-    bool isAutomaticSpellingCorrectionEnabled { false };
-    bool isAutomaticQuoteSubstitutionEnabled { false };
-    bool isAutomaticDashSubstitutionEnabled { false };
-    bool isAutomaticLinkDetectionEnabled { false };
-    bool isAutomaticTextReplacementEnabled { false };
+    AutomaticTextReplacementEnabled = 1 << 2,
+    AutomaticSpellingCorrectionEnabled = 1 << 3,
+    AutomaticQuoteSubstitutionEnabled = 1 << 4,
+    AutomaticDashSubstitutionEnabled = 1 << 5,
+    AutomaticLinkDetectionEnabled = 1 << 6,
 #endif
 };
 

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -117,16 +117,15 @@ enum class WebCore::FontSmoothingMode : uint8_t {
     SubpixelAntialiased
 };
 
-struct WebKit::TextCheckerState {
-    bool isContinuousSpellCheckingEnabled
-    bool isGrammarCheckingEnabled
-
+[OptionSet] enum class WebKit::TextCheckerState : uint8_t {
+    ContinuousSpellCheckingEnabled,
+    GrammarCheckingEnabled,
 #if USE(APPKIT)
-    bool isAutomaticSpellingCorrectionEnabled
-    bool isAutomaticQuoteSubstitutionEnabled
-    bool isAutomaticDashSubstitutionEnabled
-    bool isAutomaticLinkDetectionEnabled
-    bool isAutomaticTextReplacementEnabled
+    AutomaticTextReplacementEnabled,
+    AutomaticSpellingCorrectionEnabled,
+    AutomaticQuoteSubstitutionEnabled,
+    AutomaticDashSubstitutionEnabled,
+    AutomaticLinkDetectionEnabled
 #endif
 };
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -37,6 +37,7 @@
 #include "WebProcessDataStoreParameters.h"
 #include <WebCore/CrossOriginMode.h>
 #include <wtf/HashMap.h>
+#include <wtf/OptionSet.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
@@ -130,7 +131,7 @@ struct WebProcessCreationParameters {
     bool hasRichContentServices { false };
 #endif
 
-    TextCheckerState textCheckerState;
+    OptionSet<TextCheckerState> textCheckerState;
 
 #if PLATFORM(COCOA)
     String uiProcessBundleIdentifier;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -81,7 +81,7 @@
     bool hasRichContentServices;
 #endif
 
-    WebKit::TextCheckerState textCheckerState;
+    OptionSet<WebKit::TextCheckerState> textCheckerState;
 
 #if PLATFORM(COCOA)
     String uiProcessBundleIdentifier;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1525,7 +1525,7 @@ gboolean webkit_web_context_get_spell_checking_enabled(WebKitWebContext* context
     g_return_val_if_fail(WEBKIT_IS_WEB_CONTEXT(context), FALSE);
 
 #if ENABLE(SPELLCHECK)
-    return TextChecker::state().isContinuousSpellCheckingEnabled;
+    return TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled);
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/TextChecker.cpp
+++ b/Source/WebKit/UIProcess/TextChecker.cpp
@@ -35,13 +35,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-static TextCheckerState& checkerState()
+static OptionSet<TextCheckerState>& checkerState()
 {
-    static TextCheckerState textCheckerState;
+    static OptionSet<TextCheckerState> textCheckerState;
     return textCheckerState;
 }
 
-const TextCheckerState& TextChecker::state()
+OptionSet<TextCheckerState> TextChecker::state()
 {
     return checkerState();
 }

--- a/Source/WebKit/UIProcess/TextChecker.h
+++ b/Source/WebKit/UIProcess/TextChecker.h
@@ -32,13 +32,13 @@
 namespace WebKit {
 
 class WebPageProxy;
-struct TextCheckerState;
+enum class TextCheckerState : uint8_t;
 
 using SpellDocumentTag = int64_t;
     
 class TextChecker {
 public:
-    static const TextCheckerState& state();
+    static OptionSet<TextCheckerState> state();
     static bool isContinuousSpellCheckingAllowed();
 
     static bool setContinuousSpellCheckingEnabled(bool);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9654,27 +9654,27 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item)
         return;
 
     case ContextMenuItemTagSmartQuotes:
-        TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().isAutomaticQuoteSubstitutionEnabled);
+        TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagSmartDashes:
-        TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().isAutomaticDashSubstitutionEnabled);
+        TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagSmartLinks:
-        TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().isAutomaticLinkDetectionEnabled);
+        TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagTextReplacement:
-        TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().isAutomaticTextReplacementEnabled);
+        TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagCorrectSpellingAutomatically:
-        TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().isAutomaticSpellingCorrectionEnabled);
+        TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
@@ -9697,12 +9697,12 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item)
         break;
 
     case ContextMenuItemTagCheckSpellingWhileTyping:
-        TextChecker::setContinuousSpellCheckingEnabled(!TextChecker::state().isContinuousSpellCheckingEnabled);
+        TextChecker::setContinuousSpellCheckingEnabled(!TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagCheckGrammarWithSpelling:
-        TextChecker::setGrammarCheckingEnabled(!TextChecker::state().isGrammarCheckingEnabled);
+        TextChecker::setGrammarCheckingEnabled(!TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
@@ -12464,25 +12464,25 @@ void WebPageProxy::toggleSmartInsertDelete()
 void WebPageProxy::toggleAutomaticQuoteSubstitution()
 {
     if (TextChecker::isTestingMode())
-        TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().isAutomaticQuoteSubstitutionEnabled);
+        TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled));
 }
 
 void WebPageProxy::toggleAutomaticLinkDetection()
 {
     if (TextChecker::isTestingMode())
-        TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().isAutomaticLinkDetectionEnabled);
+        TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled));
 }
 
 void WebPageProxy::toggleAutomaticDashSubstitution()
 {
     if (TextChecker::isTestingMode())
-        TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().isAutomaticDashSubstitutionEnabled);
+        TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
 }
 
 void WebPageProxy::toggleAutomaticTextReplacement()
 {
     if (TextChecker::isTestingMode())
-        TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().isAutomaticTextReplacementEnabled);
+        TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
 }
 
 #endif

--- a/Source/WebKit/UIProcess/gtk/TextCheckerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/TextCheckerGtk.cpp
@@ -39,19 +39,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-TextCheckerState& checkerState()
+OptionSet<TextCheckerState>& checkerState()
 {
-    static TextCheckerState textCheckerState;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        textCheckerState.isContinuousSpellCheckingEnabled = false;
-        textCheckerState.isGrammarCheckingEnabled = false;
-    });
-
+    static OptionSet<TextCheckerState> textCheckerState;
     return textCheckerState;
 }
 
-const TextCheckerState& TextChecker::state()
+OptionSet<TextCheckerState> TextChecker::state()
 {
     return checkerState();
 }
@@ -88,9 +82,9 @@ bool TextChecker::isContinuousSpellCheckingAllowed()
 bool TextChecker::setContinuousSpellCheckingEnabled(bool isContinuousSpellCheckingEnabled)
 {
 #if ENABLE(SPELLCHECK)
-    if (checkerState().isContinuousSpellCheckingEnabled == isContinuousSpellCheckingEnabled)
+    if (checkerState().contains(TextCheckerState::ContinuousSpellCheckingEnabled) == isContinuousSpellCheckingEnabled)
         return false;
-    checkerState().isContinuousSpellCheckingEnabled = isContinuousSpellCheckingEnabled;
+    checkerState().set(TextCheckerState::ContinuousSpellCheckingEnabled, isContinuousSpellCheckingEnabled);
     updateStateForAllProcessPools();
 #else
     UNUSED_PARAM(isContinuousSpellCheckingEnabled);
@@ -101,9 +95,9 @@ bool TextChecker::setContinuousSpellCheckingEnabled(bool isContinuousSpellChecki
 void TextChecker::setGrammarCheckingEnabled(bool isGrammarCheckingEnabled)
 {
 #if ENABLE(SPELLCHECK)
-    if (checkerState().isGrammarCheckingEnabled == isGrammarCheckingEnabled)
+    if (checkerState().contains(TextCheckerState::GrammarCheckingEnabled) == isGrammarCheckingEnabled)
         return;
-    checkerState().isGrammarCheckingEnabled = isGrammarCheckingEnabled;
+    checkerState().set(TextCheckerState::GrammarCheckingEnabled, isGrammarCheckingEnabled);
     updateStateForAllProcessPools();
 #else
     UNUSED_PARAM(isGrammarCheckingEnabled);
@@ -113,7 +107,7 @@ void TextChecker::setGrammarCheckingEnabled(bool isGrammarCheckingEnabled)
 void TextChecker::continuousSpellCheckingEnabledStateChanged(bool enabled)
 {
 #if ENABLE(SPELLCHECK)
-    checkerState().isContinuousSpellCheckingEnabled = enabled;
+    checkerState().set(TextCheckerState::ContinuousSpellCheckingEnabled, enabled);
 #else
     UNUSED_PARAM(enabled);
 #endif
@@ -122,7 +116,7 @@ void TextChecker::continuousSpellCheckingEnabledStateChanged(bool enabled)
 void TextChecker::grammarCheckingEnabledStateChanged(bool enabled)
 {
 #if ENABLE(SPELLCHECK)
-    checkerState().isGrammarCheckingEnabled = enabled;
+    checkerState().set(TextCheckerState::GrammarCheckingEnabled, enabled);
 #else
     UNUSED_PARAM(enabled);
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11563,7 +11563,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 
 - (void)setGrammarCheckingEnabled:(BOOL)enabled
 {
-    if (static_cast<bool>(enabled) == WebKit::TextChecker::state().isGrammarCheckingEnabled)
+    if (static_cast<bool>(enabled) == WebKit::TextChecker::state().contains(WebKit::TextCheckerState::GrammarCheckingEnabled))
         return;
 
     WebKit::TextChecker::setGrammarCheckingEnabled(enabled);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2940,20 +2940,20 @@ bool WebViewImpl::validateUserInterfaceItem(id <NSValidatedUserInterfaceItem> it
 
     if (action == @selector(toggleContinuousSpellChecking:)) {
         bool enabled = TextChecker::isContinuousSpellCheckingAllowed();
-        bool checked = enabled && TextChecker::state().isContinuousSpellCheckingEnabled;
+        bool checked = enabled && TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return enabled;
     }
 
     if (action == @selector(toggleGrammarChecking:)) {
-        bool checked = TextChecker::state().isGrammarCheckingEnabled;
+        bool checked = TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return true;
     }
 
     if (action == @selector(toggleAutomaticSpellingCorrection:)) {
         bool enable = m_page->editorState().canEnableAutomaticSpellingCorrection;
-        menuItem(item).state = TextChecker::state().isAutomaticSpellingCorrectionEnabled && enable ? NSControlStateValueOn : NSControlStateValueOff;
+        menuItem(item).state = TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled) && enable ? NSControlStateValueOn : NSControlStateValueOff;
         return enable;
     }
 
@@ -2970,25 +2970,25 @@ bool WebViewImpl::validateUserInterfaceItem(id <NSValidatedUserInterfaceItem> it
     }
 
     if (action == @selector(toggleAutomaticQuoteSubstitution:)) {
-        bool checked = TextChecker::state().isAutomaticQuoteSubstitutionEnabled;
+        bool checked = TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticDashSubstitution:)) {
-        bool checked = TextChecker::state().isAutomaticDashSubstitutionEnabled;
+        bool checked = TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticLinkDetection:)) {
-        bool checked = TextChecker::state().isAutomaticLinkDetectionEnabled;
+        bool checked = TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticTextReplacement:)) {
-        bool checked = TextChecker::state().isAutomaticTextReplacementEnabled;
+        bool checked = TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled);
         [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
@@ -3090,7 +3090,7 @@ void WebViewImpl::changeSpelling(id sender)
 
 void WebViewImpl::setContinuousSpellCheckingEnabled(bool enabled)
 {
-    if (TextChecker::state().isContinuousSpellCheckingEnabled == enabled)
+    if (TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled) == enabled)
         return;
 
     TextChecker::setContinuousSpellCheckingEnabled(enabled);
@@ -3099,7 +3099,7 @@ void WebViewImpl::setContinuousSpellCheckingEnabled(bool enabled)
 
 void WebViewImpl::toggleContinuousSpellChecking()
 {
-    bool spellCheckingEnabled = !TextChecker::state().isContinuousSpellCheckingEnabled;
+    bool spellCheckingEnabled = !TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled);
     TextChecker::setContinuousSpellCheckingEnabled(spellCheckingEnabled);
 
     m_page->legacyMainFrameProcess().updateTextCheckerState();
@@ -3107,12 +3107,12 @@ void WebViewImpl::toggleContinuousSpellChecking()
 
 bool WebViewImpl::isGrammarCheckingEnabled()
 {
-    return TextChecker::state().isGrammarCheckingEnabled;
+    return TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled);
 }
 
 void WebViewImpl::setGrammarCheckingEnabled(bool flag)
 {
-    if (static_cast<bool>(flag) == TextChecker::state().isGrammarCheckingEnabled)
+    if (static_cast<bool>(flag) == TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled))
         return;
 
     TextChecker::setGrammarCheckingEnabled(flag);
@@ -3121,7 +3121,7 @@ void WebViewImpl::setGrammarCheckingEnabled(bool flag)
 
 void WebViewImpl::toggleGrammarChecking()
 {
-    bool grammarCheckingEnabled = !TextChecker::state().isGrammarCheckingEnabled;
+    bool grammarCheckingEnabled = !TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled);
     TextChecker::setGrammarCheckingEnabled(grammarCheckingEnabled);
 
     m_page->legacyMainFrameProcess().updateTextCheckerState();
@@ -3129,7 +3129,7 @@ void WebViewImpl::toggleGrammarChecking()
 
 void WebViewImpl::toggleAutomaticSpellingCorrection()
 {
-    TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().isAutomaticSpellingCorrectionEnabled);
+    TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled));
 
     m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
@@ -3157,12 +3157,12 @@ void WebViewImpl::toggleSmartInsertDelete()
 
 bool WebViewImpl::isAutomaticQuoteSubstitutionEnabled()
 {
-    return TextChecker::state().isAutomaticQuoteSubstitutionEnabled;
+    return TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
 }
 
 void WebViewImpl::setAutomaticQuoteSubstitutionEnabled(bool flag)
 {
-    if (static_cast<bool>(flag) == TextChecker::state().isAutomaticQuoteSubstitutionEnabled)
+    if (static_cast<bool>(flag) == TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled))
         return;
 
     TextChecker::setAutomaticQuoteSubstitutionEnabled(flag);
@@ -3171,18 +3171,18 @@ void WebViewImpl::setAutomaticQuoteSubstitutionEnabled(bool flag)
 
 void WebViewImpl::toggleAutomaticQuoteSubstitution()
 {
-    TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().isAutomaticQuoteSubstitutionEnabled);
+    TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled));
     m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticDashSubstitutionEnabled()
 {
-    return TextChecker::state().isAutomaticDashSubstitutionEnabled;
+    return TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled);
 }
 
 void WebViewImpl::setAutomaticDashSubstitutionEnabled(bool flag)
 {
-    if (static_cast<bool>(flag) == TextChecker::state().isAutomaticDashSubstitutionEnabled)
+    if (static_cast<bool>(flag) == TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled))
         return;
 
     TextChecker::setAutomaticDashSubstitutionEnabled(flag);
@@ -3191,18 +3191,18 @@ void WebViewImpl::setAutomaticDashSubstitutionEnabled(bool flag)
 
 void WebViewImpl::toggleAutomaticDashSubstitution()
 {
-    TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().isAutomaticDashSubstitutionEnabled);
+    TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
     m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticLinkDetectionEnabled()
 {
-    return TextChecker::state().isAutomaticLinkDetectionEnabled;
+    return TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled);
 }
 
 void WebViewImpl::setAutomaticLinkDetectionEnabled(bool flag)
 {
-    if (static_cast<bool>(flag) == TextChecker::state().isAutomaticLinkDetectionEnabled)
+    if (static_cast<bool>(flag) == TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled))
         return;
 
     TextChecker::setAutomaticLinkDetectionEnabled(flag);
@@ -3211,18 +3211,18 @@ void WebViewImpl::setAutomaticLinkDetectionEnabled(bool flag)
 
 void WebViewImpl::toggleAutomaticLinkDetection()
 {
-    TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().isAutomaticLinkDetectionEnabled);
+    TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled));
     m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticTextReplacementEnabled()
 {
-    return TextChecker::state().isAutomaticTextReplacementEnabled;
+    return TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled);
 }
 
 void WebViewImpl::setAutomaticTextReplacementEnabled(bool flag)
 {
-    if (static_cast<bool>(flag) == TextChecker::state().isAutomaticTextReplacementEnabled)
+    if (static_cast<bool>(flag) == TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled))
         return;
 
     TextChecker::setAutomaticTextReplacementEnabled(flag);
@@ -3231,7 +3231,7 @@ void WebViewImpl::setAutomaticTextReplacementEnabled(bool flag)
 
 void WebViewImpl::toggleAutomaticTextReplacement()
 {
-    TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().isAutomaticTextReplacementEnabled);
+    TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
     m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -88,7 +88,7 @@ bool WebEditorClient::isSelectTrailingWhitespaceEnabled() const
 
 bool WebEditorClient::isContinuousSpellCheckingEnabled()
 {
-    return WebProcess::singleton().textCheckerState().isContinuousSpellCheckingEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::ContinuousSpellCheckingEnabled);
 }
 
 void WebEditorClient::toggleContinuousSpellChecking()
@@ -98,7 +98,7 @@ void WebEditorClient::toggleContinuousSpellChecking()
 
 bool WebEditorClient::isGrammarCheckingEnabled()
 {
-    return WebProcess::singleton().textCheckerState().isGrammarCheckingEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::GrammarCheckingEnabled);
 }
 
 void WebEditorClient::toggleGrammarChecking()

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -33,6 +33,7 @@
 #if PLATFORM(MAC)
 
 #import "MessageSenderInlines.h"
+#import "TextCheckerState.h"
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"
 #import "WebProcess.h"
@@ -124,7 +125,7 @@ bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
     if (Ref { *m_page }->isControlledByAutomation())
         return false;
 
-    return WebProcess::singleton().textCheckerState().isAutomaticQuoteSubstitutionEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
 }
 
 void WebEditorClient::toggleAutomaticQuoteSubstitution()
@@ -134,7 +135,7 @@ void WebEditorClient::toggleAutomaticQuoteSubstitution()
 
 bool WebEditorClient::isAutomaticLinkDetectionEnabled()
 {
-    return WebProcess::singleton().textCheckerState().isAutomaticLinkDetectionEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticLinkDetectionEnabled);
 }
 
 void WebEditorClient::toggleAutomaticLinkDetection()
@@ -147,7 +148,7 @@ bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
     if (m_page->isControlledByAutomation())
         return false;
 
-    return WebProcess::singleton().textCheckerState().isAutomaticDashSubstitutionEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticDashSubstitutionEnabled);
 }
 
 void WebEditorClient::toggleAutomaticDashSubstitution()
@@ -160,7 +161,7 @@ bool WebEditorClient::isAutomaticTextReplacementEnabled()
     if (m_page->isControlledByAutomation())
         return false;
 
-    return WebProcess::singleton().textCheckerState().isAutomaticTextReplacementEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticTextReplacementEnabled);
 }
 
 void WebEditorClient::toggleAutomaticTextReplacement()
@@ -173,7 +174,7 @@ bool WebEditorClient::isAutomaticSpellingCorrectionEnabled()
     if (m_page->isControlledByAutomation())
         return false;
 
-    return WebProcess::singleton().textCheckerState().isAutomaticSpellingCorrectionEnabled;
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled);
 }
 
 void WebEditorClient::toggleAutomaticSpellingCorrection()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1469,10 +1469,10 @@ void WebProcess::stopMemorySampler()
 #endif
 }
 
-void WebProcess::setTextCheckerState(const TextCheckerState& textCheckerState)
+void WebProcess::setTextCheckerState(OptionSet<TextCheckerState> textCheckerState)
 {
-    bool continuousSpellCheckingTurnedOff = !textCheckerState.isContinuousSpellCheckingEnabled && m_textCheckerState.isContinuousSpellCheckingEnabled;
-    bool grammarCheckingTurnedOff = !textCheckerState.isGrammarCheckingEnabled && m_textCheckerState.isGrammarCheckingEnabled;
+    bool continuousSpellCheckingTurnedOff = !textCheckerState.contains(TextCheckerState::ContinuousSpellCheckingEnabled) && m_textCheckerState.contains(TextCheckerState::ContinuousSpellCheckingEnabled);
+    bool grammarCheckingTurnedOff = !textCheckerState.contains(TextCheckerState::GrammarCheckingEnabled) && m_textCheckerState.contains(TextCheckerState::GrammarCheckingEnabled);
 
     m_textCheckerState = textCheckerState;
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -65,7 +65,6 @@
 #endif
 
 #if PLATFORM(COCOA)
-#include <WebCore/ScreenProperties.h>
 #include <dispatch/dispatch.h>
 #include <wtf/MachSendRight.h>
 
@@ -115,6 +114,7 @@ struct MessagePortIdentifier;
 struct MessageWithMessagePorts;
 struct MockMediaDevice;
 struct PrewarmInformation;
+struct ScreenProperties;
 struct ServiceWorkerContextData;
 }
 
@@ -238,8 +238,8 @@ public:
     std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier(std::optional<WebCore::PageIdentifier>, RefPtr<WebCore::UserGestureToken>);
     void userGestureTokenDestroyed(WebCore::PageIdentifier, WebCore::UserGestureToken&);
     
-    const TextCheckerState& textCheckerState() const { return m_textCheckerState; }
-    void setTextCheckerState(const TextCheckerState&);
+    OptionSet<TextCheckerState> textCheckerState() const { return m_textCheckerState; }
+    void setTextCheckerState(OptionSet<TextCheckerState>);
 
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
 
@@ -713,7 +713,7 @@ private:
     using WebProcessSupplementMap = UncheckedKeyHashMap<ASCIILiteral, std::unique_ptr<WebProcessSupplement>>;
     WebProcessSupplementMap m_supplements;
 
-    TextCheckerState m_textCheckerState;
+    OptionSet<TextCheckerState> m_textCheckerState;
 
     String m_uiProcessBundleIdentifier;
     RefPtr<NetworkProcessConnection> m_networkProcessConnection;

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -66,7 +66,7 @@ messages -> WebProcess : AuxiliaryProcess NotRefCounted WantsAsyncDispatchMessag
     void StartMemorySampler(WebKit::SandboxExtensionHandle sampleLogFileHandle, String sampleLogFilePath, double interval);
     void StopMemorySampler();
 
-    SetTextCheckerState(struct WebKit::TextCheckerState textCheckerState)
+    SetTextCheckerState(OptionSet<WebKit::TextCheckerState> textCheckerState)
 
     SetEnhancedAccessibility(bool flag)
     BindAccessibilityFrameWithData(WebCore::FrameIdentifier frameID, std::span<const uint8_t> data);


### PR DESCRIPTION
#### e2d6737783b1d892337e6cf4171fedb71dcba8ed
<pre>
Make `TextCheckerState` an OptionSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=281604">https://bugs.webkit.org/show_bug.cgi?id=281604</a>
<a href="https://rdar.apple.com/137904342">rdar://137904342</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/Shared/TextCheckerState.h:
(): Deleted.
* Source/WebKit/Shared/TextFlags.serialization.in:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/TextChecker.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::toggleAutomaticQuoteSubstitution):
(WebKit::WebPageProxy::toggleAutomaticLinkDetection):
(WebKit::WebPageProxy::toggleAutomaticDashSubstitution):
(WebKit::WebPageProxy::toggleAutomaticTextReplacement):
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::mutableState):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setGrammarCheckingEnabled:]):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::mutableState):
(WebKit::TextChecker::state):
(WebKit::TextChecker::setTestingMode):
(WebKit::TextChecker::setContinuousSpellCheckingEnabled):
(WebKit::TextChecker::setGrammarCheckingEnabled):
(WebKit::TextChecker::setAutomaticSpellingCorrectionEnabled):
(WebKit::TextChecker::setAutomaticQuoteSubstitutionEnabled):
(WebKit::TextChecker::setAutomaticDashSubstitutionEnabled):
(WebKit::TextChecker::setAutomaticLinkDetectionEnabled):
(WebKit::TextChecker::setAutomaticTextReplacementEnabled):
(WebKit::TextChecker::didChangeAutomaticTextReplacementEnabled):
(WebKit::TextChecker::didChangeAutomaticSpellingCorrectionEnabled):
(WebKit::TextChecker::didChangeAutomaticQuoteSubstitutionEnabled):
(WebKit::TextChecker::didChangeAutomaticDashSubstitutionEnabled):
(WebKit::TextChecker::continuousSpellCheckingEnabledStateChanged):
(WebKit::TextChecker::grammarCheckingEnabledStateChanged):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::validateUserInterfaceItem):
(WebKit::WebViewImpl::setContinuousSpellCheckingEnabled):
(WebKit::WebViewImpl::toggleContinuousSpellChecking):
(WebKit::WebViewImpl::isGrammarCheckingEnabled):
(WebKit::WebViewImpl::setGrammarCheckingEnabled):
(WebKit::WebViewImpl::toggleGrammarChecking):
(WebKit::WebViewImpl::toggleAutomaticSpellingCorrection):
(WebKit::WebViewImpl::isAutomaticQuoteSubstitutionEnabled):
(WebKit::WebViewImpl::setAutomaticQuoteSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticQuoteSubstitution):
(WebKit::WebViewImpl::isAutomaticDashSubstitutionEnabled):
(WebKit::WebViewImpl::setAutomaticDashSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticDashSubstitution):
(WebKit::WebViewImpl::isAutomaticLinkDetectionEnabled):
(WebKit::WebViewImpl::setAutomaticLinkDetectionEnabled):
(WebKit::WebViewImpl::toggleAutomaticLinkDetection):
(WebKit::WebViewImpl::isAutomaticTextReplacementEnabled):
(WebKit::WebViewImpl::setAutomaticTextReplacementEnabled):
(WebKit::WebViewImpl::toggleAutomaticTextReplacement):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::isContinuousSpellCheckingEnabled):
(WebKit::WebEditorClient::isGrammarCheckingEnabled):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::isAutomaticQuoteSubstitutionEnabled):
(WebKit::WebEditorClient::isAutomaticLinkDetectionEnabled):
(WebKit::WebEditorClient::isAutomaticDashSubstitutionEnabled):
(WebKit::WebEditorClient::isAutomaticTextReplacementEnabled):
(WebKit::WebEditorClient::isAutomaticSpellingCorrectionEnabled):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setTextCheckerState):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/UIProcess/gtk/TextCheckerGtk.cpp:
(WebKit::checkerState):
(WebKit::TextChecker::setContinuousSpellCheckingEnabled):
(WebKit::TextChecker::setGrammarCheckingEnabled):
(WebKit::TextChecker::continuousSpellCheckingEnabledStateChanged):
(WebKit::TextChecker::grammarCheckingEnabledStateChanged):

Canonical link: <a href="https://commits.webkit.org/285351@main">https://commits.webkit.org/285351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/905d96123b3de16a0d46b0b20bfc590d75334a66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62217 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37380 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43466 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21809 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78095 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6540 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11103 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->