### PR TITLE
[Navigation] Improve cross-document traversal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange does not fire for cross-document navigation.back() and navigation.forward() assert_equals: expected 2 but got 1
+PASS currententrychange does not fire for cross-document navigation.back() and navigation.forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS navigate event destination after iframe detach
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+PASS navigate event for navigation.back() - same-document in an iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
@@ -1,3 +1,6 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigation.traverseTo() in an iframe with same-document preventDefault in its parent Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after traverse assert_equals: expected 2 but got 1
+PASS navigation.activation after traverse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-then-clobber-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-then-clobber-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation - traverse, then push same-document assert_equals: expected 2 but got 1
+PASS navigation.activation - traverse, then push same-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT entries() in an iframe must be updated after navigating back to a bfcached page Test timed out
+NOTRUN entries() in an iframe must be updated after navigating back to a bfcached page Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS navigation.entries() behavior after forward-pruning due to cross-document navs
+FAIL navigation.entries() behavior after forward-pruning due to cross-document navs assert_array_equals: lengths differ, expected array ["", "?fork"] length 2, got ["", "?2", "?3", "?fork"] length 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-cross-document-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Error: assert_equals: expected 2 but got 1
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT NavigationHistoryEntry's key and id on cross-document back navigation Test timed out
+PASS NavigationHistoryEntry's key and id on cross-document back navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+FAIL The url of a document is censored by a no-referrer policy dynamically assert_equals: expected (object) null but got (string) "http://localhost:8800/common/blank.html"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.sameDocument is properly restored after cross-document back assert_equals: expected 3 but got 1
+PASS entry.sameDocument is properly restored after cross-document back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() is properly restored after cross-document back assert_equals: expected 3 but got 1
+PASS entry.getState() is properly restored after cross-document back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
@@ -1,3 +1,6 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigation.back() and navigation.forward() can navigate multiple frames Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL back() promises to 204s never settle assert_unreached: committed must not reject Reached unreachable code
-FAIL back() promises to 205s never settle assert_unreached: committed must not reject Reached unreachable code
-FAIL back() promises to Content-Disposition: attachment responses never settle assert_unreached: committed must not reject Reached unreachable code
+FAIL back() promises to 204s never settle assert_unreached: onunload should not be called Reached unreachable code
+FAIL back() promises to 205s never settle assert_unreached: onunload should not be called Reached unreachable code
+PASS back() promises to Content-Disposition: attachment responses never settle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-already-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-already-detached-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT forward() in a detached window Test timed out
+PASS forward() in a detached window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
@@ -1,2 +1,0 @@
-FAIL: Timed out waiting for notifyDone to be called
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL traverseTo() promise never settle when preventDefault()ing the navigate event (cross-document) assert_equals: expected 2 but got 1
+PASS traverseTo() promise never settle when preventDefault()ing the navigate event (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL traverseTo() promise rejections when detaching an iframe inside onnavigate (cross-document) assert_equals: expected 2 but got 1
+PASS traverseTo() promise rejections when detaching an iframe inside onnavigate (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL cross-document traverseTo(), back(), and forward() assert_equals: expected 2 but got 1
+PASS cross-document traverseTo(), back(), and forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() should be correct after a traversal that navigates multiple browsing contexts assert_equals: expected 2 but got 1
+PASS entries() should be correct after a traversal that navigates multiple browsing contexts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT back() event ordering for cross-document traversal Test timed out
+PASS back() event ordering for cross-document traversal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
@@ -1,10 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS cross-document reload() must leave transition null
 PASS cross-document navigate() must leave transition null
-TIMEOUT cross-document back() must leave transition null Test timed out
+PASS cross-document back() must leave transition null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-cross-document-expected.txt
@@ -1,8 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Invalid key
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Invalid key
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT No dispose events are fired due to cross-document forward pruning Test timed out
+PASS No dispose events are fired due to cross-document forward pruning
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL Dispose events should fire when entries are removed by a navigation in a different frame assert_equals: expected 0 but got 3
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Dispose events should fire when entries are removed by a navigation in a different frame Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
+
+Harness Error (FAIL), message = Unhandled rejection
 
 PASS scroll: after-transition should not scroll when the intercept() handler rejects
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
@@ -16,7 +16,7 @@ promise_test(async t => {
     e.preventDefault();
     assert_throws_dom("InvalidStateError", () => e.scroll());
   }), { once : true });
-  assertBothRejectDOM(t, navigation.navigate("#frag"), "AbortError");
+  await assertBothRejectDOM(t, navigation.navigate("#frag"), "AbortError");
 }, "scroll: scroll() should throw after preventDefault");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after navigating away and back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after navigating away and back
 


### PR DESCRIPTION
#### ce94c4ef89254a3b19fa509575162a069907e1fb
<pre>
[Navigation] Improve cross-document traversal
<a href="https://bugs.webkit.org/show_bug.cgi?id=281605">https://bugs.webkit.org/show_bug.cgi?id=281605</a>

Reviewed by Alex Christensen.

We introduced ScheduledHistoryNavigationByKey to handle traversals by key, but the implementation was incorrect
for subframes: Page::goToItem only operates on b/f cache history items, so introduce findBackForwardItemByKey to
find such items for both main frames and subframes.

For subframe traversal we may end up with a new window, in case there is a previous window we can reuse the previous
window navigation information for same document traversals, for cross document traversal we fall back to the main algorithm.

Finally, to protect against HistoryItem copies, we compare in more places using itemSequenceNumber instead of HistoryItem pointers.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-then-clobber-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-already-detached-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::dispatchTraversalNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/286180@main">https://commits.webkit.org/286180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c48c71f2a116f75529d21c81bb559534525c96c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17174 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24610 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1440 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66461 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8564 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2319 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->