### PR TITLE
Make IPC::Identifier noncopyable

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -125,13 +125,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<NetworkConnectionToWebProcess> NetworkConnectionToWebProcess::create(NetworkProcess& networkProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, NetworkProcessConnectionParameters&& parameters, IPC::Connection::Identifier connectionIdentifier)
+Ref<NetworkConnectionToWebProcess> NetworkConnectionToWebProcess::create(NetworkProcess& networkProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, NetworkProcessConnectionParameters&& parameters, IPC::Connection::Identifier&& connectionIdentifier)
 {
-    return adoptRef(*new NetworkConnectionToWebProcess(networkProcess, webProcessIdentifier, sessionID, WTFMove(parameters), connectionIdentifier));
+    return adoptRef(*new NetworkConnectionToWebProcess(networkProcess, webProcessIdentifier, sessionID, WTFMove(parameters), WTFMove(connectionIdentifier)));
 }
 
-NetworkConnectionToWebProcess::NetworkConnectionToWebProcess(NetworkProcess& networkProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, NetworkProcessConnectionParameters&& parameters, IPC::Connection::Identifier connectionIdentifier)
-    : m_connection(IPC::Connection::createServerConnection(connectionIdentifier))
+NetworkConnectionToWebProcess::NetworkConnectionToWebProcess(NetworkProcess& networkProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, NetworkProcessConnectionParameters&& parameters, IPC::Connection::Identifier&& connectionIdentifier)
+    : m_connection(IPC::Connection::createServerConnection(WTFMove(connectionIdentifier)))
     , m_networkProcess(networkProcess)
     , m_sessionID(sessionID)
     , m_networkResourceLoaders([this](bool hasUpload) { hasUploadStateChanged(hasUpload); })

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -146,7 +146,7 @@ public:
 
     using RegistrableDomain = WebCore::RegistrableDomain;
 
-    static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);
+    static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);
     virtual ~NetworkConnectionToWebProcess();
 
     using IPC::Connection::Client::checkedPtrCount;
@@ -268,7 +268,7 @@ public:
     bool isAlwaysOnLoggingAllowed() const;
 
 private:
-    NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);
+    NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);
 
     void didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, const WebCore::ResourceError&);
     WebCore::NetworkStorageSession* storageSession();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -371,7 +371,7 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
         return;
     }
 
-    auto newConnection = NetworkConnectionToWebProcess::create(*this, identifier, sessionID, WTFMove(parameters), connectionIdentifiers->server);
+    auto newConnection = NetworkConnectionToWebProcess::create(*this, identifier, sessionID, WTFMove(parameters), WTFMove(connectionIdentifiers->server));
     Ref connection = newConnection;
 
     ASSERT(!m_webProcessConnections.contains(identifier));

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -340,14 +340,14 @@ struct Connection::PendingSyncReply {
     }
 };
 
-Ref<Connection> Connection::createServerConnection(Identifier identifier, Thread::QOS receiveQueueQOS)
+Ref<Connection> Connection::createServerConnection(Identifier&& identifier, Thread::QOS receiveQueueQOS)
 {
-    return adoptRef(*new Connection(identifier, true, receiveQueueQOS));
+    return adoptRef(*new Connection(WTFMove(identifier), true, receiveQueueQOS));
 }
 
-Ref<Connection> Connection::createClientConnection(Identifier identifier)
+Ref<Connection> Connection::createClientConnection(Identifier&& identifier)
 {
-    return adoptRef(*new Connection(identifier, false));
+    return adoptRef(*new Connection(WTFMove(identifier), false));
 }
 
 static HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock)
@@ -356,7 +356,7 @@ static HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& connec
     return map;
 }
 
-Connection::Connection(Identifier identifier, bool isServer, Thread::QOS receiveQueueQOS)
+Connection::Connection(Identifier&& identifier, bool isServer, Thread::QOS receiveQueueQOS)
     : m_uniqueID(UniqueID::generate())
     , m_isServer(isServer)
     , m_connectionQueue(WorkQueue::create("com.apple.IPC.ReceiveQueue"_s, receiveQueueQOS))
@@ -366,7 +366,7 @@ Connection::Connection(Identifier identifier, bool isServer, Thread::QOS receive
         connectionMap().add(m_uniqueID, this);
     }
 
-    platformInitialize(identifier);
+    platformInitialize(WTFMove(identifier));
 }
 
 Connection::~Connection()

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -43,6 +43,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/NativePromise.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
@@ -243,7 +244,12 @@ public:
     using Handle = ConnectionHandle;
 
     struct Identifier {
+        WTF_MAKE_NONCOPYABLE(Identifier);
+
         Identifier() = default;
+        Identifier(Identifier&&) = default;
+        Identifier& operator=(Identifier&&) = default;
+
 #if USE(UNIX_DOMAIN_SOCKETS)
         explicit Identifier(Handle&& handle)
             : Identifier(handle.release())
@@ -280,7 +286,7 @@ public:
             , xpcConnection(WTFMove(xpcConnection))
         {
         }
-        explicit operator bool() const { return MACH_PORT_VALID(port); }
+        operator bool() const { return MACH_PORT_VALID(port); }
         mach_port_t port { MACH_PORT_NULL };
         OSObjectPtr<xpc_connection_t> xpcConnection;
 #endif
@@ -292,8 +298,8 @@ public:
     pid_t remoteProcessID() const;
 #endif
 
-    static Ref<Connection> createServerConnection(Identifier, Thread::QOS = Thread::QOS::Default);
-    static Ref<Connection> createClientConnection(Identifier);
+    static Ref<Connection> createServerConnection(Identifier&&, Thread::QOS = Thread::QOS::Default);
+    static Ref<Connection> createClientConnection(Identifier&&);
 
     struct ConnectionIdentifierPair {
         IPC::Connection::Identifier server;
@@ -442,7 +448,9 @@ public:
     bool inSendSync() const { return m_inSendSyncCount; }
     unsigned inDispatchSyncMessageCount() const { return m_inDispatchSyncMessageCount; }
 
+#if PLATFORM(COCOA)
     Identifier identifier() const;
+#endif
 
 #if PLATFORM(COCOA) && !USE(EXTENSIONKIT_PROCESS_TERMINATION)
     bool kill();
@@ -489,8 +497,8 @@ public:
 #endif
 
 private:
-    Connection(Identifier, bool isServer, Thread::QOS = Thread::QOS::Default);
-    void platformInitialize(Identifier);
+    Connection(Identifier&&, bool isServer, Thread::QOS = Thread::QOS::Default);
+    void platformInitialize(Identifier&&);
     bool platformPrepareForOpen();
     void platformOpen();
     void platformInvalidate();

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -74,7 +74,7 @@ std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnecti
     // For Connection, "client" means the connection which was established by receiving it through IPC and creating IPC::Connection out from the identifier.
     // The "Client" in StreamClientConnection means the party that mostly does sending, e.g. untrusted party.
     // The "Server" in StreamServerConnection means the party that mostly does receiving, e.g. the trusted party which holds the destination object to communicate with.
-    auto dedicatedConnection = Connection::createServerConnection(connectionIdentifiers->server);
+    auto dedicatedConnection = Connection::createServerConnection(WTFMove(connectionIdentifiers->server));
     auto clientConnection = adoptRef(*new StreamClientConnection(WTFMove(dedicatedConnection), WTFMove(*buffer), defaultTimeoutDuration));
     StreamServerConnection::Handle serverHandle {
         WTFMove(connectionIdentifiers->client),

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -135,7 +135,7 @@ void Connection::cancelReceiveSource()
     m_receivePort = MACH_PORT_NULL;
 }
 
-void Connection::platformInitialize(Identifier identifier)
+void Connection::platformInitialize(Identifier&& identifier)
 {
     if (m_isServer) {
         RELEASE_ASSERT(MACH_PORT_VALID(identifier.port)); // Caller error. MACH_DEAD_NAME does not make sense, as we do not transfer receive rights.

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -108,7 +108,7 @@ int Connection::socketDescriptor() const
 #endif
 }
 
-void Connection::platformInitialize(Identifier identifier)
+void Connection::platformInitialize(Identifier&& identifier)
 {
 #if USE(GLIB)
     GUniqueOutPtr<GError> error;

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -71,7 +71,7 @@ bool createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientId
     return true;
 }
 
-void Connection::platformInitialize(Identifier identifier)
+void Connection::platformInitialize(Identifier&& identifier)
 {
     m_connectionPipe = identifier.handle;
 }

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -76,7 +76,7 @@ void AuxiliaryProcess::didClose(IPC::Connection&)
 #endif
 }
 
-void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters& parameters)
+void AuxiliaryProcess::initialize(AuxiliaryProcessInitializationParameters&& parameters)
 {
     WTF::RefCountedBase::enableThreadingChecksGlobally();
 
@@ -110,7 +110,7 @@ void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters
     ContentWorldIdentifier::enableGenerationProtection();
     WebPageProxyIdentifier::enableGenerationProtection();
 
-    Ref connection = IPC::Connection::createClientConnection(parameters.connectionIdentifier);
+    Ref connection = IPC::Connection::createClientConnection(WTFMove(parameters.connectionIdentifier));
     m_connection = connection.ptr();
     initializeConnection(connection.ptr());
     connection->open(*this);

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -60,7 +60,7 @@ class AuxiliaryProcess : public IPC::Connection::Client, public IPC::MessageSend
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AuxiliaryProcess);
 public:
-    void initialize(const AuxiliaryProcessInitializationParameters&);
+    void initialize(AuxiliaryProcessInitializationParameters&&);
 
     // disable and enable termination of the process. when disableTermination is called, the
     // process won't terminate unless a corresponding enableTermination call is made.

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -327,7 +327,7 @@ bool AuxiliaryProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC
     return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
 }
 
-void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)
+void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     ASSERT(!m_connection);
     ASSERT(isMainRunLoop());
@@ -344,7 +344,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
     m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
 #endif
 
-    RefPtr connection = IPC::Connection::createServerConnection(connectionIdentifier, Thread::QOS::UserInteractive);
+    RefPtr connection = IPC::Connection::createServerConnection(WTFMove(connectionIdentifier), Thread::QOS::UserInteractive);
     m_connection = connection.copyRef();
     auto addResult = connectionToProcessMap().add(m_connection->uniqueID(), *this);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -255,7 +255,7 @@ public:
 
 protected:
     // ProcessLauncher::Client
-    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
+    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
     bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -634,13 +634,15 @@ void GPUProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC:
     didClose(connection);
 }
 
-void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)
+void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     RELEASE_LOG(Process, "%p - GPUProcessProxy::didFinishLaunching:", this);
 
-    AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
+    bool didTerminate = !connectionIdentifier;
 
-    if (!connectionIdentifier) {
+    AuxiliaryProcessProxy::didFinishLaunching(launcher, WTFMove(connectionIdentifier));
+
+    if (didTerminate) {
         gpuProcessExited(ProcessTerminationReason::Crash);
         return;
     }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -182,7 +182,7 @@ private:
     void sendProcessDidResume(ResumeReason) final;
 
     // ProcessLauncher::Client
-    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
+    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
@@ -59,7 +59,7 @@ void ProcessLauncher::platformDestroy()
 }
 #endif
 
-void ProcessLauncher::didFinishLaunchingProcess(ProcessID processIdentifier, IPC::Connection::Identifier identifier)
+void ProcessLauncher::didFinishLaunchingProcess(ProcessID processIdentifier, IPC::Connection::Identifier&& identifier)
 {
     m_processID = processIdentifier;
     m_isLaunching = false;
@@ -67,16 +67,15 @@ void ProcessLauncher::didFinishLaunchingProcess(ProcessID processIdentifier, IPC
     tracePoint(ProcessLaunchEnd, m_launchOptions.processIdentifier.toUInt64(), static_cast<uint64_t>(m_launchOptions.processType), static_cast<uint64_t>(m_processID));
 
     if (!m_client) {
-        // FIXME: Make Identifier a move-only object and release port rights/connections in the destructor.
-#if OS(DARWIN) && !PLATFORM(GTK)
-        // FIXME: Should really be something like USE(MACH)
+#if OS(DARWIN) && !USE(UNIX_DOMAIN_SOCKETS)
+        // FIXME: Release port rights/connections in the Connection::Identifier destructor.
         if (identifier.port)
             mach_port_mod_refs(mach_task_self(), identifier.port, MACH_PORT_RIGHT_RECEIVE, -1);
 #endif
         return;
     }
     
-    m_client->didFinishLaunching(this, identifier);
+    m_client->didFinishLaunching(this, WTFMove(identifier));
 }
 
 void ProcessLauncher::invalidate()

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -125,7 +125,7 @@ public:
     public:
         virtual ~Client() { }
         
-        virtual void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) = 0;
+        virtual void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) = 0;
         virtual bool shouldConfigureJSCForTesting() const { return false; }
         virtual bool isJITEnabled() const { return true; }
         virtual bool shouldEnableSharedArrayBuffer() const { return false; }
@@ -169,7 +169,7 @@ private:
 
     void launchProcess();
     void finishLaunchingProcess(ASCIILiteral name);
-    void didFinishLaunchingProcess(ProcessID, IPC::Connection::Identifier);
+    void didFinishLaunchingProcess(ProcessID, IPC::Connection::Identifier&&);
 
     void platformInvalidate();
     void platformDestroy();

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -229,11 +229,13 @@ void ModelProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IP
     didClose(connection);
 }
 
-void ModelProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)
+void ModelProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
-    AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
+    bool didTerminate = !connectionIdentifier;
 
-    if (!connectionIdentifier) {
+    AuxiliaryProcessProxy::didFinishLaunching(launcher, WTFMove(connectionIdentifier));
+
+    if (didTerminate) {
         modelProcessExited(ProcessTerminationReason::Crash);
         return;
     }

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -92,7 +92,7 @@ private:
     void sendProcessDidResume(ResumeReason) final;
 
     // ProcessLauncher::Client
-    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
+    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -563,16 +563,16 @@ void NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation(WebPage
         completionHandler(false);
 }
 
-void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)
+void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     RELEASE_LOG(Process, "%p - NetworkProcessProxy::didFinishLaunching", this);
 
-    AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
+    bool didTerminate = !connectionIdentifier;
 
-    if (!connectionIdentifier) {
+    AuxiliaryProcessProxy::didFinishLaunching(launcher, WTFMove(connectionIdentifier));
+
+    if (didTerminate)
         networkProcessDidTerminate(ProcessTerminationReason::Crash);
-        return;
-    }
 }
 
 void NetworkProcessProxy::logDiagnosticMessage(WebPageProxyIdentifier pageID, const String& message, const String& description, WebCore::ShouldSample shouldSample)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -407,7 +407,7 @@ private:
     WebsiteDataStore* websiteDataStoreFromSessionID(PAL::SessionID);
 
     // ProcessLauncher::Client
-    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
+    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
 #if PLATFORM(COCOA)
     RefPtr<XPCEventHandler> xpcEventHandler() const override;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1417,15 +1417,16 @@ void WebProcessProxy::setIgnoreInvalidMessageForTesting()
 }
 #endif
 
-void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)
+void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "didFinishLaunching:");
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
 
     Ref protectedThis { *this };
-    AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
+    bool didTerminate = !connectionIdentifier;
+    AuxiliaryProcessProxy::didFinishLaunching(launcher, WTFMove(connectionIdentifier));
 
-    if (!connectionIdentifier) {
+    if (didTerminate) {
         WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "didFinishLaunching: Invalid connection identifier (web process failed to launch)");
         processDidTerminateOrFailedToLaunch(ProcessTerminationReason::Crash);
         return;
@@ -3032,3 +3033,4 @@ const WebCore::ProcessIdentity& WebProcessProxy::processIdentity()
 #undef MESSAGE_CHECK_COMPLETION
 #undef WEBPROCESSPROXY_RELEASE_LOG
 #undef WEBPROCESSPROXY_RELEASE_LOG_ERROR
+

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -544,7 +544,7 @@ private:
 #endif
 
     // ProcessLauncher::Client
-    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
+    void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
     bool shouldConfigureJSCForTesting() const final;
     bool isJITEnabled() const final;
     bool shouldEnableSharedArrayBuffer() const final { return m_crossOriginMode == WebCore::CrossOriginMode::Isolated; }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -94,7 +94,7 @@ void WebInspectorUI::updateConnection()
     if (!connectionIdentifiers)
         return;
 
-    m_backendConnection = IPC::Connection::createServerConnection(connectionIdentifiers->server);
+    m_backendConnection = IPC::Connection::createServerConnection(WTFMove(connectionIdentifiers->server));
     m_backendConnection->open(*this);
 
     sendToParentProcess(Messages::WebInspectorUIProxy::SetFrontendConnection(WTFMove(connectionIdentifiers->client)));

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
@@ -71,7 +71,7 @@ RefPtr<ModelProcessConnection> ModelProcessConnection::create(IPC::Connection& p
 }
 
 ModelProcessConnection::ModelProcessConnection(IPC::Connection::Identifier&& connectionIdentifier)
-    : m_connection(IPC::Connection::createServerConnection(connectionIdentifier))
+    : m_connection(IPC::Connection::createServerConnection(WTFMove(connectionIdentifier)))
 {
     m_connection->open(*this);
 }

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -80,8 +80,8 @@
 namespace WebKit {
 using namespace WebCore;
 
-NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier connectionIdentifier, HTTPCookieAcceptPolicy cookieAcceptPolicy)
-    : m_connection(IPC::Connection::createClientConnection(connectionIdentifier))
+NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier&& connectionIdentifier, HTTPCookieAcceptPolicy cookieAcceptPolicy)
+    : m_connection(IPC::Connection::createClientConnection(WTFMove(connectionIdentifier)))
     , m_cookieAcceptPolicy(cookieAcceptPolicy)
 {
     m_connection->open(*this);

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -64,7 +64,7 @@ class NetworkProcessConnection final : public RefCounted<NetworkProcessConnectio
 public:
     static Ref<NetworkProcessConnection> create(IPC::Connection::Identifier&& connectionIdentifier, WebCore::HTTPCookieAcceptPolicy httpCookieAcceptPolicy)
     {
-        return adoptRef(*new NetworkProcessConnection(connectionIdentifier, httpCookieAcceptPolicy));
+        return adoptRef(*new NetworkProcessConnection(WTFMove(connectionIdentifier), httpCookieAcceptPolicy));
     }
     ~NetworkProcessConnection();
 
@@ -98,7 +98,7 @@ public:
     void updateCachedCookiesEnabled();
     void loadCancelledDownloadRedirectRequestInFrame(WebCore::ResourceRequest&&, WebCore::FrameIdentifier, WebCore::PageIdentifier);
 private:
-    NetworkProcessConnection(IPC::Connection::Identifier, WebCore::HTTPCookieAcceptPolicy);
+    NetworkProcessConnection(IPC::Connection::Identifier&&, WebCore::HTTPCookieAcceptPolicy);
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;


### PR DESCRIPTION
#### 0341886292336dcb7421047c5c72728522387a32
<pre>
Make IPC::Identifier noncopyable
<a href="https://bugs.webkit.org/show_bug.cgi?id=281613">https://bugs.webkit.org/show_bug.cgi?id=281613</a>

Reviewed by Don Olmstead.

This is groundwork for using UnixFileDescriptor to reduce the risk of
file descriptor leaks.

I&apos;ve also made the operator bool non-explicit on Cocoa platforms, to
match the Linux and Windows behavior, since implicit conversion to bool
is convenient (unlike implicit constructors) and this seems nicer than
changing the Windows and Linux implementations to match Cocoa.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::create):
(WebKit::NetworkConnectionToWebProcess::NetworkConnectionToWebProcess):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::createServerConnection):
(IPC::Connection::createClientConnection):
(IPC::Connection::Connection):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::Identifier::operator bool const):
(IPC::Connection::ConnectionIdentifierPair::ConnectionIdentifierPair):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformInitialize):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::platformInitialize):
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::Connection::platformInitialize):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::initialize):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp:
(WebKit::ProcessLauncher::didFinishLaunchingProcess):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::updateConnection):
* Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp:
(WebKit::ModelProcessConnection::ModelProcessConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:

Canonical link: <a href="https://commits.webkit.org/287469@main">https://commits.webkit.org/287469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79b14c9ed98ce8fe2a368f56bb6b8aeeab5d03ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62357 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49757 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69852 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12779 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6971 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->