### PR TITLE
Unreviewed, another VisionOS build fix after 285485@main

### DIFF
--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm
@@ -46,16 +46,16 @@ PlatformVideoTarget RemoteMediaPlayerManagerProxy::videoTargetForMediaElementIde
 
 void RemoteMediaPlayerManagerProxy::handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage& endpointMessage)
 {
-    ASSERT(endpointMessage.mediaElementIdentifier().isValid());
-    if (!endpointMessage.mediaElementIdentifier().isValid())
+    ASSERT(endpointMessage.mediaElementIdentifier());
+    if (!endpointMessage.mediaElementIdentifier())
         return;
 
-    auto cachedEntry = m_videoReceiverEndpointCache.find(endpointMessage.mediaElementIdentifier());
+    auto cachedEntry = m_videoReceiverEndpointCache.find(*endpointMessage.mediaElementIdentifier());
     if (cachedEntry == m_videoReceiverEndpointCache.end()) {
         // If no entry for the specified mediaElementIdentifier exists, add a new entry to
         // the cache, and set the new t on the specified MediaPlayer.
         auto videoTarget = WebCore::VideoTargetFactory::createTargetFromEndpoint(endpointMessage.endpoint());
-        m_videoReceiverEndpointCache.set(endpointMessage.mediaElementIdentifier(), VideoRecevierEndpointCacheEntry { endpointMessage.playerIdentifier(), endpointMessage.endpoint(), videoTarget });
+        m_videoReceiverEndpointCache.set(*endpointMessage.mediaElementIdentifier(), VideoRecevierEndpointCacheEntry { endpointMessage.playerIdentifier(), endpointMessage.endpoint(), videoTarget });
 
         if (RefPtr mediaPlayer = this->mediaPlayer(endpointMessage.playerIdentifier()))
             mediaPlayer->setVideoTarget(videoTarget);

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -39,20 +39,18 @@ namespace WebKit {
 
 class VideoReceiverEndpointMessage {
 public:
-    VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier>, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, WebCore::VideoReceiverEndpoint);
+    VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier>, WebCore::HTMLMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier>, WebCore::VideoReceiverEndpoint);
 
     static ASCIILiteral messageName() { return "video-receiver-endpoint"_s; }
     static VideoReceiverEndpointMessage decode(xpc_object_t);
     OSObjectPtr<xpc_object_t> encode() const;
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
-    const WebCore::HTMLMediaElementIdentifier& mediaElementIdentifier() const { return m_mediaElementIdentifier; }
+    std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier() const { return m_mediaElementIdentifier; }
     const WebCore::MediaPlayerIdentifier& playerIdentifier() const { return m_playerIdentifier; }
     const WebCore::VideoReceiverEndpoint& endpoint() const { return m_endpoint; }
 
 private:
-    VideoReceiverEndpointMessage() = default;
-
     Markable<WebCore::ProcessIdentifier> m_processIdentifier;
     WebCore::HTMLMediaElementIdentifier m_mediaElementIdentifier;
     WebCore::MediaPlayerIdentifier m_playerIdentifier;

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -39,7 +39,7 @@ static constexpr ASCIILiteral playerIdentifierKey = "video-receiver-player-ident
 static constexpr ASCIILiteral endpointKey = "video-receiver-endpoint"_s;
 static constexpr ASCIILiteral cacheCommandKey = "video-receiver-cache-command"_s;
 
-VideoReceiverEndpointMessage::VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, WebCore::VideoReceiverEndpoint endpoint)
+VideoReceiverEndpointMessage::VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier, WebCore::VideoReceiverEndpoint endpoint)
     : m_processIdentifier { WTFMove(processIdentifier) }
     , m_mediaElementIdentifier { WTFMove(mediaElementIdentifier) }
     , m_playerIdentifier { WTFMove(playerIdentifier) }
@@ -58,7 +58,7 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
     return {
         processIdentifier ? std::optional { WebCore::ProcessIdentifier(processIdentifier) } : std::nullopt,
         WebCore::HTMLMediaElementIdentifier(mediaElementIdentifier),
-        WebCore::MediaPlayerIdentifier(playerIdentifier),
+        playerIdentifier ? std::optional { WebCore::MediaPlayerIdentifier(playerIdentifier) } : std::nullopt,
         WebCore::VideoReceiverEndpoint(endpoint)
     };
 }
@@ -69,7 +69,7 @@ OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());
-    xpc_dictionary_set_uint64(message.get(), playerIdentifierKey.characters(), m_playerIdentifier.toUInt64());
+    xpc_dictionary_set_uint64(message.get(), playerIdentifierKey.characters(), m_playerIdentifier ? m_playerIdentifier->toUInt64() : 0);
     xpc_dictionary_set_value(message.get(), endpointKey.characters(), m_endpoint.get());
     return message;
 }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -962,7 +962,7 @@ void PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint(PlaybackSessionCo
     if (!xpcConnection)
         return;
 
-    VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), contextId, { }, nullptr);
+    VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), contextId, std::nullopt, nullptr);
     xpc_connection_send_message(xpcConnection.get(), endpointMessage.encode().get());
 #else
     UNUSED_PARAM(contextId);


### PR DESCRIPTION
#### 418b9800e295a4ce49b81f85a91e2128fb113a42
<pre>
Unreviewed, another VisionOS build fix after 285485@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=281606">https://bugs.webkit.org/show_bug.cgi?id=281606</a>
<a href="https://rdar.apple.com/138054534">rdar://138054534</a>

* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerManagerProxy::handleVideoReceiverEndpointMessage):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h:
(WebKit::VideoReceiverEndpointMessage::mediaElementIdentifier const):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm:
(WebKit::VideoReceiverEndpointMessage::VideoReceiverEndpointMessage):
(WebKit::VideoReceiverEndpointMessage::decode):
(WebKit::VideoReceiverEndpointMessage::encode const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint):

Canonical link: <a href="https://commits.webkit.org/285285@main">https://commits.webkit.org/285285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c60b44ea49c9a2a8add2554772a5cfbe4bf1abc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72135 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/51556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24923 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/59360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/23166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75202 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/59360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/59360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/59360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/23166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11066 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/47354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->