### PR TITLE
Make UnixFileDescriptor noncopyable again

### DIFF
--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -35,6 +35,10 @@ namespace WTF {
 
 class UnixFileDescriptor {
 public:
+    // This class is noncopyable because otherwise it's very hard to avoid accidental file
+    // descriptor duplication. If you intentionally want a dup, call the duplicate method.
+    WTF_MAKE_NONCOPYABLE(UnixFileDescriptor);
+
     UnixFileDescriptor() = default;
 
     enum AdoptionTag { Adopt };
@@ -52,12 +56,6 @@ public:
     UnixFileDescriptor(UnixFileDescriptor&& o)
     {
         m_value = o.release();
-    }
-
-    explicit UnixFileDescriptor(const UnixFileDescriptor& o)
-    {
-        if (o.m_value >= 0)
-            m_value = dupCloseOnExec(o.m_value);
     }
 
     UnixFileDescriptor& operator=(UnixFileDescriptor&& o)

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -70,7 +70,11 @@ public:
 #endif
 
     SharedMemoryHandle(SharedMemoryHandle&&) = default;
+#if USE(UNIX_DOMAIN_SOCKETS)
+    explicit SharedMemoryHandle(const SharedMemoryHandle&);
+#else
     explicit SharedMemoryHandle(const SharedMemoryHandle&) = default;
+#endif
     WEBCORE_EXPORT SharedMemoryHandle(SharedMemoryHandle::Type&&, size_t);
 
     SharedMemoryHandle& operator=(SharedMemoryHandle&&) = default;

--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -52,6 +52,12 @@
 
 namespace WebCore {
 
+SharedMemoryHandle::SharedMemoryHandle(const SharedMemoryHandle& handle)
+{
+    m_handle = handle.m_handle.duplicate();
+    m_size = handle.m_size;
+}
+
 UnixFileDescriptor SharedMemoryHandle::releaseHandle()
 {
     return WTFMove(m_handle);


### PR DESCRIPTION
#### ef66440cf7fc0df67b25d65eb5c37f65acb7a467
<pre>
Make UnixFileDescriptor noncopyable again
<a href="https://bugs.webkit.org/show_bug.cgi?id=281609">https://bugs.webkit.org/show_bug.cgi?id=281609</a>

Reviewed by Carlos Garcia Campos.

Make UnixFileDescriptor noncopyable again. Otherwise, it&apos;s very
difficult to use the class without accidentally duping the underlying
file descriptor.

This is a partial revert of 272365@main. We can manually duplicate the
file descriptor in the SharedMemoryHandle copy constructor, since we
really do want a copy there.

This un-reverts 261281@main.

* Source/WTF/wtf/unix/UnixFileDescriptor.h:
* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::SharedMemoryHandle::SharedMemoryHandle):

Canonical link: <a href="https://commits.webkit.org/285336@main">https://commits.webkit.org/285336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d0bf4449e96b4e195bd8488cabf3b3a2f9f6c61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56894 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19606 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21704 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65274 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77990 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71399 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65360 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6475 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93180 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2148 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->