### PR TITLE
[iOS] Text selection highlight does not honor layer occlusion/clipping

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container-expected.txt
@@ -1,0 +1,10 @@
+Verifies that the selection highlight inside a fixed-position container remains visible while scrolling
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Selected text
+PASS selectionRects.length is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Select me

--- a/LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container.html
+++ b/LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    height: 3000px;
+    margin: 0;
+}
+
+.container {
+    width: 100%;
+    height: 100px;
+    top: 0;
+    background: tomato;
+    color: white;
+    position: fixed;
+    text-align: center;
+    font-size: 32px;
+    line-height: 32px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection highlight inside a fixed-position container remains visible while scrolling");
+
+    await UIHelper.longPressElement(document.getElementById("target"));
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Selected text");
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(150, 400)
+        .move(150, 80, 0.25)
+        .end()
+        .takeResult());
+
+    selectionRects = await UIHelper.getUISelectionViewRects();
+    shouldBe("selectionRects.length", "1");
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="description"></div>
+    <div id="console"></div>
+    <div class="container">
+        <p><span id="target">Select</span> me</p>
+    </div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1990,7 +1990,8 @@ window.UIHelper = class UIHelper {
 
     static async longPressElement(element)
     {
-        return this.longPressAtPoint(element.offsetLeft + element.offsetWidth / 2, element.offsetTop + element.offsetHeight / 2);
+        const { x, y } = this.midPointOfRect(element.getBoundingClientRect());
+        return this.longPressAtPoint(x, y);
     }
 
     static async longPressAtPoint(x, y)

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6447,11 +6447,14 @@ SelectionHonorsOverflowScrolling:
   status: internal
   humanReadableName: "Selection Honors Overflow Scrolling"
   humanReadableDescription: "Selection honors overflow scrolling"
-  webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
       default: false
 
 SendMouseEventsToDisabledFormControlsEnabled:

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -250,7 +250,7 @@ Position lastPositionInNode(Node* anchorNode);
 
 bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode);
 
-WEBCORE_EXPORT Node* commonInclusiveAncestor(const Position&, const Position&);
+Node* commonInclusiveAncestor(const Position&, const Position&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Position&);
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -182,7 +182,7 @@ public:
     RenderLayer* firstChild() const { return m_first; }
     RenderLayer* lastChild() const { return m_last; }
     bool isDescendantOf(const RenderLayer&) const;
-    RenderLayer* commonAncestorWithLayer(const RenderLayer&) const;
+    WEBCORE_EXPORT RenderLayer* commonAncestorWithLayer(const RenderLayer&) const;
 
     // This does an ancestor tree walk. Avoid it!
     const RenderLayer* root() const
@@ -593,7 +593,7 @@ public:
     RenderLayer* enclosingAncestorForPosition(PositionType) const;
     
     RenderLayer* enclosingLayerInContainingBlockOrder() const;
-    RenderLayer* enclosingContainingBlockLayer(CrossFrameBoundaries) const;
+    WEBCORE_EXPORT RenderLayer* enclosingContainingBlockLayer(CrossFrameBoundaries) const;
     RenderLayer* enclosingFrameRenderLayer() const;
 
     // The layer relative to which clipping rects for this layer are computed.

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -199,7 +199,7 @@ public:
     IntPoint convertFromScrollbarToContainingView(const Scrollbar&, const IntPoint&) const final;
     IntPoint convertFromContainingViewToScrollbar(const Scrollbar&, const IntPoint&) const final;
     void setScrollOffset(const ScrollOffset&) final;
-    WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeID() const final;
+    std::optional<ScrollingNodeID> scrollingNodeID() const final;
 
     IntRect visibleContentRectInternal(VisibleContentRectIncludesScrollbars, VisibleContentRectBehavior) const final;
     IntSize overhangAmount() const final;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -736,7 +736,7 @@ public:
     inline bool preservesNewline() const;
 
     RenderView& view() const { return *document().renderView(); }
-    WEBCORE_EXPORT CheckedRef<RenderView> checkedView() const;
+    CheckedRef<RenderView> checkedView() const;
 
     HostWindow* hostWindow() const;
 
@@ -769,7 +769,7 @@ public:
     // Returns the object containing this one. Can be different from parent for positioned elements.
     // If repaintContainer and repaintContainerSkipped are not null, on return *repaintContainerSkipped
     // is true if the renderer returned is an ancestor of repaintContainer.
-    WEBCORE_EXPORT RenderElement* container() const;
+    RenderElement* container() const;
     RenderElement* container(const RenderLayerModelObject* repaintContainer, bool& repaintContainerSkipped) const;
 
     RenderBoxModelObject* offsetParent() const;

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -31,7 +31,7 @@
 #include <WebCore/ElementContext.h>
 #include <WebCore/FontAttributes.h>
 #include <WebCore/IntRect.h>
-#include <WebCore/ScrollingNodeID.h>
+#include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/WritingDirection.h>
 #include <wtf/text/WTFString.h>
 
@@ -154,8 +154,8 @@ struct EditorState {
         Vector<WebCore::SelectionGeometry> markedTextRects;
         WebCore::IntRect markedTextCaretRectAtStart;
         WebCore::IntRect markedTextCaretRectAtEnd;
-        std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
-#endif
+        std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+#endif // PLATFORM(IOS_FAMILY)
     };
 
     bool hasVisualData() const { return !!visualData; }

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -125,6 +125,6 @@ struct WebKit::EditorState {
     Vector<WebCore::SelectionGeometry> markedTextRects;
     WebCore::IntRect markedTextCaretRectAtStart;
     WebCore::IntRect markedTextCaretRectAtEnd;
-    std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
+    std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
 #endif
 };

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -53,7 +53,7 @@
 @end
 
 @interface UIView (WebKitInternal)
-- (BOOL)_wk_isAncestorOf:(UIView *)child;
+@property (nonatomic, readonly) UIScrollView *_wk_parentScrollView;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -219,13 +219,13 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 @implementation UIView (WebKitInternal)
 
-- (BOOL)_wk_isAncestorOf:(UIView *)child
+- (UIScrollView *)_wk_parentScrollView
 {
-    for (RetainPtr parent = [child superview]; parent; parent = [parent superview]) {
-        if (parent == self)
-            return YES;
+    for (RetainPtr parent = [self superview]; parent; parent = [parent superview]) {
+        if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>(parent.get()))
+            return scrollView.get();
     }
-    return NO;
+    return nil;
 }
 
 - (UIViewController *)_wk_viewControllerForFullScreenPresentation

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -49,8 +49,6 @@
 @property (nonatomic, weak) id<WKBaseScrollViewDelegate> baseScrollViewDelegate;
 @property (nonatomic, readonly) UIAxis axesToPreventMomentumScrolling;
 
-@property (nonatomic, readonly) UIView *scrolledContentView;
-
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 @property (nonatomic) NSUInteger _scrollingBehavior;
 @property (nonatomic, readonly, getter=overlayRegionsForTesting) HashSet<WebCore::IntRect>& overlayRegionRects;

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -216,24 +216,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return [super gestureRecognizerShouldBegin:gestureRecognizer];
 }
 
-- (UIView *)scrolledContentView
-{
-    auto firstNonEmptyWebKitChildView = [](UIView *view) -> UIView * {
-        for (UIView *subview in view.subviews) {
-            if (![subview isKindOfClass:WKCompositingView.class] && ![subview isKindOfClass:WKContentView.class])
-                continue;
-
-            if (CGRectIsEmpty(subview.bounds))
-                continue;
-
-            return subview;
-        }
-
-        return nil;
-    };
-    return firstNonEmptyWebKitChildView(self) ?: firstNonEmptyWebKitChildView(self.subviews.firstObject);
-}
-
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4778,7 +4778,6 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
 #if PLATFORM(IOS_FAMILY)
     setForceAlwaysUserScalable(m_forceAlwaysUserScalable || store.getBoolValueForKey(WebPreferencesKey::forceAlwaysUserScalableKey()));
-    m_selectionHonorsOverflowScrolling = store.getBoolValueForKey(WebPreferencesKey::selectionHonorsOverflowScrollingKey());
 #endif
 
     if (store.getBoolValueForKey(WebPreferencesKey::serviceWorkerEntitlementDisabledForTestingKey()))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1887,7 +1887,7 @@ private:
     void clearSelectionAfterTapIfNeeded();
     void scheduleLayoutViewportHeightExpansionUpdate();
     void scheduleEditorStateUpdateAfterAnimationIfNeeded(const WebCore::Element&);
-    void computeSelectionClipRectAndEnclosingScroller(EditorState&, const WebCore::VisibleSelection&, const WebCore::IntRect& editableRootBounds) const;
+    void computeEnclosingLayerID(EditorState&, const WebCore::VisibleSelection&) const;
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
@@ -2731,7 +2731,6 @@ private:
     std::unique_ptr<WebCore::IgnoreSelectionChangeForScope> m_ignoreSelectionChangeScopeForDictation;
 
     bool m_isMobileDoctype { false };
-    bool m_selectionHonorsOverflowScrolling { false };
 #endif // PLATFORM(IOS_FAMILY)
 
     WebCore::Timer m_layerVolatilityTimer;


### PR DESCRIPTION
#### b7fc2d972516a068452fd5676e26e8a354841670
<pre>
[iOS] Text selection highlight does not honor layer occlusion/clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=281601">https://bugs.webkit.org/show_bug.cgi?id=281601</a>
<a href="https://rdar.apple.com/107058373">rdar://107058373</a>

Reviewed by Abrar Rahman Protyasha.

Currently, the &quot;Selection Honors Overflow Scrolling&quot; flag allows us to slot native selection views
underneath composited subscrollable areas (i.e. `WKChildScrollView`s), by plumbing the enclosing
scrolling node ID over to the UI process via `EditorState` with each layer tree transaction.

While this enables selection UI in subscrollable containers to scroll smoothly along with the
selected content and also fixes occlusion in the case where occluding content is in a compositing
view that covers the selection in a subscrollable container, this approach *doesn&apos;t* address the
more general problem of native selection UI appearing over content that should otherwise occlude the
selection, if:

1.  The selection is in the main frame, or
2.  The content that would otherwise occlude the selection is in the same scrollable container as
    the selection.

To fix *most* (not all) of these remaining scenarios, we make further changes to the &quot;Selection
Honors Overflow Scrolling&quot; behavior, such that we no longer propagate a scrolling node ID via
`EditorState` to the UI process; instead, we now propagate the ID of the graphics layer that backs
the selection&apos;s `RenderLayer` (or the scrolled contents layer, if appropriate), and then map this ID
to a platform compositing view which we use as the parent for the selection views.

See below for more details.

* LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-highlight-in-fixed-position-container.html: Added.

Add a layout test to verify that a selection inside a fixed-position container stays on screen when
scrolling.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async longPressElement):

Make this work when long pressing content inside fixed-position containers, by using
`getBoundingClientRect()`.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Expose this on `WebCore::Settings` too, so that we don&apos;t need to store a flag on `WebPage` when
checking this state.

* Source/WebCore/dom/Position.h:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderObject.h:

Shuffle around some `WEBCORE_EXPORT`s, some of which are no longer needed.

* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Replace the `ScrollingNodeID` with a `PlatformLayerIdentifier`.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_parentScrollView]):
(-[UIView _wk_isAncestorOf:]): Deleted.

Replace this category helper method with a new one, which finds the ancestor scroller of a given
view.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView scrolledContentView]): Deleted.

Remove this now-unused helper method.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView shouldHideSelectionWhenScrolling]):

Now that we (more) correctly paint native selection UI in fixed-position containers, we can stop
hiding the selection every time we scroll now, when the selection is inside fixed-position content.

(-[WKContentView _pointIsInsideSelectionRect:outBoundingRect:]):

Make a small adjustment here to ensure that hit-testing for the purposes of toggling the edit menu
still honors overflow scrolling clip.

(-[WKContentView _selectionContainerViewInternal]):

Make this grab the corresponding layer tree node for the platform layer ID that encloses the
selection endpoints, and use that as the selection container.

(-[WKContentView _selectionContainerScrollView]): Deleted.
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

Additionally make sure that the selection views are hosted above the tile grid controller container
layer; this is necessary to ensure that selection views show up above selected content, but under
any composited content (fixed/sticky-position banners, z-ordered elements, etc.) that should occlude
it.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Add a helper method to search up the layer tree for the closest ancestor backed by a graphics layer.

(WebKit::enclosingScroller): Deleted.
(WebKit::forEachEnclosingScroller): Deleted.
(WebKit::WebPage::computeSelectionClipRectAndEnclosingScroller const): Deleted.

Canonical link: <a href="https://commits.webkit.org/285350@main">https://commits.webkit.org/285350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c824b8c6ddefeb1e8813721de739c68515929b28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23366 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15508 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62297 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21894 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65464 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78182 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71589 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62315 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6602 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93370 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47554 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->