### PR TITLE
[WebGPU] Destroyed canvas backing shouldn't be allowed as a render target

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281614-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281614-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281614.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281614.html
@@ -1,0 +1,27775 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter();
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxVertexAttributes: 16,
+    minStorageBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 43065849,
+    maxStorageBufferBindingSize: 168684882,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 125,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 67, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let buffer0 = device0.createBuffer({
+  size: 6217,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder0 = device0.createCommandEncoder();
+let texture0 = device0.createTexture({
+  label: '\ue761\uf1ba\u6730\uf519\uac7c\u0a2b\u{1fc97}',
+  size: {width: 768, height: 1, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture1 = device0.createTexture({
+  label: '\u18e9\u0af3\u086f\u3079\u0601\u0af0\u7b65\u6f18\u08eb\u{1f80e}',
+  size: {width: 768},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView0 = texture0.createView({dimension: '2d', mipLevelCount: 1});
+let texture2 = device0.createTexture({size: [1536, 1, 1], mipLevelCount: 2, format: 'rg32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 94.80,
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 180,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer1 = device0.createBuffer({
+  size: 6832,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  size: [21, 10, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView1 = texture3.createView({label: '\u0913\u4c5d', dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let sampler1 = device0.createSampler({
+  label: '\u0377\u{1ff1e}\ue998\u032f\u{1fab3}\ud627\u0f99\u{1fe2b}\u0747',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.08,
+  maxAnisotropy: 8,
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1]});
+let buffer2 = device0.createBuffer({
+  label: '\u08e2\u{1fa7f}',
+  size: 3702,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler2 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.82,
+  lodMaxClamp: 57.51,
+});
+let textureView2 = texture1.createView({});
+let computePassEncoder2 = commandEncoder2.beginComputePass({label: '\uccb9\u{1f700}\u{1fdeb}\u0d02\u073a\u{1fd58}\u{1fe96}'});
+let texture4 = device0.createTexture({size: {width: 120}, dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], sampleCount: 1, depthReadOnly: true});
+try {
+buffer0.unmap();
+} catch {}
+let buffer3 = device0.createBuffer({size: 9597, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint16', 6, 1_967);
+} catch {}
+let textureView3 = texture1.createView({label: '\u{1fa9b}\u250f\u0fe2\ua3f6\u054b\ua359\u{1fa6b}\u0e2a\u6fa9\u{1fbfe}'});
+let texture5 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 3},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let img0 = await imageWithData(66, 1, '#10101010', '#20202020');
+let bindGroup0 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView0},
+    {binding: 67, resource: {buffer: buffer2, offset: 256, size: 533}},
+  ],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm']});
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer0, 0, 358);
+} catch {}
+await gc();
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer4 = device0.createBuffer({size: 2201, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture6 = device0.createTexture({size: [768], dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 46.78,
+  lodMaxClamp: 95.68,
+  compare: 'greater-equal',
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u06a0\u0c45\u{1f806}\u7861\u{1f962}\u0ea2',
+  entries: [
+    {
+      binding: 223,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 429,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView0},
+    {binding: 67, resource: {buffer: buffer2, offset: 0, size: 672}},
+  ],
+});
+let texture7 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView4 = texture3.createView({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(2277), 78, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 828, 1_306);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\ue8db\u{1f88b}\u{1f814}';
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let texture8 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder3.beginComputePass({});
+let sampler4 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.01,
+  lodMaxClamp: 90.59,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(4699), 738, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer0, 0);
+} catch {}
+document.body.append(img0);
+let texture9 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 3},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture10 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb']});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 120, new Float32Array(1465), 79, 4);
+} catch {}
+let buffer5 = device0.createBuffer({
+  label: '\u3d0f\u28ca\u7e82\u{1f715}\u18a1\u{1faad}',
+  size: 198,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture11 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder4 = commandEncoder4.beginComputePass({});
+let renderBundle0 = renderBundleEncoder2.finish({label: '\u860b\ueff5\u31a7\u{1f837}\u37f6'});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint16', 426, 1_053);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 92, new Float32Array(11727), 2464, 148);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer6 = device0.createBuffer({
+  size: 3453,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView5 = texture9.createView({label: '\uaeaa\u0b2b\u8ab1\u{1fe74}\u00e8', arrayLayerCount: 1});
+let textureView6 = texture3.createView({dimension: '2d-array'});
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 72.08,
+});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(164), 11, 0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  label: '\u02a5\ub10f\u8a88\uba45',
+  size: [768, 1, 103],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass({});
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(524), 177, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer3, 'uint16', 2_848, 748);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView0},
+    {binding: 67, resource: {buffer: buffer2, offset: 0, size: 344}},
+  ],
+});
+let buffer7 = device0.createBuffer({
+  size: 25910,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  label: '\u{1fdef}\u0610',
+  size: [120, 8, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle1 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(144), 45, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(15).fill(72), /* required buffer size: 15 */
+{offset: 15, bytesPerRow: 47, rowsPerImage: 38}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData0 = new ImageData(36, 8);
+let commandEncoder7 = device0.createCommandEncoder({});
+let textureView7 = texture7.createView({label: '\u0793\u0c79\u575d\ub613\u1579\ufad3', arrayLayerCount: 1});
+let textureView8 = texture10.createView({dimension: 'cube', baseArrayLayer: 1});
+let computePassEncoder6 = commandEncoder7.beginComputePass();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 492, 335);
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\u{1ff8a}\uae69\u{1feaa}\u16a4',
+  size: 14677,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder8 = device0.createCommandEncoder();
+let texture14 = device0.createTexture({
+  size: {width: 60, height: 4, depthOrArrayLayers: 22},
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture15 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 7},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture8.createView({});
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0, 196, 71);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 1476, new DataView(new ArrayBuffer(14168)), 4535, 200);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  label: '\u058c\u7eea\ucc43\u0b3b\u0c48\ue786',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle2 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(2407), 932, 0);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 116 */
+  offset: 116,
+  buffer: buffer7,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder6.pushDebugGroup('\u0bca');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+globalThis.someLabel = sampler2.label;
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder();
+let texture17 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder8.beginComputePass({});
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1884 */
+  offset: 1884,
+  bytesPerRow: 16896,
+  buffer: buffer0,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 768, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer8, 3804, 3768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 672, new Int16Array(15529), 1261, 708);
+} catch {}
+document.body.append(img0);
+let buffer9 = device0.createBuffer({
+  size: 7307,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView10 = texture14.createView({dimension: '2d', baseArrayLayer: 5});
+let textureView11 = texture11.createView({});
+let computePassEncoder8 = commandEncoder6.beginComputePass({});
+let renderBundle3 = renderBundleEncoder1.finish();
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 116 */
+  offset: 116,
+  rowsPerImage: 20,
+  buffer: buffer0,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 768, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u6fbc\u{1fa20}\uf989\u{1fadd}\u0fc7',
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+@group(0) @binding(180) var st0: texture_storage_2d_array<r32float, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp1 = array(array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())));
+
+struct VertexOutput0 {
+  @location(13) f0: f32,
+  @invariant @builtin(position) f1: vec4f,
+}
+
+struct T0 {
+  @align(2) @size(56) f0: vec2h,
+}
+
+struct FragmentOutput0 {
+  @location(2) @interpolate(flat, center) f0: vec2u,
+  @location(3) f1: u32,
+  @location(0) f2: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr2: ptr<private, vec3h> = &vp0.whole;
+  let ptr3 = &vp0;
+  let ptr4 = &vp0;
+  let ptr5: ptr<private, vec3h> = &(*ptr3).whole;
+  let ptr6 = &(*ptr4);
+  let ptr7: ptr<private, vec3h> = &(*ptr6).fract;
+  out.f0 = vec3f(vp0.fract)[2];
+  out.f0 = f32((*ptr6).whole.r);
+  out.f1 = vec4f(f32(vp1[3][0].fract));
+  let ptr8: ptr<private, vec3h> = &(*ptr6).fract;
+  out.f1 = vec4f((*ptr2).xxyx);
+  var vf0: f16 = (*ptr2)[1];
+  vf0 = (*ptr3).whole.g;
+  out.f0 = f32((*ptr7)[u32(unconst_u32(611))]);
+  let ptr9: ptr<private, vec3h> = &(*ptr4).fract;
+  let ptr10: ptr<private, vec3h> = &(*ptr3).whole;
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp0 = modf(vec3h());
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> array<f16, 50> {
+  var out: array<f16, 50>;
+  let ptr0 = &vp1[3][0];
+  let ptr1: ptr<private, f16> = &(*ptr0).whole;
+  return out;
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f0 *= f32(normalize(vec3h(unconst_f16(26735.8), unconst_f16(22784.7), unconst_f16(152.0)))[2]);
+  fn1();
+  out.f0 = f32(vp1[3][0].fract);
+  fn0();
+  var vf1 = fn0();
+  vp1[u32(unconst_u32(118))][u32(vp1[3][0].fract)] = modf(determinant(mat4x4h(unconst_f16(10121.7), unconst_f16(510.1), unconst_f16(252.9), unconst_f16(1448.3), unconst_f16(-6304.1), unconst_f16(16406.2), unconst_f16(20854.2), unconst_f16(8833.0), unconst_f16(35171.1), unconst_f16(9546.0), unconst_f16(9751.9), unconst_f16(18172.4), unconst_f16(21861.6), unconst_f16(-3412.5), unconst_f16(10167.1), unconst_f16(14639.9))));
+  var vf2: f16 = exp(vp0.whole.y);
+  vp1[u32(unconst_u32(146))][pack4xI8Clamp(vec4i(unconst_i32(31), unconst_i32(201), unconst_i32(19), unconst_i32(-142)))] = modf(vp0.fract.y);
+  out.f0 = faceForward(vec3f(f32(exp(vp1[3][0].fract))), vec3f(unconst_f32(0.07355), unconst_f32(0.2241), unconst_f32(0.1671)), vec3f(vp0.fract)).b;
+  out.f0 -= f32(vf1[49]);
+  out.f0 = f32(vf1[49]);
+  vf1[u32(unconst_u32(304))] = vf1[49];
+  return out;
+}
+
+@fragment
+fn fragment0(@location(13) a0: f32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let ptr11: ptr<private, f16> = &vp1[3][0].whole;
+  out.f2 = vec4f(f32(vp1[3][0].whole));
+  out.f0 |= textureDimensions(st0);
+  out.f1 = pack2x16unorm(pow(vec2f(f32(vp1[u32(a0)][0].whole)), vec2f(unconst_f32(0.1577), unconst_f32(-0.01252))));
+  var vf3 = fn1();
+  let ptr12 = &vp1[3][0];
+  fn1();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+  vp1[bitcast<u32>(atan(f32(unconst_f32(0.1413))))][u32(unconst_u32(1))] = vp1[u32(unconst_u32(19))][0];
+  vp0.whole = vec3h(f16(atan(f32(unconst_f32(0.2540)))));
+  let vf4: vec2h = log2(vec2h(unconst_f16(10170.8), unconst_f16(3275.7)));
+  let vf5: vec2h = log2(vec2h(unconst_f16(1537.5), unconst_f16(30318.6)));
+  let vf6: vec2h = vf4;
+  vp0.whole = vp0.fract;
+  var vf7 = fn1();
+  vp0 = modf(vf5.rgr);
+  vp1[u32(unconst_u32(280))][u32(unconst_u32(46))] = modf(f16(vf7.f0));
+}`,
+  sourceMap: {},
+});
+let textureView12 = texture15.createView({label: '\u12f1\u{1f67b}\uf2d1\u{1fa0b}\u257a\u960d', arrayLayerCount: 1});
+let texture18 = device0.createTexture({size: [768], dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+let textureView13 = texture10.createView({dimension: 'cube'});
+let computePassEncoder9 = commandEncoder10.beginComputePass({});
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 20, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(81), /* required buffer size: 27 */
+{offset: 27, bytesPerRow: 206}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 180, resource: textureView6}]});
+let commandEncoder11 = device0.createCommandEncoder({});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1, new Uint32Array(570), 46, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 1236, new DataView(new ArrayBuffer(12806)), 2077, 1744);
+} catch {}
+let texture19 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder10 = commandEncoder11.beginComputePass({label: '\u1a57\u03ca\u1a0b\u{1fafc}\ua073\u0ea4\u0b80\u1efa\u0937\u10a0'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u0ba3\u{1fbf7}\u0694\u818a\u097f\uafc1\u37ff\u{1ffa1}',
+  colorFormats: ['rgba8unorm'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 56, new Int16Array(1124), 10, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 72.43,
+  lodMaxClamp: 99.04,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer3, 'uint32', 172, 352);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer6, 412, 333);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer9, 680, buffer5, 28, 28);
+} catch {}
+try {
+adapter0.label = '\u409c\u09b3\u6d0b\u0078\u4271\uaeba\u0201\u04bd\u8300';
+} catch {}
+let texture20 = device0.createTexture({size: [30], dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView14 = texture12.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 20, arrayLayerCount: 1});
+let renderBundle4 = renderBundleEncoder4.finish();
+try {
+computePassEncoder2.setBindGroup(1, bindGroup2, new Uint32Array(10000), 133, 0);
+} catch {}
+try {
+commandEncoder9.insertDebugMarker('\ua97a');
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'iec6196624'} });
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView15 = texture20.createView({arrayLayerCount: 1});
+let computePassEncoder11 = commandEncoder9.beginComputePass({label: '\u0a29\ubb96\u83e5'});
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: [84],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.prepend(img0);
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 205, resource: textureView4},
+    {binding: 30, resource: textureView14},
+    {binding: 78, resource: textureView12},
+    {binding: 37, resource: {buffer: buffer8, offset: 1280, size: 648}},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let buffer10 = device0.createBuffer({
+  size: 2080,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture22 = device0.createTexture({size: {width: 192}, dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let textureView16 = texture19.createView({label: '\u59c0\u4669\u8b71\ue361'});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(3, bindGroup3, new Uint32Array(4071), 454, 0);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(1, bindGroup4, new Uint32Array(690), 190, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 125, resource: textureView0}, {binding: 67, resource: {buffer: buffer10, offset: 512}}],
+});
+let querySet0 = device0.createQuerySet({label: '\u0dc2\ub0b3', type: 'occlusion', count: 311});
+let textureView17 = texture22.createView({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(3, bindGroup3, new Uint32Array(513), 78, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\uf326\u567a\u{1f972}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 180, resource: textureView1}],
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let computePassEncoder13 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView18 = texture18.createView({label: '\u069e\u0258\ua53f\u4db2\u8790\u0d86\u0a85\u481a\u{1fd8f}\uedf3\u1318'});
+let sampler7 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 93.64, lodMaxClamp: 93.84});
+let externalTexture0 = device0.importExternalTexture({label: '\u3a7f\u0dd5\uc50c\u0e94', source: videoFrame0});
+try {
+buffer6.unmap();
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture23 = device0.createTexture({size: [30, 2, 1], format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let imageData1 = new ImageData(176, 160);
+let commandEncoder15 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup0, new Uint32Array(3475), 1_755, 0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 21248,
+  buffer: buffer0,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 816, new Float32Array(50602), 19279, 1192);
+} catch {}
+await gc();
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 137, resource: textureView5},
+    {binding: 223, resource: textureView7},
+    {binding: 429, resource: {buffer: buffer2, offset: 2304, size: 140}},
+  ],
+});
+let buffer11 = device0.createBuffer({size: 8230, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder16 = device0.createCommandEncoder({});
+let computePassEncoder14 = commandEncoder16.beginComputePass({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.17,
+  compare: 'never',
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup6, new Uint32Array(4155), 361, 0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8 */
+  offset: 8,
+  bytesPerRow: 1792,
+  rowsPerImage: 1838,
+  buffer: buffer11,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 768, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 223, resource: textureView7},
+    {binding: 62, resource: textureView11},
+    {binding: 429, resource: {buffer: buffer0, offset: 1536, size: 160}},
+    {binding: 137, resource: textureView5},
+  ],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView19 = texture16.createView({aspect: 'depth-only'});
+let computePassEncoder15 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup4, new Uint32Array(3980), 282, 0);
+} catch {}
+try {
+commandEncoder17.insertDebugMarker('\uc1e3');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 52, new DataView(new ArrayBuffer(2398)), 72, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder17.finish({});
+let texture24 = device0.createTexture({
+  label: '\u{1fa38}\u{1f771}\u{1fd3f}\u0009\u00ad\u020d\u76a5\u{1ff3a}\u016d\u6888',
+  size: [32, 32, 20],
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+let textureView20 = texture5.createView({dimension: '2d'});
+let computePassEncoder16 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3072 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12 */
+  offset: 12,
+  buffer: buffer6,
+}, {width: 768, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+let textureView21 = texture15.createView({dimension: '2d', aspect: 'all', arrayLayerCount: 1});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet0, 46, 113, buffer11, 4352);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 6, y: 1 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 7, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 429, resource: {buffer: buffer9, offset: 1792, size: 1336}},
+    {binding: 62, resource: textureView9},
+    {binding: 223, resource: textureView7},
+    {binding: 137, resource: textureView5},
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  label: '\ufb7e\ud6a2\u0998\u9bb5\u{1fafa}\u{1fd5b}\uef17\u736a\u01df\ua9ef',
+  size: [192, 1, 92],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer7, 'uint32', 2_824, 2_375);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer9, 516, 1_809);
+} catch {}
+try {
+computePassEncoder6.pushDebugGroup('\u4e0e');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 360, new Float32Array(475), 56);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  label: '\u{1fe23}\u0cd8\uda5b\u0ec2\ua7d9\ud8e2\ua73c',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 223, resource: textureView7},
+    {binding: 62, resource: textureView9},
+    {binding: 137, resource: textureView5},
+    {binding: 429, resource: {buffer: buffer8, offset: 512, size: 5972}},
+  ],
+});
+let textureView22 = texture11.createView({aspect: 'stencil-only', arrayLayerCount: 1});
+let computePassEncoder18 = commandEncoder19.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup1, new Uint32Array(1381), 140, 0);
+} catch {}
+try {
+computePassEncoder6.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: [60, 4, 58],
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler9 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 33.56,
+  lodMaxClamp: 68.99,
+});
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1544 */
+  offset: 1544,
+  buffer: buffer7,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 768, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 2152});
+let textureView23 = texture22.createView({});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(0, bindGroup2, new Uint32Array(1348), 100, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup0, new Uint32Array(1397), 481, 0);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 436 */
+  offset: 436,
+  bytesPerRow: 9472,
+  buffer: buffer10,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet1, 34, 150, buffer11, 1792);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData1,
+  origin: { x: 12, y: 74 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'bt2020_10bit'} });
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 265,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 204,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 221, visibility: 0, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {
+      binding: 171,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 219,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup11 = device0.createBindGroup({
+  label: '\u3d46\u0726\ub044\u{1fadf}\u6110\ua23a\u3f61\u0cf9\u1a2f',
+  layout: bindGroupLayout0,
+  entries: [{binding: 125, resource: textureView0}, {binding: 67, resource: {buffer: buffer10, offset: 256}}],
+});
+let buffer12 = device0.createBuffer({size: 3703, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView24 = texture24.createView({
+  label: '\uf7ef\u{1f756}\u{1fb3f}\udf7c\u{1ff8b}\u050d',
+  dimension: 'cube-array',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer9, 'uint16', 616, 387);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 436 */
+  offset: 436,
+  bytesPerRow: 15360,
+  buffer: buffer11,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder22.pushDebugGroup('\u5740');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1612, new Int16Array(23356), 5408, 8);
+} catch {}
+document.body.append(img0);
+await gc();
+let canvas0 = document.createElement('canvas');
+let buffer13 = device0.createBuffer({
+  size: 3202,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture27 = device0.createTexture({
+  label: '\u233c\u{1f97d}\u{1f7b8}\ud1c2\u{1fad2}\u0764\u2ad6',
+  size: [120, 8, 1],
+  mipLevelCount: 4,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let renderBundle5 = renderBundleEncoder6.finish({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.04,
+  lodMaxClamp: 90.64,
+  maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ, 0, 236);
+} catch {}
+try {
+commandEncoder22.popDebugGroup();
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView25 = texture27.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let texture28 = device0.createTexture({
+  size: [120, 8, 187],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder0 = commandEncoder22.beginRenderPass({colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'store'}]});
+let renderBundle6 = renderBundleEncoder7.finish({label: '\u{1fff2}\u451d\u0fb8\ue8ba\u{1f61e}\u395e\u{1f727}\u9de9\u6424\u118f'});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup4, new Uint32Array(527), 323, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer9, 'uint32', 876, 542);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1792 */
+  offset: 1792,
+  rowsPerImage: 470,
+  buffer: buffer13,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 665});
+let textureView26 = texture28.createView({});
+let texture29 = device0.createTexture({
+  size: {width: 1536},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle7 = renderBundleEncoder5.finish({});
+let sampler11 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 66.03,
+  lodMaxClamp: 98.57,
+});
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {mask: 0x20e80a87},
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+try {
+  await promise3;
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder19 = commandEncoder24.beginComputePass();
+let externalTexture1 = device0.importExternalTexture({label: '\ubc8c\udabd\uc09d\u3d10\u{1fea0}', source: videoFrame0});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup10, new Uint32Array(504), 219, 0);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let textureView27 = texture23.createView({dimension: '2d-array'});
+let computePassEncoder20 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(408), 140, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 845});
+let textureView28 = texture3.createView({baseMipLevel: 0, mipLevelCount: 1});
+let textureView29 = texture20.createView({aspect: 'all'});
+let computePassEncoder21 = commandEncoder23.beginComputePass({});
+let sampler12 = device0.createSampler({
+  label: '\u57ad\uc719\ud924',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.477,
+  lodMaxClamp: 67.79,
+  maxAnisotropy: 4,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup6, new Uint32Array(3040), 66, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1736 */
+  offset: 1736,
+  bytesPerRow: 2560,
+  buffer: buffer7,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 436, new Int16Array(9484), 620, 288);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let commandBuffer1 = commandEncoder20.finish({});
+let textureView30 = texture8.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, new Uint32Array(508), 95, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 168, 597);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12 */
+  offset: 12,
+  buffer: buffer5,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout3, bindGroupLayout0, bindGroupLayout1]});
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture30 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 22},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder22 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(0, bindGroup3, new Uint32Array(155), 17, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle3]);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 936 */
+  offset: 936,
+  buffer: buffer0,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  label: '\uc866\u0555\u8770\u0ae7\u002f\u9af2\ub141\u0106\u0d11\u061a\u{1fd80}',
+  size: {width: 84, height: 40, depthOrArrayLayers: 65},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(862), 109, 0);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2280 */
+  offset: 2280,
+  bytesPerRow: 1536,
+  buffer: buffer11,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 476, new Float32Array(6067), 2153, 220);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 1_512, 98);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 312, new Float32Array(2144), 61, 44);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 189, resource: {buffer: buffer10, offset: 0}},
+    {binding: 219, resource: textureView21},
+    {binding: 221, resource: {buffer: buffer13, offset: 768, size: 152}},
+    {binding: 204, resource: textureView26},
+    {binding: 86, resource: textureView19},
+    {binding: 105, resource: textureView24},
+    {binding: 265, resource: {buffer: buffer9, offset: 768, size: 561}},
+    {binding: 171, resource: textureView25},
+    {binding: 139, resource: {buffer: buffer11, offset: 768, size: 1286}},
+    {binding: 18, resource: externalTexture2},
+  ],
+});
+let commandEncoder30 = device0.createCommandEncoder();
+let textureView31 = texture3.createView({dimension: '2d-array'});
+let computePassEncoder23 = commandEncoder29.beginComputePass({});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(1839), 356, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 724, 3_848);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer6, 'uint16', 1_030, 516);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise4;
+} catch {}
+let querySet4 = device0.createQuerySet({label: '\u0d59\u3565\u{1fe2c}\u8a95', type: 'occlusion', count: 175});
+let texture32 = device0.createTexture({
+  label: '\u{1fcf1}\ue39c\u0c5b\u0777\u0c11\u88d7\ufdb9\u0725\ue790\u{1f683}\ud282',
+  size: {width: 1536, height: 1, depthOrArrayLayers: 954},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView32 = texture23.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 604, 26);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer9, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint32', 884, 430);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(3, buffer6);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let texture33 = device0.createTexture({
+  size: {width: 30},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView33 = texture16.createView({dimension: '2d-array', aspect: 'stencil-only'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup12, new Uint32Array(1143), 165, 1);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup3, new Uint32Array(1684), 286, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer7, 'uint16', 1_226, 400);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup13 = device0.createBindGroup({
+  label: '\u0469\u0e4e\u573e\u5ac8\u0337\u53c2\udc61\u{1fff4}\uc20c',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView0},
+    {binding: 67, resource: {buffer: buffer8, offset: 512, size: 129}},
+  ],
+});
+let textureView34 = texture23.createView({dimension: '2d-array'});
+let renderBundle8 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer7, 'uint32', 13_084, 4_682);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 184 */
+  offset: 184,
+  bytesPerRow: 512,
+  rowsPerImage: 882,
+  buffer: buffer10,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder22.insertDebugMarker('\u{1f822}');
+} catch {}
+document.body.append(canvas0);
+let textureView35 = texture7.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder24 = commandEncoder31.beginComputePass({});
+let renderPassEncoder1 = commandEncoder26.beginRenderPass({
+  label: '\u08f4\u0d2a\u{1f6d0}',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -106.9, g: -672.2, b: 318.9, a: -335.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup3, new Uint32Array(29), 6, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 2_196, 736);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint32', 2_504, 137);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u36a5\u058e\u{1fe06}\u0584\u{1f881}\u6bb7\u{1fead}\u8008\u1351\u{1f95e}\u2f59'});
+let texture34 = device0.createTexture({
+  size: [84, 40, 1],
+  mipLevelCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder25 = commandEncoder22.beginComputePass({});
+let renderPassEncoder2 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -221.2, g: -578.1, b: -498.2, a: -595.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle9 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(1306), 182, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4]);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1580 */
+  offset: 1580,
+  rowsPerImage: 19,
+  buffer: buffer8,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise2;
+} catch {}
+await gc();
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder26 = commandEncoder21.beginComputePass();
+let renderPassEncoder3 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 233.3, g: -596.0, b: -450.7, a: -235.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 216521068,
+});
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.204,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup13, new Uint32Array(647), 62, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 328 widthInBlocks: 328 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 157 */
+  offset: 157,
+  buffer: buffer0,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 328, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 78, resource: textureView12},
+    {binding: 37, resource: {buffer: buffer6, offset: 0, size: 344}},
+    {binding: 48, resource: textureView19},
+    {binding: 205, resource: textureView28},
+    {binding: 30, resource: textureView10},
+  ],
+});
+let buffer14 = device0.createBuffer({
+  label: '\ud106\u38c3\u9969\ub9eb\u02a8\u0d14\u05f2\u06eb',
+  size: 13140,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let computePassEncoder27 = commandEncoder30.beginComputePass();
+let sampler14 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 82.51,
+  lodMaxClamp: 93.89,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint16', 328, 4_584);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 10, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 64, new Float32Array(9937), 8697, 392);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  size: {width: 42},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder28 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder28.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(1, bindGroup3, new Uint32Array(186), 79, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -659.1, g: -483.6, b: 751.1, a: -236.8, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(61.58504463174054, 0.07430840425989516, 30.20161428165033, 6.618969900438452, 0.5322761269331305, 0.5585979380455462);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet3, 39, 280, buffer1, 256);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup14, new Uint32Array(628), 370, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup2, new Uint32Array(4747), 694, 0);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u1022\ub797\ud64b\u21d9\u0bca\u{1fe4c}\u{1fe7f}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 218, resource: sampler8}],
+});
+let buffer15 = device0.createBuffer({size: 8581, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder36 = device0.createCommandEncoder({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.07,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3, new Uint32Array(807), 37, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer6, 'uint32', 956, 467);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer6, 764);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 1,
+  origin: {x: 4, y: 10, z: 2},
+  aspect: 'all',
+}, new Uint8Array(1_155).fill(28), /* required buffer size: 1_155 */
+{offset: 435, bytesPerRow: 30, rowsPerImage: 24}, {width: 9, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: imageData1,
+  origin: { x: 103, y: 0 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 52},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'logSqrt'} });
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u08fa\u{1fee2}\ua7fd',
+  entries: [
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder29 = commandEncoder35.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData1,
+  origin: { x: 15, y: 8 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData2 = new ImageData(64, 12);
+let buffer16 = device0.createBuffer({size: 25869, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView36 = texture13.createView({});
+let computePassEncoder30 = commandEncoder33.beginComputePass({});
+let renderPassEncoder4 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: 248.8, g: 655.9, b: -178.4, a: 881.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.41,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup15, new Uint32Array(2977), 78, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(132);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 862.3, g: 63.82, b: 115.0, a: -712.0, });
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer10, 32, buffer7, 2532, 128);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 155, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 260 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1068 */
+  offset: 1068,
+  buffer: buffer10,
+}, {width: 65, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet3, 95, 63, buffer6, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u7e39\u{1fc2f}\u0365\u888b\u{1ff79}\u{1fbdf}\u30d7\u0eca\u0928\u0db9',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 37, resource: {buffer: buffer15, offset: 512, size: 2264}},
+    {binding: 30, resource: textureView10},
+    {binding: 205, resource: textureView10},
+    {binding: 78, resource: textureView12},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let textureView37 = texture11.createView({});
+let computePassEncoder31 = commandEncoder36.beginComputePass({label: '\u80c6\ua834\ub055\ue7cd\u{1f8ea}\u0df7'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup12, [256]);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 24, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(67).fill(34), /* required buffer size: 67 */
+{offset: 67, bytesPerRow: 34}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder38.beginComputePass();
+try {
+computePassEncoder13.setBindGroup(3, bindGroup1, new Uint32Array(5330), 1_158, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2).fill(65), /* required buffer size: 2 */
+{offset: 2, bytesPerRow: 106, rowsPerImage: 11}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\ub2c7\u5d69\u6e93\uac77\u83ed\u3dc5\u0130\u{1fef0}',
+  code: `
+requires pointer_composite_access;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+@group(0) @binding(180) var st1: texture_storage_2d_array<r32float, read_write>;
+
+var<private> vp3: VertexOutput1 = VertexOutput1(vec2u(), vec2i(), vec2i(), vec4f());
+
+var<private> vp2 = modf(vec3f());
+
+var<workgroup> vw1: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw0: vec2f;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  @size(60) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp4 = modf(vec3h());
+
+struct VertexOutput2 {
+  @location(13) @interpolate(perspective, center) f6: vec2h,
+  @location(15) f7: vec2f,
+  @builtin(position) f8: vec4f,
+  @location(2) f9: vec2h,
+  @location(4) @interpolate(flat, centroid) f10: u32,
+  @location(3) f11: f16,
+  @location(10) @interpolate(perspective, centroid) f12: f32,
+  @location(5) f13: vec4u,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput1 {
+  @location(11) f2: vec2u,
+  @location(15) f3: vec2i,
+  @location(4) @interpolate(flat, centroid) f4: vec2i,
+  @builtin(position) f5: vec4f,
+}
+
+@vertex
+fn vertex1(@location(14) @interpolate(linear, sample) a0: f16, @location(13) @interpolate(flat, center) a1: vec4i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let ptr13: ptr<private, vec2i> = &vp3.f3;
+  vp3.f3 = vec2i(bitcast<i32>(vp3.f5[0]));
+  let ptr14: ptr<private, VertexOutput1> = &vp3;
+  vp4.fract -= vp4.whole;
+  let vf8: i32 = a1[2];
+  vp3.f4 = bitcast<vec2i>(vp3.f5.rb);
+  var vf9: u32 = pack4x8unorm(vp2.whole.brbr);
+  let vf10: i32 = vp3.f4[u32(unconst_u32(18))];
+  let vf11: vec2f = unpack2x16snorm(bitcast<u32>(ceil(length(bitcast<vec2f>(vp3.f2)))));
+  var vf12: f32 = vp3.f5[u32(unconst_u32(121))];
+  vf9 = bitcast<u32>(length(vec2f(unconst_f32(0.06489), unconst_f32(0.1060))));
+  let vf13: vec2f = ldexp(vec2f(unconst_f32(0.1104), unconst_f32(0.00619)), vec2i(unconst_i32(-29), unconst_i32(54)));
+  vf12 += vf11[1];
+  var vf14: u32 = pack4x8unorm(vec4f(vf11[pack2x16unorm(vf13)]));
+  let vf15: f32 = length(vec2f(unconst_f32(0.2551), unconst_f32(0.6247)));
+  vp3 = VertexOutput1(vp3.f2, vec2i(vp3.f2), vec2i(vp3.f2), vec4f(vp3.f2.ggrg));
+  let vf16: u32 = (*ptr14).f2[1];
+  out.f5 = vec4f(vf11[1]);
+  return out;
+}
+
+@vertex
+fn vertex2() -> VertexOutput2 {
+  var out: VertexOutput2;
+  let ptr15: ptr<private, vec4f> = &vp3.f5;
+  let ptr16: ptr<private, vec3f> = &vp2.whole;
+  let ptr17 = &vp4;
+  let ptr18: ptr<private, vec3f> = &(*ptr16);
+  vp2 = modf(vec3f((*ptr17).fract));
+  let ptr19: ptr<private, vec2u> = &vp3.f2;
+  out.f11 = f16((*ptr16)[1]);
+  var vf17: u32 = vp3.f2[0];
+  let ptr20 = &vp2;
+  out.f11 *= (*ptr17).whole[2];
+  let vf18: f32 = (*ptr15)[2];
+  var vf19: u32 = pack4xI8Clamp(vec4i(unconst_i32(35), unconst_i32(679), unconst_i32(603), unconst_i32(-352)));
+  var vf20: u32 = pack4xU8Clamp(vec4u(unconst_u32(9), unconst_u32(53), unconst_u32(77), unconst_u32(56)));
+  let ptr21: ptr<private, vec4f> = &(*ptr15);
+  let ptr22: ptr<private, vec2i> = &vp3.f4;
+  let vf21: f16 = atanh(f16(vp3.f2.x));
+  let vf22: f16 = atanh(f16(unconst_f16(8100.9)));
+  let ptr23: ptr<private, vec4f> = &(*ptr15);
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer17 = device0.createBuffer({
+  size: 4135,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder39 = device0.createCommandEncoder({label: '\u0fd2\u{1ff3e}\u{1fc6a}\u6eff\u{1fd5d}'});
+try {
+renderPassEncoder4.beginOcclusionQuery(309);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 1_312, 1_240);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let texture36 = device0.createTexture({
+  size: {width: 84},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView38 = texture12.createView({aspect: 'depth-only', baseArrayLayer: 62, arrayLayerCount: 1});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup14, new Uint32Array(1873), 141, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture37 = device0.createTexture({
+  label: '\u{1feeb}\u0101',
+  size: {width: 168, height: 80, depthOrArrayLayers: 131},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer0, 0, 32);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder();
+let computePassEncoder33 = commandEncoder39.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup12, [1792]);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer10, 8, buffer17, 1952, 1200);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer18 = device0.createBuffer({size: 13574, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder41 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  label: '\u7235\uf38e\u{1f624}\u{1f9cf}\ue78b\u1111\u082d\u{1f6d3}\u{1fa1d}',
+  size: {width: 60, height: 4, depthOrArrayLayers: 93},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(3849), 467, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(41.09579835384062, 3.1712339072022484, 47.092047978277954, 4.74090064036867, 0.4129437047663357, 0.6404385551203247);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 18, resource: externalTexture2},
+    {binding: 265, resource: {buffer: buffer1, offset: 0}},
+    {binding: 86, resource: textureView14},
+    {binding: 221, resource: {buffer: buffer13, offset: 0, size: 396}},
+    {binding: 204, resource: textureView26},
+    {binding: 171, resource: textureView25},
+    {binding: 189, resource: {buffer: buffer17, offset: 0, size: 168}},
+    {binding: 105, resource: textureView24},
+    {binding: 139, resource: {buffer: buffer11, offset: 0, size: 1582}},
+    {binding: 219, resource: textureView36},
+  ],
+});
+let buffer19 = device0.createBuffer({
+  size: 9005,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let textureView39 = texture25.createView({label: '\u0916\u07e7\u53af\u{1fc8a}\u{1fda4}\u430c\u0667\u08f1\ud66d'});
+let computePassEncoder34 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(2, bindGroup0, new Uint32Array(3581), 255, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup15);
+} catch {}
+document.body.prepend(img0);
+await gc();
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView40 = texture26.createView({baseArrayLayer: 23, arrayLayerCount: 16});
+let computePassEncoder35 = commandEncoder42.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(78), 17, 0);
+} catch {}
+let arrayBuffer0 = buffer4.getMappedRange(0, 24);
+let computePassEncoder36 = commandEncoder43.beginComputePass({label: '\u9a53\u0264\u6006\uc7c9\uf105\uab01\u5d09\u0178'});
+let renderPassEncoder5 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: -787.7, g: 926.1, b: 891.7, a: 284.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 839917318,
+});
+let sampler17 = device0.createSampler({
+  label: '\u092b\uea33\u{1fb41}\u08d0\ub5cb\u0d6a',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 75.88,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup12, new Uint32Array(477), 10, 1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+let promise7 = shaderModule1.getCompilationInfo();
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let sampler18 = device0.createSampler({
+  label: '\u0b73\u0129\u0776\u0d46\ubef7\ub5bd\u8380\u064c\u0b3e\u0c7c\u02c3',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.367,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup6, new Uint32Array(2594), 161, 0);
+} catch {}
+let arrayBuffer1 = buffer4.getMappedRange(24, 16);
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 332, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(224), /* required buffer size: 26 */
+{offset: 26, rowsPerImage: 120}, {width: 650, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(40, 0);
+try {
+device0.queue.writeBuffer(buffer19, 1060, new BigUint64Array(17038), 2846, 0);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 86, resource: textureView19},
+    {binding: 219, resource: textureView36},
+    {binding: 265, resource: {buffer: buffer19, offset: 512, size: 690}},
+    {binding: 171, resource: textureView25},
+    {binding: 105, resource: textureView24},
+    {binding: 204, resource: textureView26},
+    {binding: 189, resource: {buffer: buffer8, offset: 1792, size: 1517}},
+    {binding: 18, resource: externalTexture2},
+    {binding: 221, resource: {buffer: buffer9, offset: 2560, size: 544}},
+    {binding: 139, resource: {buffer: buffer8, offset: 2048, size: 2256}},
+  ],
+});
+let buffer20 = device0.createBuffer({
+  size: 8083,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture39 = device0.createTexture({size: [60, 4, 93], dimension: '3d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder37 = commandEncoder44.beginComputePass({});
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.12,
+  lodMaxClamp: 65.28,
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup16, new Uint32Array(5622), 1_349, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint16', 2_730, 8_481);
+} catch {}
+let sampler20 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.06,
+  lodMaxClamp: 84.62,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer6, 140, 207);
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.prepend(canvas0);
+let img1 = await imageWithData(81, 99, '#10101010', '#20202020');
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer21 = device0.createBuffer({
+  size: 6960,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder45 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder45.beginComputePass({label: '\u0e3d\u{1f70e}\u0a8e\ubad0\u50d8\u3e78\u02cf'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer21, 'uint32', 284, 422);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw3: VertexOutput3;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput3 {
+  @builtin(position) f14: vec4f,
+  @location(12) @interpolate(flat, centroid) f15: u32,
+}
+
+var<workgroup> vw11: mat4x3h;
+
+fn fn0() -> VertexOutput3 {
+  var out: VertexOutput3;
+  var vf23: vec2h = sinh(vec2h(countOneBits(vec3u(unconst_u32(542), unconst_u32(271), unconst_u32(158))).xy));
+  out.f14 += cross(vec3f(unconst_f32(-0.1077), unconst_f32(0.02561), unconst_f32(0.3379)), vec3f(unconst_f32(0.2303), unconst_f32(0.3001), unconst_f32(0.07546))).zzxx;
+  vp6.f14 = vec4f(vf23.yxyy);
+  vp6.f14 += trunc(vec4f(unconst_f32(0.01467), unconst_f32(0.2843), unconst_f32(0.1774), unconst_f32(0.1207)));
+  vp6.f14 = vec4f(f32(override0));
+  out.f14 = cross(vec3f(vp6.f14[vp6.f15]), ceil(unpack4x8snorm(vp6.f15)).zwx).ggbr;
+  let vf24: vec3u = countOneBits(vec3u(quantizeToF16(vec2f(vf23)).yxx));
+  let ptr24: ptr<private, vec4f> = &vp6.f14;
+  return out;
+  _ = override0;
+}
+
+var<workgroup> vw7: VertexOutput3;
+
+var<workgroup> vw4: atomic<u32>;
+
+fn fn2(a0: array<array<array<array<f16, 1>, 1>, 1>, 116>, a1: ptr<function, VertexOutput3>, a2: VertexOutput3, a3: ptr<workgroup, atomic<i32>>, a4: VertexOutput3, a5: ptr<workgroup, atomic<i32>>, a6: ptr<storage, mat2x2f, read_write>, a7: ptr<workgroup, vec2f>, a8: ptr<private, VertexOutput3>, a9: VertexOutput3, a10: ptr<storage, array<u32>, read>, a11: VertexOutput3, a12: ptr<storage, array<u32>, read>, a13: VertexOutput3, a14: mat4x4h, a15: f32, a16: ptr<workgroup, array<atomic<u32>, 14>>, a17: VertexOutput3, a18: ptr<function, array<VertexOutput3, 7>>, a19: mat3x4h, a20: ptr<private, mat3x3f>, a21: mat4x3h, a22: array<mat2x2f, 11>, a23: mat3x3h, a24: ptr<function, VertexOutput3>, a25: ptr<uniform, array<array<array<u32, 1>, 1>, 11>>, a26: ptr<function, VertexOutput3>, a27: array<VertexOutput3, 3>, a28: ptr<workgroup, vec4i>, a29: u32, a30: ptr<storage, array<u32>, read>, a31: array<bool, 32>, a32: ptr<uniform, VertexOutput3>, a33: ptr<workgroup, array<array<array<array<array<atomic<i32>, 1>, 1>, 4>, 1>, 4>>, a34: ptr<storage, array<u32>, read_write>, a35: VertexOutput3, a36: vec4f, a37: ptr<uniform, VertexOutput3>, a38: ptr<private, mat4x3h>, a39: mat3x3h, a40: vec4f, a41: ptr<storage, array<u32>, read_write>, a42: array<f16, 12>, a43: ptr<storage, VertexOutput3, read_write>, a44: VertexOutput3, a45: ptr<storage, array<array<f32, 1>, 24>, read>, a46: mat3x3f, a47: ptr<storage, array<u32>, read>, a48: ptr<function, VertexOutput3>, a49: ptr<function, mat2x4f>, a50: ptr<storage, array<VertexOutput3>, read>, a51: ptr<storage, f16, read_write>, a52: ptr<storage, array<u32>, read_write>, a53: VertexOutput3, a54: array<f32, 15>) -> VertexOutput3 {
+  var out: VertexOutput3;
+  let ptr27: ptr<storage, mat2x2f, read_write> = &(*a6);
+  (*a26) = VertexOutput3((*a32).f14, pack4x8unorm((*a32).f14));
+  var vf30: VertexOutput3 = a4;
+  let vf31: vec4f = inverseSqrt(vec4f(bitcast<f32>((*a47)[arrayLength(&(*a47))])));
+  (*a26) = VertexOutput3(vec4f(bitcast<f32>(vp6.f15)), vp6.f15);
+  let vf32: f16 = a42[u32(unconst_u32(5))];
+  return out;
+}
+
+var<workgroup> vw6: mat3x4h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw12: array<VertexOutput3, 1>;
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+@id(53740) override override0: i32;
+
+fn fn1() -> VertexOutput3 {
+  var out: VertexOutput3;
+  fn0();
+  var vf25 = fn0();
+  let ptr25: ptr<function, u32> = &vf25.f15;
+  var vf26 = fn0();
+  let vf27: f32 = vp6.f14[0];
+  vf26.f15 |= u32(vf25.f14[0]);
+  fn0();
+  let ptr26: ptr<function, vec4f> = &vf26.f14;
+  vp5.fract -= vec2f(vf26.f14[u32(unconst_u32(172))]);
+  fn0();
+  var vf28: f32 = sign((*ptr26).x);
+  vf28 *= trunc(vec2f(unconst_f32(-0.1024), unconst_f32(0.2451))).x;
+  vp5 = modf(vec2f(vp6.f14[u32(unconst_u32(25))]));
+  vp5 = modf(unpack2x16unorm(vf25.f15));
+  out.f15 -= bitcast<u32>(override0);
+  let vf29: f32 = vf26.f14[3];
+  return out;
+  _ = override0;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp5 = modf(vec2f());
+
+var<workgroup> vw8: array<u32, 47>;
+
+var<workgroup> vw10: VertexOutput3;
+
+@group(0) @binding(180) var st2: texture_storage_2d_array<r32float, read_write>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw2: atomic<u32>;
+
+var<private> vp6: VertexOutput3 = VertexOutput3();
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw5: mat2x4f;
+
+var<workgroup> vw9: VertexOutput3;
+
+@vertex
+fn vertex3() -> VertexOutput3 {
+  var out: VertexOutput3;
+  let vf33: f32 = vp6.f14[bitcast<u32>(degrees(bitcast<f32>(pack2x16snorm(vec2f(sign(vec2h(insertBits(vec3i(override0), vec3i(i32(all(bool(unconst_bool(false))))), u32(unconst_u32(443)), pack4x8unorm(vec4f(cos(vec4h(f16(all(bool(unconst_bool(false))))))))).xx)))))))];
+  vp5.fract = unpack2x16unorm(u32(unconst_u32(42)));
+  fn1();
+  let vf34: vec4h = cos(vec4h(unconst_f16(-7020.2), unconst_f16(7094.1), unconst_f16(9934.5), unconst_f16(2852.2)));
+  var vf35: u32 = pack2x16float(vec2f(unconst_f32(-0.3445), unconst_f32(0.1817)));
+  vp5.whole = bitcast<vec2f>(smoothstep(vec4h(unconst_f16(1503.2), unconst_f16(582.8), unconst_f16(13673.5), unconst_f16(18786.8)), vec4h(unconst_f16(11197.4), unconst_f16(3876.6), unconst_f16(22092.4), unconst_f16(8181.1)), vec4h(unconst_f16(-6439.9), unconst_f16(3973.8), unconst_f16(8470.4), unconst_f16(-8711.8))));
+  var vf36 = fn0();
+  vf36 = VertexOutput3(vec4f(vf34), vec4u(vf34)[3]);
+  vf35 >>= vp6.f15;
+  vp5.fract -= vec2f(f32(vf34[u32(unconst_u32(15))]));
+  let ptr28: ptr<private, vec2f> = &vp5.fract;
+  var vf37: vec3h = tan(vec3h(vf36.f14.rrb));
+  var vf38: vec2f = unpack2x16unorm(u32(unconst_u32(10)));
+  fn0();
+  vf37 = vec3h(f16(vp6.f14[3]));
+  vp6 = VertexOutput3((*ptr28).gggr, vec2u((*ptr28))[1]);
+  let vf39: f32 = vf38[1];
+  var vf40: f32 = vf36.f14[3];
+  vp6.f15 -= bitcast<u32>(vf38[1]);
+  vf36 = VertexOutput3(unpack2x16unorm(u32(unconst_u32(16))).yxyx, bitcast<u32>(unpack2x16unorm(u32(unconst_u32(16)))[0]));
+  let ptr29: ptr<private, vec2f> = &vp5.whole;
+  return out;
+  _ = override0;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  let ptr30: ptr<workgroup, u32> = &(*&vw7).f15;
+  let ptr31: ptr<workgroup, u32> = &(*&vw9).f15;
+  atomicStore(&vw4, u32(unconst_u32(635)));
+  fn1();
+  atomicExchange(&vw2, u32(unconst_u32(194)));
+  vw11 = mat4x3h(vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))], vw11[u32(unconst_u32(262))][u32(unconst_u32(210))]);
+  vw5 = mat2x4f(bitcast<f32>(vw3.f15), f32(vw3.f15), f32(vw3.f15), f32(vw3.f15), f32(vw3.f15), f32(vw3.f15), bitcast<f32>(vw3.f15), bitcast<f32>(vw3.f15));
+  _ = override0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let renderPassEncoder6 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 30,
+  clearValue: { r: -313.4, g: -714.1, b: -755.3, a: 653.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\u{1fab0}\u8e5f\ufb6a\u0e59',
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+@group(0) @binding(180) var st3: texture_storage_2d_array<r32float, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat) f0: u32,
+  @location(6) f1: vec2i,
+}
+
+var<workgroup> vw14: FragmentOutput1;
+
+var<workgroup> vw15: vec2i;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+override override1: i32 = 65;
+
+var<private> vp8 = modf(vec2h());
+
+var<private> vp7: vec4f = vec4f();
+
+var<workgroup> vw16: array<atomic<u32>, 1>;
+
+struct T0 {
+  @align(1) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw13: atomic<i32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T2 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f0 <<= bitcast<u32>(vp7[0]);
+  out.f1 *= countLeadingZeros(vec2i(unconst_i32(92), unconst_i32(393)));
+  out.f1 += vec2i(vp8.fract);
+  let ptr32: ptr<private, vec2h> = &vp8.fract;
+  let vf41: f32 = vp7[u32(unconst_u32(238))];
+  vp7 += unpack4x8snorm(pack4x8unorm(vec4f(unconst_f32(0.4259), unconst_f32(0.1836), unconst_f32(0.07396), unconst_f32(0.3431))));
+  let ptr33: ptr<private, vec2h> = &vp8.whole;
+  vp8.whole = (*ptr32);
+  let vf42: u32 = pack4xU8Clamp(vec4u(unconst_u32(133), unconst_u32(240), unconst_u32(10), unconst_u32(43)));
+  vp8 = modf(bitcast<vec2h>(vf42));
+  vp7 *= vec4f(select(vec4<bool>((*ptr32).xxyy), vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(true)), bool(unconst_bool(false))));
+  vp7 += vec4f(f32((*ptr33)[u32(unconst_u32(39))]));
+  vp8 = modf(ldexp(bitcast<vec2h>(vf41), vec2i(select(vec4<bool>(asinh(vec2h(unconst_f16(2681.9), unconst_f16(3504.0))).ggrg), vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false), unconst_bool(false)), bool(unconst_bool(false))).ab)));
+  var vf43: u32 = dot(vec2u(vp8.whole), vec2u(unconst_u32(71), unconst_u32(60)));
+  vp7 = vec4f(vp8.fract.xxxx);
+  let vf44: u32 = dot(vec2u(unconst_u32(44), unconst_u32(328)), vec2u(unconst_u32(204), unconst_u32(87)));
+  var vf45: f32 = vp7[0];
+  out.f0 = pack2x16float(unpack2x16float(pack4xU8Clamp(unpack4xU8(bitcast<u32>(vp7[0])))));
+  out = FragmentOutput1(bitcast<u32>(extractBits(vec4i(unconst_i32(210), unconst_i32(176), unconst_i32(27), unconst_i32(153)), vf42, pack4xI8Clamp(extractBits(vec4i(unconst_i32(247), unconst_i32(28), unconst_i32(-16), unconst_i32(397)), u32(unconst_u32(77)), pack4xU8Clamp(vec4u(textureNumLayers(st3))))))[0]), extractBits(vec4i(unconst_i32(210), unconst_i32(176), unconst_i32(27), unconst_i32(153)), vf42, pack4xI8Clamp(extractBits(vec4i(unconst_i32(247), unconst_i32(28), unconst_i32(-16), unconst_i32(397)), u32(unconst_u32(77)), pack4xU8Clamp(vec4u(textureNumLayers(st3)))))).rb);
+  var vf46: f16 = (*ptr32)[u32(unconst_u32(30))];
+  var vf47: f16 = (*ptr32)[0];
+  out.f0 = pack4x8unorm(vec4f(unconst_f32(-0.05023), unconst_f32(0.07434), unconst_f32(0.06911), unconst_f32(0.2662)));
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute2() {
+  atomicXor(&vw13, atomicExchange(&(*&vw13), i32(unconst_i32(70))));
+}`,
+  hints: {},
+});
+let texture40 = device0.createTexture({
+  size: [32, 32, 9],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView41 = texture32.createView({aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder5.setViewport(30.181688164466586, 4.622528603377257, 82.05165841234317, 0.7361704725641337, 0.6613422844326973, 0.8092146749873063);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer10);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer22 = device0.createBuffer({size: 25863, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView42 = texture17.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3);
+} catch {}
+await gc();
+let texture41 = device0.createTexture({size: {width: 84}, dimension: '1d', format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup9, new Uint32Array(5124), 766, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder47 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder47.beginComputePass();
+let sampler21 = device0.createSampler({
+  label: '\u6e0b\u{1f808}\u{1ffa2}\ubce6\ue740\u{1fd67}\u84ba\u045c\u02a9',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.4992,
+  lodMaxClamp: 84.76,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(105.04981106968982, 5.70002815785722, 1.7441221709752204, 2.2688991887906282, 0.34601842379573544, 0.7753281692245778);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u05ad');
+} catch {}
+let buffer23 = device0.createBuffer({size: 3036, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup16, new Uint32Array(937), 418, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer0, 0, 517);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView43 = texture26.createView({dimension: '2d', baseArrayLayer: 3});
+let textureView44 = texture21.createView({label: '\u5920\u772d\udd06', dimension: '1d'});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup15, new Uint32Array(2050), 753, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(1050), 118, 0);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 45, y: 1, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 1},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 16});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder40 = commandEncoder48.beginComputePass({label: '\u09a3\u7684\u0591\u0406\u8b35\u98d7\u06f2'});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup18, [512]);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\ue953');
+} catch {}
+try {
+computePassEncoder18.setBindGroup(2, bindGroup13, new Uint32Array(204), 59, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint16', 3_774, 623);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 300, new BigUint64Array(6643), 3838, 60);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt470m', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 18, resource: {buffer: buffer15, offset: 0, size: 844}},
+    {binding: 174, resource: {buffer: buffer6, offset: 0, size: 992}},
+  ],
+});
+let buffer24 = device0.createBuffer({
+  size: 7789,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder49 = device0.createCommandEncoder({label: '\u0ba3\u2e49\uc094\u3825'});
+let texture42 = device0.createTexture({
+  size: [240, 16, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture33.createView({});
+let computePassEncoder41 = commandEncoder49.beginComputePass({});
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise9;
+} catch {}
+document.body.append(canvas0);
+let buffer25 = device0.createBuffer({
+  size: 24576,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture43 = device0.createTexture({size: {width: 768}, sampleCount: 1, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup13, new Uint32Array(452), 100, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 2_516, 154);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise6;
+} catch {}
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 121});
+try {
+renderPassEncoder4.setViewport(85.69174149652856, 4.614756071992261, 24.7767663899369, 1.1236892260624216, 0.532157392048721, 0.9327903541041234);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer10, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView10},
+    {binding: 4, resource: {buffer: buffer0, offset: 3328, size: 196}},
+  ],
+});
+let texture44 = device0.createTexture({
+  size: [42, 20, 141],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView46 = texture1.createView({label: '\u0e78\u0413\u151a\u08b0\u{1fe28}\u07f1\u{1fdd4}\u640a\u{1f96f}\u{1f78e}'});
+let sampler22 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.38,
+  lodMaxClamp: 70.15,
+  compare: 'less',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup20, new Uint32Array(485), 236, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer13, 0, 1_915);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 824, new DataView(new ArrayBuffer(2108)), 89, 404);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(151), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 80}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 103});
+let textureView47 = texture15.createView({dimension: '2d', baseArrayLayer: 1});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 98.36,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup21 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 218, resource: sampler3}]});
+let buffer26 = device0.createBuffer({size: 2611, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u5df8\u0626\u3e62\u4d48\u05cf\uf359'});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(927), 55, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer25, 'uint32', 9_376, 899);
+} catch {}
+let textureView48 = texture32.createView({mipLevelCount: 1});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup16, new Uint32Array(1074), 47, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(96.18977650493936, 3.780038685639947, 23.097729603902096, 3.98088271465342, 0.5446598852936909, 0.9514472239483238);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer6, 'uint16', 1_348, 268);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer23);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 792 */
+  offset: 792,
+  bytesPerRow: 32768,
+  buffer: buffer10,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder41.pushDebugGroup('\u0117');
+} catch {}
+let sampler24 = device0.createSampler({
+  label: '\u0213\u{1f9d9}\u{1f89a}\u9b38',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 98.91,
+  lodMaxClamp: 99.27,
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup17, [256]);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 288 */
+  offset: 288,
+  buffer: buffer0,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 10},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 218, resource: sampler4}]});
+let buffer27 = device0.createBuffer({size: 28048, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView49 = texture24.createView({dimension: 'cube-array', baseArrayLayer: 6, arrayLayerCount: 6});
+let texture45 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView50 = texture31.createView({mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder50.beginComputePass();
+try {
+computePassEncoder35.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer24, 1_212, 4_001);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  label: '\u{1fc67}\u332c\u06bd\u9fb1',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 204, resource: textureView26},
+    {binding: 18, resource: externalTexture2},
+    {binding: 265, resource: {buffer: buffer10, offset: 0}},
+    {binding: 86, resource: textureView19},
+    {binding: 221, resource: {buffer: buffer0, offset: 0, size: 32}},
+    {binding: 219, resource: textureView47},
+    {binding: 139, resource: {buffer: buffer21, offset: 3328}},
+    {binding: 189, resource: {buffer: buffer9, offset: 2048, size: 1489}},
+    {binding: 105, resource: textureView24},
+    {binding: 171, resource: textureView25},
+  ],
+});
+let buffer28 = device0.createBuffer({
+  size: 5205,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle4, renderBundle3, renderBundle4, renderBundle3, renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer21, 'uint16', 4_040, 111);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 18, resource: {buffer: buffer19, offset: 2048, size: 28}},
+    {binding: 174, resource: {buffer: buffer0, offset: 0, size: 452}},
+  ],
+});
+let commandEncoder51 = device0.createCommandEncoder();
+let texture46 = device0.createTexture({
+  size: [60, 4, 93],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder51.beginComputePass({label: '\u66c8\u05f1\u8c45\u0bc8\u09f6\u6a7e\uea52\u{1f713}\u2dff'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.07,
+  lodMaxClamp: 93.38,
+  compare: 'less',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup16, new Uint32Array(98), 7, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder6.setViewport(95.4734724124227, 0.13477891410530085, 14.56771679617645, 0.35826158734777774, 0.18589620847217925, 0.5181000821666197);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 8, new Float32Array(4843), 117, 364);
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder41.label;
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 368,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture47 = device0.createTexture({
+  size: [42, 20, 32],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView51 = texture34.createView({baseMipLevel: 0});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u01ef\u7980\u7fc7\uc9bf\u{1fe61}\ueb6f\u41a0\u1215\u4410',
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+var<workgroup> vw26: atomic<u32>;
+
+var<workgroup> vw37: atomic<u32>;
+
+var<workgroup> vw35: vec4i;
+
+fn fn1(a0: ptr<function, vec2<bool>>) -> array<array<array<array<bool, 3>, 1>, 1>, 1> {
+  var out: array<array<array<array<bool, 3>, 1>, 1>, 1>;
+  let ptr38: ptr<workgroup, array<vec2i, 10>> = &vw28;
+  let ptr39: ptr<uniform, array<f16, 1>> = &buffer31[0][0][0][28][0][u32(unconst_u32(284))];
+  var vf56: vec4h = vw25[u32(distance(vec4f((*ptr38)[9].rggr), unpack4x8unorm(atomicLoad(&vw32[8][0]))))];
+  let ptr40: ptr<workgroup, array<array<atomic<i32>, 1>, 1>> = &(*&vw29)[8];
+  let ptr41: ptr<workgroup, atomic<i32>> = &(*&vw29)[8][0][0];
+  let ptr42: ptr<workgroup, array<atomic<i32>, 1>> = &vw29[8][0];
+  let ptr43: ptr<workgroup, bool> = &(*&vw30);
+  atomicAdd(&vw29[u32(vw25[0][3])][u32(unconst_u32(170))][u32(buffer31[0][0][0][28][0][0][0])], i32(vp11[0][u32(unconst_u32(56))]));
+  vp10 = modf(vec3h(vw17[u32(unconst_u32(188))].bgb));
+  vw24 = mat4x2h(f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]), f16(vp9[u32(unconst_u32(185))]));
+  buffer30[u32(vw25[u32(workgroupUniformLoad(&vw36)[1][2])][u32(unconst_u32(53))])][u32(unconst_u32(66))][u32(unconst_u32(18))] = f16(textureDimensions(tex2, i32(unconst_i32(24)))[0]);
+  vp11[u32(vp11[0][u32(unconst_u32(314))])] = vec4<bool>((*&vw28)[9].gggg);
+  var vf57: f16 = (*&vw36)[textureDimensions(tex2, i32(unconst_i32(100)))[1]][u32(unconst_u32(167))];
+  let ptr44: ptr<workgroup, vec4u> = &vw17[8];
+  let ptr45: ptr<uniform, array<f16, 1>> = &buffer31[0][0][0][28][0][0];
+  vf56 = vec4h(f16(atomicLoad(&vw34[0])));
+  var vf58: u32 = atomicLoad(&(*&vw38));
+  workgroupBarrier();
+  let ptr46: ptr<workgroup, array<array<array<atomic<i32>, 1>, 1>, 9>> = &(*&vw29);
+  vw36 = mat3x4h(vec4h((*&vw39)[0][3]), vec4h((*&vw39)[0][3]), vec4h((*&vw39)[0][2]));
+  return out;
+}
+
+var<workgroup> vw27: atomic<i32>;
+
+var<workgroup> vw24: mat4x2h;
+
+var<workgroup> vw36: mat3x4h;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(2) @binding(67) var<uniform> buffer31: array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 29>, 1>, 1>, 1>;
+
+var<workgroup> vw33: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(1) @binding(30) var tex4: texture_depth_2d;
+
+@group(0) @binding(30) var tex0: texture_depth_2d;
+
+@group(0) @binding(78) var tex2: texture_2d_array<f32>;
+
+var<workgroup> vw17: array<vec4u, 9>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw28: array<vec2i, 10>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw32: array<array<atomic<u32>, 1>, 9>;
+
+var<workgroup> vw23: array<atomic<u32>, 7>;
+
+@group(1) @binding(205) var tex7: texture_2d<f32>;
+
+var<workgroup> vw30: bool;
+
+fn fn0(a0: u32) -> array<bool, 4> {
+  var out: array<bool, 4>;
+  var vf48: vec2u = textureDimensions(tex4, i32(unconst_i32(342)));
+  vp11[u32(unconst_u32(189))] = vec4<bool>(textureLoad(tex8, vec2i(vp11[textureDimensions(tex8, i32(unconst_i32(44)))[1]].yz), i32(unconst_i32(24))));
+  var vf49: u32 = textureNumLevels(tex0);
+  let ptr34 = &vp10;
+  let vf50: vec2u = textureDimensions(tex0, i32(unconst_i32(276)));
+  vp9 -= unpack4xI8(vf50[u32(unconst_u32(50))]);
+  let ptr35: ptr<private, vec3h> = &(*ptr34).fract;
+  let vf51: vec2u = textureDimensions(tex0, i32(unconst_i32(134)));
+  vf48 -= vec2u(u32((*ptr35)[1]));
+  vp9 -= vec4i((*ptr35).xzxx);
+  vf49 += vf50[0];
+  vp11[vf50[u32(unconst_u32(190))]] = vec4<bool>(fract(vec2h(unconst_f16(2803.3), unconst_f16(2754.4))).rrgr);
+  vf48 *= vec2u(vf48[u32(unconst_u32(127))]);
+  let vf52: i32 = vp9[textureDimensions(tex8)[1]];
+  vf49 &= u32(textureLoad(tex0, vec2i(bitcast<i32>(vf48[0])), i32(unconst_i32(172))));
+  vf48 ^= textureDimensions(tex0);
+  out[pack4xU8Clamp(countOneBits(vec4u(unconst_u32(146), unconst_u32(18), unconst_u32(74), unconst_u32(58))))] = any(vp11[0]);
+  vf49 *= a0;
+  let ptr36: ptr<private, vec3h> = &(*ptr34).whole;
+  var vf53: u32 = textureNumLevels(tex1);
+  let ptr37: ptr<private, vec3h> = &(*ptr36);
+  var vf54: f16 = (*ptr37)[pack4xU8Clamp(countOneBits(bitcast<vec4u>(saturate(vec3f(unconst_f32(0.5101), unconst_f32(0.02211), unconst_f32(0.05241))).xyyy)))];
+  var vf55: vec2u = vf51;
+  return out;
+}
+
+var<workgroup> vw40: atomic<i32>;
+
+@group(2) @binding(125) var tex8: texture_2d<u32>;
+
+var<workgroup> vw34: array<atomic<u32>, 1>;
+
+struct T0 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+fn fn2(a0: array<mat4x2f, 2>) -> mat3x2h {
+  var out: mat3x2h;
+  var vf59: vec4i = insertBits(vec4i(vp11[0]), vec4i(unconst_i32(20), unconst_i32(24), unconst_i32(3), unconst_i32(285)), u32(unconst_u32(151)), pack2x16float(a0[1][0]));
+  vp9 = vec4i(a0[1][1].grgg);
+  vf59 *= vec4i(a0[u32(a0[1][2][0])][3].yxyx);
+  out += mat3x2h(vec2h(a0[1][3]), vec2h(a0[1][3]), vec2h(a0[1][1]));
+  var vf60: vec4u = reverseBits(vec4u(unconst_u32(1), unconst_u32(38), unconst_u32(12), unconst_u32(152)));
+  var vf61: f32 = a0[1][2][0];
+  let ptr47: ptr<function, vec4i> = &vf59;
+  let vf62: vec3f = ceil(vec3f(unconst_f32(0.1432), unconst_f32(0.2624), unconst_f32(0.9605)));
+  var vf63: f32 = a0[1][2][0];
+  let vf64: vec2f = a0[1][u32(unconst_u32(20))];
+  let vf65: vec4u = reverseBits(vec4u(unconst_u32(105), unconst_u32(169), unconst_u32(8), unconst_u32(185)));
+  vp10.fract *= vec3h(f16(vf64[0]));
+  out = mat3x2h(distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))), distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))), distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))), distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))), distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))), distance(vec3h(cross(vec3f(vp11[0].gbr), vec3f(f32(vf59[3])))), vec3h(unconst_f16(3837.9), unconst_f16(23072.9), unconst_f16(-17024.1))));
+  let vf66: vec3f = vf62;
+  vf63 = a0[u32(unconst_u32(59))][3].y;
+  vf61 *= f32(sinh(f16(unconst_f16(3268.0))));
+  let vf67: vec3f = ceil(vec3f(f32(sinh(f16(ceil(vec3f(unconst_f32(0.5726), unconst_f32(0.1325), unconst_f32(0.2126))).b)))));
+  return out;
+}
+
+var<private> vp11: array<vec4<bool>, 1> = array<vec4<bool>, 1>();
+
+var<workgroup> vw39: array<mat4x4f, 1>;
+
+var<workgroup> vw41: vec4u;
+
+@group(1) @binding(37) var<storage, read_write> buffer30: array<array<array<f16, 3>, 1>, 1>;
+
+var<workgroup> vw18: array<array<f16, 1>, 48>;
+
+var<workgroup> vw25: mat2x4h;
+
+var<workgroup> vw38: atomic<u32>;
+
+@group(1) @binding(48) var tex5: texture_depth_2d;
+
+@group(0) @binding(48) var tex1: texture_depth_2d;
+
+var<workgroup> vw19: atomic<u32>;
+
+var<workgroup> vw22: atomic<u32>;
+
+var<workgroup> vw29: array<array<array<atomic<i32>, 1>, 1>, 9>;
+
+@group(1) @binding(78) var tex6: texture_2d_array<f32>;
+
+var<workgroup> vw31: array<vec4u, 11>;
+
+@group(0) @binding(205) var tex3: texture_2d<f32>;
+
+var<private> vp10 = modf(vec3h());
+
+var<workgroup> vw20: array<atomic<i32>, 23>;
+
+@group(3) @binding(180) var st4: texture_storage_2d_array<r32float, read_write>;
+
+var<workgroup> vw21: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp9: vec4i = vec4i();
+
+@compute @workgroup_size(1, 2, 2)
+fn compute3(@builtin(global_invocation_id) a0: vec3u) {
+  vw41 ^= unpack4xU8(u32(vw28[9][0]));
+  let vf68: u32 = atomicLoad(&vw19);
+  vp11[bitcast<u32>(atomicExchange(&vw40, i32(unconst_i32(284))))] = vec4<bool>(bool(atomicLoad(&vw29[8][0][0])));
+  atomicExchange(&vw34[u32(unconst_u32(35))], u32(unconst_u32(409)));
+  let ptr48: ptr<workgroup, array<array<array<atomic<i32>, 1>, 1>, 9>> = &(*&vw29);
+  let ptr49: ptr<workgroup, array<f16, 1>> = &(*&vw18)[u32(unconst_u32(285))];
+  textureBarrier();
+  var vf69 = fn2(array<mat4x2f, 2>(mat4x2f(f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30)), mat4x2f(f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30), f32(vw30))));
+  let ptr50: ptr<uniform, f16> = &(*&buffer31)[0][0][0][28][0][0][0];
+  var vf70: u32 = atomicLoad(&(*&vw26));
+  vw17[vec4u(vw25[0]).y] ^= unpack4xU8(bitcast<u32>(atomicLoad(&vw29[u32(unconst_u32(179))][0][0])));
+  var vf71 = fn2(array<mat4x2f, 2>(mat4x2f(bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2])), mat4x2f(bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2]), bitcast<vec2f>((*&vw36)[2]))));
+  let ptr51: ptr<uniform, f16> = &(*ptr50);
+  let ptr52: ptr<workgroup, atomic<i32>> = &(*&vw29)[8][0][u32(unconst_u32(8))];
+  fn2(array<mat4x2f, 2>(mat4x2f(f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0])), mat4x2f(f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]), f32(vw18[47][0]))));
+  let ptr53: ptr<workgroup, mat2x4h> = &(*&vw25);
+  var vf72 = fn2(array<mat4x2f, 2>(mat4x2f(f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2])), mat4x2f(f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]), f32((*&vw36)[2][2]))));
+  var vf73 = fn2(array<mat4x2f, 2>(mat4x2f(f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0])), mat4x2f(f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]), f32((*&buffer31)[0][0][0][28][0][0][0]))));
+  atomicXor(&vw40, bitcast<vec4i>(vw17[u32(vw18[47][0])]).w);
+  let ptr54: ptr<workgroup, atomic<u32>> = &vw23[6];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture48 = device0.createTexture({size: [32, 32, 20], format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView52 = texture38.createView({baseArrayLayer: 0});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup17, [2560]);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setViewport(113.52047433990805, 6.628841361740708, 1.3637976171239479, 0.5458424125683857, 0.6751694785744711, 0.8277919492185353);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint32', 64, 475);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder41.popDebugGroup();
+} catch {}
+let texture49 = device0.createTexture({
+  label: '\u{1fcd0}\u{1f765}\u0de4\u{1fe6a}\u023a\u69bc',
+  size: [1536, 1, 1],
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 85.11,
+  lodMaxClamp: 90.08,
+});
+document.body.append(canvas0);
+let videoFrame5 = new VideoFrame(videoFrame0, {timestamp: 0});
+let texture50 = device0.createTexture({
+  size: [768, 1, 45],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(2, bindGroup9, new Uint32Array(1867), 329, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(137);
+} catch {}
+try {
+renderPassEncoder6.setViewport(57.51481716698062, 0.22805353282206253, 53.105579812894014, 0.7642988301631101, 0.36735501356265277, 0.4951004202153063);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint16', 1_414, 706);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer24);
+} catch {}
+let arrayBuffer3 = buffer4.getMappedRange(48, 8);
+document.body.prepend(canvas0);
+let texture51 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup12, [1024]);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup13, new Uint32Array(27), 1, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer32 = device0.createBuffer({
+  size: 12418,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(1, bindGroup21, new Uint32Array(63), 4, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(1089), 50, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle7]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 0, new Int16Array(5302), 587, 12);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(1, bindGroup18, [256]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint32', 14_312, 1_739);
+} catch {}
+let arrayBuffer4 = buffer4.getMappedRange(56, 0);
+let bindGroup25 = device0.createBindGroup({
+  label: '\u0b33\u5f6f\ufd65\u628e\u89d9\u2abc\u6658\uc015\u06bf',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 37, resource: {buffer: buffer20, offset: 512, size: 612}},
+    {binding: 30, resource: textureView14},
+    {binding: 78, resource: textureView12},
+    {binding: 48, resource: textureView10},
+    {binding: 205, resource: textureView28},
+  ],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2);
+} catch {}
+let arrayBuffer5 = buffer4.getMappedRange(64, 24);
+try {
+device0.queue.writeBuffer(buffer14, 1116, new Float32Array(27301), 2524, 700);
+} catch {}
+await gc();
+let buffer33 = device0.createBuffer({size: 19285, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder52 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setViewport(4.545246197135104, 2.5688979574503366, 33.88680914110892, 3.971551154069171, 0.37829708024981545, 0.7467214265070676);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer7, 'uint16', 158, 516);
+} catch {}
+let buffer34 = device0.createBuffer({
+  size: 7629,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView53 = texture12.createView({
+  label: '\u{1f88c}\u4c5e\u4408\u{1fd40}\u{1fbec}\u095c\u6330\u{1f9ae}',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup12, new Uint32Array(1262), 77, 1);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(592);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer32, 'uint16', 1_522, 189);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: canvas0,
+  origin: { x: 68, y: 0 },
+  flipY: false,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+canvas0.width = 15;
+let textureView54 = texture34.createView({});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 300 widthInBlocks: 75 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 24320,
+  buffer: buffer9,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture52 = device0.createTexture({
+  label: '\ua6bb\u73aa\u5075\uebd4\u77a0\ucdb3\uc969\uf343\u831f\uc796',
+  size: {width: 240, height: 16, depthOrArrayLayers: 96},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer28, 0, 737);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(buffer32, 3244, buffer19, 3492, 1220);
+} catch {}
+let bindGroup26 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView21}]});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u6284\u06ff\u091a\u3627\u5771'});
+let texture53 = device0.createTexture({
+  label: '\u6673\u{1f753}\u{1f9ea}\u4062\u7f71\u0369\u{1fbdc}\ue514\u0c41',
+  size: {width: 21},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder44 = commandEncoder52.beginComputePass({});
+let renderPassEncoder7 = commandEncoder54.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -298.1, g: 609.4, b: 460.4, a: 909.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 277314995,
+});
+let sampler27 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.53,
+  lodMaxClamp: 94.67,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup16, new Uint32Array(651), 0, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer32, 'uint32', 3_024, 2_492);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 290 widthInBlocks: 145 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 840 */
+  offset: 840,
+  bytesPerRow: 9216,
+  buffer: buffer10,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 145, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\u5d40');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 516, new Float32Array(29538), 3927, 644);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer35 = device0.createBuffer({size: 16728, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup19, new Uint32Array(677), 7, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+commandEncoder53.insertDebugMarker('\u0d13');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6]});
+let texture54 = device0.createTexture({
+  size: [240, 16, 375],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder45 = commandEncoder37.beginComputePass({});
+let sampler28 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 55.43,
+  lodMaxClamp: 88.90,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup16, new Uint32Array(1058), 38, 0);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(buffer35, 1272, buffer19, 1160, 1824);
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+let texture55 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder46 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup14, new Uint32Array(1459), 19, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.append(canvas0);
+let imageData3 = new ImageData(52, 148);
+let bindGroup27 = device0.createBindGroup({
+  label: '\u9515\u{1fb86}\u74d5\u89aa\uffee\u3560\u7bcd',
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView14},
+    {binding: 4, resource: {buffer: buffer15, offset: 0, size: 1036}},
+  ],
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView55 = texture55.createView({mipLevelCount: 1});
+let computePassEncoder47 = commandEncoder55.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup20, new Uint32Array(405), 28, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint16', 336, 405);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  label: '\u58fa\u3701\u4466\u0697\u18ae\u108d\u2e76\u{1f886}\u{1fd7d}\uacca',
+  layout: bindGroupLayout8,
+  entries: [{binding: 47, resource: textureView53}],
+});
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout9]});
+let texture56 = device0.createTexture({size: [240], mipLevelCount: 1, dimension: '1d', format: 'r32float', usage: GPUTextureUsage.COPY_SRC});
+let textureView56 = texture56.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup22, new Uint32Array(596), 257, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer15, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 16, new DataView(new ArrayBuffer(9358)), 38, 32);
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\uffe9\ub38b\u0a0a\ueacf\ueaf1\u11f5\u0969',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, constants: {53_740: 0}},
+});
+let textureView57 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+let textureView58 = texture36.createView({});
+try {
+renderPassEncoder7.beginOcclusionQuery(335);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let texture57 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer24, 848, 480);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 218, resource: sampler8}]});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 1409});
+let sampler29 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 72.22, lodMaxClamp: 98.57});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 1196});
+let computePassEncoder48 = commandEncoder56.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup26, new Uint32Array(1398), 14, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture58 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder49 = commandEncoder57.beginComputePass({});
+try {
+renderPassEncoder5.executeBundles([renderBundle2]);
+} catch {}
+let arrayBuffer6 = buffer4.getMappedRange(88, 4);
+let textureView59 = texture25.createView({});
+let sampler30 = device0.createSampler({
+  label: '\u{1fdbe}\u05cb\u{1fa0d}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.23,
+  lodMaxClamp: 57.20,
+  compare: 'greater',
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup2, new Uint32Array(615), 13, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer21, 'uint16', 404, 313);
+} catch {}
+let bindGroup30 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView47}]});
+let texture59 = device0.createTexture({size: [192, 1, 1], format: 'r8uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup7, new Uint32Array(2281), 7, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 624, 1_737);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer36 = device0.createBuffer({
+  size: 9223,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder58 = device0.createCommandEncoder();
+let texture60 = device0.createTexture({
+  size: [168, 80, 20],
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder50 = commandEncoder58.beginComputePass({});
+let sampler31 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.99,
+  lodMaxClamp: 44.72,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(1857), 150, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint16', 532, 1_677);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise11;
+} catch {}
+document.body.prepend(canvas0);
+let shaderModule5 = device0.createShaderModule({
+  label: '\u{1fec6}\u0a90\u06eb\u053b',
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+struct T1 {
+  @size(8) f0: array<u32>,
+}
+
+var<private> vp13 = array(modf(vec4h()), modf(vec4h()), modf(vec4h()), modf(vec4h()), modf(vec4h()), modf(vec4h()));
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0() -> vec2i {
+  var out: vec2i;
+  var vf74: vec2f = inverseSqrt(vec2f(unconst_f32(0.1396), unconst_f32(0.5249)));
+  return out;
+}
+
+var<private> vp12 = modf(f16());
+
+var<workgroup> vw42: array<atomic<i32>, 12>;
+
+@group(0) @binding(100) var tex9: texture_2d<f32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T2 {
+  @align(2) @size(28) f0: array<u32>,
+}
+
+struct FragmentOutput2 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @location(6) @interpolate(flat) f1: vec4u,
+  @location(2) f2: vec2f,
+}
+
+struct VertexOutput4 {
+  @builtin(position) f16: vec4f,
+}
+
+var<private> vp14: f32 = f32();
+
+struct T3 {
+  f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex4() -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f16 = vec4f(vp13[5].fract);
+  vp14 += vec3f(atanh(vec3h(f16(max(f32(unconst_f32(0.3096)), f32(unconst_f32(0.00197)))))))[1];
+  let vf75: u32 = pack4xU8Clamp(bitcast<vec4u>(insertBits(vec4i(unconst_i32(98), unconst_i32(380), unconst_i32(59), unconst_i32(521)), vec4i(unconst_i32(-151), unconst_i32(228), unconst_i32(49), unconst_i32(13)), u32(unconst_u32(68)), bitcast<u32>(max(f32(step(vec4h(f16(pack2x16snorm(unpack2x16unorm(pack4xU8Clamp(vec4u(faceForward(vec4f(unconst_f32(0.1425), unconst_f32(0.3443), unconst_f32(0.1349), unconst_f32(0.00582)), vec4f(unconst_f32(0.2134), unconst_f32(0.01574), unconst_f32(-0.1518), unconst_f32(0.01574)), vec4f(unconst_f32(0.1671), unconst_f32(0.1307), unconst_f32(0.1022), unconst_f32(-0.2986))))))))), vec4h(f16(pack2x16snorm(ldexp(vec3f(unconst_f32(0.04862), unconst_f32(0.2113), unconst_f32(0.2551)), clamp(vec3i(trunc(vec3h(unconst_f16(29219.7), unconst_f16(-5323.1), unconst_f16(2435.3)))), vec3i(unconst_i32(80), unconst_i32(465), unconst_i32(13)), vec3i(unconst_i32(75), unconst_i32(80), unconst_i32(58)))).rb)))).r), vec4f(vp13[5].fract)[0])))));
+  let vf76: u32 = pack4xU8Clamp(vec4u(unconst_u32(45), unconst_u32(210), unconst_u32(288), unconst_u32(411)));
+  let ptr55: ptr<private, f16> = &vp12.fract;
+  let vf77: vec2f = ceil(vec2f(unconst_f32(-0.1491), unconst_f32(0.2769)));
+  var vf78: vec4f = unpack4x8snorm(u32(atanh(vp13[5].whole.wyz).y));
+  let vf79: vec3f = round(bitcast<vec3f>(insertBits(vec4i(i32((*ptr55))), vec4i(vp13[5].fract), u32(unconst_u32(209)), u32(unconst_u32(62))).gbg));
+  vp13[5] = modf(trunc(vec3h(unconst_f16(1629.5), unconst_f16(11177.5), unconst_f16(10225.3))).yxxx);
+  let vf80: f32 = length(vec4f(unconst_f32(0.09528), unconst_f32(0.03396), unconst_f32(0.3206), unconst_f32(0.7049)));
+  let ptr56 = &vp13;
+  out.f16 = vec4f(vf78[u32(unconst_u32(78))]);
+  var vf81: f32 = vf77[1];
+  vp13[u32(unconst_u32(168))] = modf(vec4h(vf78));
+  vf78 = vec4f(f32((*ptr55)));
+  out.f16 = bitcast<vec4f>(max(vec4u(unconst_u32(700), unconst_u32(273), unconst_u32(91), unconst_u32(181)), unpack4xU8(bitcast<u32>(max(bitcast<f32>(atan(vec2h(unconst_f16(16280.1), unconst_f16(-7779.2)))), f32(unconst_f32(-0.1527)))))));
+  var vf82: vec4f = unpack4x8snorm(u32(unconst_u32(140)));
+  vf82 = vec4f(bitcast<f32>(abs(i32(unconst_i32(252)))));
+  let vf83: f32 = vf77[u32(unconst_u32(101))];
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  fn0();
+  let vf84: vec4h = cosh(vec4h(unconst_f16(5618.4), unconst_f16(12264.3), unconst_f16(4797.5), unconst_f16(-6274.0)));
+  out.f0 |= vec4u(acosh(vp13[5].fract.xw).yxyx);
+  var vf85 = fn0();
+  fn0();
+  vp12 = modf(f16(mix(vec4f(unconst_f32(0.4443), unconst_f32(0.07289), unconst_f32(0.04520), unconst_f32(0.4998)), vec4f(unconst_f32(0.5916), unconst_f32(0.1647), unconst_f32(0.00779), unconst_f32(0.5069)), vec4f(unconst_f32(0.01465), unconst_f32(-0.05943), unconst_f32(-0.03099), unconst_f32(0.03047))).g));
+  vp13[extractBits(pack4x8snorm(cosh(vec4f(unconst_f32(0.1119), unconst_f32(-0.05212), unconst_f32(0.1899), unconst_f32(0.02314)))), pack4xU8Clamp(vec4u(vp13[5].whole)), pack2x16float(vec2f(f32(vf84[0]))))] = modf(bitcast<vec4h>(vf85));
+  out.f1 >>= vec4u(sign(vec2h(unconst_f16(6397.0), unconst_f16(12316.5))).yxxx);
+  vf85 = bitcast<vec2i>(vf84);
+  var vf86: u32 = pack2x16unorm(vec2f(acosh(bitcast<vec2h>(pack2x16float(vec2f(unconst_f32(0.2827), unconst_f32(0.08132)))))));
+  fn0();
+  var vf87 = fn0();
+  out.f2 += vec2f(bitcast<f32>(vf85[u32(unconst_u32(702))]));
+  vp13[u32(unconst_u32(45))].fract = vec4h(mix(vec4f(unconst_f32(0.08944), unconst_f32(0.06748), unconst_f32(0.2830), unconst_f32(0.00345)), vec4f(f32(vf86)), vec4f(unconst_f32(0.09157), unconst_f32(0.05181), unconst_f32(0.05093), unconst_f32(0.2992))));
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute4() {
+  var vf88 = fn0();
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute5(@builtin(workgroup_id) a0: vec3u, @builtin(num_workgroups) a1: vec3u) {
+  vp14 += f32(any(vec3<bool>(a1)));
+  var vf89: u32 = a1[1];
+  vp14 = f32(vp13[textureDimensions(tex9, i32(unconst_i32(45)))[0]].fract.r);
+  vp12 = modf(fract(vec3h(unconst_f16(19682.0), unconst_f16(5346.5), unconst_f16(4256.2))).z);
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute6() {
+  var vf90: f32 = cos(f32(unconst_f32(0.1042)));
+  var vf91 = fn0();
+  let ptr57: ptr<workgroup, atomic<i32>> = &vw42[11];
+  vf91 = bitcast<vec2i>(vp13[5].whole);
+  let vf92: f32 = cos(f32(unconst_f32(0.01830)));
+  vp13[5] = modf(vec4h(f16(vf90)));
+  vp13[u32(atomicExchange(&(*ptr57), vf91[u32(unconst_u32(402))]))] = modf(vec4h(f16(distance(bitcast<vec2f>(unpack4xI8(u32(atomicExchange(&(*&vw42)[11], i32(unconst_i32(-349))))).wz), vec2f(unconst_f32(0.1609), unconst_f32(0.01050))))));
+  fn0();
+  atomicCompareExchangeWeak(&vw42[pack4x8unorm(asin(vec4f(unconst_f32(-0.1612), unconst_f32(0.05030), unconst_f32(0.09042), unconst_f32(0.09685))))], unconst_i32(17), unconst_i32(22));
+  var vf93 = fn0();
+  var vf94 = fn0();
+  vp13[u32(unconst_u32(19))] = modf(vec4h(f16(vf94[0])));
+  var vf95 = fn0();
+  let ptr58: ptr<function, vec2i> = &vf95;
+  let vf96: i32 = atomicLoad(&vw42[11]);
+  let vf97: vec2u = textureDimensions(tex9, i32(unconst_i32(50)));
+  let vf98: i32 = vf91[0];
+  var vf99 = fn0();
+  let vf100: i32 = vf94[0];
+  var vf101 = fn0();
+  fn0();
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let textureView60 = texture60.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder51 = commandEncoder59.beginComputePass({label: '\udafb\u0176\uf88a\u860e\u{1f804}\u0e3b\u96c9\u38c7\u9887\u0336'});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup26, new Uint32Array(1266), 76, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup12, [0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 1_004, 1_151);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 440, new DataView(new ArrayBuffer(17247)), 1578, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 21},
+  aspect: 'all',
+}, new Uint8Array(4_502).fill(215), /* required buffer size: 4_502 */
+{offset: 19, bytesPerRow: 16, rowsPerImage: 56}, {width: 3, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let texture61 = device0.createTexture({size: {width: 30}, dimension: '1d', format: 'rg16float', usage: GPUTextureUsage.COPY_DST});
+let sampler32 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.9714,
+});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup10, new Uint32Array(4681), 1_326, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let textureView61 = texture13.createView({dimension: '2d-array', baseArrayLayer: 0});
+let textureView62 = texture37.createView({label: '\u{1ff0b}\uadec\ub124\u671b\u0f7d', mipLevelCount: 1});
+try {
+renderPassEncoder3.setScissorRect(4, 1, 41, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 11, y: 2, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({label: '\u{1f803}\u02b3\uc68b\uf454\u0764\u76ef', type: 'occlusion', count: 46});
+let textureView63 = texture12.createView({
+  label: '\u0684\u7c31\uf4dd\u245a\u{1f95f}\u6062\u0826',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseArrayLayer: 6,
+  arrayLayerCount: 1,
+});
+let renderPassEncoder8 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{view: textureView59, depthSlice: 24, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 136069312,
+});
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup18, [2304]);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup26, new Uint32Array(229), 33, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 511.7, g: -350.6, b: -371.5, a: 142.2, });
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer32, 2_292, 2_718);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9_743).fill(138), /* required buffer size: 9_743 */
+{offset: 100, bytesPerRow: 95, rowsPerImage: 99}, {width: 12, height: 3, depthOrArrayLayers: 2});
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame4);
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 4, resource: {buffer: buffer2, offset: 0, size: 1192}},
+    {binding: 42, resource: textureView28},
+  ],
+});
+let buffer37 = device0.createBuffer({
+  label: '\u27b9\u0bc4\u2e1c\u3f3f\u{1f762}\u7ff7',
+  size: 25130,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder61 = device0.createCommandEncoder();
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.44,
+  lodMaxClamp: 90.21,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(821), 270, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint32', 940, 886);
+} catch {}
+let buffer38 = device0.createBuffer({
+  size: 5122,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let sampler34 = device0.createSampler({
+  label: '\ud374\u724b\u7643\u{1f9e9}\u5bc1\u4231\u6866\u7fc1\uaded\u433c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 96.38,
+  lodMaxClamp: 97.49,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup2);
+} catch {}
+let arrayBuffer7 = buffer4.getMappedRange(112, 24);
+try {
+commandEncoder61.copyBufferToBuffer(buffer38, 988, buffer14, 2020, 604);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView28},
+    {binding: 4, resource: {buffer: buffer13, offset: 256, size: 888}},
+  ],
+});
+let textureView64 = texture23.createView({label: '\u033b\u{1f9d0}\u{1f89c}\u0af9\uab85\uf16d\u0b5b\u{1f636}', baseArrayLayer: 0});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup10, new Uint32Array(459), 36, 0);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 4352,
+  buffer: buffer10,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 1},
+  aspect: 'all',
+}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 7800, new Int16Array(5555), 1995, 1332);
+} catch {}
+try {
+globalThis.someLabel = texture56.label;
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView65 = texture0.createView({
+  label: '\u7926\u{1fde0}\u{1ffc0}\u958d\u3797\u0f75\u{1f7f4}\u{1f72b}',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let texture62 = device0.createTexture({
+  size: {width: 168, height: 80, depthOrArrayLayers: 43},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup1, new Uint32Array(328), 43, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer20, 0, 1_725);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView53},
+    {binding: 4, resource: {buffer: buffer13, offset: 0, size: 164}},
+  ],
+});
+let commandEncoder63 = device0.createCommandEncoder({});
+let textureView66 = texture57.createView({label: '\u62f8\u0ca3', dimension: '2d', mipLevelCount: 1});
+let texture63 = device0.createTexture({
+  size: [60, 4, 1],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(203);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer36, 'uint16', 344, 913);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 164 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1016 */
+  offset: 1016,
+  bytesPerRow: 14080,
+  buffer: buffer10,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 64},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+document.body.prepend(canvas0);
+let textureView67 = texture31.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder52 = commandEncoder62.beginComputePass();
+let sampler35 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 63.48,
+  lodMaxClamp: 67.70,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder8.setViewport(130.25503886355932, 0.33904729468064376, 9.982726686038646, 0.5569835641970557, 0.511629501694263, 0.5922867646146349);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer25, 'uint16', 106, 1_169);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer13, 412, buffer5, 4, 0);
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({});
+let textureView68 = texture17.createView({dimension: '2d-array'});
+let textureView69 = texture30.createView({label: '\u{1fb21}\u458e', format: 'rgba8unorm', baseArrayLayer: 1, arrayLayerCount: 7});
+let computePassEncoder53 = commandEncoder61.beginComputePass({});
+let renderPassEncoder9 = commandEncoder63.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 57,
+  clearValue: { r: 186.8, g: 742.6, b: -533.1, a: -884.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup7, new Uint32Array(333), 152, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup22, new Uint32Array(844), 112, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: img0,
+  origin: { x: 12, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 22, y: 5, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer39 = device0.createBuffer({size: 4823, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder54 = commandEncoder64.beginComputePass({});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 57.26,
+  lodMaxClamp: 97.69,
+});
+let externalTexture6 = device0.importExternalTexture({label: '\u0c12\u{1f9cd}\uf051', source: videoFrame1});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u39fa\u64e6\u889c\u{1fa50}\u06b2',
+  colorFormats: ['r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer6, 'uint32', 312, 1_956);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer6, 0, 522);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+adapter0.label = '\u1128\u03ab\u002b\u{1f7a5}\u052d\u654f\u0efb\u0fe0\u0bd6\ud489\u822f';
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 999,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let sampler37 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.42,
+  lodMaxClamp: 98.97,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder5.setViewport(10.153638089621628, 5.192847825664259, 109.38974291441508, 2.1451484981384645, 0.3058332452019813, 0.40605266277541857);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer23);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\ub063\u304c\uda03\uacac\u8230\u0999',
+  entries: [
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup14, new Uint32Array(602), 63, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer7, 'uint16', 5_430, 1_607);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  label: '\u{1fc44}\u53fc\u{1f68b}\u012f\u97c1\u8b34\u{1fa42}\u{1f7aa}\u{1f949}\u0703',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 18, resource: {buffer: buffer38, offset: 0, size: 1352}},
+    {binding: 174, resource: {buffer: buffer24, offset: 512, size: 108}},
+  ],
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.69,
+  lodMaxClamp: 46.86,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup17, [0]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(90.59525609617066, 7.596527302161818, 25.39399097462876, 0.16128957532676733, 0.3871494609918835, 0.5362662821023808);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint16', 104, 1_221);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup26, new Uint32Array(1326), 20, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer29, 0, 191);
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 171, resource: textureView25},
+    {binding: 265, resource: {buffer: buffer32, offset: 768, size: 384}},
+    {binding: 18, resource: externalTexture1},
+    {binding: 219, resource: textureView36},
+    {binding: 221, resource: {buffer: buffer18, offset: 0, size: 488}},
+    {binding: 189, resource: {buffer: buffer37, offset: 512, size: 3153}},
+    {binding: 105, resource: textureView24},
+    {binding: 139, resource: {buffer: buffer23, offset: 256}},
+    {binding: 86, resource: textureView53},
+    {binding: 204, resource: textureView26},
+  ],
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let texture64 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView70 = texture58.createView({dimension: '2d'});
+let sampler39 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 60.01,
+  lodMaxClamp: 65.35,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer32, 0, 1_595);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 520 */
+  offset: 520,
+  bytesPerRow: 11264,
+  buffer: buffer32,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\uca4a');
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\u0444');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 28, new Int16Array(21174), 4793, 12);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({size: [1536], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder2.setIndexBuffer(buffer32, 'uint16', 2_492, 505);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup17, new Uint32Array(104), 11, 1);
+} catch {}
+let renderPassEncoder10 = commandEncoder66.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  clearValue: { r: 781.8, g: -965.9, b: -286.9, a: 285.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer15);
+} catch {}
+let promise12 = shaderModule5.getCompilationInfo();
+try {
+commandEncoder65.copyBufferToBuffer(buffer26, 28, buffer14, 548, 660);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u0fd2\u{1fbff}\ub2ab\u{1fabb}\uad8a\u{1fdd4}\u{1fc28}\ua1ff\u{1f9a2}\uff16'});
+let computePassEncoder55 = commandEncoder65.beginComputePass({label: '\uec78\u{1f652}\u0c89\u7c0a\u2f91\u{1f99a}\ubada\ud7ff\u{1fd5a}'});
+let renderPassEncoder11 = commandEncoder67.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: 179.7, g: -628.9, b: 491.5, a: 511.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 57303928,
+});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer7, 'uint32', 1_372, 825);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer32);
+} catch {}
+let arrayBuffer8 = buffer4.getMappedRange(96, 0);
+let promise13 = device0.queue.onSubmittedWorkDone();
+let renderBundle10 = renderBundleEncoder10.finish();
+let sampler40 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.08,
+  lodMaxClamp: 76.32,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup30, new Uint32Array(600), 188, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer10, 64);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+computePassEncoder43.setBindGroup(2, bindGroup25, new Uint32Array(20), 0, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer10, 104);
+} catch {}
+try {
+  await promise12;
+} catch {}
+canvas0.height = 2620;
+let textureView71 = texture53.createView({arrayLayerCount: 1});
+let sampler41 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.71,
+  lodMaxClamp: 80.81,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup8, new Uint32Array(4125), 1_023, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+document.body.prepend(canvas0);
+await gc();
+let commandEncoder68 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup31, new Uint32Array(846), 55, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 296, new BigUint64Array(4840), 195, 24);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'pq'} });
+let buffer40 = device0.createBuffer({
+  size: 4989,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder69 = device0.createCommandEncoder();
+let textureView72 = texture9.createView({arrayLayerCount: 1});
+let computePassEncoder57 = commandEncoder69.beginComputePass();
+let sampler42 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.14,
+  lodMaxClamp: 66.79,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer36, 'uint32', 1_044, 147);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer37, 0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+externalTexture5.label = '\u0b30\ub206\u06c0\u0e6a\u2771\u{1fe1f}\u0efb\u{1fb8d}\ucc5f\ub853';
+} catch {}
+let buffer41 = device0.createBuffer({
+  size: 12432,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup22, []);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer32, 'uint16', 2_490, 19);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u{1fd9f}');
+} catch {}
+let texture66 = device0.createTexture({
+  size: [768, 1, 385],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView73 = texture47.createView({format: 'r16uint', mipLevelCount: 1});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup21, new Uint32Array(579), 0, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -282.1, g: 571.4, b: -704.5, a: 182.6, });
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer36, 'uint32', 508, 174);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer10);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1424});
+let texture67 = device0.createTexture({
+  label: '\u64f8\u038b\u8315\ua3be\u{1fb84}\u9ac2\u{1fbca}\u4651\u517d\u076b',
+  size: {width: 768, height: 1, depthOrArrayLayers: 3},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder58 = commandEncoder70.beginComputePass({label: '\u0ce9\u{1fcb0}\u1046\uf0d8\ub2f9\u3132\u1029'});
+let externalTexture7 = device0.importExternalTexture({label: '\u{1faba}\u0013\u0b69\u5556', source: videoFrame2});
+try {
+computePassEncoder38.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup3, new Uint32Array(3320), 1_637, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture68 = device0.createTexture({
+  label: '\u35c3\u9c28\u0d69\u{1fa59}\u0e38\u{1f626}',
+  size: [384, 1, 57],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView74 = texture6.createView({label: '\u0c88\u89bc\u41a4\u7561\u00d9\u6bb1\u4503\u{1f9bf}', format: 'rgba8unorm'});
+let computePassEncoder59 = commandEncoder71.beginComputePass({});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup9, new Uint32Array(763), 162, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(72.50730279670411, 7.656356757383673, 5.89245682215103, 0.023526261877643808, 0.7138756650603368, 0.9237234782429046);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 2_672, 2_227);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer23, 160, 335);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 96, new Int16Array(5430), 1340, 1556);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture69 = device0.createTexture({
+  size: [768, 1, 1],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture70 = device0.createTexture({
+  size: [84, 40, 1],
+  mipLevelCount: 6,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture71 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 39},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture72 = device0.createTexture({
+  size: [30],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.65,
+  lodMaxClamp: 85.94,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(1, bindGroup14, new Uint32Array(668), 141, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer9 = buffer41.getMappedRange(0, 512);
+try {
+  await promise14;
+} catch {}
+let textureView75 = texture69.createView({label: '\u6a02\u9f31\u0f78\u0b31\u{1ff1b}\u6f72\u6155\ubfdf\uae67\uaf33', dimension: '2d-array'});
+let sampler44 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.69,
+  lodMaxClamp: 52.37,
+});
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer15, 2_168, 288);
+} catch {}
+let arrayBuffer10 = buffer41.getMappedRange(512, 776);
+let bindGroup36 = device0.createBindGroup({
+  label: '\u7591\u5364\u{1fcf3}\u{1ffee}\u0237',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 62, resource: textureView37},
+    {binding: 429, resource: {buffer: buffer15, offset: 256, size: 2404}},
+    {binding: 223, resource: textureView35},
+    {binding: 137, resource: textureView72},
+  ],
+});
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView76 = texture71.createView({});
+let computePassEncoder60 = commandEncoder72.beginComputePass({});
+try {
+renderPassEncoder1.setBlendConstant({ r: 806.2, g: 495.9, b: -270.1, a: 515.0, });
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 22, y: 2, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView77 = texture14.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder61 = commandEncoder73.beginComputePass({});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup22, new Uint32Array(457), 135, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup9, new Uint32Array(1741), 482, 0);
+} catch {}
+let textureView78 = texture52.createView({mipLevelCount: 1, baseArrayLayer: 86, arrayLayerCount: 2});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup16, new Uint32Array(739), 335, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 218},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler45 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.25,
+  lodMaxClamp: 75.02,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer21, 'uint16', 336, 874);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer28, 188, buffer1, 180, 536);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 204 */
+  offset: 204,
+  bytesPerRow: 3584,
+  buffer: buffer9,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 4, y: 6, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+let computePassEncoder62 = commandEncoder74.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup13, new Uint32Array(838), 59, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder11.setViewport(237.74249040138943, 6.005724773146104, 0.5529606862337694, 2.5268330870749582, 0.24486176064628884, 0.47733628934290084);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+canvas0.width = 518;
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView66},
+    {binding: 67, resource: {buffer: buffer10, offset: 0, size: 486}},
+  ],
+});
+let texture74 = device0.createTexture({
+  size: [42, 20, 1],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup1, new Uint32Array(5353), 231, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup7, new Uint32Array(4367), 1_132, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+externalTexture5.label = '\u02c0\ufb2d';
+} catch {}
+let buffer42 = device0.createBuffer({size: 4758, usage: GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(195);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 756.7, g: -245.1, b: 406.3, a: -892.1, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(0, 0, 29, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer23, 'uint16', 856, 105);
+} catch {}
+let buffer43 = device0.createBuffer({size: 6578, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder75 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 830});
+let textureView79 = texture68.createView({format: 'rgba8unorm', mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 10});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline1);
+} catch {}
+document.body.prepend(img0);
+let bindGroup38 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 218, resource: sampler35}]});
+let sampler46 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.46,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder8.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer36, 0, 1_685);
+} catch {}
+document.body.prepend(img0);
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 205, resource: textureView4},
+    {binding: 30, resource: textureView19},
+    {binding: 78, resource: textureView61},
+    {binding: 48, resource: textureView19},
+    {binding: 37, resource: {buffer: buffer38, offset: 1792, size: 168}},
+  ],
+});
+let commandEncoder76 = device0.createCommandEncoder({label: '\u{1fd89}\u{1f7a5}\u{1f9a9}\u0e96\u{1fe8e}\udf4c\u00c2\ua35e'});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup31, new Uint32Array(6385), 416, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint32', 760, 367);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 8, y: 8, z: 1},
+  aspect: 'all',
+}, new Uint8Array(25_601).fill(42), /* required buffer size: 25_601 */
+{offset: 325, bytesPerRow: 44, rowsPerImage: 114}, {width: 5, height: 5, depthOrArrayLayers: 6});
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView47}]});
+let buffer44 = device0.createBuffer({size: 2177, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandBuffer2 = commandEncoder75.finish({});
+let renderPassEncoder12 = commandEncoder61.beginRenderPass({
+  label: '\u78a4\uf23b\ue1c8\u731b\u06b8\u9f52\u888d',
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: -408.2, g: 335.2, b: 906.8, a: 624.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup12, new Uint32Array(1798), 224, 1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer20, 0);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 39 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3153 */
+  offset: 3153,
+  bytesPerRow: 30720,
+  buffer: buffer7,
+}, {width: 39, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let img2 = await imageWithData(84, 91, '#10101010', '#20202020');
+let imageData4 = new ImageData(8, 4);
+let texture75 = device0.createTexture({
+  size: [30, 2, 54],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView80 = texture26.createView({baseArrayLayer: 4, arrayLayerCount: 32});
+let computePassEncoder63 = commandEncoder76.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer44, 'uint16', 470, 347);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'unspecified'} });
+let buffer45 = device0.createBuffer({
+  size: 5893,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture76 = device0.createTexture({
+  size: [30, 2, 46],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler47 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.06,
+  lodMaxClamp: 82.99,
+  maxAnisotropy: 7,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame2});
+try {
+device0.queue.writeBuffer(buffer5, 8, new DataView(new ArrayBuffer(6691)), 1715, 20);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let buffer46 = device0.createBuffer({
+  label: '\u0a5a\u{1f6c5}\u8e50',
+  size: 6500,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(2, bindGroup29, new Uint32Array(1602), 705, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup29, new Uint32Array(983), 347, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 430.6, g: 43.60, b: 983.8, a: 414.5, });
+} catch {}
+try {
+computePassEncoder54.pushDebugGroup('\u{1fd33}');
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let buffer47 = device0.createBuffer({size: 1708, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  label: '\u{1f86c}\u2797\u{1fdcf}\u0d42\u2818\u{1fc51}\uf056\u9806\uc084\u6d93',
+  size: [1536, 1, 28],
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder64 = commandEncoder77.beginComputePass({});
+let sampler48 = device0.createSampler({
+  label: '\u{1fe16}\u0f61\u5707\u9ce0\u{1fddf}\ud799\u0292\u0767',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.90,
+  lodMaxClamp: 69.28,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setViewport(89.27823510142305, 0.38105575474243647, 3.2304539340190055, 5.572585382728731, 0.7901861939460728, 0.9615341147179708);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 820, new Int16Array(21635), 343, 1516);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 9}
+*/
+{
+  source: canvas0,
+  origin: { x: 61, y: 198 },
+  flipY: true,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 7, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+try {
+adapter0.label = '\ub0d9\u{1f95f}\ud2d6\ue31b';
+} catch {}
+let texture78 = device0.createTexture({
+  size: [192, 1, 27],
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView81 = texture17.createView({label: '\u{1ffd1}\u3296\u0f1f\ub6c3\u{1fc7a}\u{1fae7}\u5611\u9653', format: 'depth24plus'});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(531);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer3, 'uint32', 340, 1_313);
+} catch {}
+try {
+computePassEncoder54.popDebugGroup();
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 278,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture79 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 44},
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder65 = commandEncoder78.beginComputePass({label: '\u0aa1\u0816\u0e19\u{1f7d7}\u088c\uae4f\u08b1\ud405\ud905\u9d1f\u0210'});
+try {
+computePassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer40, 'uint32', 44, 1_396);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(66).fill(158), /* required buffer size: 66 */
+{offset: 66}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView82 = texture20.createView({});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(58);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer36);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup41 = device0.createBindGroup({
+  label: '\u6ddd\u{1ffaf}\uf8e6\u6d94\u6729\u5426\u67cf\u2892',
+  layout: bindGroupLayout12,
+  entries: [{binding: 84, resource: textureView75}],
+});
+let commandEncoder79 = device0.createCommandEncoder({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 92.34,
+  compare: 'always',
+});
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u492c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(3_440).fill(119), /* required buffer size: 3_440 */
+{offset: 78, bytesPerRow: 23, rowsPerImage: 65}, {width: 1, height: 17, depthOrArrayLayers: 3});
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'bt2020_10bit'} });
+let commandEncoder80 = device0.createCommandEncoder({});
+let texture80 = device0.createTexture({
+  size: [30, 2, 1],
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder66 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup15, new Uint32Array(143), 0, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer40, 1_420);
+} catch {}
+try {
+commandEncoder79.copyBufferToTexture({
+  /* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2552 */
+  offset: 2552,
+  bytesPerRow: 10496,
+  buffer: buffer28,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 252, new BigUint64Array(6531), 1044, 344);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 21, y: 41 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470bg', transfer: 'bt2020_12bit'} });
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 48, resource: textureView19},
+    {binding: 78, resource: textureView61},
+    {binding: 205, resource: textureView53},
+    {binding: 37, resource: {buffer: buffer13, offset: 256, size: 476}},
+    {binding: 30, resource: textureView81},
+  ],
+});
+let commandEncoder81 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 1014});
+let textureView83 = texture15.createView({dimension: '2d'});
+let computePassEncoder67 = commandEncoder81.beginComputePass({});
+let renderPassEncoder13 = commandEncoder79.beginRenderPass({colorAttachments: [{view: textureView52, depthSlice: 83, loadOp: 'clear', storeOp: 'store'}]});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 99.86,
+  lodMaxClamp: 99.88,
+  compare: 'less-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup15, new Uint32Array(5855), 1_039, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6, renderBundle6, renderBundle6]);
+} catch {}
+document.body.append(img2);
+try {
+globalThis.someLabel = commandEncoder19.label;
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder();
+let computePassEncoder68 = commandEncoder82.beginComputePass();
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer29, 'uint32', 76, 8);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({size: [42], dimension: '1d', format: 'rgb9e5ufloat', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder69 = commandEncoder83.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup16, new Uint32Array(116), 4, 0);
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let renderPassEncoder14 = commandEncoder84.beginRenderPass({
+  label: '\u78db\u5f0c\u4154\u6fe9\u0baa\u053c\u06a1',
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -197.2, g: 994.1, b: -995.6, a: 912.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 507028103,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r8uint']});
+let sampler51 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 91.39});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup28, new Uint32Array(534), 6, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer36, 'uint16', 32, 1_848);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer34, 5_032, 792);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup41);
+} catch {}
+let arrayBuffer11 = buffer41.getMappedRange(5616, 3216);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer48 = device0.createBuffer({size: 1564, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture82 = device0.createTexture({
+  size: {width: 240},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder12.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(207.8767322191869, 12.742936454515498, 4.196250974974194, 0.837708471401162, 0.8493048910854296, 0.9911397525237465);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 2952, new BigUint64Array(17461), 5227, 16);
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 137, resource: textureView72},
+    {binding: 223, resource: textureView35},
+    {binding: 62, resource: textureView37},
+    {binding: 429, resource: {buffer: buffer15, offset: 0, size: 236}},
+  ],
+});
+let textureView84 = texture82.createView({});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(2, bindGroup9, new Uint32Array(709), 531, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup38, new Uint32Array(818), 310, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup20, new Uint32Array(3714), 1_478, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 168, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp15: FragmentOutput3 = FragmentOutput3(u32(), f32());
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput3 {
+  @location(0) f0: u32,
+  @location(1) @interpolate(perspective) f1: f32,
+}
+
+@id(44357) override override2: bool;
+
+fn fn1() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf109: u32 = pack4x8unorm(vec4f(unconst_f32(0.04897), unconst_f32(0.00111), unconst_f32(0.1098), unconst_f32(0.05925)));
+  return out;
+}
+
+var<workgroup> vw43: FragmentOutput3;
+
+@group(0) @binding(100) var tex10: texture_2d<f32>;
+
+fn fn0() -> array<array<array<f16, 1>, 1>, 22> {
+  var out: array<array<array<f16, 1>, 1>, 22>;
+  let vf102: vec4h = asin(vec4h(unconst_f16(16105.1), unconst_f16(8732.4), unconst_f16(7104.8), unconst_f16(2313.6)));
+  out[21][u32(unconst_u32(184))][pack2x16snorm(unpack2x16snorm(u32(unconst_u32(197))))] = ldexp(vec3h(unconst_f16(7881.6), unconst_f16(3811.6), unconst_f16(197.6)), vec3i(unconst_i32(94), unconst_i32(448), unconst_i32(169)))[2];
+  vp15.f0 &= vec3u(ldexp(vec3h(tan(vec3f(unconst_f32(0.1525), unconst_f32(0.02747), unconst_f32(-0.08308)))), vec3i(unconst_i32(39), unconst_i32(163), unconst_i32(60))))[1];
+  let vf103: vec4i = reverseBits(vec4i(i32(vf102[u32(unconst_u32(79))])));
+  var vf104: bool = override2;
+  var vf105: vec3f = tan(vec3f(f32(vf102[2])));
+  let vf106: vec4i = vf103;
+  out[u32(unconst_u32(106))][vp15.f0][0] *= f16(vp15.f1);
+  let vf107: i32 = vf103[2];
+  var vf108: i32 = vf103[u32(unconst_u32(719))];
+  return out;
+  _ = override2;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn2() -> mat2x4h {
+  var out: mat2x4h;
+  fn0();
+  out = mat2x4h(f16(vp15.f1), f16(vp15.f1), f16(vp15.f1), f16(vp15.f1), f16(vp15.f1), f16(vp15.f1), f16(vp15.f1), f16(vp15.f1));
+  out = mat2x4h(vec4h(ceil(vec3f(unconst_f32(0.1376), unconst_f32(0.01596), unconst_f32(-0.08673))).rgbb), vec4h(ceil(vec3f(unconst_f32(0.1376), unconst_f32(0.01596), unconst_f32(-0.08673))).brrb));
+  var vf110 = fn0();
+  vp15.f1 += f32(vf110[21][0][u32(vf110[21][0][0])]);
+  let ptr59: ptr<function, array<array<array<f16, 1>, 1>, 22>> = &vf110;
+  vp15 = FragmentOutput3(u32((*ptr59)[21][0][0]), f32((*ptr59)[21][0][0]));
+  fn0();
+  var vf111: bool = any(vec4<bool>(bool(vf110[21][0][0])));
+  var vf112 = fn0();
+  var vf113 = fn0();
+  var vf114 = fn0();
+  let ptr60: ptr<function, array<array<f16, 1>, 1>> = &vf112[21];
+  return out;
+  _ = override2;
+}
+
+@vertex
+fn vertex5() -> @builtin(position) vec4f {
+  var out: vec4f;
+  fn1();
+  out *= vec4f(vp15.f1);
+  let ptr61: ptr<private, f32> = &vp15.f1;
+  out = exp2(vec4f(bitcast<f32>(vp15.f0)));
+  fn1();
+  var vf115: vec2f = unpack2x16float(u32(unconst_u32(40)));
+  var vf116: vec4f = saturate(vec4f(vf115[vp15.f0]));
+  return out;
+}
+
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  fn2();
+  let vf117: vec3f = exp(vec3f(unconst_f32(-0.07585), unconst_f32(0.2716), unconst_f32(0.1098)));
+  let vf118: bool = all(bool(pack2x16unorm(vec2f(unconst_f32(0.1385), unconst_f32(0.2310)))));
+  out.f0 ^= pack4xI8(vec4i(bitcast<i32>(dot4U8Packed(u32(unpack4x8snorm(u32(unconst_u32(132)))[2]), u32(unconst_u32(99))))));
+  out.f0 = pack4xU8Clamp(vec4u(exp(vec4h(unconst_f16(9575.1), unconst_f16(4901.4), unconst_f16(9945.4), unconst_f16(1527.3)))));
+  out = FragmentOutput3(u32(mix(f16(unconst_f16(-3865.9)), f16(vp15.f0), f16(unconst_f16(6788.4)))), f32(mix(f16(unconst_f16(-3865.9)), f16(vp15.f0), f16(unconst_f16(6788.4)))));
+  let vf119: f32 = vf117[u32(unconst_u32(492))];
+  var vf120 = fn2();
+  var vf121 = fn0();
+  var vf122: u32 = pack2x16snorm(vec2f(unconst_f32(0.2274), unconst_f32(-0.02759)));
+  discard;
+  fn0();
+  let vf123: u32 = pack2x16snorm(vec2f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.1418), unconst_f32(0.00624))))));
+  let ptr62: ptr<private, f32> = &vp15.f1;
+  var vf124 = fn2();
+  let vf125: vec4f = atan2(vec4f(unconst_f32(0.1989), unconst_f32(-0.1324), unconst_f32(0.1181), unconst_f32(0.1066)), vec4f(f32(vf121[21][0][u32(unconst_u32(120))])));
+  fn0();
+  vf120 += mat2x4h(vf121[21][0][0], vf121[21][0][0], vf121[21][0][0], vf121[21][0][0], vf121[21][0][0], vf121[21][0][0], vf121[21][0][0], vf121[21][0][0]);
+  return out;
+  _ = override2;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  vp15.f0 &= bitcast<u32>(fract(vec2h(unconst_f16(2407.1), unconst_f16(2368.3))));
+  vp15 = FragmentOutput3(bitcast<u32>((*&vw43).f1), (*&vw43).f1);
+  vw43 = FragmentOutput3(u32(textureLoad(tex10, bitcast<vec2i>(log(vec4f(unconst_f32(0.2020), unconst_f32(0.2153), unconst_f32(-0.2421), unconst_f32(0.3661))).aa), i32(unconst_i32(206))).a), textureLoad(tex10, bitcast<vec2i>(log(vec4f(unconst_f32(0.2020), unconst_f32(0.2153), unconst_f32(-0.2421), unconst_f32(0.3661))).aa), i32(unconst_i32(206))).a);
+  fn2();
+  var vf126: vec4f = textureLoad(tex10, vec2i(unconst_i32(157), unconst_i32(-348)), i32(textureLoad(tex10, vec2i(faceForward(fract(vec2h(unconst_f16(11424.1), unconst_f16(2762.6))), bitcast<vec2h>((*&vw43).f0), bitcast<vec2h>(determinant(mat4x4f(f32(vw43.f0), f32(vw43.f0), bitcast<f32>(vw43.f0), f32(vw43.f0), f32(vw43.f0), bitcast<f32>(vw43.f0), bitcast<f32>(vw43.f0), f32(vw43.f0), bitcast<f32>(vw43.f0), bitcast<f32>(vw43.f0), f32(vw43.f0), bitcast<f32>(vw43.f0), bitcast<f32>(vw43.f0), f32(vw43.f0), bitcast<f32>(vw43.f0), bitcast<f32>(vw43.f0)))))), i32(unconst_i32(266)))[3]));
+  var vf127 = fn1();
+  var vf128 = fn2();
+  let ptr63: ptr<workgroup, u32> = &(*&vw43).f0;
+  fn1();
+  let vf129: f16 = vf128[1][textureDimensions(tex10)[0]];
+  vf126 += vec4f(bitcast<f32>(vp15.f0));
+  vf128 = mat2x4h(vec4h(normalize(vec3f(bitcast<f32>(vf127.f0))).yxzz), vec4h(normalize(vec3f(bitcast<f32>(vf127.f0))).rggr));
+  var vf130: vec4f = log(vec4f(unconst_f32(0.4728), unconst_f32(0.1033), unconst_f32(-0.1983), unconst_f32(0.1402)));
+  var vf131 = fn0();
+  var vf132 = fn2();
+  var vf133 = fn0();
+  vw43.f1 = vec4f(vf128[u32(unconst_u32(275))]).x;
+  var vf134 = fn2();
+  fn2();
+  vf127 = FragmentOutput3(bitcast<u32>(vf126[1]), vf126[1]);
+  let vf135: f32 = determinant(mat4x4f(unconst_f32(0.08339), unconst_f32(0.2592), unconst_f32(0.09551), unconst_f32(0.1229), unconst_f32(0.2317), unconst_f32(0.01549), unconst_f32(0.2992), unconst_f32(-0.1441), unconst_f32(0.2146), unconst_f32(0.03983), unconst_f32(0.1238), unconst_f32(0.3108), unconst_f32(0.07392), unconst_f32(0.5148), unconst_f32(0.2435), unconst_f32(0.03828)));
+  fn1();
+  var vf136 = fn2();
+  fn2();
+  _ = override2;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer49 = device0.createBuffer({
+  size: 1527,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let textureView85 = texture82.createView({});
+let computePassEncoder70 = commandEncoder85.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer23, 'uint16', 246, 228);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(1201), 23, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 725.7, g: 265.2, b: -22.74, a: -687.5, });
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer36, 'uint16', 3_292, 655);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 351,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture83 = device0.createTexture({
+  label: '\u{1fd5b}\u0777',
+  size: {width: 42, height: 20, depthOrArrayLayers: 30},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView86 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup25, new Uint32Array(4010), 1_025, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup1, []);
+} catch {}
+let arrayBuffer12 = buffer41.getMappedRange(1288, 1272);
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData5 = new ImageData(56, 40);
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView87 = texture44.createView({dimension: '2d', format: 'rgba8unorm', baseArrayLayer: 16, arrayLayerCount: 1});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup1, new Uint32Array(301), 42, 0);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -728.8, g: -511.2, b: -390.4, a: -174.8, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(701);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup17, [0]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup25, new Uint32Array(6935), 175, 0);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 188, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 240, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 481, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet6, 3, 9, buffer3, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'bt2020_12bit'} });
+let textureView88 = texture23.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(448), 359, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer49, 'uint16', 90, 853);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer37, 'uint16', 2_360, 428);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer0, 1_468, 2_142);
+} catch {}
+let texture84 = device0.createTexture({
+  size: [30, 2, 1],
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\ub4d5\u{1fba8}\u1104\u8754\u0fc8',
+  colorFormats: ['r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup12, [0]);
+} catch {}
+let arrayBuffer13 = buffer41.getMappedRange(2560, 1276);
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture85 = gpuCanvasContext0.getCurrentTexture();
+let textureView89 = texture20.createView({});
+let renderPassEncoder15 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 80,
+  clearValue: { r: -60.29, g: 346.1, b: -929.9, a: -705.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 88439294,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(2, bindGroup13, new Uint32Array(4628), 597, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer29, 'uint32', 28, 25);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 768 widthInBlocks: 768 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1416 */
+  offset: 1416,
+  bytesPerRow: 14336,
+  rowsPerImage: 219,
+  buffer: buffer46,
+}, {width: 768, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet6, 65, 3, buffer29, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(2_703).fill(52), /* required buffer size: 2_703 */
+{offset: 127, bytesPerRow: 4, rowsPerImage: 92}, {width: 0, height: 0, depthOrArrayLayers: 8});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 200, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData6 = new ImageData(148, 92);
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup38, new Uint32Array(464), 61, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer40, 'uint32', 1_504, 793);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData3,
+  origin: { x: 12, y: 2 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u019e\u65bb\uc01e\u284e\u{1fb0c}\u0f4c\u{1f686}';
+} catch {}
+let texture86 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture87 = device0.createTexture({
+  size: {width: 384},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView90 = texture64.createView({aspect: 'all'});
+let computePassEncoder71 = commandEncoder87.beginComputePass({});
+let renderBundle11 = renderBundleEncoder12.finish();
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 2, depthOrArrayLayers: 46}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let computePassEncoder72 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder24.setBindGroup(3, bindGroup2, new Uint32Array(2399), 49, 0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline1);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'smpteSt4281'} });
+let bindGroup44 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView77}]});
+let buffer50 = device0.createBuffer({
+  label: '\u0d85\u9555\u510f\ub864\u083b\u096e',
+  size: 8159,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler52 = device0.createSampler({
+  label: '\u0a01\u04cc\u3f2d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.571,
+  lodMaxClamp: 69.64,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder61.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup12, [256]);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer34, 4_196, 176);
+} catch {}
+let bindGroup45 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 180, resource: textureView1}]});
+let buffer51 = device0.createBuffer({size: 1610, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder88 = device0.createCommandEncoder({});
+let renderPassEncoder16 = commandEncoder88.beginRenderPass({
+  label: '\u0e3d\u0246\u3cf7\u0668',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -985.6, g: 378.7, b: 834.1, a: 966.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler53 = device0.createSampler({
+  label: '\u00e3\u{1fd46}\u6434\uc550\u2baf\u5a74\uf2ff',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.12,
+  lodMaxClamp: 93.49,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer29);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer40, 'uint16', 896, 379);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, buffer23, 580, 172);
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\u{1ff0c}');
+} catch {}
+await gc();
+let shaderModule7 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+enable f16;
+
+fn fn0(a0: ptr<storage, array<u32>, read_write>, a1: bool, a2: ptr<function, i32>) -> u32 {
+  var out: u32;
+  (*a2) = i32((*a0)[extractBits(vec2u(unconst_u32(320), unconst_u32(45)), (*a0)[u32(unconst_u32(65))], u32(unconst_u32(240)))[0]]);
+  let vf137: vec3h = mix(vec3h(f16(pack4xU8(vec4u(unconst_u32(73), unconst_u32(807), unconst_u32(917), unconst_u32(341))))), vec3h(unconst_f16(20207.6), unconst_f16(5017.0), unconst_f16(14590.4)), vec3h(unconst_f16(-5779.2), unconst_f16(5845.5), unconst_f16(5768.3)));
+  let ptr64: ptr<storage, u32, read_write> = &(*a0)[arrayLength(&(*a0))];
+  out = (*a0)[arrayLength(&(*a0))];
+  let ptr65: ptr<storage, u32, read_write> = &(*a0)[arrayLength(&(*a0))];
+  var vf138: u32 = arrayLength(&(*a0));
+  out = (*ptr64);
+  let ptr66: ptr<storage, u32, read_write> = &(*ptr65);
+  return out;
+}
+
+struct T2 {
+  f0: array<u32>,
+}
+
+struct T1 {
+  @size(100) f0: array<u32>,
+}
+
+var<workgroup> vw45: VertexOutput5;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> VertexOutput5 {
+  var out: VertexOutput5;
+  let vf139: vec4f = inverseSqrt(max(reflect(fma(vec2f(log(vec3h(unconst_f16(21809.0), unconst_f16(32287.0), unconst_f16(6000.1))).xy), vec2f(atan(vec3h(unconst_f16(12719.8), unconst_f16(-1866.9), unconst_f16(1639.0))).bb), bitcast<vec2f>(reverseBits(reverseBits(vec4i(unconst_i32(80), unconst_i32(241), unconst_i32(-198), unconst_i32(174)))).yz)).rgr, inverseSqrt(vec4f(unconst_f32(0.06153), unconst_f32(0.1821), unconst_f32(0.00654), unconst_f32(0.1901))).wzw).yx, vec2f(unconst_f32(0.1324), unconst_f32(0.1087))).yxxy);
+  out.f17 += vec4h(reflect(vec3f(log(vec3h(unconst_f16(4086.5), unconst_f16(3827.6), unconst_f16(22769.2)))), vec3f(unconst_f32(0.3889), unconst_f32(0.1488), unconst_f32(0.4257))).xyzx);
+  out.f22 ^= vec4i(log(vec3h(unconst_f16(3197.2), unconst_f16(4895.9), unconst_f16(19212.6))).rbrr);
+  out.f23 = bitcast<vec2f>(countTrailingZeros(vec2i(i32(determinant(mat2x2f(unconst_f32(0.2393), unconst_f32(0.06532), unconst_f32(0.3832), unconst_f32(0.3015)))))))[0];
+  out.f18 = max(vec2f(atan(vec3h(inverseSqrt(vec4f(unconst_f32(0.2204), unconst_f32(0.2094), unconst_f32(-0.7765), unconst_f32(0.05183))).raa)).br), vec2f(unconst_f32(0.3763), unconst_f32(0.6509))).yxxx;
+  let vf140: vec3h = atan(vec3h(unconst_f16(6484.3), unconst_f16(14299.9), unconst_f16(16602.9)));
+  let vf141: f16 = vf140[0];
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw44: f16;
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(180) var st5: texture_storage_2d_array<r32float, read_write>;
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput5 {
+  @location(6) @interpolate(flat, centroid) f17: vec4h,
+  @builtin(position) f18: vec4f,
+  @location(14) @interpolate(flat, center) f19: vec2i,
+  @location(0) f20: vec4h,
+  @location(9) @interpolate(perspective, centroid) f21: f16,
+  @location(8) f22: vec4i,
+  @location(15) @interpolate(flat, centroid) f23: f32,
+  @location(10) @interpolate(flat, center) f24: vec2u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex6() -> VertexOutput5 {
+  var out: VertexOutput5;
+  var vf142: f32 = cos(round(vec4f(unconst_f32(-0.07060), unconst_f32(0.2750), unconst_f32(0.09022), unconst_f32(0.3603))).g);
+  out.f19 += unpack4xI8(u32(unconst_u32(587))).yw;
+  var vf143 = fn1();
+  fn1();
+  let vf144: u32 = pack4x8snorm(vec4f(unconst_f32(0.2276), unconst_f32(0.00763), unconst_f32(0.3515), unconst_f32(0.01571)));
+  fn1();
+  let ptr67: ptr<function, vec4h> = &vf143.f17;
+  var vf145: f32 = vf143.f18[u32(unconst_u32(204))];
+  var vf146: i32 = vf143.f19[u32(unconst_u32(167))];
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView4},
+    {binding: 4, resource: {buffer: buffer28, offset: 0, size: 2236}},
+  ],
+});
+let commandEncoder89 = device0.createCommandEncoder();
+let texture88 = device0.createTexture({
+  size: [192, 1, 8],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder73 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(2, bindGroup2, new Uint32Array(1070), 102, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer29, 'uint16', 50, 174);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> array<f32, 32> {
+  var out: array<f32, 32>;
+  let vf152: f16 = override7;
+  vw47 -= mat2x3f(f32(atomicLoad(&(*&vw46))), bitcast<f32>(atomicLoad(&(*&vw46))), bitcast<f32>(atomicLoad(&(*&vw46))), bitcast<f32>(atomicLoad(&(*&vw46))), f32(atomicLoad(&(*&vw46))), bitcast<f32>(atomicLoad(&(*&vw46))));
+  vw48 = mat4x4f(reflect(vec3f(vw48[2][u32(unconst_u32(81))]), vec3f(vw47[1][0])).zyzy, reflect(vec3f(vw48[2][u32(unconst_u32(81))]), vec3f(vw47[1][0])).xzxz, reflect(vec3f(vw48[2][u32(unconst_u32(81))]), vec3f(vw47[1][0])).rrgg, reflect(vec3f(vw48[2][u32(unconst_u32(81))]), vec3f(vw47[1][0])).xzxy);
+  out[u32(unconst_u32(10))] = reflect(vec3f(unconst_f32(0.2210), unconst_f32(-0.2022), unconst_f32(0.05844)), vec3f(unconst_f32(0.2144), unconst_f32(0.02898), unconst_f32(0.02431))).g;
+  vw48 += mat4x4f(vec4f(vp16.whole.xzxz), vec4f(vp16.whole.rbgb), vec4f(vp16.whole.rbgg), vec4f(vp16.whole.rgrg));
+  atomicAdd(&vw46, pack4xU8(vec4u(vw48[bitcast<u32>(asinh(asinh(bitcast<vec2h>(vw47[1][0]))))])));
+  out[u32(unconst_u32(26))] += unpack4x8unorm(pack4x8unorm(vw48[u32(unconst_u32(23))])).r;
+  vw48 = mat4x4f((*&vw47)[u32(unconst_u32(25))].bgbr, (*&vw47)[u32(unconst_u32(25))].brrb, (*&vw47)[u32(unconst_u32(25))].xxzz, (*&vw47)[u32(unconst_u32(25))].rbgb);
+  let vf153: vec4f = unpack4x8unorm(u32(unconst_u32(61)));
+  let vf154: vec3h = cosh(vec3h(unconst_f16(6021.5), unconst_f16(-6116.4), unconst_f16(3524.7)));
+  out[u32(override4)] *= bitcast<f32>(atomicLoad(&(*&vw46)));
+  vw47 = mat2x3f(f32(override5), f32(override5), f32(override5), f32(override5), f32(override5), f32(override5));
+  atomicCompareExchangeWeak(&vw46, unconst_u32(200), unconst_u32(46));
+  out[u32(unconst_u32(126))] = vw48[u32(unconst_u32(130))][1];
+  vw48 = mat4x4f((*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])], (*&vw48)[1][u32(select(vec4i(unconst_i32(548), unconst_i32(12), unconst_i32(245), unconst_i32(168)), vec4i(unconst_i32(-22), unconst_i32(174), unconst_i32(70), unconst_i32(-121)), bool(unconst_bool(true)))[1])]);
+  var vf155: vec2u = textureDimensions(tex11);
+  var vf156: vec2i = firstTrailingBit(vec2i(unconst_i32(15), unconst_i32(4)));
+  let ptr72: ptr<workgroup, atomic<i32>> = &vw49;
+  return out;
+  _ = override4;
+  _ = override5;
+  _ = override7;
+}
+
+override override7: f16;
+
+@id(65063) override override10: u32 = 16;
+
+@group(0) @binding(100) var tex11: texture_2d<f32>;
+
+var<workgroup> vw49: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct S0 {
+  @location(13) f0: f32,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(32488) override override9: f16;
+
+fn fn2(a0: ptr<workgroup, S0>) {
+  var vf157: vec4f = floor(vec4f(unconst_f32(0.02262), unconst_f32(0.1671), unconst_f32(0.1605), unconst_f32(-0.00003)));
+  (*a0).f0 -= f32(override4);
+  var vf158: vec4h = degrees(vec4h(unconst_f16(6673.4), unconst_f16(12648.3), unconst_f16(1294.8), unconst_f16(38533.1)));
+  (*a0).f0 -= length(vec3f(f32(override4)));
+  let ptr73: ptr<workgroup, f32> = &(*a0).f0;
+  let ptr74: ptr<function, vec4f> = &vf157;
+  (*a0).f0 = (*a0).f0;
+  let vf159: f32 = dot(vec3f(f32(pack4xI8(vec4i(unconst_i32(265), unconst_i32(211), unconst_i32(72), unconst_i32(109))))), vec3f(unconst_f32(0.1632), unconst_f32(0.00524), unconst_f32(0.1032)));
+  vf157 = vec4f(f32(override9));
+  let vf160: u32 = override6;
+  let vf161: f32 = vf159;
+  let vf162: vec3f = quantizeToF16(vec3f(unconst_f32(0.1314), unconst_f32(0.04498), unconst_f32(0.03759)));
+  let vf163: vec4f = floor(vec4f((*a0).f0));
+  vf157 = vec4f(f32(override5));
+  vp16 = modf(vec3h(abs(vec2f(unconst_f32(0.08287), unconst_f32(0.06058))).xyx));
+  vf157 = vec4f(f32(override9));
+  let vf164: u32 = override6;
+  vf157 = vec4f(dot(vec3f(unconst_f32(0.3464), unconst_f32(0.1984), unconst_f32(0.1722)), vec3f(unconst_f32(0.01425), unconst_f32(0.02764), unconst_f32(0.08241))));
+  let ptr75: ptr<workgroup, f32> = &(*a0).f0;
+  var vf165: f16 = override7;
+  _ = override6;
+  _ = override4;
+  _ = override7;
+  _ = override9;
+  _ = override5;
+}
+
+var<workgroup> vw48: mat4x4f;
+
+alias vec3b = vec3<bool>;
+
+var<private> vp16 = modf(vec3h());
+
+@id(47035) override override3 = -69;
+
+var<workgroup> vw46: atomic<u32>;
+
+override override6: u32 = 1;
+
+fn fn0(a0: ptr<storage, array<u32>, read>) -> array<S0, 10> {
+  var out: array<S0, 10>;
+  vp16.fract -= vp16.whole;
+  var vf147: vec3h = fma(vec3h(unconst_f16(2887.2), unconst_f16(10070.6), unconst_f16(15891.8)), vec3h(unconst_f16(24662.5), unconst_f16(-18644.2), unconst_f16(18473.8)), vec3h(f16(inverseSqrt(f32(unconst_f32(0.4136))))));
+  let vf148: vec3h = degrees(vec3h(unconst_f16(7734.0), unconst_f16(10113.8), unconst_f16(-594.3)));
+  out[9] = S0(f32(vf148.b));
+  let ptr68: ptr<private, vec3h> = &vp16.whole;
+  vf147 = vec3h(f16(length(f32(unconst_f32(0.4997)))));
+  out[u32(unconst_u32(44))].f0 = f32(override6);
+  out[u32(unconst_u32(360))] = S0(inverseSqrt(vec4f(unconst_f32(0.03515), unconst_f32(0.04879), unconst_f32(0.04798), unconst_f32(0.01162))).y);
+  let vf149: f32 = determinant(mat4x4f(vec4f(countLeadingZeros(vec4i(unconst_i32(9), unconst_i32(47), unconst_i32(535), unconst_i32(161)))), vec4f(countLeadingZeros(vec4i(unconst_i32(9), unconst_i32(47), unconst_i32(535), unconst_i32(161)))), vec4f(countLeadingZeros(vec4i(unconst_i32(9), unconst_i32(47), unconst_i32(535), unconst_i32(161)))), vec4f(countLeadingZeros(vec4i(unconst_i32(9), unconst_i32(47), unconst_i32(535), unconst_i32(161))))));
+  out[pack4x8unorm(vec4f(unconst_f32(0.03092), unconst_f32(0.5649), unconst_f32(0.1014), unconst_f32(0.1878)))] = S0(f32(override7));
+  vf147 = vec3h(countLeadingZeros(min(vec3i(unconst_i32(118), unconst_i32(-135), unconst_i32(27)), vec3i(unconst_i32(39), unconst_i32(111), unconst_i32(125))).zxxy).agr);
+  vf147 -= vp16.whole;
+  out[9].f0 = vec3f(vp16.whole)[0];
+  out[u32(unconst_u32(5))] = S0(inverseSqrt(f32(unconst_f32(0.01712))));
+  let ptr69: ptr<storage, u32, read> = &(*a0)[override10];
+  let vf150: vec3u = extractBits(vec3u(unconst_u32(1000), unconst_u32(13), unconst_u32(4)), vec3u(fma(vp16.fract, vec3h(f16(pack4x8unorm(vec4f(f32(override4))))), vec3h(unconst_f16(12079.8), unconst_f16(20071.4), unconst_f16(9014.3))))[1], pack4x8unorm(vec4f(unconst_f32(-0.3493), unconst_f32(0.1971), unconst_f32(0.1492), unconst_f32(0.2175))));
+  let ptr70: ptr<storage, u32, read> = &(*a0)[arrayLength(&(*a0)) - 1];
+  let ptr71: ptr<storage, array<u32>, read> = &(*a0);
+  let vf151: f16 = vf148[u32(unconst_u32(64))];
+  return out;
+  _ = override10;
+  _ = override4;
+  _ = override7;
+  _ = override6;
+}
+
+struct T0 {
+  @align(1) @size(8) f0: array<u32>,
+}
+
+override override5: f16 = 10311.8;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput4 {
+  @location(7) f0: vec2i,
+  @location(0) f1: u32,
+}
+
+var<workgroup> vw47: mat2x3f;
+
+struct VertexOutput6 {
+  @builtin(position) f25: vec4f,
+}
+
+@id(60113) override override8: f16;
+
+override override4: f16;
+
+@vertex
+fn vertex7(@location(3) @interpolate(flat) a0: vec2i) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f25 -= normalize(vec3f(unconst_f32(0.1220), unconst_f32(0.07095), unconst_f32(0.06894))).bgbr;
+  vp16 = modf(vec3h(unpack4xU8(u32(unconst_u32(21))).yxx));
+  var vf166: f16 = override8;
+  let vf167: u32 = reverseBits(override10);
+  return out;
+  _ = override8;
+  _ = override10;
+}
+
+@fragment
+fn fragment4(a0: S0) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  out.f1 *= u32(override9);
+  out.f1 >>= pack4xI8Clamp(vec4i(unconst_i32(90), unconst_i32(137), unconst_i32(117), unconst_i32(154)));
+  let ptr76: ptr<private, vec3h> = &vp16.fract;
+  let ptr77: ptr<private, vec3h> = &vp16.fract;
+  var vf168: S0 = a0;
+  var vf169: vec4h = pow(vec4h(unconst_f16(-7512.3), unconst_f16(8893.5), unconst_f16(13316.0), unconst_f16(5499.9)), vec4h(unconst_f16(1873.5), unconst_f16(2157.2), unconst_f16(25394.5), unconst_f16(899.1)));
+  var vf170: f16 = (*ptr76)[u32(length(vec2h(unconst_f16(6555.2), unconst_f16(10051.8))))];
+  vf170 *= sinh(bitcast<vec2h>(pack4xU8(vec4u(unconst_u32(0), unconst_u32(123), unconst_u32(279), unconst_u32(16))))).y;
+  var vf171: f16 = override4;
+  out.f1 <<= u32((*ptr76)[2]);
+  let vf172: vec4h = max(vec4h(unconst_f16(2934.9), unconst_f16(14640.6), unconst_f16(1957.7), unconst_f16(5940.0)), vec4h(unconst_f16(2625.4), unconst_f16(16343.4), unconst_f16(3274.9), unconst_f16(6785.4)));
+  var vf173: f16 = (*ptr77)[2];
+  vf173 += vf169[1];
+  vf169 -= vec4h(trunc(f16(unconst_f16(6111.8))));
+  let ptr78: ptr<private, vec3h> = &vp16.whole;
+  out.f1 = u32(override4);
+  out.f1 <<= u32((*ptr76)[pack4xU8Clamp(vec4u(vf172))]);
+  vf171 -= vf170;
+  let ptr79: ptr<private, vec3h> = &(*ptr76);
+  return out;
+  _ = override4;
+  _ = override9;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture89 = device0.createTexture({size: [120], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup12, new Uint32Array(3738), 1_382, 1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer45, 0, 233);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+@id(13754) override override14: u32;
+
+var<workgroup> vw51: mat4x4f;
+
+struct FragmentOutput5 {
+  @location(0) f0: vec4f,
+  @location(2) f1: vec2f,
+  @location(1) @interpolate(flat, center) f2: vec2f,
+}
+
+@group(0) @binding(205) var tex15: texture_2d<f32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+alias vec3b = vec3<bool>;
+
+@id(4227) override override22 = -0.02551;
+
+@id(44349) override override16: bool;
+
+@group(2) @binding(67) var<uniform> buffer54: array<f16, 29>;
+
+fn fn1() -> VertexOutput7 {
+  var out: VertexOutput7;
+  out = VertexOutput7(vec4f(vp18.f2[u32(unconst_u32(83))]), vp18.f2[u32(unconst_u32(83))]);
+  var vf179: vec4f = textureLoad(tex17, vec2i(i32((*&buffer53)[arrayLength(&(*&buffer53))][0][2])), i32(unconst_i32(386)), i32(unconst_i32(24)));
+  var vf180: u32 = arrayLength(&(*&buffer52));
+  let ptr81 = &vp17;
+  let vf181: u32 = override14;
+  let ptr82: ptr<storage, f16, read_write> = &buffer53[arrayLength(&buffer53)][0][2];
+  out.f26 = vec4f(f32(buffer53[arrayLength(&buffer53) - 1][0][2]));
+  let ptr83: ptr<private, vec2f> = &vp18.f2;
+  out.f27 = vp18.f1[1];
+  let vf182: vec2u = textureDimensions(tex17);
+  vf179 += vec4f(bitcast<f32>(vf180));
+  buffer53[u32(ldexp(f16(unconst_f16(-8722.7)), i32((*&buffer52)[arrayLength(&(*&buffer52))][2])))][u32(unconst_u32(191))][u32(unconst_u32(172))] = f16(override20);
+  let ptr84 = &(*ptr81);
+  out.f26 *= radians(vec3f(unconst_f32(0.1166), unconst_f32(0.4210), unconst_f32(0.00443))).zxyx;
+  let vf183: u32 = override14;
+  out.f27 = f32(dot4I8Packed(u32(unconst_u32(69)), u32(unconst_u32(116))));
+  let ptr85: ptr<storage, array<array<f16, 3>, 1>, read_write> = &buffer53[arrayLength(&buffer53)];
+  var vf184: f32 = vp18.f0[0];
+  let ptr86: ptr<storage, array<f16, 3>, read_write> = &(*&buffer52)[arrayLength(&(*&buffer52))];
+  var vf185: u32 = override14;
+  return out;
+  _ = override14;
+  _ = override20;
+}
+
+@id(25187) override override17: u32 = 144;
+
+@id(27671) override override19: f16;
+
+fn fn2(a0: ptr<function, mat4x2f>) -> array<VertexOutput7, 4> {
+  var out: array<VertexOutput7, 4>;
+  var vf186 = fn1();
+  vp18.f0 *= vp18.f2.yyyx;
+  var vf187 = fn1();
+  fn1();
+  var vf188: vec4f = textureLoad(tex17, vec2i(i32(buffer52[bitcast<i32>(refract(vf187.f26, vec4f(unconst_f32(0.4446), unconst_f32(0.4271), unconst_f32(0.2317), unconst_f32(0.2484)), bitcast<f32>(arrayLength(&(*&buffer53)))).b)][2])), i32(buffer52[i32(buffer54[28])][2]), bitcast<i32>(vf187.f27));
+  storageBarrier();
+  return out;
+  _ = override20;
+  _ = override14;
+}
+
+override override15: f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override20: bool;
+
+override override12: bool;
+
+@group(0) @binding(30) var tex12: texture_depth_2d;
+
+@id(18427) override override18 = true;
+
+@id(15834) override override21: f16;
+
+@group(1) @binding(78) var tex17: texture_2d_array<f32>;
+
+override override11: f16;
+
+@group(1) @binding(30) var tex16: texture_depth_2d;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp17 = modf(vec3h());
+
+var<workgroup> vw50: vec4<bool>;
+
+@group(1) @binding(205) var tex18: texture_2d<f32>;
+
+struct T1 {
+  @align(2) f0: array<array<array<atomic<u32>, 1>, 1>, 1>,
+}
+
+struct VertexOutput7 {
+  @builtin(position) f26: vec4f,
+  @location(13) @interpolate(flat, center) f27: f32,
+}
+
+@group(1) @binding(37) var<storage, read_write> buffer53: array<array<array<f16, 3>, 1>>;
+
+fn fn0(a0: FragmentOutput5) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  vp18 = FragmentOutput5(a0.f0, a0.f0.rr, a0.f0.ww);
+  vp17.whole = fma(vec4h(unconst_f16(14437.1), unconst_f16(33101.4), unconst_f16(7028.6), unconst_f16(35228.1)), vec4h(unconst_f16(-12328.3), unconst_f16(3836.3), unconst_f16(748.1), unconst_f16(10531.5)), vec4h(unconst_f16(8436.5), unconst_f16(-1560.3), unconst_f16(4460.0), unconst_f16(930.4))).zyy;
+  out.f0 = vec4f(textureLoad(tex16, vec2i(unconst_i32(8), unconst_i32(132)), i32(unconst_i32(32))));
+  let vf174: vec2u = textureDimensions(tex16);
+  let vf175: vec2f = a0.f1;
+  let vf176: u32 = textureNumLevels(tex12);
+  out.f2 = vec2f(f32(override18));
+  var vf177: f16 = override11;
+  let vf178: f32 = vp18.f0[2];
+  vp18 = FragmentOutput5();
+  let ptr80: ptr<private, vec2f> = &vp18.f1;
+  out = FragmentOutput5(vec4f(f32(override19)), vec2f(f32(override19)), vec2f(f32(override19)));
+  vf177 = f16(override16);
+  return out;
+  _ = override11;
+  _ = override19;
+  _ = override18;
+  _ = override16;
+}
+
+var<private> vp18: FragmentOutput5 = FragmentOutput5();
+
+@group(2) @binding(125) var tex19: texture_2d<u32>;
+
+@group(3) @binding(180) var st6: texture_storage_2d_array<r32float, read_write>;
+
+@group(0) @binding(48) var tex13: texture_depth_2d;
+
+@group(0) @binding(37) var<storage, read_write> buffer52: array<array<f16, 3>>;
+
+@id(58066) override override13 = false;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(78) var tex14: texture_2d_array<f32>;
+
+struct T0 {
+  @align(2) @size(60) f0: array<u32>,
+}
+
+@vertex
+fn vertex8(@location(3) @interpolate(flat) a0: vec2i, @location(7) @interpolate(flat, sample) a1: vec4u) -> VertexOutput7 {
+  var out: VertexOutput7;
+  out = VertexOutput7(vec4f(sinh(vec3h(unconst_f16(8001.6), unconst_f16(6753.8), unconst_f16(6134.2))).bbbr), f32(sinh(vec3h(unconst_f16(8001.6), unconst_f16(6753.8), unconst_f16(6134.2))).b));
+  fn0(FragmentOutput5(vec4f(f32(override13)), vec2f(f32(override13)), vec2f(f32(override13))));
+  var vf189: vec3h = fma(vec3h(a0.rgg), vec3h(vp18.f0.wwz), vec3h(unconst_f16(9935.2), unconst_f16(1693.9), unconst_f16(7478.5)));
+  let ptr87: ptr<private, vec2f> = &vp18.f1;
+  vf189 = vec3h(a1.wyy);
+  var vf190 = fn0(FragmentOutput5(vec4f(bitcast<f32>(a0[u32((*ptr87)[textureLoad(tex19, bitcast<vec2i>(textureDimensions(tex12)), i32(unconst_i32(180)))[2]])])), vec2f(bitcast<f32>(a0[u32((*ptr87)[textureLoad(tex19, bitcast<vec2i>(textureDimensions(tex12)), i32(unconst_i32(180)))[2]])])), vec2f(f32(a0[u32((*ptr87)[textureLoad(tex19, bitcast<vec2i>(textureDimensions(tex12)), i32(unconst_i32(180)))[2]])]))));
+  var vf191: vec2u = textureDimensions(tex13, i32(unconst_i32(30)));
+  vp17 = modf(vec3h(textureDimensions(tex13).rrg));
+  let vf192: f32 = textureLoad(tex12, vec2i(unconst_i32(156), unconst_i32(73)), i32(vf189[1]));
+  vf191 &= vec2u(vf190.f0.rr);
+  var vf193: bool = all(bool(vf191[u32(unconst_u32(137))]));
+  var vf194: f32 = vp18.f2[0];
+  vf194 = (*ptr87).g;
+  var vf195 = fn0(FragmentOutput5(vec4f(vp18.f1[0]), vec2f(vp18.f1[0]), vec2f(vp18.f1[0])));
+  out.f26 = vec4f(vf195.f0[3]);
+  let vf196: i32 = a0[1];
+  fn0(FragmentOutput5(refract(vec3f(vf195.f2[1]), vec3f(f32(override12)), f32(unconst_f32(0.2723))).yyyx, refract(vec3f(vf195.f2[1]), vec3f(f32(override12)), f32(unconst_f32(0.2723))).bb, refract(vec3f(vf195.f2[1]), vec3f(f32(override12)), f32(unconst_f32(0.2723))).gr));
+  vf189 = vec3h(f16(override20));
+  fn0(FragmentOutput5(vec4f(asinh(f32(textureNumLevels(tex13)))), vec2f(asinh(f32(textureNumLevels(tex13)))), vec2f(asinh(f32(textureNumLevels(tex13))))));
+  vf195.f2 = vp18.f1;
+  fn0(FragmentOutput5(vec4f(vf190.f1[1]), vec2f(vf190.f1[1]), vec2f(vf190.f1[1])));
+  return out;
+  _ = override12;
+  _ = override19;
+  _ = override20;
+  _ = override11;
+  _ = override16;
+  _ = override18;
+  _ = override13;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  vp17.fract = vec3h(buffer52[arrayLength(&buffer52)][2]);
+  var vf197 = fn1();
+  out.f0 = vec4f(f32(textureNumLevels(tex14)));
+  fn1();
+  out.f2 *= vec2f(f32(override13));
+  var vf198 = fn1();
+  textureStore(st6, vec2i(unconst_i32(279), unconst_i32(176)), i32(unconst_i32(119)), vec4f(unpack2x16snorm(bitcast<u32>(vf198.f26[u32(unconst_u32(589))])).yxxy));
+  let ptr88: ptr<storage, array<f16, 3>, read_write> = &buffer53[arrayLength(&buffer53)][0];
+  var vf199 = fn1();
+  let vf200: u32 = textureNumLevels(tex14);
+  return out;
+  _ = override20;
+  _ = override13;
+  _ = override14;
+}`,
+  sourceMap: {},
+});
+let buffer55 = device0.createBuffer({
+  size: 6920,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(0, bindGroup22, new Uint32Array(1349), 53, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup12, new Uint32Array(2371), 247, 1);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer23, 'uint16', 168, 147);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u6a55');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup47 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 278, resource: textureView81}]});
+let buffer56 = device0.createBuffer({
+  size: 806,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture90 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView91 = texture63.createView({
+  label: '\ub3d1\ub62c\u0cf3',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup18, new Uint32Array(1594), 996, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroupsIndirect(buffer29, 16); };
+} catch {}
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup15);
+} catch {}
+document.body.append(img1);
+let canvas2 = document.createElement('canvas');
+let commandBuffer3 = commandEncoder62.finish();
+try {
+computePassEncoder62.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer36, 'uint16', 258, 743);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw55: mat3x3h;
+
+struct T1 {
+  @align(2) @size(116) f0: T0,
+}
+
+fn fn1() {
+  var vf203: i32 = override26;
+  vf203 |= countTrailingZeros(vec3i(unconst_i32(227), unconst_i32(113), unconst_i32(190))).b;
+  vf203 |= i32(transpose(mat4x4h(unconst_f16(-1618.8), unconst_f16(844.8), unconst_f16(1403.8), unconst_f16(15853.9), unconst_f16(2371.1), unconst_f16(12023.8), unconst_f16(28911.1), unconst_f16(11886.3), unconst_f16(3160.7), unconst_f16(5998.0), unconst_f16(7788.9), unconst_f16(10344.9), unconst_f16(1526.5), unconst_f16(6375.3), unconst_f16(8166.8), unconst_f16(27858.4)))[2][2]);
+  var vf204: mat3x4h = transpose(mat4x3h(unconst_f16(655.8), unconst_f16(4819.4), unconst_f16(-4259.3), unconst_f16(387.3), unconst_f16(8798.3), unconst_f16(5161.2), unconst_f16(15695.7), unconst_f16(5936.7), unconst_f16(26602.6), unconst_f16(10231.1), unconst_f16(35077.9), unconst_f16(23282.8)));
+  var vf205: bool = override23;
+  var vf206: bool = override23;
+  vf204 += mat3x4h(reflect(vec4h(unconst_f16(2053.1), unconst_f16(15362.0), unconst_f16(13223.8), unconst_f16(28760.8)), vec4h(unconst_f16(22798.5), unconst_f16(8454.3), unconst_f16(11907.3), unconst_f16(6946.5))), reflect(vec4h(unconst_f16(2053.1), unconst_f16(15362.0), unconst_f16(13223.8), unconst_f16(28760.8)), vec4h(unconst_f16(22798.5), unconst_f16(8454.3), unconst_f16(11907.3), unconst_f16(6946.5))), reflect(vec4h(unconst_f16(2053.1), unconst_f16(15362.0), unconst_f16(13223.8), unconst_f16(28760.8)), vec4h(unconst_f16(22798.5), unconst_f16(8454.3), unconst_f16(11907.3), unconst_f16(6946.5))));
+  _ = override23;
+  _ = override26;
+}
+
+var<workgroup> vw53: T2;
+
+struct T2 {
+  @align(1) f0: f32,
+  @align(2) @size(28) f1: array<mat2x2h, 3>,
+}
+
+@id(37233) override override26: i32;
+
+fn fn2() -> T0 {
+  var out: T0;
+  let vf207: vec3h = cross(max(bitcast<vec2h>(pack4xU8(vec4u(unconst_u32(47), unconst_u32(68), unconst_u32(94), unconst_u32(4)))), vec2h(unconst_f16(9133.1), unconst_f16(-21859.5))).yxy, vec3h(unconst_f16(7470.8), unconst_f16(-20603.8), unconst_f16(1097.4)));
+  let vf208: f16 = vf207[u32(unconst_u32(252))];
+  return out;
+}
+
+@group(0) @binding(100) var tex20: texture_2d<f32>;
+
+var<workgroup> vw57: atomic<u32>;
+
+struct VertexOutput8 {
+  @builtin(position) f28: vec4f,
+}
+
+var<workgroup> vw58: array<array<S1, 1>, 2>;
+
+struct VertexOutput9 {
+  @location(13) f29: vec4u,
+  @builtin(position) f30: vec4f,
+  @location(6) @interpolate(linear, sample) f31: f16,
+  @location(11) f32: vec2i,
+  @location(9) f33: f32,
+  @location(15) @interpolate(perspective) f34: vec4f,
+  @location(12) f35: vec4f,
+  @location(4) @interpolate(flat, centroid) f36: vec2i,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw54: array<i32, 1>;
+
+override override24: f32;
+
+var<workgroup> vw52: array<array<array<array<atomic<u32>, 1>, 1>, 1>, 15>;
+
+struct T0 {
+  f0: array<u32, 4>,
+}
+
+var<workgroup> vw56: mat2x2h;
+
+var<workgroup> vw59: mat4x2h;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S1 {
+  @location(13) @interpolate(linear) f0: f32,
+  @location(8) f1: vec2f,
+}
+
+fn fn0() -> mat2x4h {
+  var out: mat2x4h;
+  atomicAnd(&vw57, u32(unconst_u32(56)));
+  let ptr89: ptr<workgroup, mat2x2h> = &vw53.f1[u32(unconst_u32(133))];
+  let ptr90: ptr<workgroup, f32> = &vw53.f0;
+  vw59 = mat4x2h(vec2h((*&vw58)[1][0].f1), vec2h((*&vw58)[1][0].f1), vec2h((*&vw58)[1][0].f1), vec2h((*&vw58)[1][0].f1));
+  atomicMax(&vw52[u32(override25)][u32(unconst_u32(22))][u32(unconst_u32(65))][0], u32(unconst_u32(222)));
+  vw58[u32(unconst_u32(518))][u32((*&vw58)[1][0].f1[1])] = S1(bitcast<f32>(vw53.f1[2][1]), vec2f(vw53.f1[2][1]));
+  vw53.f0 *= (*&vw58)[1][0].f1[1];
+  let vf201: f16 = vw59[0][u32((*&vw55)[1][1])];
+  var vf202: f16 = (*&vw56)[0][u32(textureLoad(tex20, vec2i(unconst_i32(31), unconst_i32(70)), bitcast<i32>((*&vw53).f1[2][0]))[0])];
+  vw53.f1[bitcast<u32>(vw58[1][0].f0)] -= mat2x2h(f16(atomicLoad(&(*&vw52)[14][bitcast<u32>((*ptr89)[bitcast<u32>((*&vw58)[1][0].f1.x)])][0][0])), f16(atomicLoad(&(*&vw52)[14][bitcast<u32>((*ptr89)[bitcast<u32>((*&vw58)[1][0].f1.x)])][0][0])), f16(atomicLoad(&(*&vw52)[14][bitcast<u32>((*ptr89)[bitcast<u32>((*&vw58)[1][0].f1.x)])][0][0])), f16(atomicLoad(&(*&vw52)[14][bitcast<u32>((*ptr89)[bitcast<u32>((*&vw58)[1][0].f1.x)])][0][0])));
+  return out;
+  _ = override25;
+}
+
+override override25 = false;
+
+alias vec3b = vec3<bool>;
+
+override override23: bool;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex9(@location(2) a0: vec2f) -> VertexOutput8 {
+  var out: VertexOutput8;
+  fn1();
+  out.f28 = vec4f(fract(fract(vec3h(mix(vec2f(unconst_f32(0.4401), unconst_f32(0.00680)), fract(vec4f(a0[u32(unconst_u32(146))])).ba, sin(vec4f(unconst_f32(0.1304), unconst_f32(0.00274), unconst_f32(0.1689), unconst_f32(0.02162))).wy).rgg))).rggb);
+  out.f28 = bitcast<vec4f>(firstLeadingBit(vec3u(u32(a0[0]))).rggb);
+  let vf209: i32 = override26;
+  out.f28 = vec4f(firstTrailingBit(vec2u(unconst_u32(446), unconst_u32(181))).rrgg);
+  var vf210: vec2f = mix(unpack2x16unorm(u32(unconst_u32(161))), unpack2x16unorm(u32(unconst_u32(58))), a0);
+  var vf211: vec2f = asinh(vec2f(unconst_f32(-0.2846), unconst_f32(0.04097)));
+  return out;
+  _ = override26;
+  _ = override23;
+}
+
+@vertex
+fn vertex10(a0: S1, @location(1) a1: vec4i) -> VertexOutput9 {
+  var out: VertexOutput9;
+  var vf212: bool = override23;
+  return out;
+  _ = override23;
+}
+
+@fragment
+fn fragment6() -> @location(200) u32 {
+  var out: u32;
+  let vf213: bool = override23;
+  return out;
+  _ = override23;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture91 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle12 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer28, 876);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+commandEncoder35.label = '\u94ff\uf4b6\u0d52\uf735\u6f5e\ucbd4';
+} catch {}
+let bindGroup48 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView75}]});
+let buffer57 = device0.createBuffer({
+  size: 680,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture92 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 70},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer32, 'uint32', 1_844, 8_685);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer20, 0, 92);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 668, new Int16Array(18229), 2327, 592);
+} catch {}
+document.body.prepend(img2);
+let texture93 = device0.createTexture({
+  size: [1536, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer23, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer58 = device0.createBuffer({size: 16099, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder90 = device0.createCommandEncoder();
+let sampler54 = device0.createSampler({
+  label: '\u{1f8f7}\udfe5\u{1fd05}\u0328\u00c3',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 72.03,
+  lodMaxClamp: 86.83,
+});
+try {
+computePassEncoder66.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup40, new Uint32Array(793), 196, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer21, 'uint16', 1_046, 512);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer10, 1_308);
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let commandEncoder91 = device0.createCommandEncoder({});
+let textureView92 = texture40.createView({arrayLayerCount: 1});
+let computePassEncoder74 = commandEncoder90.beginComputePass();
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle5]);
+} catch {}
+let texture94 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture95 = device0.createTexture({
+  size: [768, 1, 85],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder75 = commandEncoder91.beginComputePass({});
+let sampler55 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.11,
+  lodMaxClamp: 87.00,
+});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(423).fill(197), /* required buffer size: 423 */
+{offset: 423}, {width: 69, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 30, resource: textureView14},
+    {binding: 78, resource: textureView91},
+    {binding: 48, resource: textureView81},
+    {binding: 37, resource: {buffer: buffer38, offset: 2048, size: 796}},
+    {binding: 205, resource: textureView47},
+  ],
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let textureView93 = texture91.createView({format: 'bgra8unorm-srgb'});
+let computePassEncoder76 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder23.setBindGroup(3, bindGroup4, new Uint32Array(2154), 569, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer37, 'uint32', 1_860, 17_445);
+} catch {}
+let imageData7 = new ImageData(40, 44);
+let bindGroup50 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView93}]});
+let textureView94 = texture22.createView({label: '\u0fdb\u0b7e\uf63a\u2add\u0442\uf34a\u{1f976}', dimension: '1d', arrayLayerCount: 1});
+try {
+renderPassEncoder8.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer28, 0, 842);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 120, new BigUint64Array(4896), 90, 68);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 4, depthOrArrayLayers: 93}
+*/
+{
+  source: imageData5,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+await gc();
+let texture96 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder67.setBindGroup(3, bindGroup39, new Uint32Array(4108), 1_143, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer21, 'uint16', 2_094, 245);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer55, 1_048, 224);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+buffer13.label = '\u4cc5\u0c71\u03c3\ua60c\u153c';
+} catch {}
+let texture97 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup47, new Uint32Array(4700), 1_165, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer45, 3_172);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup39, new Uint32Array(820), 93, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer56, 0, 74);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup51 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView14}]});
+let textureView95 = texture48.createView({dimension: 'cube'});
+let sampler56 = device0.createSampler({
+  label: '\u063b\u79ae\uefd8\ubd44\u0040\u{1fdcc}\u08aa\u0590\ubbc1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+let arrayBuffer14 = buffer41.getMappedRange(9272, 136);
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(245), /* required buffer size: 34 */
+{offset: 34}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(6, 49, '#10101010', '#20202020');
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 626,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder93 = device0.createCommandEncoder({label: '\u087e\u2bfe\ub9b4\u247f\u0482\u0af7\u727f\ub999'});
+let computePassEncoder77 = commandEncoder93.beginComputePass();
+try {
+computePassEncoder55.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(2, bindGroup40, new Uint32Array(2359), 1_277, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle7, renderBundle4, renderBundle4, renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer6, 'uint16', 1_322, 860);
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u4814\u{1f8ea}\u0758\u005b\u1e59\u0562\uf8cf',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule4, constants: {}},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 2969});
+try {
+renderPassEncoder2.setViewport(24.837412606473002, 0.6258333881626159, 24.88285211559646, 4.324920967837264, 0.9189396140208366, 0.9649484455743617);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer3, 'uint16', 2_834, 507);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer23, 'uint16', 680, 16);
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule4}});
+await gc();
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView0},
+    {binding: 67, resource: {buffer: buffer44, offset: 0, size: 107}},
+  ],
+});
+let buffer59 = device0.createBuffer({size: 4328, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder94 = device0.createCommandEncoder({});
+let renderPassEncoder17 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 90,
+  clearValue: { r: -889.7, g: 71.84, b: 743.5, a: 367.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], depthReadOnly: true});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup0, new Uint32Array(4459), 397, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer6, 164, 684);
+} catch {}
+let img4 = await imageWithData(14, 65, '#10101010', '#20202020');
+let bindGroup53 = device0.createBindGroup({
+  label: '\ud1dd\u{1fc1c}\ub4b1\u51fb\u6635',
+  layout: bindGroupLayout13,
+  entries: [{binding: 278, resource: textureView10}],
+});
+let commandEncoder95 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({size: [32, 32, 20], format: 'r32float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let renderBundle13 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup12, new Uint32Array(269), 19, 1);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 49 */
+  offset: 49,
+  buffer: buffer50,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 14},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 11276, new DataView(new ArrayBuffer(22152)), 1660, 524);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({label: '\u{1f94e}\u0db2\u{1f9ef}\u3dc8\u243c\u4de6\uf924\u079c'});
+let computePassEncoder78 = commandEncoder95.beginComputePass({});
+let renderPassEncoder18 = commandEncoder96.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 17,
+  clearValue: { r: 413.5, g: -232.1, b: -580.7, a: -925.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 195863059,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer9, 'uint32', 1_080, 500);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup19, new Uint32Array(98), 16, 0);
+} catch {}
+let texture99 = device0.createTexture({size: [1536, 1, 42], mipLevelCount: 3, format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(92);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup38, new Uint32Array(968), 33, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer40, 'uint16', 982, 394);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 14, y: 13, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData8 = new ImageData(80, 8);
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView96 = texture54.createView({dimension: '3d'});
+let texture100 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle14 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup47, new Uint32Array(390), 24, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer41, 'uint32', 616, 2_792);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 153, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 342, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder50.label;
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup47, new Uint32Array(1397), 39, 0);
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  label: '\ud422\ud62a\u8ab2',
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+struct FragmentOutput7 {
+  @location(2) f0: i32,
+  @location(4) f1: vec2f,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec4f,
+}
+
+struct T0 {
+  @size(8) f0: array<f16, 2>,
+  @size(148) f1: array<u32>,
+}
+
+@group(0) @binding(42) var tex21: texture_2d<f32>;
+
+var<workgroup> vw61: atomic<u32>;
+
+@group(0) @binding(4) var<storage, read> buffer60: array<array<array<array<f16, 13>, 1>, 6>>;
+
+struct FragmentOutput6 {
+  @location(0) f0: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0(a0: T1, a1: T1) -> array<array<array<T1, 3>, 1>, 6> {
+  var out: array<array<array<T1, 3>, 1>, 6>;
+  out[u32(unconst_u32(4))][u32(unconst_u32(87))][2] = T1(array<f32, 1>(a1.f0[0]));
+  var vf214: u32 = arrayLength(&(*&buffer60));
+  let ptr91: ptr<storage, array<f16, 13>, read> = &buffer60[arrayLength(&buffer60)][5][0];
+  let vf215: array<f32, 1> = a0.f0;
+  vf214 >>= u32(buffer60[arrayLength(&buffer60)][5][0][12]);
+  let ptr92: ptr<storage, array<array<array<f16, 13>, 1>, 6>, read> = &(*&buffer60)[arrayLength(&(*&buffer60)) - 1];
+  vf214 = u32((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]);
+  vf214 = u32(buffer60[i32(unconst_i32(444))][5][0][12]);
+  let vf216: array<f32, 1> = a0.f0;
+  let vf217: u32 = arrayLength(&(*&buffer60));
+  let ptr93: ptr<storage, array<array<array<array<f16, 13>, 1>, 6>>, read> = &buffer60;
+  let ptr94: ptr<storage, f16, read> = &(*&buffer60)[arrayLength(&(*&buffer60))][5][0][u32(unconst_u32(607))];
+  var vf218: array<f32, 1> = a1.f0;
+  let ptr95: ptr<storage, array<array<array<f16, 13>, 1>, 6>, read> = &(*&buffer60)[u32(unconst_u32(354))];
+  let ptr96: ptr<storage, array<array<array<array<f16, 13>, 1>, 6>>, read> = &buffer60;
+  vf218[bitcast<u32>(vf218[0])] = f32((*ptr96)[arrayLength(&(*ptr96)) - 1][5][0][12]);
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  @align(1) @size(8) f0: array<f32, 1>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw60: T1;
+
+@vertex
+fn vertex11(@location(3) @interpolate(flat, center) a0: vec4i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let ptr97: ptr<storage, array<array<f16, 13>, 1>, read> = &buffer60[arrayLength(&buffer60)][5];
+  out += vec4f(f32(buffer60[arrayLength(&buffer60)][5][0][12]));
+  out = vec4f(a0);
+  out = vec4f(f32(buffer60[u32((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12])][5][0][12]));
+  fn0(T1(array<f32, 1>(f32(buffer60[arrayLength(&buffer60)][5][0][12]))), T1(array<f32, 1>(tanh(vec4f(unconst_f32(0.03457), unconst_f32(0.03826), unconst_f32(0.1828), unconst_f32(0.2821)))[0])));
+  fn0(T1(array<f32, 1>(f32(buffer60[arrayLength(&buffer60)][5][0][12]))), T1(array<f32, 1>(f32((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]))));
+  let ptr98: ptr<storage, array<f16, 13>, read> = &buffer60[arrayLength(&buffer60)][5][0];
+  var vf219 = fn0(T1(array<f32, 1>(f32((*ptr97)[0][12]))), T1(array<f32, 1>(f32(buffer60[arrayLength(&buffer60)][5][0][12]))));
+  fn0(T1(array<f32, 1>(f32((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]))), vf219[5][0][2]);
+  out = vec4f(f32((*ptr97)[0][12]));
+  var vf220 = fn0(vf219[5][u32(buffer60[arrayLength(&buffer60) - 1][5][0][12])][2], T1(array<f32, 1>(f32((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]))));
+  return out;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  var vf221: vec2h = asinh(vec2h((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]));
+  let ptr99: ptr<storage, array<array<f16, 13>, 1>, read> = &buffer60[arrayLength(&buffer60)][5];
+  let ptr100: ptr<storage, array<f16, 13>, read> = &(*&buffer60)[arrayLength(&(*&buffer60))][5][0];
+  let vf222: u32 = textureNumLevels(tex21);
+  var vf223: vec4f = unpack4x8snorm(u32(unconst_u32(551)));
+  var vf224: vec2u = textureDimensions(tex21, i32(unconst_i32(28)));
+  var vf225: vec3h = cross(vec3h((*&buffer60)[arrayLength(&(*&buffer60))][5][0][u32(unconst_u32(16))]), vec3h(f16(countTrailingZeros(bitcast<vec2i>(textureDimensions(tex21))[0]))));
+  vf221 -= vec2h((*&buffer60)[arrayLength(&(*&buffer60))][5][0][12]);
+  out.f0 = vec4f(f32(buffer60[arrayLength(&buffer60) - 1][5][0][12]));
+  let ptr101: ptr<storage, array<array<array<f16, 13>, 1>, 6>, read> = &(*&buffer60)[u32(unconst_u32(29))];
+  let ptr102: ptr<storage, array<array<f16, 13>, 1>, read> = &buffer60[arrayLength(&buffer60)][5];
+  return out;
+}
+
+@fragment
+fn fragment8(@location(13) @interpolate(flat, centroid) a0: f32) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  discard;
+  let ptr103: ptr<storage, array<f16, 13>, read> = &buffer60[arrayLength(&buffer60)][5][u32(unconst_u32(116))];
+  let vf226: vec3<bool> = select(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true)), vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)), bool(textureDimensions(tex21, i32(unconst_i32(72))).x));
+  discard;
+  let ptr104: ptr<storage, array<f16, 13>, read> = &(*&buffer60)[arrayLength(&(*&buffer60))][5][u32(unconst_u32(28))];
+  let ptr105: ptr<storage, array<array<f16, 13>, 1>, read> = &(*&buffer60)[arrayLength(&(*&buffer60))][5];
+  let ptr106: ptr<storage, array<f16, 13>, read> = &buffer60[arrayLength(&buffer60)][5][0];
+  let ptr107: ptr<storage, array<f16, 13>, read> = &(*&buffer60)[arrayLength(&(*&buffer60))][5][bitcast<u32>(a0)];
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let renderPassEncoder19 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 68,
+  clearValue: { r: -138.8, g: 351.1, b: -538.1, a: 873.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder4.pushDebugGroup('\u8936');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let computePassEncoder79 = commandEncoder98.beginComputePass({});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u4821\u09a2\u019f\ucbca\uadc5\u{1f92e}\u9390\u3517',
+  colorFormats: ['r8uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer32, 'uint32', 348, 892);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer57, 0, 32);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let computePassEncoder80 = commandEncoder97.beginComputePass({});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint32', 4_984, 4_758);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 1212, new DataView(new ArrayBuffer(20318)), 306, 172);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder66.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(2, bindGroup7, new Uint32Array(2111), 1_441, 0);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle4, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer37, 'uint16', 2_194, 241);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer29, 'uint32', 28, 8);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer0, 820, buffer7, 3300, 1636);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw67: FragmentOutput8;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw66: atomic<u32>;
+
+var<private> vp21: vec4h = vec4h();
+
+var<workgroup> vw63: FragmentOutput8;
+
+var<workgroup> vw62: array<f16, 86>;
+
+var<workgroup> vw65: atomic<u32>;
+
+fn fn1() -> array<FragmentOutput8, 7> {
+  var out: array<FragmentOutput8, 7>;
+  var vf234: vec3f = exp(vec3f(unconst_f32(0.03482), unconst_f32(0.1501), unconst_f32(0.1191)));
+  let vf235: f16 = length(vp19[1]);
+  vp20 = vec4u(faceForward(vec2h(unconst_f16(14126.4), unconst_f16(3919.0)), vec2h(vf234.zy), vec2h(unconst_f16(12143.0), unconst_f16(4070.9))).yyxx);
+  vp20 = bitcast<vec4u>(cross(acosh(vec2f(unconst_f32(0.2683), unconst_f32(0.05959))).ggg, exp(vec3f(degrees(vec3h(vp21[u32(unconst_u32(97))]))))).bgbb);
+  var vf236: vec2f = select(vec2f(unconst_f32(0.1223), unconst_f32(0.00041)), vec2f(unconst_f32(0.06147), unconst_f32(0.1546)), vec2<bool>(unconst_bool(false), unconst_bool(false)));
+  var vf237: f32 = vf234[1];
+  let ptr110: ptr<private, vec2h> = &vp19;
+  vp20 |= bitcast<vec4u>(quantizeToF16(vec4f(unconst_f32(0.3115), unconst_f32(0.7061), unconst_f32(0.09209), unconst_f32(0.04864))));
+  var vf238: vec3f = exp(vec3f(unconst_f32(0.00652), unconst_f32(0.06746), unconst_f32(0.03813)));
+  out[u32(unconst_u32(1))] = FragmentOutput8(u32(vf235), u32(vf235));
+  out[u32(unconst_u32(44))].f1 = u32(vp21[u32(unconst_u32(466))]);
+  var vf239: f32 = vf234[1];
+  var vf240: vec2f = select(vec2f(bitcast<f32>(vp20[1])), vec2f(unconst_f32(0.3351), unconst_f32(0.2086)), vec2<bool>(vf236));
+  var vf241: u32 = vp20[u32(unconst_u32(30))];
+  let vf242: vec3u = insertBits(vec3u(unconst_u32(190), unconst_u32(57), unconst_u32(150)), vec3u(u32(vf237)), u32(unconst_u32(196)), u32(unconst_u32(86)));
+  var vf243: vec2i = min(vec2i(unconst_i32(-77), unconst_i32(93)), vec2i(unconst_i32(51), unconst_i32(62)));
+  return out;
+}
+
+var<workgroup> vw64: atomic<u32>;
+
+fn fn0(a0: ptr<workgroup, mat2x4f>, a1: ptr<workgroup, FragmentOutput8>) -> bool {
+  var out: bool;
+  var vf227: vec3f = cross(vec3f(countTrailingZeros(vec3i(unconst_i32(102), unconst_i32(15), unconst_i32(7)))), vec3f(unconst_f32(0.07083), unconst_f32(0.2413), unconst_f32(0.1290)));
+  let ptr108: ptr<workgroup, u32> = &(*a1).f0;
+  let vf228: vec4i = unpack4xI8(u32(unconst_u32(279)));
+  var vf229: vec4i = vf228;
+  let ptr109: ptr<workgroup, u32> = &(*a1).f0;
+  let vf230: i32 = vf229[1];
+  let vf231: vec4i = vf228;
+  var vf232: i32 = abs(i32(unconst_i32(70)));
+  var vf233: f16 = vp19[1];
+  out = bool(pow(vec3f(vp20.zzx), vec3f(unconst_f32(0.00900), unconst_f32(-0.01558), unconst_f32(0.00943)))[1]);
+  return out;
+}
+
+struct T0 {
+  @size(40) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp19: vec2h = vec2h();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput8 {
+  @location(0) f0: u32,
+  @location(1) f1: u32,
+}
+
+fn fn2() -> u32 {
+  var out: u32;
+  let vf244: vec4f = acosh(vec4f(f32(vp21[u32(vp21[0])])));
+  let vf245: u32 = vp20[bitcast<u32>(vf244[u32(vp19[u32(unconst_u32(146))])])];
+  var vf246: u32 = pack4xI8(vec4i(unconst_i32(510), unconst_i32(-38), unconst_i32(11), unconst_i32(139)));
+  return out;
+}
+
+@group(0) @binding(100) var tex22: texture_2d<f32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp20: vec4u = vec4u();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@fragment
+fn fragment9() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out.f1 = extractBits(vec4u(vp21), u32(unconst_u32(170)), bitcast<u32>(dot(vec2i(unconst_i32(181), unconst_i32(117)), bitcast<vec2i>(extractBits(bitcast<vec3u>(unpack4x8snorm(u32(unconst_u32(18))).bag), u32(unconst_u32(852)), u32(unconst_u32(306))).xy)))).b;
+  let vf247: vec4f = saturate(vec4f(unconst_f32(0.1564), unconst_f32(0.02576), unconst_f32(0.2543), unconst_f32(0.08096)));
+  var vf248 = fn2();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  vp20 |= unpack4xU8(u32((*&vw62)[85]));
+  atomicExchange(&vw65, u32(unconst_u32(55)));
+  vw62[85] *= f16(atomicLoad(&(*&vw64)));
+  var vf249 = fn2();
+  vf249 |= vw63.f0;
+  vp19 = bitcast<vec2h>((*&vw63).f0);
+  let vf250: u32 = atomicExchange(&(*&vw64), u32(unconst_u32(66)));
+  atomicCompareExchangeWeak(&vw66, unconst_u32(174), unconst_u32(216));
+  fn1();
+  vp20 &= vec4u(u32(vw62[85]));
+  var vf251 = fn2();
+  fn2();
+  var vf252 = fn2();
+  var vf253 = fn2();
+  let vf254: vec4f = textureLoad(tex22, bitcast<vec2i>(textureDimensions(tex22)), i32(unconst_i32(177)));
+  var vf255 = fn1();
+  atomicCompareExchangeWeak(&vw64, unconst_u32(66), unconst_u32(100));
+  fn1();
+  vp21 = bitcast<vec4h>(extractBits(vec2i(unconst_i32(73), unconst_i32(13)), u32(unconst_u32(21)), u32(unconst_u32(51))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler57 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.82,
+  lodMaxClamp: 93.74,
+});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup45, new Uint32Array(1240), 330, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+commandEncoder100.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 19, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 20, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 360, new Float32Array(13793), 298, 224);
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 21053,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let textureView97 = texture29.createView({});
+let computePassEncoder81 = commandEncoder100.beginComputePass({});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let externalTexture10 = device0.importExternalTexture({label: '\u36ae\ub946\ua0cb\uc77d\u05bb\u031c\u{1fe1b}\u136f\u0b9c', source: videoFrame9});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup15, new Uint32Array(3943), 1_987, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline3);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 256,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder102 = device0.createCommandEncoder({label: '\u{1ff95}\ued5f\u{1fd86}\u{1ff9b}\uc3c4\u0bd5\uebc1'});
+let renderPassEncoder20 = commandEncoder101.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -932.6, g: 592.9, b: -165.6, a: 239.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 296961349,
+});
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer61, 132);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer57, 'uint16', 54, 140);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 1,
+  origin: {x: 200, y: 0, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer37, 772, 5552);
+} catch {}
+try {
+renderPassEncoder19.insertDebugMarker('\u09f6');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame4);
+let bindGroup54 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 18, resource: {buffer: buffer57, offset: 0, size: 156}},
+    {binding: 174, resource: {buffer: buffer19, offset: 1280, size: 20}},
+  ],
+});
+let computePassEncoder82 = commandEncoder102.beginComputePass({});
+let renderPassEncoder21 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  clearValue: { r: -686.0, g: 234.4, b: 954.1, a: -342.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.draw(176, 297, 1_187_438_377, 100_699_324);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer46, 1_456);
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  label: '\u50ac\u07dd\u0225\u060b\u{1ff6b}\u{1fe94}\u3bc6\u2015\ucc99\uc16f\u{1f82d}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 137, resource: textureView79}, {binding: 42, resource: textureView21}],
+});
+let commandEncoder103 = device0.createCommandEncoder();
+let textureView98 = texture41.createView({});
+let renderPassEncoder22 = commandEncoder103.beginRenderPass({
+  label: '\u{1f94f}\u0351\u48ac\u{1fc2e}\u4f36\u{1fbb1}\u064f\u{1fd64}\u0ac7',
+  colorAttachments: [{view: textureView20, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup36, new Uint32Array(10000), 69, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder12.draw(76, 118, 2_404_675_767, 1_158_386_259);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(img4);
+let shaderModule13 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(156) f0: array<u32>,
+}
+
+var<workgroup> vw68: vec4u;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0(a0: array<u32, 2>) -> array<vec2i, 10> {
+  var out: array<vec2i, 10>;
+  let vf256: u32 = a0[1];
+  let ptr111: ptr<storage, array<array<f16, 2>, 13>, read> = &(*&buffer62)[arrayLength(&(*&buffer62))][0][0][2][0];
+  out[u32(unconst_u32(34))] &= vec2i(bitcast<i32>(a0[u32(unconst_u32(186))]));
+  let ptr112: ptr<storage, array<array<array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, 1>>, read> = &(*&buffer62);
+  let ptr113: ptr<storage, array<array<array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, 1>>, read> = &(*&buffer62);
+  vw68 *= vec4u(u32((*ptr113)[arrayLength(&(*ptr113))][0][0][2][0][12][1]));
+  let ptr114: ptr<storage, array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, read> = &buffer62[arrayLength(&buffer62)][u32(unconst_u32(36))];
+  let ptr115: ptr<storage, array<array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, 1>, read> = &buffer62[u32((*&buffer62)[arrayLength(&(*&buffer62))][0][0][2][0][12][1])];
+  vw68 = unpack4xU8(u32((*&buffer62)[arrayLength(&(*&buffer62))][0][0][2][0][12][1]));
+  let ptr116: ptr<workgroup, vec4u> = &(*&vw68);
+  workgroupBarrier();
+  vw68 = vec4u(u32(buffer62[arrayLength(&buffer62)][u32((*&buffer62)[arrayLength(&(*&buffer62))][0][0][2][0][12][1])][0][2][0][12][1]));
+  var vf257: vec2u = textureDimensions(tex23);
+  vf257 *= vec2u(u32((*ptr114)[0][2][0][12][1]));
+  let ptr117: ptr<storage, array<f16, 2>, read> = &buffer62[arrayLength(&buffer62)][0][0][2][0][12];
+  out[u32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][1])] &= vec2i(i32((*ptr112)[arrayLength(&(*ptr112))][0][0][2][0][12][1]));
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(4) var<storage, read> buffer62: array<array<array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, 1>>;
+
+@group(0) @binding(42) var tex23: texture_2d<f32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9(@builtin(num_workgroups) a0: vec3u, @builtin(global_invocation_id) a1: vec3u) {
+  fn0(array<u32, 2>(u32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][u32(unconst_u32(3))]), u32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][u32(unconst_u32(3))])));
+  var vf258: u32 = textureNumLevels(tex23);
+  fn0(array<u32, 2>(u32(cos(f16(unconst_f16(22326.8)))), u32(cos(f16(unconst_f16(22326.8))))));
+  vf258 >>= unpack4xU8(u32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][1])).x;
+  let ptr118: ptr<storage, array<array<array<f16, 2>, 13>, 1>, read> = &buffer62[arrayLength(&buffer62)][0][0][2];
+  var vf259: vec2u = textureDimensions(tex23);
+  let ptr119: ptr<storage, array<array<array<array<array<f16, 2>, 13>, 1>, 3>, 1>, read> = &buffer62[arrayLength(&buffer62)][u32((*&buffer62)[arrayLength(&(*&buffer62))][0][0][2][0][12][1])];
+  fn0(array<u32, 2>(u32(textureLoad(tex23, vec2i(unconst_i32(90), unconst_i32(107)), i32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][1])).g), u32(textureLoad(tex23, vec2i(unconst_i32(90), unconst_i32(107)), i32(buffer62[arrayLength(&buffer62)][0][0][2][0][12][1]))[3])));
+  vf258 = u32((*ptr119)[0][2][0][12][1]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView60},
+    {binding: 4, resource: {buffer: buffer6, offset: 256, size: 568}},
+  ],
+});
+let buffer63 = device0.createBuffer({
+  size: 8566,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView99 = texture88.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -35.47, g: 464.7, b: -998.6, a: -465.4, });
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer40, 2_728);
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 87, resource: textureView57},
+    {binding: 351, resource: {buffer: buffer2, offset: 1024, size: 224}},
+  ],
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let computePassEncoder83 = commandEncoder104.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer38, 544); };
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup48, new Uint32Array(4072), 988, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(72.54371104873783, 5.624783063066816, 32.604485407377396, 0.648260461453342, 0.6404649329651817, 0.9439114197331282);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData8,
+  origin: { x: 31, y: 0 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView100 = texture24.createView({baseMipLevel: 0, baseArrayLayer: 4, arrayLayerCount: 2});
+try {
+computePassEncoder65.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer6, 'uint32', 1_336, 75);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 20},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 67, resource: {buffer: buffer10, offset: 0}}, {binding: 125, resource: textureView0}],
+});
+let texture101 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.02,
+  lodMaxClamp: 88.26,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+let buffer64 = device0.createBuffer({size: 3529, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView101 = texture84.createView({format: 'rgb10a2unorm'});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(3, bindGroup34, new Uint32Array(1156), 251, 0);
+} catch {}
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer38, 56);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer32, 0);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+let texture102 = device0.createTexture({
+  size: {width: 168, height: 80, depthOrArrayLayers: 52},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView102 = texture81.createView({});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder12.draw(38, 59, 192_037_126, 470_366_754);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer46, 'uint32', 244, 2_002);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, undefined, 0, 171_291_720);
+} catch {}
+let externalTexture12 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder67.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer3, 4);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 11,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 411,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView103 = texture27.createView({mipLevelCount: 1});
+let texture103 = device0.createTexture({
+  size: [120, 8, 21],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder84 = commandEncoder48.beginComputePass({});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup39, new Uint32Array(1731), 136, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer24, 0);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule9,
+  constants: {override20: 0, 13_754: 0},
+  targets: [{format: 'rgb10a2unorm', writeMask: 0}, {format: 'r32float', writeMask: 0}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule9,
+    constants: {override12: 0, override11: 0, 27_671: 0, override20: 0, 44_349: 0},
+    buffers: [
+      {
+        arrayStride: 384,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 24, shaderLocation: 3}, {format: 'uint8x2', offset: 6, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list'},
+});
+let imageData9 = new ImageData(116, 84);
+let buffer65 = device0.createBuffer({
+  label: '\u570e\u7bc0\u0766\u{1fc21}\u0eb3\u0d38',
+  size: 8453,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup3, new Uint32Array(943), 43, 0);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup37, new Uint32Array(1306), 229, 0);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer5, 12, 32);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder();
+let texture104 = device0.createTexture({
+  size: [120, 8, 1],
+  mipLevelCount: 4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder23 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 24,
+  clearValue: { r: -72.50, g: -306.1, b: 472.5, a: 903.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler59 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.30,
+  lodMaxClamp: 63.27,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(2, bindGroup37, new Uint32Array(1250), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer46, 2_608);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2144 */
+  offset: 2144,
+  buffer: buffer17,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 64, new Int16Array(10631), 588, 144);
+} catch {}
+try {
+globalThis.someLabel = bindGroup37.label;
+} catch {}
+let commandBuffer4 = commandEncoder61.finish({});
+let textureView104 = texture12.createView({
+  label: '\uca64\u9ae5\u4f73\u0a57\u0e4b\u47a9\u{1fa27}\uefa9\uf730\uc4cb\uf634',
+  dimension: '2d-array',
+  baseArrayLayer: 16,
+  arrayLayerCount: 28,
+});
+let renderBundle16 = renderBundleEncoder16.finish({label: '\u9592\u0391\ua90d\u{1f723}\ub96b\u8e1f\u004c\u554e\u{1fb4d}\uaada'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup26, new Uint32Array(238), 31, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer40, 776); };
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer36, 'uint16', 588, 1_184);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 62, resource: textureView11},
+    {binding: 223, resource: textureView7},
+    {binding: 137, resource: textureView5},
+    {binding: 429, resource: {buffer: buffer45, offset: 4352, size: 104}},
+  ],
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup43, new Uint32Array(940), 259, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer46, 'uint32', 24, 821);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer24, 0, 3_707);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder81.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup44, new Uint32Array(1504), 452, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint32', 636, 112);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 47},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData10 = new ImageData(40, 68);
+let bindGroup60 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView14}]});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(3, bindGroup25, new Uint32Array(794), 188, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup29, new Uint32Array(259), 22, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 557.1, g: 357.4, b: 97.06, a: 93.92, });
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer41, 'uint32', 304, 454);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture105 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 66},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture13 = device0.importExternalTexture({label: '\u{1f75f}\u6641\u49c3', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer36, 'uint32', 604, 605);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(211).fill(41), /* required buffer size: 211 */
+{offset: 211}, {width: 638, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({label: '\u0a50\u1444\uaefe\u{1f67c}\u0744\ubae1\u092b\u2a97\ubaaa\u9426'});
+let texture106 = device0.createTexture({
+  size: [120, 8, 1],
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView105 = texture36.createView({});
+let renderPassEncoder24 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 85,
+  clearValue: { r: 483.2, g: -627.7, b: -141.9, a: 162.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(28, 4, 20, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 678, 25);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(240).fill(14), /* required buffer size: 240 */
+{offset: 240, rowsPerImage: 211}, {width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture107 = device0.createTexture({size: [30, 2, 99], format: 'rg16float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder85 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup27);
+} catch {}
+let texture108 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup12, new Uint32Array(1826), 646, 1);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -833.9, g: -614.1, b: 655.1, a: -344.1, });
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer9, 'uint16', 1_476, 691);
+} catch {}
+await gc();
+let bindGroup61 = device0.createBindGroup({label: '\u{1fb59}\ud60f', layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView53}]});
+let commandEncoder108 = device0.createCommandEncoder({});
+let commandBuffer5 = commandEncoder40.finish({});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup12, new Uint32Array(187), 17, 1);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup31, new Uint32Array(1063), 274, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer29, 16, 69);
+} catch {}
+let arrayBuffer15 = buffer41.getMappedRange(3840, 4);
+try {
+commandEncoder108.copyBufferToBuffer(buffer36, 1640, buffer65, 3484, 916);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u{1f739}\u{1f627}\u08eb\u9ef3\u83bc\u231d\u659a\u82b6\u4e44\u03b8\ue5fc';
+} catch {}
+let buffer66 = device0.createBuffer({
+  size: 16,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView106 = texture44.createView({baseMipLevel: 0, baseArrayLayer: 30, arrayLayerCount: 41});
+let computePassEncoder86 = commandEncoder108.beginComputePass({});
+let renderPassEncoder25 = commandEncoder109.beginRenderPass({
+  label: '\u0bb6\uaf49\u{1fd88}\ua575\u8790\u21d2\u{1fa93}\u42b2\uffa9\ue510',
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: -438.1, g: -589.5, b: -936.3, a: 196.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup59, new Uint32Array(440), 8, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup33, new Uint32Array(97), 1, 0);
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 137, resource: textureView72},
+    {binding: 223, resource: textureView35},
+    {binding: 62, resource: textureView37},
+    {binding: 429, resource: {buffer: buffer57, offset: 0}},
+  ],
+});
+let commandEncoder110 = device0.createCommandEncoder({label: '\u62b9\u0dd5'});
+let renderPassEncoder26 = commandEncoder110.beginRenderPass({
+  label: '\ucee8\u2a12\u4762\u{1fcc7}\u3cf4\ue1fa\ue681\uc696\u0f1b',
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: 300.1, g: 416.2, b: 979.5, a: -514.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\u808b\u51da\u{1fd7e}\u4bdd\u00ec\u0650\u1488',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule13, constants: {}},
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup33, new Uint32Array(878), 1, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup38);
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 190,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture109 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 389},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture110 = device0.createTexture({
+  size: {width: 42},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder79.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 843});
+let textureView107 = texture109.createView({mipLevelCount: 1});
+let texture111 = device0.createTexture({
+  size: [240, 16, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView108 = texture109.createView({aspect: 'all'});
+let computePassEncoder87 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup62, new Uint32Array(1066), 290, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint16', 82, 680);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await buffer59.mapAsync(GPUMapMode.READ, 0, 744);
+} catch {}
+document.body.prepend(img1);
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u95be\ubfff\u08ee\u14b8\u{1f950}\uf863',
+  entries: [
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer67 = device0.createBuffer({
+  size: 10608,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let textureView109 = texture27.createView({format: 'r32sint', baseMipLevel: 0, mipLevelCount: 1});
+let textureView110 = texture39.createView({baseMipLevel: 0});
+let sampler60 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 99.99});
+await gc();
+let textureView111 = texture69.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 51.27,
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle15, renderBundle15, renderBundle9, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer45);
+} catch {}
+let img5 = await imageWithData(22, 10, '#10101010', '#20202020');
+let texture112 = device0.createTexture({
+  label: '\u0f7b\u03a0\u2adb\u8a6b\u0d95\u{1fb4a}\uc7a3\u015b\u20b4',
+  size: {width: 60, height: 4, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup22, new Uint32Array(4724), 1_741, 0);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(51).fill(252), /* required buffer size: 51 */
+{offset: 51}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img4);
+let commandEncoder112 = device0.createCommandEncoder();
+let texture113 = device0.createTexture({
+  size: [768, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup25, new Uint32Array(195), 0, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2624 */
+  offset: 2624,
+  bytesPerRow: 15360,
+  buffer: buffer7,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 3, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let texture114 = device0.createTexture({
+  size: [240, 16, 375],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture115 = device0.createTexture({
+  size: [120, 8, 30],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup39, new Uint32Array(152), 99, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3, new Uint32Array(1857), 0, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(10, 0, 13, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let textureView112 = texture37.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let textureView113 = texture55.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder88 = commandEncoder112.beginComputePass({label: '\u0657\u08b4\u{1f743}\u0724\u{1f917}'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float']});
+let renderBundle17 = renderBundleEncoder17.finish({});
+try {
+computePassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setViewport(112.27539307283811, 4.953452714649012, 0.11152193376355522, 1.9342471587439471, 0.33764679629623173, 0.9108442905678491);
+} catch {}
+let img6 = await imageWithData(3, 76, '#10101010', '#20202020');
+let commandEncoder113 = device0.createCommandEncoder({});
+let textureView114 = texture112.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(3, 2); };
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer29);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule2, constants: {53_740: 0}}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let canvas3 = document.createElement('canvas');
+let textureView115 = texture113.createView({dimension: '2d-array'});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(0, bindGroup38, new Uint32Array(960), 27, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer34, 500); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer0, 'uint16', 1_818, 107);
+} catch {}
+try {
+commandEncoder113.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let renderPassEncoder27 = commandEncoder113.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 722.7, g: -114.8, b: 692.7, a: 826.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup48, new Uint32Array(143), 30, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(106).fill(3), /* required buffer size: 106 */
+{offset: 106}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  label: '\ubce9\u01a7\u0510\u89f6',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule5,
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule8,
+    constants: {60_113: 0},
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: [{format: 'sint32', offset: 8, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16'},
+});
+let buffer68 = device0.createBuffer({
+  label: '\u005e\u9095\u55a7',
+  size: 3794,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder114 = device0.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder114.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer9, 'uint16', 38, 48);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let textureView116 = texture87.createView({label: '\u0386\ue3f2\u022e\u{1fded}\u2997\u0be2\u095c\ue761'});
+let renderPassEncoder28 = commandEncoder103.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 52,
+  clearValue: { r: -585.0, g: 642.5, b: -912.4, a: 823.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 19232586,
+});
+try {
+computePassEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer61, 0, 12_791);
+} catch {}
+document.body.append(img5);
+let shaderModule14 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw70: array<array<FragmentOutput9, 2>, 1>;
+
+struct T0 {
+  @align(1) f0: array<array<vec2h, 1>, 16>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(41729) override override28 = true;
+
+@id(51660) override override29: f16;
+
+@id(9495) override override27: u32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(100) var tex24: texture_2d<f32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(52185) override override33 = true;
+
+struct FragmentOutput9 {
+  @location(3) @interpolate(flat, sample) f0: vec2i,
+  @location(4) f1: i32,
+  @location(0) @interpolate(linear, sample) f2: vec4f,
+}
+
+@id(53195) override override30 = 0.6065;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override34: f16;
+
+override override32: u32;
+
+@id(63132) override override31 = false;
+
+var<workgroup> vw69: vec4h;
+
+@fragment
+fn fragment10(@location(12) a0: vec4f, @location(13) a1: vec4u, @location(11) a2: vec2i) -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  let vf260: u32 = pack4x8snorm(vec4f(countOneBits(vec2u(pack4xI8(vec4i(unconst_i32(59), unconst_i32(325), unconst_i32(62), unconst_i32(327))))).yxyx));
+  return out;
+}
+
+@fragment
+fn fragment11(@location(11) a0: vec2i) -> @location(200) u32 {
+  var out: u32;
+  let vf261: u32 = override32;
+  out >>= bitcast<u32>(countOneBits(i32(unconst_i32(150))));
+  out = u32(override34);
+  out >>= bitcast<u32>(atanh(bitcast<f32>(a0[vec2u(reverseBits(vec2i(unconst_i32(96), unconst_i32(133)))).r])));
+  return out;
+  _ = override32;
+  _ = override34;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute10() {
+  let ptr120: ptr<workgroup, vec2i> = &(*&vw70)[0][1].f0;
+  vw70[u32(unconst_u32(186))][1] = FragmentOutput9(vec2i(vw70[0][1].f1), vw70[0][1].f1, vec4f(f32(vw70[0][1].f1)));
+  let vf262: vec3f = log(vec3f(unconst_f32(0.2725), unconst_f32(0.03677), unconst_f32(0.05705)));
+  let ptr121: ptr<workgroup, FragmentOutput9> = &(*&vw70)[0][1];
+  let vf263: f16 = vw69[u32(unconst_u32(475))];
+  let ptr122: ptr<workgroup, FragmentOutput9> = &vw70[0][1];
+  let ptr123: ptr<workgroup, array<FragmentOutput9, 2>> = &vw70[0];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder115.beginComputePass({});
+let sampler62 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 86.23});
+try {
+computePassEncoder89.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle11, renderBundle10, renderBundle11]);
+} catch {}
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer69 = device0.createBuffer({size: 3471, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder116 = device0.createCommandEncoder({label: '\u{1ff6b}\ufb5e\u5bec\u58b9\ua900\uc1e6\u6053\u{1f7af}\uea9e\u03ac\u20f1'});
+let textureView117 = texture113.createView({
+  label: '\ucc75\u3f5e\u{1fb80}\u062b\u{1fca4}\u028e\u4255\u000c\u09d5\ue691\u{1fba2}',
+  dimension: '2d-array',
+});
+let textureView118 = texture91.createView({label: '\u{1f718}\u5a97\u0e04', format: 'bgra8unorm'});
+let sampler63 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.70,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder80.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer41, 'uint16', 430, 171);
+} catch {}
+let arrayBuffer16 = buffer67.getMappedRange();
+try {
+commandEncoder116.copyBufferToBuffer(buffer66, 0, buffer17, 2536, 4);
+} catch {}
+try {
+commandEncoder116.resolveQuerySet(querySet8, 263, 264, buffer1, 512);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(47).fill(42), /* required buffer size: 47 */
+{offset: 47, bytesPerRow: 166}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer70 = device0.createBuffer({label: '\u8a11\u684f', size: 12896, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder117 = device0.createCommandEncoder({label: '\uaa81\u01f7\u{1f83d}\ue71c'});
+let texture116 = device0.createTexture({
+  size: [120, 8, 187],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(2, bindGroup19, new Uint32Array(259), 4, 0);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint16', 9_524, 1_134);
+} catch {}
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 496 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1136 */
+  offset: 1136,
+  bytesPerRow: 29696,
+  buffer: buffer50,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule13, constants: {}}});
+let imageData11 = new ImageData(52, 8);
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView83}]});
+let buffer71 = device0.createBuffer({size: 10118, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder118 = device0.createCommandEncoder({});
+let computePassEncoder91 = commandEncoder10.beginComputePass();
+try {
+computePassEncoder84.setBindGroup(0, bindGroup18, [0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer15, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 214,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup64 = device0.createBindGroup({
+  label: '\u3d17\u01b8\u0a0a\u5c7a\u{1f8f8}',
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView53},
+    {binding: 4, resource: {buffer: buffer51, offset: 0, size: 464}},
+  ],
+});
+let renderPassEncoder29 = commandEncoder118.beginRenderPass({colorAttachments: [{view: textureView59, depthSlice: 83, loadOp: 'clear', storeOp: 'store'}]});
+let sampler64 = device0.createSampler({
+  label: '\u8eb7\u0ead\u0193\u90de\u4129\u{1fce9}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 79.09,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer29, 'uint16', 34, 2);
+} catch {}
+try {
+computePassEncoder90.pushDebugGroup('\u09cd');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 27}
+*/
+{
+  source: imageData5,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView119 = texture11.createView({baseArrayLayer: 0});
+let renderPassEncoder30 = commandEncoder117.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: 353.8, g: 819.1, b: -79.98, a: -62.53, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet13,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup30, new Uint32Array(684), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer46, 'uint16', 30, 2_245);
+} catch {}
+let arrayBuffer17 = buffer41.getMappedRange(3848, 264);
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: {x: 17, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 9, y: 1, z: 7},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let img7 = await imageWithData(4, 22, '#10101010', '#20202020');
+let commandBuffer6 = commandEncoder32.finish();
+let texture117 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder92 = commandEncoder116.beginComputePass({label: '\u{1ff49}\ud3ad\u0426\u0975\ub78e\u056a\u059b'});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer24);
+} catch {}
+let textureView120 = texture52.createView({mipLevelCount: 1, baseArrayLayer: 59, arrayLayerCount: 8});
+let sampler65 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.64,
+  lodMaxClamp: 75.00,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle4, renderBundle7, renderBundle7, renderBundle4]);
+} catch {}
+let imageData12 = new ImageData(12, 12);
+let commandEncoder119 = device0.createCommandEncoder({label: '\ufa1b\udcb2\u0714\u7e51\u{1faf0}\u7d5c\u751a\u{1f72e}'});
+let commandBuffer7 = commandEncoder13.finish({label: '\u{1f698}\u02f7\u89a5\u9625\u7362\u451f\u909a\u15d2'});
+let textureView121 = texture1.createView({});
+let computePassEncoder93 = commandEncoder119.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let texture118 = device0.createTexture({
+  size: [1536, 1, 1],
+  dimension: '2d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder23.executeBundles([renderBundle5, renderBundle14]);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 4, y: 19, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView122 = texture94.createView({dimension: '2d-array', baseArrayLayer: 1, arrayLayerCount: 10});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup56, []);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer46, 'uint32', 172, 908);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline4);
+} catch {}
+let bindGroup65 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView111}]});
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture119 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 15},
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder31 = commandEncoder120.beginRenderPass({
+  label: '\u1267\u33d9\u0f32\u0694\u6ec2\u0f43\u0677\u9549',
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: 592.0, g: -661.6, b: -260.4, a: 446.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder79.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder90.popDebugGroup();
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let commandEncoder121 = device0.createCommandEncoder({});
+let computePassEncoder94 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer23, 1_148, 181);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer34);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(7_399).fill(109), /* required buffer size: 7_399 */
+{offset: 175, bytesPerRow: 43, rowsPerImage: 8}, {width: 10, height: 0, depthOrArrayLayers: 22});
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 411, resource: textureView103}, {binding: 11, resource: {buffer: buffer10, offset: 0}}],
+});
+let texture120 = device0.createTexture({
+  size: {width: 168},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle18 = renderBundleEncoder18.finish({});
+let sampler66 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.97,
+  lodMaxClamp: 63.81,
+});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+document.body.prepend(img4);
+let imageBitmap3 = await createImageBitmap(imageData1);
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 144, resource: textureView107}, {binding: 190, resource: textureView100}],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let textureView123 = texture89.createView({});
+let renderPassEncoder32 = commandEncoder122.beginRenderPass({
+  label: '\u{1fb6a}\ude88\ucb87\u0f41\u0d58\u{1f83b}\u068d\u738a\u26bc',
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 8,
+  clearValue: { r: 197.5, g: -474.6, b: -256.7, a: -463.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder88.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder72.pushDebugGroup('\u{1fe3b}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(94), /* required buffer size: 27 */
+{offset: 27}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer72 = device0.createBuffer({size: 857, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let textureView124 = texture103.createView({dimension: '2d', baseArrayLayer: 2});
+let sampler67 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 44.09, lodMaxClamp: 91.96});
+try {
+computePassEncoder93.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle1, renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer41, 'uint32', 2_976, 334);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer57, 0, 212);
+} catch {}
+try {
+renderPassEncoder31.insertDebugMarker('\u0b13');
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder123 = device0.createCommandEncoder();
+let texture121 = device0.createTexture({
+  size: [768],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder95 = commandEncoder123.beginComputePass();
+let sampler68 = device0.createSampler({
+  label: '\u294c\udcd4\u0f90\u{1fc08}\u0085\u0b7b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 25.08,
+  lodMaxClamp: 79.64,
+});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer10, 44, 360);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  label: '\u606b\u0bda\uc910\u72ae\u1bf6\uc3af\u2aa3\u019f',
+  layout: bindGroupLayout11,
+  entries: [{binding: 137, resource: textureView104}, {binding: 42, resource: textureView21}],
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({label: '\u477a\u24d0', type: 'occlusion', count: 1313});
+let textureView125 = texture121.createView({label: '\u945e\u9d6a\u{1faf2}\u4fd2\uc30c\u1352', baseArrayLayer: 0});
+let computePassEncoder96 = commandEncoder124.beginComputePass({label: '\u0a5e\u5ac8\u16f1\u{1fc62}\u7d25\u0849\u1a2b\u{1f873}\u{1ff28}'});
+try {
+computePassEncoder95.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle5]);
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 189, resource: {buffer: buffer37, offset: 0, size: 4448}},
+    {binding: 18, resource: externalTexture8},
+    {binding: 86, resource: textureView19},
+    {binding: 171, resource: textureView111},
+    {binding: 265, resource: {buffer: buffer23, offset: 512}},
+    {binding: 204, resource: textureView26},
+    {binding: 221, resource: {buffer: buffer57, offset: 0}},
+    {binding: 139, resource: {buffer: buffer44, offset: 256, size: 130}},
+    {binding: 219, resource: textureView93},
+    {binding: 105, resource: textureView24},
+  ],
+});
+let buffer73 = device0.createBuffer({
+  size: 18925,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder96.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle11, renderBundle10]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(43_744).fill(143), /* required buffer size: 43_744 */
+{offset: 96, bytesPerRow: 62, rowsPerImage: 32}, {width: 15, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 27}
+*/
+{
+  source: canvas2,
+  origin: { x: 17, y: 5 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer74 = device0.createBuffer({
+  size: 15207,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture122 = device0.createTexture({size: [768, 1, 337], dimension: '3d', format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView126 = texture24.createView({
+  label: '\u09e8\u0bbb\u0cc2\u00fb\u0ab5\uefb9\ucc0e\u72c4',
+  dimension: 'cube-array',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let sampler69 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 22.42,
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame11, colorSpace: 'display-p3'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer0, 'uint32', 2_132, 440);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(7, buffer20, 1_552, 2_132);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(18_886).fill(159), /* required buffer size: 18_886 */
+{offset: 16, bytesPerRow: 30, rowsPerImage: 37}, {width: 0, height: 1, depthOrArrayLayers: 18});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 33}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView127 = texture74.createView({dimension: '2d-array'});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup38, new Uint32Array(209), 34, 0);
+} catch {}
+try {
+renderPassEncoder28.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setViewport(219.63240225602286, 14.00157394859478, 1.3287878884756505, 1.0131182473299918, 0.19581896352778472, 0.7909066146538274);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline7);
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView128 = texture13.createView({dimension: '2d-array'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 40.04,
+  lodMaxClamp: 46.53,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup63, new Uint32Array(867), 82, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(127.51308205111772, 0.20162534816009714, 1.6730486878307909, 0.11097601493172543, 0.9192622789270136, 0.9250249896383357);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer63, 'uint16', 3_972, 732);
+} catch {}
+try {
+commandEncoder125.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 7, y: 16, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder97 = commandEncoder125.beginComputePass();
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.92,
+  lodMaxClamp: 97.74,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder97.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder36.pushDebugGroup('\ub3fd');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 16, depthOrArrayLayers: 375}
+*/
+{
+  source: imageData6,
+  origin: { x: 15, y: 4 },
+  flipY: true,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 214},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img6);
+let commandEncoder126 = device0.createCommandEncoder({label: '\u0f66\ue1d5\u6895\u{1f9af}\u{1f956}\u0aea\ue6cf\u{1fac8}\u{1fe42}\uae2f\u2cd2'});
+let texture123 = device0.createTexture({
+  size: [84, 40, 1],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder98 = commandEncoder126.beginComputePass({label: '\u7fcb\u0cbb\u{1f645}\u{1f72e}'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup65, new Uint32Array(853), 128, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer74, 'uint16', 114, 6_781);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 144, resource: textureView107}, {binding: 190, resource: textureView61}],
+});
+let commandEncoder127 = device0.createCommandEncoder({});
+let computePassEncoder99 = commandEncoder127.beginComputePass({});
+try {
+computePassEncoder92.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer55, 924, 1_095);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 150,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 69,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer75 = device0.createBuffer({
+  size: 20974,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture124 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup53, new Uint32Array(610), 7, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer37, 'uint32', 1_612, 1_054);
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 23825,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture125 = device0.createTexture({
+  size: [32],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView129 = texture22.createView({baseMipLevel: 0});
+let sampler72 = device0.createSampler({addressModeW: 'clamp-to-edge', magFilter: 'nearest', lodMinClamp: 89.58, lodMaxClamp: 91.11});
+try {
+computePassEncoder98.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline7);
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'logSqrt'} });
+try {
+globalThis.someLabel = bindGroupLayout16.label;
+} catch {}
+let textureView130 = texture30.createView({label: '\u6552\u3c60', dimension: '2d', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(2, bindGroup1, new Uint32Array(1532), 98, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer29, 'uint16', 116, 195);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer46, 0, 873);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(4_455).fill(170), /* required buffer size: 4_455 */
+{offset: 115, bytesPerRow: 35, rowsPerImage: 31}, {width: 3, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({});
+let textureView131 = texture93.createView({});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup60, new Uint32Array(2231), 196, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup31);
+} catch {}
+let arrayBuffer18 = buffer41.getMappedRange(8832, 0);
+try {
+commandEncoder128.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 536 */
+  offset: 536,
+  buffer: buffer47,
+}, {
+  texture: texture68,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 5792,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let computePassEncoder100 = commandEncoder128.beginComputePass();
+let renderPassEncoder33 = commandEncoder129.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: 727.7, g: -335.7, b: -765.2, a: 242.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+globalThis.someLabel = externalTexture15.label;
+} catch {}
+let texture126 = device0.createTexture({
+  label: '\u29b1\u5cde\ue6e6\u52ed\u828b\u0da7\u0e29\u0b3a\u{1f99c}',
+  size: {width: 240},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler73 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.30,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup0, new Uint32Array(863), 240, 0);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer1, 'uint32', 16, 288);
+} catch {}
+try {
+  await buffer47.mapAsync(GPUMapMode.WRITE, 200, 8);
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  label: '\uc731\u{1ff47}\u0649\uf94e\u0b86\u{1fa3f}\u{1fe72}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 218, resource: sampler45}],
+});
+let textureView132 = texture64.createView({});
+try {
+renderPassEncoder21.setPipeline(pipeline0);
+} catch {}
+document.body.append(canvas1);
+let texture127 = device0.createTexture({
+  size: [42, 20, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView133 = texture34.createView({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u{1ffa7}\ufa08\u993a',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer65, 'uint16', 410, 1_406);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer55, 'uint16', 1_308, 628);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer29, 92, 53);
+} catch {}
+try {
+  await buffer70.mapAsync(GPUMapMode.READ, 0, 1256);
+} catch {}
+try {
+computePassEncoder69.pushDebugGroup('\u53a1');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(71).fill(165), /* required buffer size: 71 */
+{offset: 71, rowsPerImage: 58}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 155});
+let texture128 = device0.createTexture({
+  size: [240, 16, 1],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView134 = texture56.createView({label: '\u{1ffe4}\u{1f7a1}\ucf2f\ua998\u334d\u0da7\u7208\u0750\u035c', arrayLayerCount: 1});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+renderPassEncoder30.setIndexBuffer(buffer9, 'uint16', 34, 703);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer9, 2_752, 406);
+} catch {}
+let textureView135 = texture70.createView({mipLevelCount: 3});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup51, new Uint32Array(246), 109, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer61, 'uint16', 1_244, 1_326);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView42}]});
+let buffer78 = device0.createBuffer({
+  size: 5281,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder130 = device0.createCommandEncoder({});
+let textureView136 = texture97.createView({});
+let renderPassEncoder34 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -510.2, g: -582.0, b: 578.4, a: 903.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 2228, new Float32Array(8996), 301, 588);
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder();
+let textureView137 = texture32.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder101 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder101.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup51, new Uint32Array(1190), 255, 0);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline7);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer79 = device0.createBuffer({
+  size: 17765,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder132 = device0.createCommandEncoder({label: '\u{1ff39}\u3375\u798a\u0896\u0de1\u0051'});
+let renderPassEncoder35 = commandEncoder132.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 14,
+  clearValue: { r: 903.5, g: -504.4, b: -666.7, a: -332.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler74 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 84.89,
+  compare: 'equal',
+});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup45, new Uint32Array(2087), 60, 0);
+} catch {}
+try {
+renderPassEncoder11.setViewport(227.11806876011858, 1.842052382371417, 4.5276351086060505, 0.28818255814171284, 0.9369221904478081, 0.9442949665023554);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let buffer80 = device0.createBuffer({
+  size: 24900,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let textureView138 = texture110.createView({label: '\uec01\u8002\u{1ff0f}\ua264\u{1fe22}\u046b\u3131\u6d9e\u0752'});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup32, new Uint32Array(22), 6, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer23, 0, 327);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 592, new BigUint64Array(3949), 30, 180);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 68},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas3);
+let buffer81 = device0.createBuffer({
+  size: 32740,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup21, new Uint32Array(59), 2, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder();
+let textureView139 = texture124.createView({dimension: '2d-array', format: 'rgb10a2unorm', mipLevelCount: 1});
+try {
+renderPassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer20);
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 999, resource: {buffer: buffer76, offset: 15872, size: 3256}}],
+});
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer82 = device0.createBuffer({
+  size: 8308,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let textureView140 = texture64.createView({});
+let computePassEncoder102 = commandEncoder134.beginComputePass({});
+try {
+computePassEncoder102.setPipeline(pipeline5);
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {mask: 0x4577871f},
+  fragment: {
+  module: shaderModule3,
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.prepend(img3);
+let texture129 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView141 = texture59.createView({});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(0, bindGroup57, new Uint32Array(463), 26, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer81, 'uint32', 9_940, 1_645);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer23, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 209, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(56).fill(227), /* required buffer size: 56 */
+{offset: 56, rowsPerImage: 23}, {width: 229, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer83 = device0.createBuffer({
+  size: 4382,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView142 = texture40.createView({});
+let computePassEncoder103 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup43, new Uint32Array(841), 55, 0);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 121.8, g: -971.2, b: -357.8, a: 402.4, });
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer32, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(413).fill(20), /* required buffer size: 413 */
+{offset: 413, bytesPerRow: 7, rowsPerImage: 0}, {width: 1, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\u043a\u40e0\ue056',
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<workgroup> vw72: array<array<u32, 4>, 3>;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw71: vec2f;
+
+@group(0) @binding(100) var tex25: texture_2d<f32>;
+
+struct FragmentOutput10 {
+  @location(2) f0: u32,
+  @location(5) @interpolate(flat) f1: vec4u,
+  @location(6) f2: vec4i,
+  @location(0) @interpolate(linear) f3: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex12(@location(8) a0: vec4u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = round(vec4f(bitcast<f32>(a0[0])));
+  out = bitcast<vec4f>(countLeadingZeros(bitcast<vec2i>(refract(vec4h(unconst_f16(-7896.5), unconst_f16(3035.3), unconst_f16(21453.3), unconst_f16(2784.5)), vec4h(unconst_f16(22647.7), unconst_f16(1752.0), unconst_f16(7151.0), unconst_f16(6536.4)), f16(unconst_f16(8957.6))))).xxyy);
+  out = vec4f(refract(vec4h(ldexp(vec4f(unconst_f32(-0.1899), unconst_f32(0.04771), unconst_f32(0.06357), unconst_f32(0.4243)), vec4i(unconst_i32(226), unconst_i32(102), unconst_i32(1), unconst_i32(3)))), vec4h(unconst_f16(3004.7), unconst_f16(5086.4), unconst_f16(3033.0), unconst_f16(2438.9)), f16(unconst_f16(2391.1))));
+  var vf264: vec4h = refract(vec4h(unconst_f16(14792.9), unconst_f16(19266.9), unconst_f16(1535.6), unconst_f16(3982.8)), vec4h(step(vec3f(unconst_f32(0.07899), unconst_f32(0.2236), unconst_f32(0.1481)), vec3f(unconst_f32(0.06837), unconst_f32(-0.05239), unconst_f32(0.00785))).rgrb), vec4h(round(vec4f(unconst_f32(0.3117), unconst_f32(0.04261), unconst_f32(0.3338), unconst_f32(0.01250)))).b);
+  vf264 *= vec4h(vf264[u32(log2(log2(vec3h(unconst_f16(24658.9), unconst_f16(8591.1), unconst_f16(9673.0))))[1])]);
+  var vf265: f16 = vf264[a0[u32(unconst_u32(384))]];
+  vf264 -= vec4h(vf264[u32(unconst_u32(18))]);
+  vf265 -= f16(a0[1]);
+  var vf266: f16 = vf264[3];
+  var vf267: u32 = a0[0];
+  let ptr124: ptr<function, u32> = &vf267;
+  let vf268: vec3f = step(vec3f(unconst_f32(0.1556), unconst_f32(-0.03191), unconst_f32(0.2308)), vec3f(vf264.wyz));
+  let ptr125: ptr<function, f16> = &vf266;
+  let vf269: u32 = a0[vf267];
+  vf266 *= vf264[3];
+  let vf270: vec4h = refract(vec4h(unconst_f16(1769.3), unconst_f16(7100.6), unconst_f16(34045.2), unconst_f16(3192.9)), vec4h(unconst_f16(657.6), unconst_f16(2071.7), unconst_f16(3285.5), unconst_f16(-3698.5)), f16(unconst_f16(13644.1)));
+  var vf271: vec4f = round(vec4f(unconst_f32(0.01085), unconst_f32(0.01170), unconst_f32(0.2237), unconst_f32(-0.2062)));
+  let ptr126: ptr<function, u32> = &(*ptr124);
+  return out;
+}
+
+@fragment
+fn fragment12() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let vf272: vec2h = min(vec2h(unconst_f16(14196.2), unconst_f16(11840.2)), vec2h(unpack2x16snorm(bitcast<vec2u>(unpack2x16snorm(bitcast<vec3u>(sin(vec3f(unconst_f32(-0.02281), unconst_f32(0.05735), unconst_f32(0.02133))))[2]))[0])));
+  var vf273: f16 = sqrt(f16(unconst_f16(21849.0)));
+  var vf274: vec3f = sin(sin(vec3f(unconst_f32(0.6445), unconst_f32(0.3334), unconst_f32(0.07817))));
+  let vf275: f32 = vf274[2];
+  let vf276: vec4i = max(vec4i(unconst_i32(16), unconst_i32(132), unconst_i32(13), unconst_i32(148)), vec4i(sin(vec3f(f32(pack2x16snorm(vec2f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(-0.2309), unconst_f32(0.1449))))))))).bggg));
+  var vf277: f32 = sinh(f32(vf272[u32(unconst_u32(112))]));
+  vf277 = f32(vf276[1]);
+  var vf278: f16 = sqrt(f16(vf275));
+  out.f3 += vec4f(countTrailingZeros(vec4u(min(vec2h(unconst_f16(-9757.3), unconst_f16(3462.8)), min(bitcast<vec2h>(pack2x16snorm(vec2f(unconst_f32(0.2292), unconst_f32(0.1754)))), bitcast<vec2h>(pack2x16snorm(vec2f(unconst_f32(0.1185), unconst_f32(0.04848)))))).rgrr)));
+  let vf279: vec2h = min(vec2h(unconst_f16(10518.9), unconst_f16(34956.2)), bitcast<vec2h>(vf274[2]));
+  out = FragmentOutput10(u32(vf275), unpack4xU8(bitcast<u32>(vf275)), vec4i(bitcast<i32>(vf275)), vec4f(vf275));
+  out = FragmentOutput10(bitcast<u32>(vf274[2]), unpack4xU8(bitcast<u32>(vf274[2])), vec4i(i32(vf274[2])), vec4f(vf274[2]));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11() {
+  let ptr127: ptr<workgroup, array<u32, 4>> = &(*&vw72)[2];
+  vw72[2][u32(unconst_u32(91))] |= vw72[2][3];
+  vw72[2][pack4xU8(vec4u(unconst_u32(96), unconst_u32(153), unconst_u32(135), unconst_u32(57)))] >>= (*ptr127)[3];
+  vw72[vw72[pack2x16float(workgroupUniformLoad(&vw71))][3]][pack4xI8Clamp(vec4i(unconst_i32(344), unconst_i32(417), unconst_i32(460), unconst_i32(91)))] = (*&vw72)[2][u32(unconst_u32(275))];
+  var vf280: u32 = textureNumLevels(tex25);
+  let ptr128: ptr<workgroup, array<u32, 4>> = &(*ptr127);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder135 = device0.createCommandEncoder({label: '\u0147\uac83\u0d89\u{1fdc5}\u{1faf6}\udad4\u2ce0\u0e4d\u062a'});
+let textureView143 = texture127.createView({label: '\u0d29\u{1fb0c}\u{1fe40}', mipLevelCount: 1});
+let computePassEncoder104 = commandEncoder135.beginComputePass({});
+let sampler75 = device0.createSampler({
+  label: '\u2de4\ub55f\ufbaf',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.71,
+  lodMaxClamp: 64.12,
+});
+try {
+renderPassEncoder34.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 840, new BigUint64Array(16964), 2122, 24);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u291f\u1c61\u{1f975}\u02df\u0322\u294c\ub199',
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+struct FragmentOutput11 {
+  @location(0) @interpolate(flat, sample) f0: vec4f,
+}
+
+@group(0) @binding(180) var st7: texture_storage_2d_array<r32float, read_write>;
+
+var<workgroup> vw83: atomic<u32>;
+
+var<workgroup> vw79: vec2<bool>;
+
+struct T0 {
+  @align(2) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw78: vec2h;
+
+var<workgroup> vw81: atomic<u32>;
+
+var<workgroup> vw74: vec2f;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw76: atomic<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw77: FragmentOutput11;
+
+var<workgroup> vw82: FragmentOutput11;
+
+var<workgroup> vw75: mat3x4h;
+
+var<workgroup> vw80: mat2x3h;
+
+var<workgroup> vw73: mat4x3f;
+
+@vertex
+fn vertex13(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf281: f16 = distance(f16(unconst_f16(-24398.3)), vec3h(faceForward(vec3f(abs(f32(unconst_f32(0.01658)))), vec3f(atan2(f32(unconst_f32(0.1034)), f32(unconst_f32(0.2720)))), vec3f(unconst_f32(-0.1975), unconst_f32(-0.1668), unconst_f32(0.06178))))[2]);
+  out = cross(vec3f(unconst_f32(0.01974), unconst_f32(0.1191), unconst_f32(0.07196)), vec3f(unconst_f32(0.1020), unconst_f32(-0.07611), unconst_f32(0.00581))).zyzx;
+  out -= vec4f(f32(vf281));
+  let vf282: f32 = atan2(f32(unconst_f32(-0.5705)), f32(unconst_f32(0.08930)));
+  out = faceForward(vec3f(vf282), vec3f(unconst_f32(0.09319), unconst_f32(0.3628), unconst_f32(0.1657)), vec3f(vf282)).zxzy;
+  out = cross(vec3f(unconst_f32(0.00288), unconst_f32(0.1218), unconst_f32(0.06353)), vec3f(unconst_f32(0.3483), unconst_f32(0.1329), unconst_f32(0.07664))).bbrb;
+  var vf283: vec3h = cross(vec3h(unconst_f16(50784.2), unconst_f16(-1212.2), unconst_f16(16958.7)), vec3h(unconst_f16(2153.2), unconst_f16(2944.5), unconst_f16(16134.1)));
+  vf283 *= vec3h(f16(length(vec4f(unconst_f32(0.5815), unconst_f32(0.03499), unconst_f32(0.4683), unconst_f32(-0.1812)))));
+  var vf284: f16 = distance(f16(unconst_f16(998.0)), f16(unconst_f16(31318.7)));
+  var vf285: u32 = a0;
+  let vf286: vec3h = cross(vec3h(f16(vf285)), vec3h(unconst_f16(10756.3), unconst_f16(13993.8), unconst_f16(2366.6)));
+  let vf287: f16 = distance(f16(unconst_f16(1191.3)), f16(unconst_f16(3864.3)));
+  vf283 = vec3h(cross(vec3f(unconst_f32(0.2400), unconst_f32(0.1677), unconst_f32(0.05837)), vec3f(unconst_f32(0.1256), unconst_f32(0.2167), unconst_f32(0.02869))));
+  out -= vec4f(reverseBits(vec3i(unconst_i32(719), unconst_i32(147), unconst_i32(379))).bbrr);
+  vf285 <<= bitcast<u32>(length(vec4f(unconst_f32(0.04508), unconst_f32(0.08210), unconst_f32(0.03666), unconst_f32(0.2981))));
+  let vf288: f32 = length(vec4f(unconst_f32(0.4279), unconst_f32(0.1280), unconst_f32(0.06168), unconst_f32(0.9199)));
+  var vf289: vec3h = cross(vec3h(unconst_f16(32518.6), unconst_f16(1984.0), unconst_f16(7665.0)), vec3h(unconst_f16(20411.4), unconst_f16(3781.4), unconst_f16(1083.9)));
+  vf284 = vf289[u32(unconst_u32(302))];
+  let vf290: u32 = a1;
+  vf285 += u32(distance(f16(unconst_f16(6793.8)), f16(a1)));
+  out = vec4f(reverseBits(vec2u(vf289.yz)).gggg);
+  vf283 = vec3h(f16(a0));
+  var vf291: f16 = vf287;
+  vf283 = vec3h(faceForward(vec3f(unconst_f32(0.5028), unconst_f32(-0.04301), unconst_f32(0.03659)), vec3f(f32(a1)), vec3f(unconst_f32(0.1548), unconst_f32(0.00964), unconst_f32(0.02405))));
+  let vf292: f16 = vf283[u32(vf289[0])];
+  return out;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  let vf293: vec3h = atanh(vec3h(f16(min(u32(unconst_u32(121)), u32(unconst_u32(142))))));
+  var vf294: vec2f = ceil(vec2f(unconst_f32(0.1748), unconst_f32(0.2587)));
+  let vf295: i32 = min(i32(unconst_i32(356)), vec4i(refract(vec4h(unconst_f16(38508.9), unconst_f16(9946.0), unconst_f16(1037.9), unconst_f16(31009.3)), refract(step(vec2h(degrees(tanh(degrees(vec4f(unconst_f32(0.1124), unconst_f32(0.1444), unconst_f32(0.02795), unconst_f32(0.07983))))).yw), vec2h(f16(all(bool(unconst_bool(true)))))).yxxx, vec4h(unconst_f16(195.9), unconst_f16(16747.4), unconst_f16(4599.2), unconst_f16(6854.1)), f16(unconst_f16(3705.2))), f16(unconst_f16(5352.6)))).w);
+  var vf296: vec2h = step(vec2h(unconst_f16(5488.9), unconst_f16(2366.3)), vec2h(unconst_f16(1690.2), unconst_f16(-1521.0)));
+  var vf297: f16 = asin(f16(unconst_f16(2662.1)));
+  let vf298: vec3h = vf293;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute12() {
+  let vf299: vec2f = cosh(vec2f((*&vw74)[0]));
+  let ptr129: ptr<workgroup, atomic<u32>> = &vw81;
+  atomicCompareExchangeWeak(&vw76, unconst_u32(239), unconst_u32(46));
+  vw82.f0 = (*&vw82).f0;
+  let ptr130: ptr<workgroup, vec4f> = &(*&vw77).f0;
+  let vf300: f16 = (*&vw75)[0][2];
+  let vf301: f16 = (*&vw75)[0][2];
+  let vf302: mat4x3f = workgroupUniformLoad(&vw73);
+  var vf303: vec2h = workgroupUniformLoad(&vw78);
+}`,
+  sourceMap: {},
+});
+let bindGroup74 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 42, resource: textureView21}, {binding: 137, resource: textureView104}],
+});
+let texture130 = device0.createTexture({size: [768], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView144 = texture64.createView({label: '\u5d4d\u{1ff14}\u3f50', dimension: '1d', baseArrayLayer: 0});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(1, bindGroup44, new Uint32Array(7005), 5_430, 0);
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 137, resource: textureView5},
+    {binding: 223, resource: textureView7},
+    {binding: 429, resource: {buffer: buffer19, offset: 512, size: 156}},
+    {binding: 62, resource: textureView30},
+  ],
+});
+let commandEncoder136 = device0.createCommandEncoder({label: '\u06da\ua3f4\u0108\u17fc\u8c32\ue6b6\uc5d2\u{1f6db}\ubc1f\u051f\u0ad8'});
+let textureView145 = texture3.createView({arrayLayerCount: 1});
+let computePassEncoder105 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup60, new Uint32Array(76), 13, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle5]);
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder();
+let texture131 = device0.createTexture({
+  size: [60, 4, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder36 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView128,
+  clearValue: { r: -380.7, g: 695.0, b: 894.1, a: -1.586, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(2, bindGroup61, new Uint32Array(2985), 181, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer15, 852); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup13, new Uint32Array(1063), 134, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer81, 'uint32', 18_100, 1_142);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 624, new DataView(new ArrayBuffer(1102)), 307, 140);
+} catch {}
+try {
+globalThis.someLabel = pipeline7.label;
+} catch {}
+let texture132 = device0.createTexture({
+  label: '\u577f\u{1ff78}\u2ddb',
+  size: {width: 768, height: 1, depthOrArrayLayers: 35},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView146 = texture123.createView({label: '\u073e\u0bcc', mipLevelCount: 1});
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({label: '\u33f0\uba54'});
+let texture133 = device0.createTexture({
+  size: [21, 10, 12],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView147 = texture35.createView({});
+let renderPassEncoder37 = commandEncoder138.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  depthSlice: 31,
+  clearValue: { r: -773.8, g: 161.1, b: -565.9, a: -724.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 178662552,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup57, new Uint32Array(9010), 408, 0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer71, 0, 1_968);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet12, 251, 3, buffer78, 1792);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let textureView148 = texture97.createView({});
+let renderPassEncoder38 = commandEncoder110.beginRenderPass({
+  label: '\u0fc3\uf982\uda8d\ua6fa\u{1f79d}\u16d5\u0f01\u3070\u2c90\u0376',
+  colorAttachments: [{view: textureView59, depthSlice: 30, loadOp: 'clear', storeOp: 'discard'}],
+});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.06,
+  lodMaxClamp: 97.87,
+  maxAnisotropy: 3,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup68, new Uint32Array(92), 53, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img6);
+let textureView149 = texture104.createView({format: 'rgba8unorm', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup29);
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 190, resource: textureView127}, {binding: 144, resource: textureView108}],
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: {width: 168},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup76);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup70, new Uint32Array(1602), 202, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup37, new Uint32Array(1718), 25, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer61, 'uint32', 1_312, 7_189);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer56);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder139.copyBufferToBuffer(buffer22, 788, buffer56, 672, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(35).fill(230), /* required buffer size: 35 */
+{offset: 35}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let buffer84 = device0.createBuffer({size: 14853, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder140 = device0.createCommandEncoder({label: '\u6a50\u2c03\u{1fdc5}\u{1f8f7}\u04df\u888c'});
+let texture135 = device0.createTexture({
+  label: '\u06ef\uabdf\u30c8',
+  size: {width: 42, height: 20, depthOrArrayLayers: 32},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1); };
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup77 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 50, resource: textureView84}]});
+let texture136 = device0.createTexture({
+  size: [1536, 1, 1],
+  mipLevelCount: 6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView150 = texture34.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder106 = commandEncoder139.beginComputePass({label: '\u3bd9\udc16\u{1fd40}\u{1fb3b}\u{1fa4c}\u0ced\u0662\u114e\u{1f6a3}\u0d58\u{1f792}'});
+try {
+computePassEncoder106.setPipeline(pipeline6);
+} catch {}
+let textureView151 = texture7.createView({});
+let computePassEncoder107 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup67, new Uint32Array(434), 93, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer37, 'uint32', 6_944, 4_316);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer82);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let buffer85 = device0.createBuffer({size: 9044, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture137 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 37},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView152 = texture38.createView({});
+let computePassEncoder108 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder51.setBindGroup(3, bindGroup17, [0]);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup70);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer66, 'uint32', 0, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1536, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 60 },
+  flipY: false,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 507, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer86 = device0.createBuffer({
+  size: 37286,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder142 = device0.createCommandEncoder({});
+let texture138 = device0.createTexture({
+  label: '\u61cf\ub677',
+  size: [60, 4, 1],
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({label: '\ubf48\u0a47\u018f\u023a\u6c13\ude38', colorFormats: ['rgba8unorm'], stencilReadOnly: false});
+let sampler77 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 62.68, lodMaxClamp: 73.85});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup37, new Uint32Array(229), 0, 0);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer57, 116, 189);
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 201, y: 0, z: 53},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let computePassEncoder109 = commandEncoder142.beginComputePass({});
+let renderPassEncoder39 = commandEncoder141.beginRenderPass({
+  label: '\u0a75\uf009\u0790\u0c7d\u02f1\u{1ffb6}',
+  colorAttachments: [{view: textureView70, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 982605914,
+});
+let renderBundle21 = renderBundleEncoder21.finish();
+let sampler78 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.18,
+  lodMaxClamp: 30.15,
+});
+try {
+computePassEncoder107.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup57, new Uint32Array(3679), 218, 0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(589);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer76, 'uint16', 294, 456);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 160, new BigUint64Array(2426), 111, 8);
+} catch {}
+let buffer87 = device0.createBuffer({size: 10597, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let texture139 = device0.createTexture({size: [84], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup71, new Uint32Array(878), 45, 0);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle5, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer82, 'uint32', 5_588, 380);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 83, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(448).fill(122), /* required buffer size: 448 */
+{offset: 448, bytesPerRow: 107}, {width: 7, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  label: '\ufa56\u069f\u93ec\u0411\u{1fa9c}',
+  layout: bindGroupLayout16,
+  entries: [{binding: 626, resource: sampler6}],
+});
+let textureView153 = texture121.createView({});
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer82, 'uint32', 548, 1_460);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 88, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(180).fill(158), /* required buffer size: 180 */
+{offset: 180, rowsPerImage: 2}, {width: 42, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let buffer88 = device0.createBuffer({
+  label: '\u18a8\u0fda\u02f3\u{1fdd5}\u613c\u0f0f\u088f',
+  size: 4086,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture140 = device0.createTexture({
+  size: [384],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView154 = texture68.createView({format: 'rgba8unorm', mipLevelCount: 2, baseArrayLayer: 39, arrayLayerCount: 2});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(28).fill(224), /* required buffer size: 28 */
+{offset: 28}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = commandEncoder37.label;
+} catch {}
+let sampler79 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 33.25,
+});
+try {
+computePassEncoder108.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(99, 0, 15, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer23, 'uint32', 596, 236);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  label: '\u1b7e\u0fa4\u{1fe29}\udfcf\u07b7\u53f0',
+  layout: bindGroupLayout22,
+  entries: [{binding: 160, resource: textureView125}],
+});
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup31, new Uint32Array(1062), 246, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer41, 'uint32', 3_592, 1_335);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let buffer89 = device0.createBuffer({size: 2652, usage: GPUBufferUsage.UNIFORM});
+let textureView155 = texture14.createView({label: '\u0cd1\u54fa\u3fe6\u0817', dimension: '2d', aspect: 'depth-only', baseArrayLayer: 1});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer61, 4_884, 993);
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\uecc6\u3981\ua092\ubd52',
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let bindGroup80 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 87, resource: textureView57},
+    {binding: 351, resource: {buffer: buffer79, offset: 768, size: 2344}},
+  ],
+});
+let querySet17 = device0.createQuerySet({label: '\u{1fc43}\u02ff\u1bef\u3b35\u081a\u{1f615}', type: 'occlusion', count: 300});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup77, new Uint32Array(3745), 332, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 5, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 130,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture141 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture142 = device0.createTexture({
+  label: '\u09ed\u54cd\ucf3f\u{1f65f}\uf120',
+  size: [42],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder104.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer57, 'uint32', 256, 64);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer46, 544);
+} catch {}
+let arrayBuffer19 = buffer82.getMappedRange(840);
+try {
+  await promise17;
+} catch {}
+let texture143 = device0.createTexture({
+  size: [168, 80, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle16]);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u67c6');
+} catch {}
+let textureView156 = texture59.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup50, []);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer82, 'uint16', 802, 557);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer36, 1_616);
+} catch {}
+let texture144 = device0.createTexture({
+  size: [60],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer24, 720);
+} catch {}
+try {
+  await buffer69.mapAsync(GPUMapMode.WRITE, 0, 904);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\uec56');
+} catch {}
+document.body.append(canvas0);
+let imageData13 = new ImageData(16, 12);
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'film', transfer: 'smpte170m'} });
+let commandEncoder143 = device0.createCommandEncoder({});
+let textureView157 = texture73.createView({});
+let computePassEncoder110 = commandEncoder143.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup68, new Uint32Array(652), 218, 0);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer56, 4);
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView158 = texture6.createView({baseMipLevel: 0});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup25, new Uint32Array(730), 16, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder39.setStencilReference(130);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer61, 'uint32', 1_912, 112);
+} catch {}
+let buffer90 = device0.createBuffer({
+  size: 507,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder144 = device0.createCommandEncoder();
+let texture145 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView159 = texture77.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 5});
+let computePassEncoder111 = commandEncoder144.beginComputePass();
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder23.finish();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer46, 0, 184);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData14 = new ImageData(24, 96);
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup58, []);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle19, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 14, y: 3, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  label: '\u0e88\uf6bd\u0d71\u0a01',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 11, resource: {buffer: buffer29, offset: 0, size: 52}},
+    {binding: 411, resource: textureView103},
+  ],
+});
+let buffer91 = device0.createBuffer({size: 6658, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], sampleCount: 1});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer77, 'uint32', 276, 437);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder();
+let computePassEncoder112 = commandEncoder145.beginComputePass();
+let renderBundle24 = renderBundleEncoder24.finish();
+try {
+computePassEncoder112.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 33}
+*/
+{
+  source: imageData3,
+  origin: { x: 7, y: 12 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer92 = device0.createBuffer({
+  label: '\ub063\u5039\u7001\u6af6\ud337',
+  size: 16648,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView160 = texture57.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder40 = commandEncoder146.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 77,
+  clearValue: { r: -731.7, g: -756.8, b: -342.7, a: 771.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 115229494,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup26, new Uint32Array(1569), 370, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup47, new Uint32Array(4062), 2_025, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 8712, new Float32Array(27), 7, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder();
+let textureView161 = texture145.createView({format: 'r32float'});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup28, new Uint32Array(260), 46, 0);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer79, 4496, buffer73, 1936, 5492);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({
+  size: [240, 16, 60],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler80 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.45,
+  lodMaxClamp: 81.66,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup31, new Uint32Array(998), 83, 0);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u0065');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 4, depthOrArrayLayers: 93}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(5, 440);
+let bindGroup82 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 4, resource: {buffer: buffer18, offset: 4096, size: 3416}},
+    {binding: 42, resource: textureView4},
+  ],
+});
+let buffer93 = device0.createBuffer({size: 467, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder113 = commandEncoder148.beginComputePass({label: '\u05aa\u0ddf\ud9e0'});
+try {
+computePassEncoder113.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle11, renderBundle11]);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer38, 3872, buffer45, 544, 96);
+} catch {}
+let texture147 = device0.createTexture({
+  size: {width: 30, height: 2, depthOrArrayLayers: 46},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder41 = commandEncoder147.beginRenderPass({
+  label: '\uc22c\uc2fd\u{1fc5b}',
+  colorAttachments: [{
+  view: textureView160,
+  clearValue: { r: -587.9, g: -296.9, b: 365.3, a: -324.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 668234686,
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup65, new Uint32Array(1708), 270, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup6, new Uint32Array(1184), 182, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 2228, new DataView(new ArrayBuffer(8956)), 338, 4252);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 187}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 46},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+computePassEncoder74.setBindGroup(0, bindGroup50, new Uint32Array(4591), 1_424, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup64, new Uint32Array(2138), 466, 0);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -106.2, g: 448.7, b: 889.2, a: -946.9, });
+} catch {}
+try {
+computePassEncoder67.pushDebugGroup('\u{1f894}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 14, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(106), /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 9, rowsPerImage: 127}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas0.getContext('webgpu');
+let buffer94 = device0.createBuffer({size: 1062, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let textureView162 = texture129.createView({aspect: 'all'});
+try {
+renderPassEncoder32.setIndexBuffer(buffer29, 'uint16', 274, 3);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let imageData15 = new ImageData(108, 52);
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout19]});
+let commandEncoder149 = device0.createCommandEncoder();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 157});
+let renderPassEncoder42 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 21,
+  clearValue: { r: 510.9, g: 169.3, b: 185.8, a: -207.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 726094246,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup81, new Uint32Array(18), 6, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder67.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(165), /* required buffer size: 52 */
+{offset: 52}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture148 = device0.createTexture({
+  size: [384, 1, 8],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer68, 'uint32', 840, 1_032);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer85, 0, 12);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(152, 143);
+let textureView163 = texture80.createView({dimension: '2d-array', format: 'bgra8unorm-srgb', mipLevelCount: 1});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r16uint']});
+let sampler81 = device0.createSampler({
+  label: '\ua9ad\u424d\ucc34\u0c2c\uc8c1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.32,
+  lodMaxClamp: 70.38,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer29);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageData16 = new ImageData(4, 28);
+let bindGroup83 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 125, resource: textureView66},
+    {binding: 67, resource: {buffer: buffer8, offset: 256, size: 1280}},
+  ],
+});
+let textureView164 = texture112.createView({label: '\u002a\u0d97\ubbb5\ub73e\u0e0a\u75b1', mipLevelCount: 1});
+let textureView165 = texture107.createView({dimension: '2d', baseArrayLayer: 19});
+try {
+renderPassEncoder21.setViewport(18.47580889705263, 2.8487104355742643, 12.695415338927747, 2.3883273769342814, 0.5581941874664734, 0.7006646505849701);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 2, y: 6, z: 5},
+  aspect: 'all',
+}, new Uint8Array(247).fill(156), /* required buffer size: 247 */
+{offset: 175, bytesPerRow: 24, rowsPerImage: 9}, {width: 12, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule10,
+  constants: {override23: 0},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex10',
+    constants: {override23: 0},
+    buffers: [
+      {
+        arrayStride: 632,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 8},
+          {format: 'float32x2', offset: 76, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {},
+});
+let commandEncoder150 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder150.beginComputePass({});
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 62.76,
+  lodMaxClamp: 71.35,
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup49, new Uint32Array(2087), 4, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: canvas2,
+  origin: { x: 19, y: 40 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder151 = device0.createCommandEncoder({});
+let texture149 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView166 = texture5.createView({dimension: '2d', format: 'rgba8unorm', mipLevelCount: 1});
+let computePassEncoder115 = commandEncoder151.beginComputePass({label: '\u{1fc06}\u{1fe0c}\u0c41\ua5d1\uc585\ue750\u997e\u{1f933}'});
+let renderBundle25 = renderBundleEncoder25.finish();
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup22, new Uint32Array(2578), 519, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle22, renderBundle7, renderBundle20, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(405);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer50, 1_100);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 256, resource: {buffer: buffer32, offset: 256, size: 556}}],
+});
+let buffer95 = device0.createBuffer({size: 3427, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder152 = device0.createCommandEncoder();
+let textureView167 = texture141.createView({dimension: '2d', format: 'rgba16float', arrayLayerCount: 1});
+let texture150 = device0.createTexture({
+  size: [768, 1, 1],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder116 = commandEncoder152.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup46, new Uint32Array(14), 3, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline10);
+} catch {}
+document.body.append(canvas2);
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 168,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 29,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder153 = device0.createCommandEncoder({});
+let computePassEncoder117 = commandEncoder153.beginComputePass();
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.85,
+  lodMaxClamp: 75.82,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder117.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer80, 'uint16', 3_574, 1_036);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2668 */
+  offset: 2668,
+  bytesPerRow: 512,
+  rowsPerImage: 409,
+  buffer: buffer19,
+}, {
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer96 = device0.createBuffer({size: 6178, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer55, 0);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(buffer27, 4876, buffer74, 840, 6764);
+} catch {}
+try {
+adapter0.label = '\u00a8\u04e1\u0c0f\udf1d\u0933\u5068\u3d89\u5017\u6396\u{1fe98}';
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({label: '\u0a62\ue688\u7764\u302c\u01fe', type: 'occlusion', count: 453});
+let computePassEncoder118 = commandEncoder154.beginComputePass({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder100); computePassEncoder100.dispatchWorkgroupsIndirect(buffer61, 2_756); };
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup72, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 216, new DataView(new ArrayBuffer(1755)), 117, 84);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas1.getContext('webgpu');
+let img8 = await imageWithData(37, 11, '#10101010', '#20202020');
+let texture151 = device0.createTexture({
+  size: {width: 168, height: 80, depthOrArrayLayers: 9},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder119 = commandEncoder109.beginComputePass({});
+let sampler84 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 17.03,
+  lodMaxClamp: 41.77,
+});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame14});
+try {
+computePassEncoder114.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer7, 'uint16', 3_708, 1_154);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(378).fill(14), /* required buffer size: 378 */
+{offset: 378}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let buffer97 = device0.createBuffer({
+  size: 11740,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView168 = texture57.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler85 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.43,
+  lodMaxClamp: 95.25,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup3, new Uint32Array(6550), 1_436, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup16, new Uint32Array(5754), 8, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup73, new Uint32Array(1662), 585, 0);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline7);
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame8);
+let bindGroup85 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 50, resource: textureView85}]});
+let renderBundle26 = renderBundleEncoder26.finish({label: '\u0991\ub2e7\u{1f853}\u{1fbf5}'});
+let sampler86 = device0.createSampler({
+  label: '\u1f90\u{1fb68}\u06f3\u{1fd8d}\u043f\ue01d\u{1f934}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.75,
+  lodMaxClamp: 88.38,
+  compare: 'equal',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder11.setViewport(190.6770430069375, 3.9160501575524407, 17.09172637797536, 1.01154780593108, 0.17866078708178978, 0.5644866036039797);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer45, 4_072);
+} catch {}
+try {
+renderPassEncoder11.pushDebugGroup('\ue02f');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(10_975).fill(202), /* required buffer size: 10_975 */
+{offset: 415, bytesPerRow: 55, rowsPerImage: 48}, {width: 34, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = externalTexture15.label;
+} catch {}
+let texture152 = device0.createTexture({
+  label: '\u{1fa97}\u7d8c\u{1fcd6}\u0bfd\u0138\u03ed',
+  size: {width: 120, height: 8, depthOrArrayLayers: 13},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView169 = texture118.createView({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup44, new Uint32Array(3214), 61, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer37, 'uint32', 2_960, 3_691);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 80, new BigUint64Array(7262), 361, 4);
+} catch {}
+let bindGroup86 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 106, resource: sampler13}]});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder100); computePassEncoder100.dispatchWorkgroupsIndirect(buffer15, 1_860); };
+} catch {}
+try {
+computePassEncoder100.end();
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup64, new Uint32Array(524), 63, 0);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: -30.50, g: -482.9, b: 286.1, a: -359.3, });
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\udf9e');
+} catch {}
+await gc();
+let renderPassEncoder43 = commandEncoder128.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 6,
+  clearValue: { r: -485.9, g: -110.2, b: 965.6, a: 766.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup27, new Uint32Array(3446), 48, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup36, new Uint32Array(1292), 135, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer82, 1_296);
+} catch {}
+let sampler87 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.78,
+  lodMaxClamp: 69.23,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup80, new Uint32Array(604), 29, 0);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup74);
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder();
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 429});
+let texture153 = device0.createTexture({
+  size: [60, 4, 1],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder120 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder120.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(10, 0, 17, 1);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer93, 'uint32', 24, 61);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline9);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 9}
+*/
+{
+  source: img1,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 47, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup32, new Uint32Array(3640), 573, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires pointer_composite_access;
+
+@id(27725) override override41: f32;
+
+@id(36336) override override40: bool;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0(a0: ptr<function, array<mat2x3h, 6>>) -> vec2u {
+  var out: vec2u;
+  let ptr131: ptr<storage, array<u32>, read> = &(*&buffer98).f0;
+  out *= vec2u((*a0)[5][1].rb);
+  var vf304: vec2u = min(vec2u(unconst_u32(47), unconst_u32(519)), unpack4xU8(u32(unconst_u32(23))).yw);
+  out <<= vec2u(arrayLength(&buffer98.f0));
+  vf304 |= vec2u(buffer98.f0[u32(unconst_u32(348))]);
+  vf304 = vec2u((*ptr131)[(*&buffer98).f0[arrayLength(&(*&buffer98).f0)]]);
+  let vf305: bool = override40;
+  var vf306: vec4i = insertBits(vec4i(unconst_i32(39), unconst_i32(105), unconst_i32(310), unconst_i32(3)), vec4i(unconst_i32(100), unconst_i32(96), unconst_i32(89), unconst_i32(103)), u32(unconst_u32(86)), buffer98.f0[u32(unconst_u32(213))]);
+  let vf307: vec2f = unpack2x16float(u32(unconst_u32(542)));
+  vf304 |= textureDimensions(tex26, bitcast<i32>(override35));
+  return out;
+  _ = override35;
+  _ = override40;
+}
+
+struct T0 {
+  @size(156) f0: array<u32>,
+}
+
+override override36: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(4) var<storage, read> buffer98: T0;
+
+override override44: f16;
+
+struct FragmentOutput13 {
+  @location(0) f0: u32,
+  @builtin(sample_mask) f1: u32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(14106) override override45: u32 = 103;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override39: i32;
+
+@group(0) @binding(42) var tex26: texture_2d<f32>;
+
+@id(64950) override override38: i32 = 137;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(5903) override override43: f16;
+
+fn fn2() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  fn1();
+  var vf313: f16 = override43;
+  out.f0 *= vec4f(bitcast<f32>((*&buffer98).f0[(*&buffer98).f0[arrayLength(&(*&buffer98).f0) - 1]]));
+  out.f0 = unpack4x8snorm(buffer98.f0[arrayLength(&buffer98.f0)]);
+  out.f0 = unpack4x8snorm(pack4xU8(unpack4xU8(u32(override36))));
+  out.f0 += smoothstep(vec4f(unconst_f32(0.00983), unconst_f32(0.2026), unconst_f32(0.1484), unconst_f32(0.00359)), vec4f(f32(buffer98.f0[bitcast<i32>(override36)])), vec4f(unconst_f32(0.8566), unconst_f32(0.2545), unconst_f32(0.1460), unconst_f32(0.1689)));
+  vw84 *= vec4h(f16(buffer98.f0[i32(unconst_i32(-59))]));
+  return out;
+  _ = override38;
+  _ = override37;
+  _ = override36;
+  _ = override43;
+}
+
+@id(53825) override override37: f16;
+
+fn fn1() -> vec2h {
+  var out: vec2h;
+  let vf308: f32 = fract(f32(unconst_f32(0.03613)));
+  let ptr132: ptr<storage, array<u32>, read> = &(*&buffer98).f0;
+  out = bitcast<vec2h>((*ptr132)[u32(unconst_u32(35))]);
+  var vf309: u32 = arrayLength(&buffer98.f0);
+  let ptr133: ptr<storage, u32, read> = &buffer98.f0[arrayLength(&buffer98.f0) - 1];
+  var vf310: f16 = override37;
+  let ptr134: ptr<storage, array<u32>, read> = &(*ptr132);
+  vf309 = (*&buffer98).f0[arrayLength(&(*&buffer98).f0)];
+  vf310 = f16(buffer98.f0[arrayLength(&buffer98.f0)]);
+  var vf311: f16 = override37;
+  let ptr135: ptr<storage, u32, read> = &(*&buffer98).f0[(*&buffer98).f0[arrayLength(&(*&buffer98).f0) - 1]];
+  vf311 -= f16(override38);
+  vf309 <<= vf309;
+  out = bitcast<vec2h>(buffer98.f0[arrayLength(&buffer98.f0)]);
+  let ptr136: ptr<storage, u32, read> = &(*ptr133);
+  let vf312: u32 = arrayLength(&(*ptr132));
+  let ptr137: ptr<storage, u32, read> = &(*&buffer98).f0[i32(unconst_i32(57))];
+  vf310 = f16(pack4xI8Clamp(vec4i(unconst_i32(305), unconst_i32(2), unconst_i32(219), unconst_i32(57))));
+  let ptr138: ptr<storage, u32, read> = &(*ptr132)[i32(unconst_i32(96))];
+  return out;
+  _ = override38;
+  _ = override37;
+}
+
+var<workgroup> vw84: vec4h;
+
+struct FragmentOutput12 {
+  @location(0) @interpolate(perspective, centroid) f0: vec4f,
+}
+
+struct VertexOutput10 {
+  @builtin(position) f37: vec4f,
+  @location(14) f38: f16,
+}
+
+override override42: u32 = 164;
+
+@id(23326) override override35: u32;
+
+@vertex
+fn vertex14(@location(1) a0: vec2i) -> VertexOutput10 {
+  var out: VertexOutput10;
+  out.f38 = f16((*&buffer98).f0[arrayLength(&(*&buffer98).f0)]);
+  var vf314: u32 = pack4xI8(vec4i(unconst_i32(47), unconst_i32(-65), unconst_i32(302), unconst_i32(138)));
+  vf314 = pack4xI8Clamp(countTrailingZeros(vec4i(unconst_i32(11), unconst_i32(437), unconst_i32(10), unconst_i32(125))));
+  out.f37 = vec4f(countTrailingZeros(vec4i(unconst_i32(14), unconst_i32(116), unconst_i32(182), unconst_i32(6))));
+  vf314 = bitcast<vec4u>(countTrailingZeros(vec4i(unconst_i32(48), unconst_i32(82), unconst_i32(219), unconst_i32(20))))[2];
+  let vf315: u32 = override35;
+  var vf316 = fn1();
+  let vf317: vec2f = atan2(vec2f(unconst_f32(0.1025), unconst_f32(0.2476)), vec2f(bitcast<f32>(override38)));
+  fn1();
+  let vf318: f16 = override43;
+  let vf319: f16 = override37;
+  vf314 ^= u32(a0.r);
+  var vf320: u32 = override35;
+  return out;
+  _ = override38;
+  _ = override37;
+  _ = override43;
+  _ = override35;
+}
+
+@fragment
+fn fragment14() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  let vf321: u32 = override45;
+  out = FragmentOutput12(vec4f(extractBits(vec2i(unconst_i32(192), unconst_i32(591)), u32(unconst_u32(47)), u32(unconst_u32(19))).rggg));
+  let vf322: vec4f = atan2(vec4f(unconst_f32(0.04813), unconst_f32(0.6358), unconst_f32(0.1187), unconst_f32(0.05406)), vec4f(bitcast<f32>(buffer98.f0[arrayLength(&buffer98.f0) - 1])));
+  out.f0 *= vec4f(f32(buffer98.f0[arrayLength(&buffer98.f0)]));
+  out.f0 = unpack4x8snorm((*&buffer98).f0[arrayLength(&(*&buffer98).f0)]);
+  return out;
+  _ = override45;
+}
+
+@fragment
+fn fragment15() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  out.f1 |= u32(determinant(mat2x2h(unconst_f16(-5368.8), unconst_f16(891.1), unconst_f16(3052.0), unconst_f16(10714.5))));
+  out.f1 = u32(override43);
+  var vf323: i32 = override38;
+  return out;
+  _ = override38;
+  _ = override43;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute13() {
+  var vf324 = fn2();
+  vw84 += vec4h(insertBits(vec4u((*&buffer98).f0[arrayLength(&(*&buffer98).f0) - 1]), vec4u(override42), (*&buffer98).f0[arrayLength(&(*&buffer98).f0) - 1], u32(unconst_u32(134))));
+  vw84 = vec4h(vf324.f0);
+  var vf325 = fn1();
+  vf324 = FragmentOutput12(vec4f(override41));
+  fn2();
+  vw84 = vec4h(f16((*&buffer98).f0[arrayLength(&(*&buffer98).f0) - 1]));
+  vw84 *= vec4h(f16(override41));
+  vw84 = vec4h(f16(arrayLength(&buffer98.f0)));
+  var vf326 = fn2();
+  fn1();
+  var vf327 = fn2();
+  var vf328: u32 = override45;
+  let vf329: vec3h = faceForward(vec3h(f16(arrayLength(&buffer98.f0))), vec3h(acosh(saturate(vec2f(override41)).rgrg).aaa), vec3h(unconst_f16(451.7), unconst_f16(12400.4), unconst_f16(3707.2)));
+  var vf330 = fn2();
+  var vf331: u32 = override45;
+  fn2();
+  _ = override45;
+  _ = override42;
+  _ = override38;
+  _ = override41;
+  _ = override36;
+  _ = override43;
+  _ = override37;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer99 = device0.createBuffer({
+  label: '\u1986\u{1fb9f}\u0f89\u0ee0\uef10\u3387\u{1fef8}\u4651\u09da\ub0f0',
+  size: 1000,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler88 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.02,
+  lodMaxClamp: 79.73,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder107.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(3, bindGroup3, new Uint32Array(2381), 615, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup77, new Uint32Array(681), 18, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer84, 5112, 1568);
+} catch {}
+document.body.prepend(img1);
+let buffer100 = device0.createBuffer({size: 13807, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder121 = commandEncoder156.beginComputePass({});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup77, new Uint32Array(7021), 293, 0);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline5);
+} catch {}
+document.body.prepend(img6);
+let commandEncoder157 = device0.createCommandEncoder({});
+let textureView170 = texture110.createView({label: '\u098c\u0999\uc25e', format: 'r16uint', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup49, new Uint32Array(296), 82, 0);
+} catch {}
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup55, new Uint32Array(2306), 876, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(34);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle9, renderBundle9, renderBundle16, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 1524 widthInBlocks: 381 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 840 */
+  offset: 840,
+  buffer: buffer17,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 199, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 381, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder157.copyTextureToBuffer({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 68 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1396 */
+  offset: 1396,
+  buffer: buffer46,
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule6, constants: {44_357: 0}}});
+let commandEncoder158 = device0.createCommandEncoder({});
+let renderPassEncoder44 = commandEncoder150.beginRenderPass({
+  colorAttachments: [{view: textureView73, depthSlice: 25, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer7, 'uint32', 40, 12_478);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer85, 0);
+} catch {}
+let sampler89 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.20,
+  lodMaxClamp: 87.76,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup12, [256]);
+} catch {}
+try {
+commandEncoder157.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1008 */
+  offset: 1008,
+  bytesPerRow: 32000,
+  buffer: buffer28,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 4, depthOrArrayLayers: 93}
+*/
+{
+  source: imageData14,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1f8a3}\ue0fa\u87e4\u0996';
+} catch {}
+let buffer101 = device0.createBuffer({size: 34983, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder159 = device0.createCommandEncoder({});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 376});
+let computePassEncoder122 = commandEncoder158.beginComputePass({});
+let renderPassEncoder45 = commandEncoder159.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  clearValue: { r: 2.263, g: 153.4, b: -856.9, a: -903.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder86.setBindGroup(3, bindGroup36, new Uint32Array(314), 103, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup45, new Uint32Array(6141), 636, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle19, renderBundle2, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder21.draw(218, 107, 920_143_509, 503_252_051);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(30, 157, 68, 789_265_698, 1_268_418_712);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer35, 708);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer36, 788);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder157.copyBufferToBuffer(buffer79, 1692, buffer75, 208, 1380);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView171 = texture50.createView({mipLevelCount: 1, baseArrayLayer: 11, arrayLayerCount: 2});
+let computePassEncoder123 = commandEncoder157.beginComputePass();
+let renderPassEncoder46 = commandEncoder160.beginRenderPass({
+  colorAttachments: [{
+  view: textureView163,
+  clearValue: { r: 419.1, g: -911.4, b: 758.5, a: -71.79, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+let sampler90 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.3339,
+  lodMaxClamp: 39.15,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup83, new Uint32Array(2663), 703, 0);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder21.draw(35, 133, 1_115_469_673, 84_334_418);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer21, 540);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer90, 0, 185);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+  await buffer47.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+renderPassEncoder43.insertDebugMarker('\u497e');
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 450,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture155 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder123.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup73, new Uint32Array(325), 51, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle24, renderBundle15, renderBundle23, renderBundle24, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(0, 2, 14, 1);
+} catch {}
+try {
+renderPassEncoder21.draw(165, 168, 739_188_667, 3_542_880_019);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(50, 14, 35, 991_865_355, 837_579_160);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer57, 16, 112);
+} catch {}
+let arrayBuffer20 = buffer70.getMappedRange(8, 148);
+await gc();
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer3, 1_600);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer65, 'uint16', 1_524, 1_512);
+} catch {}
+try {
+renderPassEncoder30.insertDebugMarker('\u0f4a');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img5);
+let commandEncoder161 = device0.createCommandEncoder({label: '\u6117\u{1fc00}\u{1f930}\uce32\ub149\u{1ff2e}\uba1d'});
+let computePassEncoder124 = commandEncoder161.beginComputePass({label: '\u0b2c\u0e36\u01d6'});
+try {
+computePassEncoder106.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(2, bindGroup72, new Uint32Array(1317), 7, 0);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer61, 536);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 5836, new DataView(new ArrayBuffer(7010)), 142, 856);
+} catch {}
+let texture156 = device0.createTexture({
+  size: [84, 40, 7],
+  mipLevelCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView172 = texture75.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 11});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true, stencilReadOnly: false});
+let sampler91 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 10.97,
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle5, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder34.setViewport(152.61950659922866, 14.381797979094417, 25.002197705208655, 0.7879062522381867, 0.6443073426735352, 0.7293150148056626);
+} catch {}
+try {
+renderPassEncoder21.draw(13, 80, 652_743_403, 1_775_530_207);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer57, 'uint16', 100, 34);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup82, new Uint32Array(247), 29, 0);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer56, 52, 14);
+} catch {}
+document.body.append(img6);
+let texture157 = gpuCanvasContext1.getCurrentTexture();
+let textureView173 = texture8.createView({baseMipLevel: 0});
+try {
+computePassEncoder108.setBindGroup(3, bindGroup8, new Uint32Array(654), 15, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(121, 28, 8, 37_790_025, 3_120_045_499);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer78, 'uint16', 88, 188);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(2, buffer37);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer44, 'uint16', 344, 228);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1536, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 14, y: 15 },
+  flipY: true,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 386, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer103 = device0.createBuffer({size: 4988, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let textureView174 = texture119.createView({dimension: '2d', mipLevelCount: 1});
+let sampler92 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.27,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(108).fill(23), /* required buffer size: 108 */
+{offset: 108, bytesPerRow: 103}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 4, resource: {buffer: buffer97, offset: 5632}}, {binding: 42, resource: textureView124}],
+});
+let texture158 = device0.createTexture({
+  size: [120, 8, 187],
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView175 = texture75.createView({
+  label: '\u069d\u12f5\u05b7\u{1f927}\u{1f664}\u00e6\u7298\u0779\u0407',
+  dimension: '2d',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder21.draw(93, 367, 2_592_567_814, 991_771_040);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup82, new Uint32Array(2310), 1_381, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(2, buffer74, 0, 828);
+} catch {}
+document.body.prepend(img1);
+let buffer104 = device0.createBuffer({
+  size: 11894,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder162 = device0.createCommandEncoder({});
+let renderPassEncoder47 = commandEncoder162.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: 688.3, g: -16.80, b: -384.0, a: -465.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle27 = renderBundleEncoder27.finish();
+let sampler93 = device0.createSampler({
+  label: '\u07b5\u{1f755}\uf98c\ue818\u0482\u9d67\u0dea\u0df0',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.406,
+  lodMaxClamp: 46.63,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer86, 'uint16', 1_542, 15_536);
+} catch {}
+let arrayBuffer21 = buffer47.getMappedRange(0, 0);
+try {
+commandEncoder86.copyBufferToBuffer(buffer50, 804, buffer68, 1172, 172);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3368 */
+  offset: 3368,
+  buffer: buffer74,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet7, 811, 0, buffer29, 0);
+} catch {}
+try {
+computePassEncoder36.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 2, depthOrArrayLayers: 46}
+*/
+{
+  source: canvas0,
+  origin: { x: 182, y: 2343 },
+  flipY: false,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder();
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 135});
+let computePassEncoder125 = commandEncoder86.beginComputePass({});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+renderPassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup21, new Uint32Array(210), 47, 0);
+} catch {}
+try {
+commandEncoder163.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 986 */
+  offset: 986,
+  bytesPerRow: 20224,
+  rowsPerImage: 300,
+  buffer: buffer83,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(175).fill(52), /* required buffer size: 175 */
+{offset: 175}, {width: 329, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img9 = await imageWithData(2, 48, '#10101010', '#20202020');
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder164 = device0.createCommandEncoder();
+try {
+computePassEncoder60.setBindGroup(0, bindGroup53, new Uint32Array(1111), 3, 0);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -578.4, g: 6.991, b: 308.9, a: 85.68, });
+} catch {}
+try {
+renderPassEncoder16.setViewport(40.331172298231365, 1.2025169310515897, 21.809195987838002, 2.647474925242204, 0.8305369195770725, 0.8900991607955225);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer57, 'uint32', 52, 52);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer27, 25388, buffer4, 40, 592);
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  label: '\u{1fb1e}\u{1f95d}',
+  layout: bindGroupLayout21,
+  entries: [{binding: 214, resource: textureView41}],
+});
+let commandEncoder165 = device0.createCommandEncoder({});
+let texture159 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 36},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder48 = commandEncoder164.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  clearValue: { r: -49.12, g: -964.0, b: 255.1, a: -953.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder163.clearBuffer(buffer81);
+} catch {}
+try {
+globalThis.someLabel = renderBundleEncoder24.label;
+} catch {}
+let textureView176 = texture75.createView({dimension: '2d', aspect: 'all', format: 'r8uint', mipLevelCount: 1, baseArrayLayer: 7});
+let computePassEncoder126 = commandEncoder165.beginComputePass({});
+let sampler94 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.11,
+  lodMaxClamp: 75.70,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder126.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(1, buffer103, 0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  label: '\uc175\u824b',
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 4, resource: {buffer: buffer0, offset: 768, size: 1316}},
+    {binding: 42, resource: textureView130},
+  ],
+});
+let texture160 = device0.createTexture({
+  size: [168, 80, 1],
+  mipLevelCount: 3,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder125.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle25, renderBundle25]);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup39, new Uint32Array(1073), 580, 0);
+} catch {}
+try {
+computePassEncoder72.popDebugGroup();
+} catch {}
+try {
+  await promise20;
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 23, resource: textureView126}, {binding: 130, resource: textureView159}],
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({label: '\u0cd4\u{1ff12}', colorFormats: ['r16uint'], stencilReadOnly: true});
+let sampler95 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.59,
+  lodMaxClamp: 84.72,
+});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup57, new Uint32Array(1456), 160, 0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(1, buffer37);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({});
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer91, 'uint32', 404, 1_879);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 1000, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(118).fill(125), /* required buffer size: 118 */
+{offset: 118}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView177 = texture156.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let renderPassEncoder49 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{
+  view: textureView163,
+  clearValue: { r: -995.9, g: 410.9, b: 622.7, a: 954.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler96 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 39.54,
+  lodMaxClamp: 88.45,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup80, new Uint32Array(4113), 584, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer10, 416, 4);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(3, undefined, 0);
+} catch {}
+try {
+commandEncoder166.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3580 */
+  offset: 3580,
+  buffer: buffer22,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer105 = device0.createBuffer({size: 13417, usage: GPUBufferUsage.INDIRECT});
+let texture161 = device0.createTexture({
+  size: {width: 168},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle28 = renderBundleEncoder29.finish({});
+try {
+computePassEncoder120.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 100, new BigUint64Array(7631), 129, 0);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView169}]});
+let buffer106 = device0.createBuffer({size: 1355, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder127 = commandEncoder166.beginComputePass({});
+let sampler97 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.52,
+  lodMaxClamp: 87.83,
+  compare: 'not-equal',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup2, new Uint32Array(1885), 34, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle0, renderBundle28]);
+} catch {}
+try {
+renderPassEncoder49.setBlendConstant({ r: -818.2, g: 824.1, b: -633.8, a: -834.5, });
+} catch {}
+try {
+renderPassEncoder45.insertDebugMarker('\u0b6e');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 5216, new Int16Array(10137), 630, 2228);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let commandEncoder167 = device0.createCommandEncoder({});
+let computePassEncoder128 = commandEncoder167.beginComputePass({label: '\u92fd\u0612\u07b1'});
+try {
+computePassEncoder4.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer34, 220);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer82, 'uint32', 3_908, 41);
+} catch {}
+try {
+  await buffer92.mapAsync(GPUMapMode.READ, 488);
+} catch {}
+try {
+renderBundleEncoder28.insertDebugMarker('\u377c');
+} catch {}
+let bindGroup92 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 106, resource: sampler56}]});
+let commandEncoder168 = device0.createCommandEncoder({label: '\u9368\u092e\u{1f959}\u88b6\ub2dd\u007f\u1536'});
+let texture162 = device0.createTexture({
+  label: '\u079a\u337f\ud0e5\u09a6',
+  size: [384, 1, 91],
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler98 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup73, new Uint32Array(442), 151, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(237);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer73, 'uint32', 500, 12_183);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData17 = new ImageData(20, 44);
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\udf11\u{1f8e8}\u3595\u0448\u{1f6a5}\u0e6f',
+  entries: [
+    {
+      binding: 121,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup93 = device0.createBindGroup({
+  label: '\u6f0f\u007e\u{1fea1}\u{1fdf2}\u0fec\uc30b\u51e1\u5a86',
+  layout: bindGroupLayout14,
+  entries: [{binding: 50, resource: textureView85}],
+});
+let buffer107 = device0.createBuffer({size: 17863, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderPassEncoder50 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView128,
+  clearValue: { r: -826.6, g: 827.5, b: -406.6, a: -768.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle29 = renderBundleEncoder30.finish({});
+try {
+computePassEncoder107.setBindGroup(3, bindGroup45, []);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup73, new Uint32Array(1213), 24, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup55, new Uint32Array(2534), 242, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle15, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer83, 'uint32', 632, 350);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer93, 'uint16', 48, 23);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 1808, new BigUint64Array(1213), 234, 16);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 223, resource: textureView7},
+    {binding: 62, resource: textureView37},
+    {binding: 137, resource: textureView5},
+    {binding: 429, resource: {buffer: buffer18, offset: 6912, size: 300}},
+  ],
+});
+let commandEncoder169 = device0.createCommandEncoder({});
+let renderBundle30 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup40, new Uint32Array(2833), 544, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup94, new Uint32Array(1243), 82, 0);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(207).fill(220), /* required buffer size: 207 */
+{offset: 207, rowsPerImage: 42}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 429, resource: {buffer: buffer73, offset: 2048, size: 5000}},
+    {binding: 223, resource: textureView35},
+    {binding: 137, resource: textureView5},
+    {binding: 62, resource: textureView22},
+  ],
+});
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: []});
+let renderPassEncoder51 = commandEncoder169.beginRenderPass({
+  label: '\u{1fc7c}\u{1f6b2}',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -161.4, g: -759.3, b: -734.9, a: 843.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 1632, new Int16Array(8303), 356, 916);
+} catch {}
+let imageData18 = new ImageData(8, 4);
+let buffer108 = device0.createBuffer({size: 5691, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder170 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder170.beginComputePass({});
+try {
+renderPassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = buffer99.label;
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder({});
+let renderPassEncoder52 = commandEncoder171.beginRenderPass({
+  label: '\u{1f63a}\u{1fe48}\u8f44\u0991\u{1faf4}\u096a',
+  colorAttachments: [{
+  view: textureView61,
+  clearValue: { r: -581.8, g: 9.421, b: -320.6, a: -247.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+let sampler99 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.165,
+});
+try {
+computePassEncoder129.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer81, 'uint16', 94, 1_625);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+offscreenCanvas1.width = 1010;
+let texture163 = gpuCanvasContext4.getCurrentTexture();
+let textureView178 = texture125.createView({});
+let sampler100 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.86,
+  lodMaxClamp: 74.46,
+  compare: 'less-equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(1, 0, 18, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 60.15,
+});
+try {
+computePassEncoder119.setBindGroup(2, bindGroup92, new Uint32Array(1190), 60, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4_294_967_295, undefined, 271_386_884, 318_577_923);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(3, bindGroup90, []);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup86);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer57, 'uint16', 214, 18);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer106);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 2600, new Int16Array(2631), 378, 16);
+} catch {}
+document.body.append(img5);
+let shaderModule18 = device0.createShaderModule({
+  label: '\u5479\u7f66\u3de4\uc10b\u{1fd62}\u6343\u04f8',
+  code: `
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn0() -> T0 {
+  var out: T0;
+  out.f0[u32(vp24.f0[1][0])][vec3u(cross(vec3h(unconst_f16(17196.6), unconst_f16(18783.2), unconst_f16(11187.3)), vec3h(unconst_f16(6369.1), unconst_f16(9572.2), unconst_f16(11961.5)))).r] *= f16(vp22[0].fract.r);
+  vp23 = modf(vp24.f0[1][0]);
+  var vf332: vec4h = log2(vec4h(unconst_f16(2001.7), unconst_f16(7984.3), unconst_f16(2529.9), unconst_f16(8063.1)));
+  out.f0[u32(unconst_u32(137))][u32(unconst_u32(504))] = vp24.f0[1][0];
+  vp22[pack4xU8Clamp(vec4u(log2(vec4h(exp2(vec4f(unconst_f32(0.1917), unconst_f32(0.1618), unconst_f32(-0.04282), unconst_f32(0.2676)))))))] = modf(trunc(vec2f(unconst_f32(-0.03198), unconst_f32(0.2389))).yyyy);
+  vp22[u32(unconst_u32(148))].whole = vec4f(f32(any(bool(reflect(vec3h(unconst_f16(3284.8), unconst_f16(6242.6), unconst_f16(4592.4)), vec3h(unconst_f16(1498.3), unconst_f16(2263.8), unconst_f16(6790.2))).b))));
+  let ptr139 = &vp22[u32(vp24.f0[1][0])];
+  vf332 = bitcast<vec4h>(trunc(vec2f(unconst_f32(0.07052), unconst_f32(0.06345))));
+  vp23.fract *= vp24.f0[1][0];
+  let ptr140: ptr<private, array<array<f16, 1>, 2>> = &vp24.f0;
+  vp24.f0[u32(vp24.f0[1][0])][0] -= vp24.f0[1][0];
+  let ptr141: ptr<private, f16> = &vp23.whole;
+  var vf333: vec3h = reflect(vec3h((*ptr139).whole.yzz), vec3h(vp24.f0[1][u32(unconst_u32(32))]));
+  vf332 -= vec4h(f16(any(bool((*ptr139).whole[0]))));
+  vp23 = modf(f16(any(bool(vp22[0].fract.a))));
+  out.f0[u32(unconst_u32(27))][u32((*ptr141))] = f16((*ptr139).whole[1]);
+  let ptr142: ptr<private, f16> = &(*ptr140)[1][0];
+  var vf334: bool = any(bool(unconst_bool(false)));
+  let ptr143: ptr<function, bool> = &vf334;
+  vf333 *= vec3h(vp22[0].whole.zxy);
+  return out;
+}
+
+@group(0) @binding(190) var tex27: texture_2d_array<f32>;
+
+var<private> vp23 = modf(f16());
+
+fn fn1(a0: FragmentOutput16, a1: f16, a2: ptr<function, array<array<array<FragmentOutput14, 1>, 1>, 56>>, a3: array<array<array<array<vec2<bool>, 1>, 1>, 1>, 1>, a4: ptr<uniform, f32>, a5: ptr<private, vec2h>, a6: vec2f, a7: array<T4, 1>, a8: array<S2, 33>, a9: ptr<storage, vec4h, read_write>, a10: ptr<uniform, mat4x3h>, a11: ptr<function, array<array<f16, 1>, 21>>, a12: ptr<private, S2>, a13: array<vec2<bool>, 14>, a14: array<mat2x2h, 11>, a15: u32, a16: array<array<FragmentOutput14, 1>, 13>, a17: ptr<storage, array<array<f16, 1>, 1>, read>, a18: T0, a19: ptr<workgroup, array<atomic<u32>, 15>>, a20: array<f32, 4>, a21: ptr<uniform, vec4<bool>>, a22: ptr<storage, vec2i, read>, a23: i32, a24: ptr<storage, array<u32>, read_write>, a25: ptr<storage, array<u32>, read>, a26: array<T4, 3>, a27: ptr<storage, array<u32>, read>, a28: ptr<private, mat3x2f>, a29: mat3x4h, a30: ptr<storage, array<u32>, read_write>, a31: array<array<array<bool, 1>, 1>, 25>, a32: mat4x2f, a33: ptr<private, vec4f>, a34: ptr<storage, mat3x3f, read>, a35: FragmentOutput14, a36: ptr<private, u32>, a37: array<S2, 14>, a38: ptr<storage, array<u32>, read>, a39: mat3x2f, a40: ptr<storage, T1, read>, a41: ptr<workgroup, mat4x4f>, a42: ptr<storage, array<u32>, read_write>, a43: ptr<storage, array<u32>, read>, a44: ptr<storage, array<u32>, read>, a45: ptr<workgroup, atomic<u32>>, a46: FragmentOutput16, a47: ptr<uniform, vec4u>, a48: ptr<uniform, mat4x2f>, a49: ptr<private, vec2h>) -> FragmentOutput16 {
+  var out: FragmentOutput16;
+  let vf335: f32 = a20[u32(unconst_u32(575))];
+  fn0();
+  (*a49) += vec2h((*a11)[20][0]);
+  return out;
+}
+
+var<private> vp22 = array(modf(vec4f()));
+
+struct S2 {
+  @builtin(sample_mask) f0: u32,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct FragmentOutput14 {
+  @location(0) f0: u32,
+}
+
+struct FragmentOutput16 {
+  @location(0) @interpolate(flat, center) f0: u32,
+  @location(3) @interpolate(flat, centroid) f1: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T2 {
+  @align(2) @size(12) f0: atomic<u32>,
+}
+
+fn fn2() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  var vf336: vec3i = max(bitcast<vec3i>(vp22[0].fract.xxw), bitcast<vec3i>(log2(unpack2x16snorm(textureNumLayers(tex27))).rrg));
+  var vf337: i32 = vf336[0];
+  vp22[u32(unconst_u32(72))] = modf(unpack4x8unorm(pack2x16snorm(vec2f(unconst_f32(0.07266), unconst_f32(0.1302)))));
+  var vf338: vec2f = ldexp(vec2f(unconst_f32(0.1670), unconst_f32(0.1093)), vec2i(unconst_i32(181), unconst_i32(134)));
+  var vf339: u32 = textureNumLayers(tex27);
+  return out;
+}
+
+struct T4 {
+  @align(2) @size(16) f0: u32,
+}
+
+struct FragmentOutput15 {
+  @location(0) f0: vec2u,
+  @location(3) @interpolate(linear) f1: vec2f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp24: T0 = T0();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @size(8) f0: array<u32>,
+}
+
+struct T3 {
+  f0: array<u32>,
+}
+
+@group(0) @binding(144) var st8: texture_storage_3d<rgba8uint, read>;
+
+struct T0 {
+  @size(8) f0: array<array<f16, 1>, 2>,
+}
+
+@vertex
+fn vertex15(@location(7) @interpolate(flat) a0: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp22[u32(unconst_u32(59))] = modf(atan2(vec3f(unconst_f32(0.2129), unconst_f32(0.1574), unconst_f32(0.2385)), vec3f(unconst_f32(-0.00253), unconst_f32(0.3341), unconst_f32(-0.1555))).zxzx);
+  var vf340 = fn2();
+  var vf341 = fn2();
+  fn2();
+  var vf342 = fn2();
+  vf341.f0 = vec2u(u32(length(vec2h(unconst_f16(10051.2), unconst_f16(6600.3)))));
+  let vf343: f32 = vf341.f1[1];
+  vp24.f0[u32(unconst_u32(649))][u32(unconst_u32(122))] = vec4h(normalize(unpack4x8unorm(textureNumLayers(tex27))))[3];
+  fn2();
+  vf341.f1 *= vp22[0].whole.gr;
+  vf340 = FragmentOutput15(vec2u(bitcast<u32>(determinant(mat2x2f(unconst_f32(0.00281), unconst_f32(0.00697), unconst_f32(0.4094), unconst_f32(0.02241))))), vec2f(determinant(mat2x2f(unconst_f32(0.00281), unconst_f32(0.00697), unconst_f32(0.4094), unconst_f32(0.02241)))));
+  vf342 = FragmentOutput15(bitcast<vec2u>(vf342.f1), vf342.f1);
+  vf341.f1 = vec2f(f32(determinant(mat2x2h(f16(a0[u32(unconst_u32(181))]), f16(a0[u32(unconst_u32(181))]), f16(a0[u32(unconst_u32(181))]), f16(a0[u32(unconst_u32(181))])))));
+  fn2();
+  return out;
+}
+
+@fragment
+fn fragment16() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  fn0();
+  let ptr144: ptr<private, array<f16, 1>> = &vp24.f0[1];
+  var vf344 = fn0();
+  vp23 = modf(f16(min(vec4f(unconst_f32(0.5707), unconst_f32(0.1297), unconst_f32(0.01470), unconst_f32(0.1165)), vec4f(unconst_f32(-0.2641), unconst_f32(0.01816), unconst_f32(-0.4490), unconst_f32(0.7144)))[0]));
+  out.f0 &= pack4xU8Clamp(bitcast<vec4u>(sinh(vec4f(unconst_f32(0.03486), unconst_f32(0.00811), unconst_f32(0.02107), unconst_f32(0.05335)))));
+  return out;
+}
+
+@fragment
+fn fragment17(a0: S2) -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  var vf345: f16 = acos(vp23.fract);
+  vp22[bitcast<u32>(saturate(trunc(vec4h(unconst_f16(4502.2), unconst_f16(842.5), unconst_f16(6786.2), unconst_f16(5472.4))).rr))].whole -= vp22[0].whole;
+  vf345 += vp24.f0[1][0];
+  var vf346 = fn0();
+  return out;
+}
+
+@fragment
+fn fragment18() -> FragmentOutput16 {
+  var out: FragmentOutput16;
+  let ptr145: ptr<private, f16> = &vp23.fract;
+  vp24.f0[u32(vp24.f0[1][0])][u32(unconst_u32(274))] -= (*ptr145);
+  let ptr146 = &vp22[0];
+  var vf347: u32 = dot4U8Packed(u32(unconst_u32(152)), u32(unconst_u32(178)));
+  out.f1 = vp22[0].fract.z;
+  vp22[u32(unconst_u32(33))] = modf(vec4f(f32(vf347)));
+  vp22[0] = vp22[0];
+  let ptr147: ptr<private, vec4f> = &(*ptr146).fract;
+  let ptr148: ptr<private, array<f16, 1>> = &vp24.f0[u32(unconst_u32(188))];
+  let ptr149: ptr<private, array<f16, 1>> = &vp24.f0[u32(unconst_u32(68))];
+  vf347 *= u32((*ptr147)[2]);
+  var vf348 = fn0();
+  var vf349 = fn0();
+  vp23.fract -= vec4h((*ptr147))[2];
+  let ptr150 = &vp22[0];
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer109 = device0.createBuffer({
+  size: 8972,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder172 = device0.createCommandEncoder({});
+let texture164 = device0.createTexture({
+  size: [84, 40, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView179 = texture30.createView({dimension: '2d'});
+let computePassEncoder130 = commandEncoder172.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup83);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup10, new Uint32Array(370), 58, 0);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(7, buffer9);
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup44, new Uint32Array(1057), 324, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup9, new Uint32Array(37), 1, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer85, 0, 593);
+} catch {}
+try {
+renderPassEncoder11.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(154), /* required buffer size: 27 */
+{offset: 27, rowsPerImage: 8}, {width: 158, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer110 = device0.createBuffer({
+  label: '\u4416\uc718\u{1f683}\u10b0\udf82\u{1fe91}',
+  size: 14153,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let texture165 = device0.createTexture({
+  size: {width: 60, height: 4, depthOrArrayLayers: 66},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture166 = device0.createTexture({
+  size: [60, 4, 93],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler102 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.97,
+  lodMaxClamp: 79.32,
+});
+try {
+computePassEncoder99.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle25, renderBundle29, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+let buffer111 = device0.createBuffer({
+  size: 357,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder173 = device0.createCommandEncoder({});
+let computePassEncoder131 = commandEncoder173.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 196, new DataView(new ArrayBuffer(5891)), 748, 1028);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 168, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 11, y: 20, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder15.setBindGroup(2, bindGroup37, new Uint32Array(317), 9, 0);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle5, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(90.74651883216885, 5.576756344944124, 18.740301820637775, 2.067165383290511, 0.45341957067865535, 0.711959008148878);
+} catch {}
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView36}]});
+let texture167 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder131.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup90, new Uint32Array(863), 13, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder38.setBindGroup(3, bindGroup3, new Uint32Array(1515), 36, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 464, new BigUint64Array(628), 68, 48);
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 7863,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder174 = device0.createCommandEncoder({});
+let textureView180 = texture70.createView({mipLevelCount: 2});
+try {
+computePassEncoder107.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1000 */
+  offset: 1000,
+  bytesPerRow: 16128,
+  buffer: buffer38,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder69.popDebugGroup();
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule3}});
+let buffer113 = device0.createBuffer({size: 14686, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 123});
+let renderPassEncoder53 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 45,
+  clearValue: { r: -421.4, g: -8.033, b: 647.6, a: -335.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler103 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 81.97,
+  lodMaxClamp: 91.34,
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup29);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  layout: pipelineLayout6,
+  compute: {module: shaderModule17, constants: {5_903: 0, 53_825: 0, override36: 0, 27_725: 0}},
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn fn0() -> vec4<bool> {
+  var out: vec4<bool>;
+  let vf350: u32 = vp25.f1[0];
+  let ptr151: ptr<private, vec2f> = &vp25.f2;
+  let vf351: vec2f = trunc(bitcast<vec2f>(textureDimensions(tex28, unpack4xI8(u32(unconst_u32(10)))[0])));
+  let vf352: vec2u = textureDimensions(tex28, bitcast<i32>(fract(vec2h(unconst_f16(810.1), unconst_f16(21345.8)))));
+  var vf353: u32 = pack2x16float(vec2f(unconst_f32(-0.5301), unconst_f32(0.2146)));
+  let vf354: u32 = textureNumLayers(tex28);
+  var vf355: u32 = textureNumLayers(tex28);
+  vf355 ^= vp25.f1.g;
+  var vf356: u32 = pack4xU8Clamp(vec4u(bitcast<u32>(vp25.f2[u32(unconst_u32(66))])));
+  vf353 <<= vf352.g;
+  let vf357: f32 = vf351[1];
+  vf355 = bitcast<u32>((*ptr151)[u32(unconst_u32(183))]);
+  vp25 = FragmentOutput18(vf355, vec2u(vf355), unpack2x16float(vf355));
+  let vf358: f16 = vp26[u32(unconst_u32(4))];
+  let vf359: f32 = vf351[u32(unconst_u32(76))];
+  let vf360: f16 = mix(f16(vp25.f1.x), f16(unconst_f16(485.2)), f16(unconst_f16(-5067.1)));
+  out = vec4<bool>(bool(textureNumLevels(tex28)));
+  var vf361: u32 = pack2x16unorm(vec2f(unconst_f32(0.1955), unconst_f32(0.2870)));
+  let ptr152: ptr<function, u32> = &vf356;
+  vf355 -= u32(vf351.r);
+  vp25.f0 = bitcast<vec4u>(sqrt(vec4f(f32(vp26[bitcast<u32>(vp27)])))).b;
+  var vf362: vec4f = textureLoad(tex28, vec2i(bitcast<i32>(textureNumLevels(tex28))), i32(vf352[pack2x16unorm(unpack2x16float(u32(unconst_u32(352))))]), bitcast<vec2i>(vf352)[0]);
+  let vf363: vec2u = textureDimensions(tex28);
+  vp25.f1 ^= vf352;
+  vf355 += pack4xU8Clamp(vec4u(unconst_u32(52), unconst_u32(38), unconst_u32(175), unconst_u32(68)));
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw88: mat3x4h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp27: f32 = f32();
+
+struct VertexOutput11 {
+  @location(15) @interpolate(linear) f39: f16,
+  @location(6) @interpolate(flat, centroid) f40: vec2u,
+  @location(13) @interpolate(perspective, sample) f41: vec2f,
+  @invariant @builtin(position) f42: vec4f,
+  @location(11) @interpolate(perspective, sample) f43: vec2f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw86: FragmentOutput17;
+
+var<workgroup> vw85: mat2x2h;
+
+var<workgroup> vw87: array<atomic<u32>, 13>;
+
+var<private> vp26: vec4h = vec4h();
+
+@group(0) @binding(190) var tex28: texture_2d_array<f32>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+@group(0) @binding(144) var st9: texture_storage_3d<rgba8uint, read>;
+
+struct T1 {
+  @size(48) f0: array<u32>,
+}
+
+struct FragmentOutput18 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2u,
+  @location(7) @interpolate(perspective, center) f2: vec2f,
+}
+
+struct FragmentOutput17 {
+  @location(0) f0: vec4u,
+  @location(4) f1: vec4u,
+  @builtin(sample_mask) f2: u32,
+}
+
+var<private> vp25: FragmentOutput18 = FragmentOutput18();
+
+@vertex
+fn vertex16(@location(9) a0: i32, @location(1) a1: i32, @location(7) @interpolate(flat, centroid) a2: vec2u) -> VertexOutput11 {
+  var out: VertexOutput11;
+  out.f40 = bitcast<vec2u>(log(inverseSqrt(vec3h(f16(vp25.f1[pack4xU8Clamp(textureLoad(st9, vec3i(inverseSqrt(faceForward(vec3h(unconst_f16(6012.5), unconst_f16(4801.1), unconst_f16(3915.9)), vec3h(f16(vp25.f1[1])), vec3h(unconst_f16(6161.1), unconst_f16(28307.4), unconst_f16(2270.7)))))))]))).zxyy));
+  let ptr153: ptr<private, vec2f> = &vp25.f2;
+  var vf364 = fn0();
+  let vf365: vec2h = acos(vec2h(unconst_f16(646.3), unconst_f16(2415.0)));
+  var vf366 = fn0();
+  return out;
+}
+
+@fragment
+fn fragment19() -> FragmentOutput17 {
+  var out: FragmentOutput17;
+  let ptr154: ptr<private, u32> = &vp25.f0;
+  vp25 = FragmentOutput18(u32(vp26.w), bitcast<vec2u>(vp26), bitcast<vec2f>(vp26));
+  var vf367: u32 = vp25.f1[u32(unconst_u32(30))];
+  vp25 = FragmentOutput18(bitcast<u32>(vp25.f2[1]), bitcast<vec2u>(vp25.f2), vp25.f2);
+  var vf368: vec3u = countOneBits(vec3u(unconst_u32(114), unconst_u32(244), unconst_u32(33)));
+  let ptr155: ptr<private, vec2u> = &vp25.f1;
+  let ptr156: ptr<private, u32> = &(*ptr154);
+  var vf369: vec3h = normalize(vec3h(unconst_f16(31741.7), unconst_f16(42894.3), unconst_f16(5704.0)));
+  let ptr157: ptr<function, u32> = &vf367;
+  let ptr158: ptr<private, FragmentOutput18> = &vp25;
+  vp26 -= vec4h(f16((*ptr158).f0));
+  return out;
+}
+
+@fragment
+fn fragment20() -> FragmentOutput18 {
+  var out: FragmentOutput18;
+  discard;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute14(@builtin(global_invocation_id) a0: vec3u) {
+  let vf370: f16 = atan(f16(unconst_f16(31178.2)));
+  atomicMin(&vw87[u32(unconst_u32(121))], u32(unconst_u32(138)));
+  atomicMax(&vw87[u32(unconst_u32(449))], u32((*&vw88)[2][u32(faceForward(vec2f(vp27), vec2f(workgroupUniformLoad(&vw85)[0]), vec2f(unconst_f32(0.2528), unconst_f32(0.06998))).x)]));
+  vw88 = mat3x4h(f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))), f16(dot(vec4u(unconst_u32(150), unconst_u32(257), unconst_u32(52), unconst_u32(517)), unpack4xU8(bitcast<u32>(vp27)))));
+  vp26 = vec4h((*&vw86).f1);
+  let ptr159: ptr<workgroup, vec4u> = &vw86.f0;
+  let ptr160: ptr<workgroup, vec4h> = &vw88[1];
+  vw88 = mat3x4h(vec4h((*ptr159)), vec4h((*ptr159)), vec4h((*ptr159)));
+  let ptr161: ptr<workgroup, vec4h> = &(*&vw88)[2];
+  let ptr162: ptr<workgroup, array<atomic<u32>, 13>> = &(*&vw87);
+  let vf371: f16 = vw85[1][u32(unconst_u32(273))];
+  atomicCompareExchangeWeak(&vw87[u32(unconst_u32(28))], unconst_u32(2), unconst_u32(96));
+  vw88 += mat3x4h(f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))), f16(atomicExchange(&(*&vw87)[12], bitcast<u32>((*&vw85)[0]))));
+  atomicMax(&vw87[a0[u32(unconst_u32(52))]], u32(unconst_u32(7)));
+  vp25.f2 -= unpack2x16snorm(atomicExchange(&(*&vw87)[12], u32(unconst_u32(122))));
+  vp25 = FragmentOutput18(u32((*&vw85)[u32(unconst_u32(7))][vw86.f1[u32(unconst_u32(115))]]), vec2u(u32((*&vw85)[u32(unconst_u32(7))][vw86.f1[u32(unconst_u32(115))]])), vec2f(f32((*&vw85)[u32(unconst_u32(7))][vw86.f1[u32(unconst_u32(115))]])));
+  let ptr163: ptr<workgroup, vec4h> = &(*ptr160);
+  atomicCompareExchangeWeak(&vw87[a0[0]], unconst_u32(624), unconst_u32(424));
+  var vf372: f16 = vw88[1][1];
+  let ptr164: ptr<private, vec4h> = &vp26;
+  var vf373: u32 = atomicExchange(&(*&vw87)[12], u32(unconst_u32(163)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 30, resource: textureView14},
+    {binding: 48, resource: textureView81},
+    {binding: 37, resource: {buffer: buffer90, offset: 0, size: 32}},
+    {binding: 205, resource: textureView63},
+    {binding: 78, resource: textureView106},
+  ],
+});
+let commandEncoder175 = device0.createCommandEncoder();
+let textureView181 = texture89.createView({format: 'r8uint', mipLevelCount: 1});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup44, new Uint32Array(116), 35, 0);
+} catch {}
+try {
+commandEncoder175.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2238 */
+  offset: 2238,
+  bytesPerRow: 35584,
+  buffer: buffer88,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 24, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder175.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 22, y: 65, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture163,
+  mipLevel: 0,
+  origin: {x: 0, y: 34, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let textureView182 = texture98.createView({arrayLayerCount: 8});
+let sampler104 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 85.78,
+  lodMaxClamp: 96.02,
+});
+try {
+renderPassEncoder30.setIndexBuffer(buffer55, 'uint16', 42, 477);
+} catch {}
+try {
+buffer93.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+adapter0.label = '\u0e1d\u{1fd5f}\ue5f3\u01ad\uc73f';
+} catch {}
+let buffer114 = device0.createBuffer({
+  size: 2925,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture168 = device0.createTexture({size: [32, 32, 325], dimension: '3d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.06,
+  lodMaxClamp: 62.24,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup8, new Uint32Array(429), 11, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer76, 'uint32', 828, 3_096);
+} catch {}
+let bindGroup98 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 214, resource: textureView41}]});
+let commandEncoder176 = device0.createCommandEncoder({label: '\ucae3\u07c9\u{1fd92}\u42ea\u924c\u2887\u05e0\u0dd5\u36fe\ue4b1'});
+let textureView183 = texture117.createView({
+  label: '\uebcd\u{1fcc4}\u{1f9f8}\u051c\u0219\u0bd3\u8b15\u923b\u008b',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let computePassEncoder132 = commandEncoder176.beginComputePass({});
+let renderPassEncoder54 = commandEncoder175.beginRenderPass({colorAttachments: [{view: textureView93, loadOp: 'clear', storeOp: 'discard'}]});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], sampleCount: 1});
+let sampler106 = device0.createSampler({
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.59,
+  lodMaxClamp: 99.33,
+});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup92, []);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer57, 224);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup19, new Uint32Array(444), 102, 0);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer13, 340, 705);
+} catch {}
+let imageData19 = new ImageData(44, 132);
+let commandEncoder177 = device0.createCommandEncoder({});
+let textureView184 = texture125.createView({});
+let computePassEncoder133 = commandEncoder177.beginComputePass({});
+try {
+computePassEncoder122.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup76, new Uint32Array(2567), 199, 0);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(2, buffer82);
+} catch {}
+let bindGroup99 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView75}]});
+let texture169 = device0.createTexture({
+  size: [192, 1, 17],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle32 = renderBundleEncoder32.finish({label: '\ueebb\u2901\u40fe\u881a\u2929'});
+let sampler107 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 85.47,
+  lodMaxClamp: 97.95,
+});
+try {
+renderPassEncoder38.setIndexBuffer(buffer36, 'uint16', 1_500, 893);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline9);
+} catch {}
+let buffer115 = device0.createBuffer({
+  size: 1783,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder178 = device0.createCommandEncoder({label: '\u0a0e\u061f\u{1fafa}\uf469\u06f1\u62c4\u981e\ubc31\u{1fa2e}\u3865'});
+let computePassEncoder134 = commandEncoder178.beginComputePass();
+try {
+computePassEncoder46.setBindGroup(3, bindGroup41, new Uint32Array(917), 297, 0);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(2, buffer112, 0, 1_585);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(142).fill(207), /* required buffer size: 142 */
+{offset: 142}, {width: 164, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView75}]});
+let buffer116 = device0.createBuffer({
+  size: 3061,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView185 = texture106.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true});
+let sampler108 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.02,
+  lodMaxClamp: 87.93,
+});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer3, 'uint32', 740, 3_147);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer56, 72, 167);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup100);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 128, new DataView(new ArrayBuffer(50138)), 13664, 4);
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder();
+let textureView186 = texture166.createView({mipLevelCount: 1});
+try {
+computePassEncoder134.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup31, new Uint32Array(2577), 40, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer44, 'uint32', 448, 118);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, buffer36);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup56);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer78, 'uint32', 76, 3_074);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise21;
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 256, resource: {buffer: buffer111, offset: 0, size: 92}}],
+});
+let buffer117 = device0.createBuffer({
+  size: 12355,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder180 = device0.createCommandEncoder({});
+let renderPassEncoder55 = commandEncoder179.beginRenderPass({
+  colorAttachments: [{
+  view: textureView159,
+  clearValue: { r: 342.8, g: 984.1, b: 486.3, a: -677.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet13,
+});
+let renderBundle33 = renderBundleEncoder33.finish({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(0, bindGroup95, new Uint32Array(4009), 390, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 311.5, g: -106.2, b: -620.7, a: 764.4, });
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer34, 0);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 21}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 5, y: 7 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView187 = texture142.createView({aspect: 'all'});
+let computePassEncoder135 = commandEncoder180.beginComputePass({});
+try {
+computePassEncoder135.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+commandEncoder181.copyBufferToTexture({
+  /* bytesInLastRow: 1904 widthInBlocks: 476 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2488 */
+  offset: 2488,
+  bytesPerRow: 5632,
+  buffer: buffer63,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 476, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 2184, new Int16Array(1840), 47, 144);
+} catch {}
+let texture170 = device0.createTexture({
+  size: [192, 1, 17],
+  mipLevelCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView188 = texture110.createView({});
+let renderPassEncoder56 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView160,
+  clearValue: { r: -748.0, g: 424.5, b: 520.2, a: -257.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: -742.9, g: -204.9, b: -340.4, a: 25.27, });
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 416, new Int16Array(3530), 872, 1092);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder();
+let computePassEncoder136 = commandEncoder182.beginComputePass({});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer99, 'uint32', 388, 330);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline0);
+} catch {}
+let imageData20 = new ImageData(24, 88);
+let texture171 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView189 = texture13.createView({dimension: '2d-array'});
+try {
+computePassEncoder136.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(img3);
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer118 = device0.createBuffer({
+  label: '\u4e70\u{1f674}\u397f\u7b8d\u06a1',
+  size: 5285,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+});
+let commandEncoder183 = device0.createCommandEncoder({label: '\u03ad\u{1f9d0}\u{1fa31}'});
+let renderPassEncoder57 = commandEncoder183.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 31,
+  clearValue: { r: -628.7, g: -671.2, b: 447.2, a: 710.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler109 = device0.createSampler({
+  label: '\u23b3\u8583\uc7ce\ud67a\u7e33',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  lodMinClamp: 99.33,
+  lodMaxClamp: 99.44,
+});
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'film', transfer: 'smpte170m'} });
+let textureView190 = texture102.createView({baseArrayLayer: 2, arrayLayerCount: 9});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer40, 'uint16', 232, 518);
+} catch {}
+try {
+computePassEncoder38.pushDebugGroup('\u3d8c');
+} catch {}
+let commandEncoder184 = device0.createCommandEncoder({});
+let texture172 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView191 = texture6.createView({dimension: '1d'});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup101, new Uint32Array(756), 13, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+texture47.destroy();
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let sampler110 = device0.createSampler({
+  label: '\u{1f767}\u4b3f\ud19c\u06d8',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 21.79,
+  lodMaxClamp: 57.47,
+});
+try {
+gpuCanvasContext5.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let computePassEncoder137 = commandEncoder184.beginComputePass({});
+let sampler111 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.96,
+  lodMaxClamp: 74.36,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder20.setIndexBuffer(buffer101, 'uint32', 4_024, 3_459);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup102 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 429, resource: {buffer: buffer6, offset: 768, size: 448}},
+    {binding: 62, resource: textureView119},
+    {binding: 223, resource: textureView35},
+    {binding: 137, resource: textureView5},
+  ],
+});
+let buffer119 = device0.createBuffer({
+  size: 6568,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture173 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup98);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setViewport(5.623054577669251, 0.2943462982871423, 41.138167358155755, 0.42656648691906507, 0.08572130206307205, 0.23690912002385223);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer21, 'uint16', 420, 591);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(0, buffer117, 0, 1_559);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise22;
+} catch {}
+let buffer120 = device0.createBuffer({
+  size: 46322,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let computePassEncoder138 = commandEncoder185.beginComputePass({});
+try {
+renderPassEncoder16.executeBundles([renderBundle22]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 25, y: 15, z: 18},
+  aspect: 'all',
+}, new Uint8Array(681).fill(226), /* required buffer size: 681 */
+{offset: 160, bytesPerRow: 261}, {width: 65, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55); };
+} catch {}
+let commandEncoder186 = device0.createCommandEncoder({});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: true});
+let sampler112 = device0.createSampler({
+  label: '\u188b\u2259\u{1fcae}\u0b35\udfed\ud599\uebec\ud99e',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.26,
+  lodMaxClamp: 91.24,
+});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup41, new Uint32Array(1920), 307, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup19, new Uint32Array(152), 38, 0);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup76, new Uint32Array(2395), 62, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer102, 'uint16', 16, 8);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer46);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3046 */
+  offset: 3046,
+  bytesPerRow: 24576,
+  buffer: buffer7,
+}, {
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder186.copyTextureToBuffer({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1460 */
+  offset: 1460,
+  bytesPerRow: 6912,
+  buffer: buffer80,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  multisample: {mask: 0xaab4907},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment20',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule18,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 224,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x4', offset: 8, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.prepend(canvas3);
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: []});
+let querySet24 = device0.createQuerySet({label: '\ub249\ub921\u5803\u0198', type: 'occlusion', count: 126});
+let computePassEncoder139 = commandEncoder186.beginComputePass({label: '\u78b2\u1907\uc8b9\u{1f66e}\u{1fd68}\u34d5\u6e07\u0a5a\ua47e\u8671\u8e09'});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup64, new Uint32Array(1942), 1_249, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer55, 'uint16', 4_914, 634);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer97, 0, 1_683);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer97, 'uint32', 4_736, 2_140);
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  label: '\udf2a\u4e4a\uda74\u8ded\u{1fde2}',
+  layout: pipelineLayout6,
+  multisample: {mask: 0x6d09e541},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment7',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule17,
+    constants: {53_825: 0, 5_903: 0, 64_950: 0, 23_326: 0},
+    buffers: [
+      {arrayStride: 84, stepMode: 'instance', attributes: [{format: 'sint32', offset: 0, shaderLocation: 1}]},
+    ],
+  },
+});
+let commandEncoder187 = device0.createCommandEncoder({});
+let texture174 = device0.createTexture({
+  size: [32],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder140 = commandEncoder187.beginComputePass();
+let renderBundle34 = renderBundleEncoder34.finish({label: '\ua26e\u0639\u9fa4\u0f4b\u0a79\u0af4\uadeb\u4f07\u5724\ue11b\u{1f905}'});
+try {
+computePassEncoder138.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup96, new Uint32Array(634), 568, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6]);
+} catch {}
+let arrayBuffer22 = buffer70.getMappedRange(160, 52);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 18 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 11, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData21 = new ImageData(68, 8);
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup83, new Uint32Array(306), 24, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u{1f79b}\u0e58\u{1fd6c}\u76e1\ubba7\u0bfa\u36d0\ub531\uab5f\u764b';
+} catch {}
+let buffer121 = device0.createBuffer({
+  size: 9007,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder188 = device0.createCommandEncoder();
+let texture175 = device0.createTexture({
+  size: {width: 42},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder58 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 78,
+  clearValue: { r: 275.5, g: 6.772, b: -152.4, a: 342.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup93, new Uint32Array(515), 105, 0);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle8, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer0, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+canvas3.height = 1246;
+let offscreenCanvas2 = new OffscreenCanvas(186, 39);
+try {
+computePassEncoder103.label = '\ubbc7\u18da';
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\u1f7a\u{1fb4c}\uda5d\u1f2a\u0826\u3d66\u{1ff50}\u041b\u0244',
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let texture176 = device0.createTexture({
+  size: [84, 40, 7],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView192 = texture21.createView({aspect: 'all'});
+try {
+computePassEncoder140.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle25, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer3, 'uint16', 448, 1_094);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(7, buffer79, 1_332, 8_902);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup103 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 106, resource: sampler29}]});
+let buffer122 = device0.createBuffer({size: 87, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder189 = device0.createCommandEncoder({});
+let computePassEncoder141 = commandEncoder189.beginComputePass({label: '\u3dc3\uaa0f\u4236\ufec9\u031c\u{1f729}\ub41f\u551d\u{1fc73}\u1704'});
+try {
+computePassEncoder141.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let sampler113 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 85.96,
+  lodMaxClamp: 95.26,
+  compare: 'equal',
+});
+try {
+renderPassEncoder38.executeBundles([renderBundle15, renderBundle9]);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas2.getContext('webgpu');
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+document.body.append(canvas1);
+let commandEncoder190 = device0.createCommandEncoder({});
+let computePassEncoder142 = commandEncoder190.beginComputePass();
+try {
+computePassEncoder98.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder47.insertDebugMarker('\ufb24');
+} catch {}
+let texture177 = device0.createTexture({
+  size: [1536, 1, 1],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView193 = texture149.createView({mipLevelCount: 1});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+renderPassEncoder13.setViewport(24.318073493041574, 0.5278464668920728, 13.975581670953357, 1.5956834794626602, 0.4269848254421661, 0.660872364454564);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer6, 'uint32', 1_256, 536);
+} catch {}
+let videoFrame17 = new VideoFrame(imageBitmap4, {timestamp: 0});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup78);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(3, bindGroup45, new Uint32Array(1692), 126, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle16, renderBundle5, renderBundle5, renderBundle23, renderBundle24, renderBundle24, renderBundle30, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u{1fbcf}');
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture178 = device0.createTexture({
+  size: {width: 30, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder51.setIndexBuffer(buffer9, 'uint16', 3_760, 49);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(3, buffer55, 1_192);
+} catch {}
+let buffer123 = device0.createBuffer({size: 26596, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture179 = device0.createTexture({
+  size: [384, 1, 20],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+let img10 = await imageWithData(97, 22, '#10101010', '#20202020');
+let buffer124 = device0.createBuffer({size: 1921, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let textureView194 = texture71.createView({arrayLayerCount: 1});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], depthReadOnly: true, stencilReadOnly: true});
+let sampler114 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.48,
+  lodMaxClamp: 97.21,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder131.setBindGroup(1, bindGroup102);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(2, bindGroup44, new Uint32Array(1671), 1_363, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup47, new Uint32Array(1383), 145, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer76, 'uint16', 416, 2_984);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup12, new Uint32Array(563), 68, 1);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer101, 'uint32', 344, 2_557);
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 37, resource: {buffer: buffer32, offset: 2304, size: 60}},
+    {binding: 205, resource: textureView21},
+    {binding: 30, resource: textureView53},
+    {binding: 48, resource: textureView53},
+    {binding: 78, resource: textureView91},
+  ],
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 345});
+let renderPassEncoder59 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -960.4, g: -249.2, b: 135.8, a: 452.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 22870910,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup90);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(2, bindGroup71, new Uint32Array(402), 2, 0);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 637.1, g: 671.3, b: 413.1, a: -546.5, });
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder32.pushDebugGroup('\u43a1');
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker('\u0324');
+} catch {}
+let texture180 = device0.createTexture({
+  label: '\uc18c\ue64e\u984e\u109e\u{1feca}\u{1f996}',
+  size: [30, 2, 46],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder9.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(198);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1536, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 358, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture181 = device0.createTexture({
+  size: {width: 240},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer68, 'uint16', 218, 1_046);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline4);
+} catch {}
+let imageData22 = new ImageData(16, 24);
+let renderPassEncoder60 = commandEncoder117.beginRenderPass({
+  colorAttachments: [{
+  view: textureView159,
+  clearValue: { r: -394.1, g: -773.1, b: 754.4, a: -658.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 25146065,
+});
+let renderBundle35 = renderBundleEncoder35.finish({});
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup72, new Uint32Array(3113), 106, 0);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u5656');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture182 = device0.createTexture({
+  label: '\u{1f704}\u{1fef5}\u43ce\u9c39\u8c8e\ud22a\u04da\u7b96\u{1f687}\u029d',
+  size: [120, 8, 14],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView195 = texture176.createView({dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 1});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], stencilReadOnly: true});
+let renderBundle36 = renderBundleEncoder36.finish({label: '\u71b3\u669c\u{1ff27}\u{1f76b}\u0293'});
+let sampler115 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.68,
+  lodMaxClamp: 94.77,
+});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(0, bindGroup95, new Uint32Array(244), 9, 0);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(291);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer82, 'uint16', 1_448, 598);
+} catch {}
+let buffer125 = device0.createBuffer({size: 2370, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup102, new Uint32Array(444), 99, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer82, 0, 2_191);
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let textureView196 = texture81.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder143 = commandEncoder192.beginComputePass({});
+let sampler116 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.64,
+  lodMaxClamp: 87.84,
+});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup40, []);
+} catch {}
+try {
+computePassEncoder82.setBindGroup(2, bindGroup17, new Uint32Array(1056), 20, 1);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer83, 'uint16', 1_178, 500);
+} catch {}
+let arrayBuffer23 = buffer69.getMappedRange(256, 40);
+try {
+device0.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(58).fill(17), /* required buffer size: 58 */
+{offset: 58, rowsPerImage: 4}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer126 = device0.createBuffer({
+  label: '\u0b36\uab2b\u6512\u02f0\u9af4\u501e\u1a70\u0920\u3079\udf90',
+  size: 8073,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView197 = texture131.createView({dimension: '2d', aspect: 'all'});
+try {
+computePassEncoder120.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup88, new Uint32Array(397), 89, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer74, 'uint16', 9_108, 393);
+} catch {}
+try {
+computePassEncoder71.insertDebugMarker('\u{1f769}');
+} catch {}
+let textureView198 = texture61.createView({label: '\u00cf\ufffa\ued99\u788f\u07c5\u814a\u08da\u7d3a\ua2f4\u9413'});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup52, new Uint32Array(1923), 324, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer75);
+} catch {}
+try {
+buffer96.unmap();
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 223, resource: textureView151},
+    {binding: 62, resource: textureView37},
+    {binding: 137, resource: textureView5},
+    {binding: 429, resource: {buffer: buffer32, offset: 512, size: 1320}},
+  ],
+});
+let buffer127 = device0.createBuffer({size: 13523, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup102);
+} catch {}
+let texture183 = device0.createTexture({
+  label: '\u216d\u{1f9f5}\u0675\u734f\u{1f7a0}',
+  size: {width: 1536, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView199 = texture5.createView({label: '\u78bd\ue4aa', dimension: '2d', baseMipLevel: 0});
+try {
+renderPassEncoder10.setIndexBuffer(buffer36, 'uint16', 1_088, 1_240);
+} catch {}
+document.body.append(canvas1);
+let commandEncoder193 = device0.createCommandEncoder();
+let texture184 = device0.createTexture({size: [120], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder144 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder144.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle2, renderBundle8]);
+} catch {}
+let buffer128 = device0.createBuffer({
+  label: '\u0ea5\u458d\u{1fd82}\u9b93\u65e2\u{1f6c3}\u7ad8\u8ce9\u{1f652}\u0678\udb93',
+  size: 7535,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder141.setBindGroup(3, bindGroup102, new Uint32Array(3449), 1_308, 0);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: 709.0, g: -133.3, b: 83.06, a: -265.4, });
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer29, 'uint32', 72, 10);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer129 = device0.createBuffer({size: 3713, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler117 = device0.createSampler({
+  label: '\u1de2\u08fb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.28,
+  lodMaxClamp: 97.08,
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup31, new Uint32Array(2209), 1_596, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 128, new Int16Array(12592), 6964, 1156);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(169).fill(50), /* required buffer size: 169 */
+{offset: 169, rowsPerImage: 49}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let commandEncoder194 = device0.createCommandEncoder({label: '\u13c8\u4b51\u0d82\u001e'});
+let renderPassEncoder61 = commandEncoder194.beginRenderPass({colorAttachments: [{view: textureView160, loadOp: 'load', storeOp: 'store'}]});
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(1_029).fill(233), /* required buffer size: 1_029 */
+{offset: 345, bytesPerRow: 6, rowsPerImage: 38}, {width: 1, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = externalTexture16.label;
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 0, resource: {buffer: buffer73, offset: 4608, size: 3324}},
+    {binding: 101, resource: sampler116},
+  ],
+});
+try {
+renderPassEncoder40.executeBundles([renderBundle16, renderBundle6, renderBundle30, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(7.912791704463422, 1.6171943159495266, 3.6411917158041622, 1.4744641463889274, 0.35709352876031797, 0.933348557658068);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer114, 'uint16', 40, 962);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView77},
+    {binding: 4, resource: {buffer: buffer8, offset: 2816, size: 2432}},
+  ],
+});
+let buffer130 = device0.createBuffer({size: 2354, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder195 = device0.createCommandEncoder({});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 938});
+let textureView200 = texture20.createView({});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup8, new Uint32Array(3402), 1_957, 0);
+} catch {}
+try {
+buffer91.unmap();
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 337,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 12, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup108 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 351, resource: {buffer: buffer6, offset: 512, size: 196}},
+    {binding: 87, resource: textureView86},
+  ],
+});
+let commandEncoder196 = device0.createCommandEncoder({});
+let textureView201 = texture33.createView({aspect: 'all'});
+let computePassEncoder145 = commandEncoder195.beginComputePass({});
+let sampler118 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.08,
+  lodMaxClamp: 60.56,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder48.setScissorRect(29, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer101, 'uint16', 1_974, 15_335);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer20, 0);
+} catch {}
+let arrayBuffer24 = buffer59.getMappedRange(0, 32);
+try {
+commandEncoder196.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4060 */
+  offset: 4060,
+  buffer: buffer40,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 21},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+document.body.prepend(canvas1);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'gamma28curve'} });
+let texture185 = device0.createTexture({
+  size: [1536, 1, 6],
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder146 = commandEncoder196.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup83, new Uint32Array(834), 29, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup109 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView63}]});
+let commandEncoder197 = device0.createCommandEncoder({label: '\u5030\u{1fa9f}\ufd62'});
+let computePassEncoder147 = commandEncoder197.beginComputePass({});
+try {
+computePassEncoder145.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer68, 'uint32', 316, 648);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer74);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(3, bindGroup103);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup104);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer125, 'uint32', 228, 106);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(2, buffer71);
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder({});
+let computePassEncoder148 = commandEncoder198.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(2, bindGroup72, new Uint32Array(1492), 236, 0);
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup78, new Uint32Array(411), 194, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let buffer131 = device0.createBuffer({size: 31457, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let texture186 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 65},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true});
+let renderBundle37 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder148.setBindGroup(0, bindGroup93, new Uint32Array(639), 5, 0);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup39, new Uint32Array(1252), 173, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer79);
+} catch {}
+try {
+computePassEncoder32.popDebugGroup();
+} catch {}
+let imageData23 = new ImageData(12, 40);
+let textureView202 = texture113.createView({label: '\u{1ffad}\ue8d1\u0be5\ub252', dimension: '2d-array', arrayLayerCount: 1});
+let texture187 = device0.createTexture({
+  size: [32, 32, 20],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer29, 'uint16', 30, 58);
+} catch {}
+offscreenCanvas2.width = 1180;
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  label: '\u0adc\uf6ec\u699a\u0b65\u358b',
+  entries: [
+    {
+      binding: 36,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture188 = device0.createTexture({
+  label: '\u0b67\u0ad2\u0177\uaa82\u05f4',
+  size: [32, 32, 32],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler119 = device0.createSampler({
+  label: '\u765e\u{1fa39}\u1f9e\u{1ffbe}\u{1fc6f}\u{1ff6c}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 74.80,
+  lodMaxClamp: 94.89,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer82, 'uint32', 52, 5_481);
+} catch {}
+try {
+globalThis.someLabel = externalTexture14.label;
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 160, resource: textureView153}]});
+let textureView203 = texture188.createView({});
+let sampler120 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMinClamp: 6.210, lodMaxClamp: 14.15});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer104, 'uint32', 3_708, 355);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture189 = device0.createTexture({
+  label: '\u{1fb06}\ufa66\u1439\u03ed',
+  size: [120, 8, 1],
+  mipLevelCount: 7,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+try {
+renderPassEncoder6.setStencilReference(1455);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 536, new DataView(new ArrayBuffer(7912)), 2617, 836);
+} catch {}
+let bindGroup111 = device0.createBindGroup({layout: bindGroupLayout29, entries: [{binding: 121, resource: textureView193}]});
+let commandEncoder199 = device0.createCommandEncoder();
+let querySet27 = device0.createQuerySet({label: '\ub836\u{1ffcd}\u5cfb\u{1fde1}\u{1fe6f}\ud26d\u8c66\u0748', type: 'occlusion', count: 1697});
+let textureView204 = texture112.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder149 = commandEncoder199.beginComputePass();
+try {
+computePassEncoder121.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 254.2, g: 252.4, b: -656.3, a: -130.7, });
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData24 = new ImageData(132, 60);
+let commandEncoder200 = device0.createCommandEncoder();
+let texture190 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder149.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup86, new Uint32Array(1558), 195, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer25, 'uint32', 1_848, 6_887);
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 168, resource: textureView172},
+    {binding: 29, resource: {buffer: buffer20, offset: 512, size: 4220}},
+  ],
+});
+let texture191 = device0.createTexture({
+  label: '\u0051\ub920\u{1fa6c}\ue930',
+  size: [1536, 1, 74],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder40.setPipeline(pipeline10);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let textureView205 = texture179.createView({
+  label: '\udafe\uf6b4\u6166\u{1f94b}\u00bf\uc60e',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+let computePassEncoder150 = commandEncoder200.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder20.setViewport(173.04292619642294, 7.869350463066075, 29.50762371096019, 4.198003371237732, 0.22021272621578403, 0.3249334077992132);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer68, 'uint32', 820, 1_108);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(220).fill(78), /* required buffer size: 220 */
+{offset: 220}, {width: 706, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  label: '\u928f\ufd3f\ucf96\u{1fb17}\u411b\ufa28\u624b',
+  entries: [
+    {binding: 31, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {binding: 164, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout32, entries: [{binding: 36, resource: textureView203}]});
+let texture192 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 187},
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler121 = device0.createSampler({
+  label: '\u2ae4\u{1fa2a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.66,
+  lodMaxClamp: 88.78,
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup21, new Uint32Array(72), 18, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle19]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer83, 'uint16', 364, 1_136);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(23, 1, 13, 0);
+} catch {}
+let bindGroup114 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 278, resource: textureView155}]});
+let commandEncoder201 = device0.createCommandEncoder({});
+try {
+renderPassEncoder17.setIndexBuffer(buffer73, 'uint16', 3_034, 984);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let buffer132 = device0.createBuffer({size: 1148, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder202 = device0.createCommandEncoder({});
+let textureView206 = texture188.createView({});
+let texture193 = device0.createTexture({
+  size: [192, 1, 100],
+  mipLevelCount: 3,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView207 = texture150.createView({label: '\u5155\uc304\uf712\u0480\u83bb\u{1f89e}\u{1fea4}\uf5fa', aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder44.executeBundles([renderBundle25]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer122, 0);
+} catch {}
+try {
+commandEncoder202.copyBufferToBuffer(buffer127, 1220, buffer87, 376, 804);
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  label: '\u8703\uf999',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 137, resource: textureView72},
+    {binding: 223, resource: textureView151},
+    {binding: 62, resource: textureView9},
+    {binding: 429, resource: {buffer: buffer114, offset: 0, size: 644}},
+  ],
+});
+let texture194 = device0.createTexture({
+  label: '\u471e\u{1f8e2}\u05bc\u709f\u7d81\ubaf7\u8c1b\u2cbb\ua854\ubef2',
+  size: [84, 40, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture195 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder151 = commandEncoder201.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 900 */
+  offset: 900,
+  rowsPerImage: 611,
+  buffer: buffer38,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: imageData21,
+  origin: { x: 10, y: 1 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 23, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'bt2020_12bit'} });
+let buffer133 = device0.createBuffer({
+  size: 3172,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture196 = device0.createTexture({size: {width: 768}, dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_DST});
+let textureView208 = texture28.createView({mipLevelCount: 1});
+let renderPassEncoder62 = commandEncoder202.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 4,
+  clearValue: { r: -158.2, g: -199.5, b: -434.8, a: 553.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer79, 0, 2_047);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(57).fill(134), /* required buffer size: 57 */
+{offset: 57}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture187,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+commandEncoder153.label = '\u277d\u043c';
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer66, 'uint32', 0, 6);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4_294_967_295, undefined, 0, 1_161_056_140);
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  label: '\u4a7a\u{1fceb}',
+  entries: [
+    {
+      binding: 418,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup116 = device0.createBindGroup({layout: bindGroupLayout31, entries: [{binding: 337, resource: {buffer: buffer97, offset: 1024}}]});
+let commandEncoder203 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({
+  size: [168, 80, 5],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler122 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.311,
+});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame11, colorSpace: 'srgb'});
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer20, 276, 784);
+} catch {}
+try {
+commandEncoder203.copyBufferToBuffer(buffer20, 2132, buffer66, 0, 4);
+} catch {}
+let textureView209 = texture24.createView({dimension: 'cube', baseArrayLayer: 1});
+let textureView210 = texture15.createView({dimension: '2d'});
+let computePassEncoder152 = commandEncoder203.beginComputePass({label: '\u3852\u09ca\u0fc1\u0493'});
+try {
+renderPassEncoder14.setScissorRect(13, 0, 47, 1);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer66, 'uint32', 4, 0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let buffer134 = device0.createBuffer({
+  label: '\u{1fc4c}\uc337\uab38\ueda3\u219e\u26f3\u55b1\ucb01\u0849\u0297',
+  size: 7800,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let computePassEncoder153 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup52, new Uint32Array(1476), 570, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let textureView211 = texture79.createView({baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 10});
+let computePassEncoder154 = commandEncoder205.beginComputePass({});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.49,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup57, []);
+} catch {}
+try {
+computePassEncoder121.setBindGroup(1, bindGroup91, new Uint32Array(606), 92, 0);
+} catch {}
+document.body.append(img7);
+let bindGroup117 = device0.createBindGroup({layout: bindGroupLayout32, entries: [{binding: 36, resource: textureView203}]});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 1091});
+let textureView212 = texture145.createView({mipLevelCount: 1});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup78, new Uint32Array(1333), 526, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer75, 'uint32', 4_964, 209);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4, buffer28, 260, 2_319);
+} catch {}
+try {
+renderPassEncoder33.insertDebugMarker('\u0ff4');
+} catch {}
+let bindGroup118 = device0.createBindGroup({layout: bindGroupLayout29, entries: [{binding: 121, resource: textureView28}]});
+let textureView213 = texture147.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u0a7a\u68f3\u836b\ubce1\u2c6d\u1024',
+  colorFormats: ['rg8uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 477,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 372,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 434});
+try {
+computePassEncoder152.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer55, 0, 501);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup4, new Uint32Array(971), 22, 0);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+let videoFrame20 = new VideoFrame(videoFrame16, {timestamp: 0});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer49, 'uint32', 204, 234);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+document.body.prepend(img10);
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [
+    {binding: 13, resource: textureView209},
+    {binding: 418, resource: {buffer: buffer50, offset: 0, size: 1179}},
+    {binding: 31, resource: textureView74},
+  ],
+});
+let texture198 = device0.createTexture({
+  size: {width: 192},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.18,
+  compare: 'equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup15, new Uint32Array(633), 444, 0);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup98, new Uint32Array(479), 6, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(3, buffer49);
+} catch {}
+let arrayBuffer25 = buffer70.getMappedRange(216, 0);
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\ud9d8\u07f6\u4940\ua3b0\u{1fa85}\ua776',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment7',
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule17,
+    constants: {53_825: 0, 5_903: 0, 23_326: 0, 64_950: 0},
+    buffers: [
+      {
+        arrayStride: 216,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 4, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list'},
+});
+let commandEncoder206 = device0.createCommandEncoder({});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 113});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup105);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(1, buffer104);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup80, new Uint32Array(2617), 6, 0);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline14);
+} catch {}
+document.body.prepend(img4);
+let commandEncoder207 = device0.createCommandEncoder({label: '\u4a32\u1b73\u07ce\uf4dc\u{1f6ab}\u70e6\uc18d\ud6be'});
+let textureView214 = texture197.createView({arrayLayerCount: 1});
+let renderBundle38 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder146.setBindGroup(3, bindGroup74, new Uint32Array(956), 243, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup77, new Uint32Array(778), 4, 0);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+try {
+commandEncoder206.clearBuffer(buffer67);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 2120, new Int16Array(364), 66);
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment13',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule7, constants: {}, buffers: []},
+});
+let computePassEncoder155 = commandEncoder207.beginComputePass();
+let renderPassEncoder63 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 81,
+  clearValue: { r: -236.2, g: 868.2, b: 487.7, a: 97.41, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler125 = device0.createSampler({
+  label: '\u{1fe4b}\udccb\u804f\u04d9\u96de',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.54,
+  lodMaxClamp: 75.46,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder155.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup76, new Uint32Array(2575), 53, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer29, 'uint32', 24, 178);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let bindGroup120 = device0.createBindGroup({layout: bindGroupLayout16, entries: [{binding: 626, resource: sampler9}]});
+let textureView215 = texture24.createView({dimension: 'cube'});
+let textureView216 = texture100.createView({label: '\u0acc\u012b\u6874\u0df0', dimension: '2d-array'});
+try {
+renderPassEncoder27.setStencilReference(2);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer87);
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 174, resource: {buffer: buffer18, offset: 1280, size: 2828}},
+    {binding: 18, resource: {buffer: buffer13, offset: 0, size: 48}},
+  ],
+});
+let commandEncoder208 = device0.createCommandEncoder({});
+let texture199 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder156 = commandEncoder208.beginComputePass({});
+try {
+computePassEncoder156.setPipeline(pipeline3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 2344, new Int16Array(15411), 759, 2756);
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule16, constants: {}, buffers: []},
+});
+let buffer135 = device0.createBuffer({
+  size: 42475,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder209 = device0.createCommandEncoder({});
+try {
+renderPassEncoder37.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder209.copyBufferToBuffer(buffer80, 3836, buffer4, 296, 996);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55); };
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let buffer136 = device0.createBuffer({size: 11393, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView217 = texture60.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 2});
+let computePassEncoder157 = commandEncoder209.beginComputePass({});
+try {
+computePassEncoder157.setPipeline(pipeline11);
+} catch {}
+let buffer137 = device0.createBuffer({size: 2294, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder210 = device0.createCommandEncoder({});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 438});
+let textureView218 = texture82.createView({aspect: 'all', baseMipLevel: 0, arrayLayerCount: 1});
+let renderPassEncoder64 = commandEncoder210.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: -301.3, g: 341.4, b: -781.9, a: -106.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder92.setBindGroup(1, bindGroup99, new Uint32Array(1148), 191, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup120, new Uint32Array(1871), 561, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer55, 'uint32', 4_576, 160);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 612, new Float32Array(2629), 1063, 40);
+} catch {}
+let buffer138 = device0.createBuffer({
+  label: '\u0d20\u{1fc00}\u{1fc92}\u05b1\u0ac3\u0565\u{1f671}\u8458\ud40c',
+  size: 7395,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let texture200 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup114, new Uint32Array(248), 15, 0);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(1, buffer50, 2_896);
+} catch {}
+let arrayBuffer26 = buffer69.getMappedRange(296, 8);
+try {
+commandEncoder211.copyBufferToBuffer(buffer35, 1512, buffer10, 164, 492);
+} catch {}
+try {
+renderPassEncoder60.pushDebugGroup('\u0a76');
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw89: array<mat2x2h, 11>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput19 {
+  @location(0) f0: vec4u,
+}
+
+fn fn0(a0: FragmentOutput19, a1: array<array<array<mat2x2h, 1>, 1>, 13>) -> array<vec2h, 8> {
+  var out: array<vec2h, 8>;
+  let ptr165: ptr<private, i32> = &vp28[18][0];
+  var vf374: vec4h = reflect(vec4h(unconst_f16(739.1), unconst_f16(522.8), unconst_f16(2.707), unconst_f16(3582.2)), vec4h(buffer139[u32(a1[12][0][0][0][bitcast<u32>(a1[pack2x16float(vec2f(unconst_f32(0.1746), unconst_f32(0.1426)))][0][0][0])])][2]));
+  vf374 -= a1[12][0][0][0].xyxy;
+  vf374 = vec4h(f16(vp28[18][u32(unconst_u32(116))]));
+  let ptr166: ptr<storage, f16, read> = &(*&buffer139)[25][2];
+  let vf375: FragmentOutput19 = a0;
+  vp28[bitcast<u32>(vp28[18][0])][textureDimensions(tex29)[1]] += i32((*&buffer139)[25][2]);
+  out[dot4U8Packed(u32(unconst_u32(52)), u32(vp28[18][0]))] = vec2h(a1[12][0][0][u32(unconst_u32(107))][u32(buffer139[25][2])]);
+  out[u32(a1[12][0][0][u32(buffer139[25][2])][pack4xU8(bitcast<vec4u>(unpack4x8snorm(bitcast<u32>(a1[12][0][0][1]))))])] = vec2h(buffer139[25][2]);
+  let vf376: u32 = a0.f0[u32(unconst_u32(20))];
+  out[u32(unconst_u32(155))] = vf374.gb;
+  let ptr167: ptr<storage, array<f16, 3>, read> = &(*&buffer139)[bitcast<u32>(a1[12][0][0][1])];
+  var vf377: vec4u = vf375.f0;
+  let ptr168: ptr<storage, array<f16, 3>, read> = &buffer139[25];
+  var vf378: FragmentOutput19 = vf375;
+  let vf379: u32 = vf375.f0[1];
+  var vf380: vec2f = unpack2x16unorm(bitcast<u32>(vp28[a0.f0[u32(unconst_u32(167))]][0]));
+  vf374 = vec4h(f16(vp28[18][u32(buffer139[25][2])]));
+  vf377 ^= vec4u(a1[12][0][0][1].xxxx);
+  vf378.f0 = vf377;
+  let ptr169: ptr<function, FragmentOutput19> = &vf378;
+  vf378.f0 = vec4u(a1[12][0][0][1].grgg);
+  var vf381: u32 = a0.f0[1];
+  return out;
+}
+
+fn fn2() -> vec4u {
+  var out: vec4u;
+  let vf382: vec4h = clamp(vec4h(buffer139[25][2]), vec4h(unconst_f16(5145.8), unconst_f16(58010.0), unconst_f16(3564.4), unconst_f16(1226.1)), asinh(vec3h(f16(pack2x16unorm(vec2f(unconst_f32(0.1397), unconst_f32(0.00133)))))).bgbb);
+  out = vec4u(vf382);
+  out ^= unpack4xU8(u32(buffer139[25][2]));
+  out *= vec4u(pack2x16unorm(vec2f(unconst_f32(0.3128), unconst_f32(0.05036))));
+  out += vec4u(u32(buffer139[u32(acosh(f16(unconst_f16(1868.6))))][2]));
+  let vf383: vec3f = acos(vec3f(unconst_f32(0.03978), unconst_f32(0.02771), unconst_f32(0.2504)));
+  out ^= unpack4xU8(u32(determinant(mat3x3f(unconst_f32(0.4743), unconst_f32(0.03181), unconst_f32(0.1055), unconst_f32(0.1052), unconst_f32(0.05785), unconst_f32(0.05787), unconst_f32(0.03727), unconst_f32(0.09393), unconst_f32(0.01705)))));
+  out = vec4u(u32((*&buffer139)[25][2]));
+  var vf384: vec3f = max(vec3f(unconst_f32(0.4016), unconst_f32(0.00839), unconst_f32(0.07524)), vec3f(f32(vp28[18][0])));
+  return out;
+}
+
+var<workgroup> vw90: atomic<i32>;
+
+@group(0) @binding(4) var<storage, read> buffer139: array<array<f16, 3>, 26>;
+
+var<private> vp28: array<array<i32, 1>, 19> = array(array<i32, 1>(i32()), array(i32()), array(i32()), array(i32()), array(i32()), array<i32, 1>(), array(i32()), array<i32, 1>(), array(i32()), array(i32()), array<i32, 1>(), array(i32()), array(i32()), array(i32()), array(i32()), array(i32()), array(i32()), array<i32, 1>(), array<i32, 1>(i32()));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1(a0: ptr<workgroup, array<vec4h, 20>>, a1: ptr<workgroup, vec2f>, a2: ptr<storage, mat3x2f, read_write>) {
+  (*a0)[u32(vp28[18][0])] *= vec4h((*&buffer139)[25][2]);
+  (*a1) *= quantizeToF16(vec3f(unconst_f32(0.1486), unconst_f32(0.2387), unconst_f32(0.00804))).xy;
+}
+
+struct T0 {
+  @align(1) @size(8) f0: atomic<i32>,
+  @size(148) f1: array<u32>,
+}
+
+@group(0) @binding(42) var tex29: texture_2d<f32>;
+
+@fragment
+fn fragment21() -> FragmentOutput19 {
+  var out: FragmentOutput19;
+  let vf385: vec2h = atan2(vec2h(unconst_f16(8452.1), unconst_f16(8252.9)), vec2h(unconst_f16(2475.4), unconst_f16(1226.5)));
+  let ptr170: ptr<private, array<array<i32, 1>, 19>> = &vp28;
+  vp28[bitcast<u32>(vp28[18][0])][u32(unconst_u32(142))] ^= i32(buffer139[25][2]);
+  let ptr171: ptr<private, i32> = &vp28[18][0];
+  discard;
+  let vf386: vec4h = sin(vec4h(unconst_f16(19923.9), unconst_f16(2536.0), unconst_f16(47465.9), unconst_f16(2188.7)));
+  out.f0 <<= vec4u(u32((*&buffer139)[u32(unconst_u32(6))][2]));
+  let ptr172: ptr<storage, f16, read> = &(*&buffer139)[25][u32((*&buffer139)[25][2])];
+  let vf387: f16 = vf386[u32(unconst_u32(25))];
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute15() {
+  vw89[pack4x8unorm(exp2(vec4f(unconst_f32(0.07289), unconst_f32(0.3596), unconst_f32(0.1038), unconst_f32(0.00707))))] += mat2x2h(vec2h(exp2(vec4f(unconst_f32(0.1815), unconst_f32(0.1707), unconst_f32(0.1686), unconst_f32(0.01863))).zz), vec2h(exp2(vec4f(unconst_f32(0.1815), unconst_f32(0.1707), unconst_f32(0.1686), unconst_f32(0.01863))).ww));
+  var vf388 = fn0(FragmentOutput19(unpack4xU8(u32((*&buffer139)[25][2]))), array<array<array<mat2x2h, 1>, 1>, 13>(array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]), f16(vp28[18][0]))))));
+  fn0(FragmentOutput19(vec4u(vf388[7].grgg)), array<array<array<mat2x2h, 1>, 1>, 13>(array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2])))));
+  let ptr173: ptr<workgroup, atomic<i32>> = &vw90;
+  vw89[u32(vw89[10][1][u32(unconst_u32(21))])] = mat2x2h(vw89[10][bitcast<u32>((*&vw89)[10][1])][u32(unconst_u32(51))], vw89[10][bitcast<u32>((*&vw89)[10][1])][u32(unconst_u32(51))], vw89[10][bitcast<u32>((*&vw89)[10][1])][u32(unconst_u32(51))], vw89[10][bitcast<u32>((*&vw89)[10][1])][u32(unconst_u32(51))]);
+  fn0(FragmentOutput19(vec4u(unpack4x8snorm(u32(vp28[18][0])))), array<array<array<mat2x2h, 1>, 1>, 13>(array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10])), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(workgroupUniformLoad(&vw89)[10]))));
+  let ptr174: ptr<workgroup, atomic<i32>> = &vw90;
+  vf388[u32(unconst_u32(28))] += vec2h(unpack4x8snorm(bitcast<u32>(vp28[18][0])).wz);
+  vf388[7] *= bitcast<vec2h>(pack4x8snorm(vec4f(f32(buffer139[25][2]))));
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute16() {
+  let ptr175: ptr<private, array<i32, 1>> = &vp28[18];
+  vw89[u32(unconst_u32(167))] = mat2x2h(f16(atomicLoad(&vw90)), f16(atomicLoad(&vw90)), f16(atomicLoad(&vw90)), f16(atomicLoad(&vw90)));
+  vw89[u32(unconst_u32(29))] -= vw89[10];
+  var vf389 = fn2();
+  let ptr176: ptr<storage, array<f16, 3>, read> = &(*&buffer139)[25];
+  vp28[u32((*&vw89)[10][0][1])][u32((*&vw89)[10][u32(unconst_u32(122))][u32(unconst_u32(408))])] -= (*ptr175)[0];
+  vp28[u32(unconst_u32(85))][0] ^= atomicLoad(&vw90);
+  vp28[18][u32(unconst_u32(60))] &= atomicLoad(&vw90);
+  atomicOr(&vw90, i32((*&buffer139)[u32(unconst_u32(196))][2]));
+  fn0(FragmentOutput19(vf389), array<array<array<mat2x2h, 1>, 1>, 13>(array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2]))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h((*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2], (*&buffer139)[25][2])))));
+  let vf390: f16 = (*&vw89)[10][u32((*&buffer139)[25][2])][u32(buffer139[25][2])];
+}
+
+@compute @workgroup_size(2, 2, 1)
+fn compute17(@builtin(num_workgroups) a0: vec3u) {
+  let vf391: i32 = atomicLoad(&(*&vw90));
+  var vf392 = fn0(FragmentOutput19(textureDimensions(tex29, i32(unconst_i32(432))).xyyx), array<array<array<mat2x2h, 1>, 1>, 13>(array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0])))), array<array<mat2x2h, 1>, 1>(array<mat2x2h, 1>(mat2x2h(f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]), f16(vp28[u32(unconst_u32(59))][0]))))));
+  vf392[u32(unconst_u32(88))] -= bitcast<vec2h>(pack2x16snorm(vec2f((*&vw89)[10][0])));
+  atomicCompareExchangeWeak(&vw90, unconst_i32(77), unconst_i32(241));
+  vf392[u32(unconst_u32(3))] *= bitcast<vec2h>(atomicLoad(&vw90));
+  vw89[u32(unconst_u32(111))] = mat2x2h(vw89[10][1], vw89[10][1]);
+  vf392[bitcast<u32>(vf391)] = vec2h((*&buffer139)[25][2]);
+  vp28[a0[2]][vec3u(asinh(vec3f(unpack4xU8(u32(unconst_u32(603))).raa)))[2]] -= i32(textureNumLevels(tex29));
+  let ptr177: ptr<workgroup, array<mat2x2h, 11>> = &vw89;
+  vf392[u32(buffer139[u32(unconst_u32(310))][2])] -= vec2h((*&buffer139)[25][2]);
+  var vf393: i32 = atomicLoad(&vw90);
+  var vf394 = fn2();
+  vf394 *= bitcast<vec4u>(textureLoad(tex29, vec2i(unconst_i32(13), unconst_i32(107)), i32(unconst_i32(169))));
+  let ptr178: ptr<workgroup, mat2x2h> = &(*ptr177)[u32((*&buffer139)[25][2])];
+  var vf395 = fn2();
+  var vf396: vec2u = textureDimensions(tex29);
+  var vf397: vec4f = textureLoad(tex29, vec2i(i32((*&buffer139)[25][2])), i32(unconst_i32(304)));
+  let ptr179: ptr<private, array<array<i32, 1>, 19>> = &vp28;
+  var vf398: vec2f = ceil(vec2f((*&vw89)[10][0]));
+  var vf399 = fn2();
+  vf397 = vec4f(bitcast<f32>((*ptr179)[bitcast<u32>((*&vw89)[bitcast<u32>(vp28[18][0])][0])][0]));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer140 = device0.createBuffer({
+  size: 9360,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder212 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  size: [168, 80, 3],
+  mipLevelCount: 2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler126 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.21,
+  lodMaxClamp: 90.12,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup21, new Uint32Array(841), 6, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup66, new Uint32Array(439), 109, 0);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(7, buffer45);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 112, new BigUint64Array(3032), 984, 152);
+} catch {}
+let computePassEncoder158 = commandEncoder211.beginComputePass({label: '\ubf77\u0652\uf396\uccc9\u4fe8\u{1ff38}\ud2a4\u47b3'});
+try {
+computePassEncoder128.setBindGroup(3, bindGroup83, new Uint32Array(838), 74, 0);
+} catch {}
+let imageData25 = new ImageData(60, 56);
+try {
+adapter0.label = '\u42d2\u641d\u{1fd9f}\u{1ff6a}\ubdaa\ue29c\u3602\ub8b3\ub1c4\u{1fa10}';
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 23, resource: textureView126}, {binding: 130, resource: textureView135}],
+});
+let texture202 = device0.createTexture({size: [1536], dimension: '1d', format: 'rg8uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView219 = texture29.createView({});
+let computePassEncoder159 = commandEncoder212.beginComputePass({});
+try {
+renderPassEncoder44.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer113, 'uint16', 436, 1_716);
+} catch {}
+let shaderModule21 = device0.createShaderModule({
+  label: '\u0e04\u9be1\ubeda\u3652\u0e3b',
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw93: array<VertexOutput12, 14>;
+
+override override47: f16;
+
+@id(39926) override override48: u32;
+
+var<private> vp29 = modf(vec3h());
+
+@group(0) @binding(100) var tex30: texture_2d<f32>;
+
+override override46 = true;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw92: VertexOutput12;
+
+override override49 = 0.08704;
+
+@id(30830) override override51: f32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+@id(13552) override override52: f32;
+
+var<workgroup> vw94: atomic<i32>;
+
+struct VertexOutput12 {
+  @invariant @builtin(position) f44: vec4f,
+}
+
+var<workgroup> vw91: atomic<i32>;
+
+fn fn0(a0: array<vec4u, 1>) -> vec2u {
+  var out: vec2u;
+  out >>= vec2u(u32(override52));
+  out = abs(vec4u(pack4xU8(vec4u(unconst_u32(12), unconst_u32(564), unconst_u32(338), unconst_u32(56))))).gr;
+  let vf400: vec3h = exp2(vec3h(unconst_f16(1877.3), unconst_f16(9344.4), unconst_f16(1355.5)));
+  let vf401: u32 = override48;
+  let vf402: vec4u = abs(vec4u(u32(vf400[u32(unconst_u32(92))])));
+  return out;
+  _ = override52;
+  _ = override48;
+}
+
+override override50: i32 = 325;
+
+@vertex
+fn vertex17() -> VertexOutput12 {
+  var out: VertexOutput12;
+  out.f44 -= vec4f(override49);
+  out.f44 = unpack4x8unorm(pack4xU8Clamp(vec4u(unconst_u32(58), unconst_u32(73), unconst_u32(32), unconst_u32(222))));
+  out.f44 += vec4f(bitcast<f32>(override50));
+  out.f44 += vec4f(bitcast<f32>(override50));
+  var vf403: f16 = saturate(f16(override50));
+  vf403 = f16(firstTrailingBit(vec3u(unconst_u32(6), unconst_u32(154), unconst_u32(96)))[1]);
+  fn0(array<vec4u, 1>(vec4u(u32(override50))));
+  let vf404: i32 = override50;
+  fn0(array<vec4u, 1>(firstTrailingBit(vec3u(unconst_u32(392), unconst_u32(136), unconst_u32(641))).yyyy));
+  out.f44 += vec4f(firstLeadingBit(vec2i(unconst_i32(197), unconst_i32(23))).rgrg);
+  vf403 -= f16(override50);
+  fn0(array<vec4u, 1>(vec4u(u32(override47))));
+  vf403 = f16(pack4xI8(vec4i(unconst_i32(451), unconst_i32(224), unconst_i32(89), unconst_i32(-286))));
+  var vf405 = fn0(array<vec4u, 1>(bitcast<vec4u>(sinh(vec3f(unconst_f32(0.1329), unconst_f32(0.03237), unconst_f32(0.08038))).bbrb)));
+  let ptr180 = &vp29;
+  let vf406: f32 = smoothstep(ceil(f32(unconst_f32(0.2461))), f32(unconst_f32(0.2130)), f32(unconst_f32(0.00914)));
+  out.f44 = vec4f((*ptr180).whole.bgbr);
+  var vf407 = fn0(array<vec4u, 1>(vec4u(vp29.whole.zxyx)));
+  var vf408: u32 = pack4xU8Clamp(unpack4xU8(u32(override47)));
+  var vf409 = fn0(array<vec4u, 1>(unpack4xU8(bitcast<u32>(ceil(f32(unconst_f32(0.2703)))))));
+  vf407 += vec2u((*ptr180).whole.yy);
+  var vf410 = fn0(array<vec4u, 1>(vec4u(vf405[vec3u(vp29.fract).g])));
+  vp29 = modf(vec3h(f16(override51)));
+  return out;
+  _ = override52;
+  _ = override47;
+  _ = override49;
+  _ = override50;
+  _ = override48;
+  _ = override51;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute18() {
+  let ptr181: ptr<workgroup, vec4f> = &vw92.f44;
+  var vf411: i32 = atomicLoad(&vw94);
+  let ptr182: ptr<workgroup, vec4f> = &(*&vw93)[13].f44;
+  vw93[u32(unconst_u32(65))].f44 -= (*&vw92).f44;
+  let vf412: f32 = select(refract(vec2f(unconst_f32(0.2252), unconst_f32(0.06594)), vec2f(unconst_f32(0.06803), unconst_f32(0.4354)), override49)[0], (*&vw92).f44.w, bool((*ptr181).a));
+  let ptr183: ptr<function, i32> = &vf411;
+  vp29.fract += vec3h(vw93[13].f44.aab);
+  vp29 = modf(vec3h(fma((*&vw93)[13].f44.ar, vec2f(unconst_f32(0.01579), unconst_f32(0.1375)), (*&vw93)[13].f44.ag).ggr));
+  var vf413: f32 = (*&vw93)[13].f44[3];
+  let vf414: u32 = dot4U8Packed(u32(unconst_u32(47)), u32(unconst_u32(4)));
+  _ = override49;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler127 = device0.createSampler({
+  label: '\u7dda\u487d\u098f\u{1fb4f}',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 66.63,
+  lodMaxClamp: 79.76,
+  compare: 'always',
+});
+try {
+renderPassEncoder44.endOcclusionQuery();
+} catch {}
+let buffer141 = device0.createBuffer({
+  size: 16040,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup90, new Uint32Array(4412), 2_545, 0);
+} catch {}
+try {
+renderPassEncoder52.setBlendConstant({ r: 261.6, g: 624.5, b: -313.3, a: -479.9, });
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise23;
+} catch {}
+let buffer142 = device0.createBuffer({
+  size: 7195,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder160 = commandEncoder213.beginComputePass();
+try {
+computePassEncoder23.setBindGroup(1, bindGroup18, new Uint32Array(1135), 78, 1);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup104, new Uint32Array(2142), 218, 0);
+} catch {}
+try {
+buffer142.unmap();
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({});
+let sampler128 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.76,
+  lodMaxClamp: 60.49,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder160.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder60.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder54.insertDebugMarker('\u7ccb');
+} catch {}
+let computePassEncoder161 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(3, bindGroup9, new Uint32Array(1619), 340, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup28, new Uint32Array(710), 15, 0);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(13_523).fill(5), /* required buffer size: 13_523 */
+{offset: 104, bytesPerRow: 189, rowsPerImage: 71}, {width: 36, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let imageData26 = new ImageData(8, 136);
+let bindGroup123 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 30, resource: textureView42},
+    {binding: 48, resource: textureView10},
+    {binding: 205, resource: textureView169},
+    {binding: 78, resource: textureView69},
+    {binding: 37, resource: {buffer: buffer116, offset: 0, size: 24}},
+  ],
+});
+let commandEncoder215 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({
+  label: '\u07de\u8afd\u5fa1\u{1fafb}\u0af9\u{1fc68}\u7197\ucbba\ub328',
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder162 = commandEncoder215.beginComputePass({});
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup55, new Uint32Array(648), 62, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer46, 'uint32', 408, 3_785);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer15, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder94.setBindGroup(1, bindGroup91, new Uint32Array(843), 117, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(88.8776101815936, 0.07091279039906806, 42.46383126588325, 0.4479103280030412, 0.2944915720941712, 0.8519161036618581);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer20, 0, 806);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer143 = device0.createBuffer({
+  size: 3627,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder216 = device0.createCommandEncoder();
+let querySet32 = device0.createQuerySet({label: '\u0c28\u0f39\u{1f6d7}\u0d2b\u0ce8', type: 'occlusion', count: 193});
+let computePassEncoder163 = commandEncoder216.beginComputePass({});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(3, buffer61, 1_240, 5_130);
+} catch {}
+let arrayBuffer27 = buffer59.getMappedRange(96, 28);
+try {
+renderPassEncoder20.setPipeline(pipeline18);
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  label: '\u{1fcf9}\u{1feea}\u0506\u0eab\u878f',
+  layout: bindGroupLayout34,
+  entries: [
+    {binding: 13, resource: textureView215},
+    {binding: 31, resource: textureView71},
+    {binding: 418, resource: {buffer: buffer73, offset: 512, size: 2472}},
+  ],
+});
+let buffer144 = device0.createBuffer({
+  size: 1332,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder217 = device0.createCommandEncoder();
+let textureView220 = texture17.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder217.copyBufferToBuffer(buffer9, 224, buffer68, 224, 756);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView221 = texture175.createView({label: '\u07fe\u1609\u59a8\u{1f82b}\u0ad1\ua7de\u85bd'});
+let computePassEncoder164 = commandEncoder217.beginComputePass({});
+try {
+computePassEncoder158.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup98, new Uint32Array(1812), 441, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(108, 8, 267, -2_085_957_013, 116_996_785);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup50, new Uint32Array(1725), 553, 0);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle6, renderBundle24, renderBundle26, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer123, 'uint32', 648, 11_319);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer56, 56, 57);
+} catch {}
+let arrayBuffer28 = buffer70.getMappedRange(224, 64);
+let commandEncoder218 = device0.createCommandEncoder({label: '\ud4e0\u{1ff03}\u{1fc37}\u{1fb2d}\u0d0d\ue0e5\u0c97\ub932\ua191\u0722'});
+let renderPassEncoder65 = commandEncoder218.beginRenderPass({
+  colorAttachments: [{
+  view: textureView159,
+  clearValue: { r: 403.8, g: -554.5, b: -617.1, a: -644.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+renderPassEncoder20.draw(263, 8, 1_381_551_909, 439_943_453);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(18, 53, 9, -1_861_707_832, 1_031_267_398);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer123, 'uint16', 2_014, 22_800);
+} catch {}
+try {
+buffer122.unmap();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let imageData27 = new ImageData(52, 72);
+let buffer145 = device0.createBuffer({
+  size: 11129,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 187});
+let texture204 = device0.createTexture({
+  size: [120, 8, 18],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView222 = texture94.createView({label: '\u04ac\u6a3d\u{1fe6f}\u{1ffcc}\u{1fd25}\u5f18\u0752\u3af0', arrayLayerCount: 1});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(1, bindGroup34, new Uint32Array(2096), 196, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(50, 105, 90, 216_904_271, 64_292_257);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer99, 120);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer63, 'uint16', 1_434, 785);
+} catch {}
+let buffer146 = device0.createBuffer({size: 1461, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 20.01,
+});
+try {
+computePassEncoder161.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup31, new Uint32Array(1611), 70, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(26, 191, 138, -2_054_321_792, 23_481_303);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer105, 4_028);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer36, 1_744);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer36, 'uint16', 3_438, 528);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer138, 284, 1_358);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas3);
+try {
+externalTexture4.label = '\u001b\u{1fe3c}\u{1f855}\uac05\u03a6\u{1fa0e}\u089c\uae6c\u02b3\ube9f';
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({});
+try {
+computePassEncoder164.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder20.draw(69, 37, 959_291_280, 264_374_017);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(53, 149, 314, 183_668_530, 1_064_353_272);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer95, 436);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(img7);
+try {
+globalThis.someLabel = bindGroup119.label;
+} catch {}
+let buffer147 = device0.createBuffer({
+  size: 5525,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder220 = device0.createCommandEncoder({label: '\u032b\uc701\uc9b0\u6fff\u{1ffa4}\u7bb1'});
+let computePassEncoder165 = commandEncoder220.beginComputePass({});
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer96, 856);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer55, 860);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder219.clearBuffer(buffer39, 48, 8);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(522).fill(162), /* required buffer size: 522 */
+{offset: 522}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder221 = device0.createCommandEncoder();
+let computePassEncoder166 = commandEncoder221.beginComputePass({});
+let renderPassEncoder66 = commandEncoder219.beginRenderPass({
+  colorAttachments: [{view: textureView59, depthSlice: 32, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 458942966,
+});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle10, renderBundle11]);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup32, []);
+} catch {}
+try {
+computePassEncoder145.setBindGroup(2, bindGroup57, new Uint32Array(1901), 852, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder42.setBlendConstant({ r: -814.0, g: 927.7, b: 34.58, a: 504.4, });
+} catch {}
+let texture205 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView223 = texture10.createView({dimension: 'cube', baseArrayLayer: 4});
+let sampler130 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.53,
+  lodMaxClamp: 96.90,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder59.setIndexBuffer(buffer82, 'uint16', 586, 331);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 127, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(359).fill(100), /* required buffer size: 359 */
+{offset: 359, bytesPerRow: 332}, {width: 74, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas1.height = 1870;
+await gc();
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteRp431', transfer: 'bt2020_10bit'} });
+try {
+adapter0.label = '\u8348\u0cee';
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({label: '\u0099\u044b\u{1f825}\u080d\u8936\u1f0a\u0aec\ufd04\ub75d'});
+let textureView224 = texture36.createView({label: '\u5fd0\uc85b\u0e34\u1922\u3dff\u01ec\ub1d4\ue03d\ueb72'});
+let computePassEncoder167 = commandEncoder222.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup93, new Uint32Array(180), 17, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle24, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer9, 0, 532);
+} catch {}
+let buffer148 = device0.createBuffer({
+  size: 820,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView225 = texture117.createView({dimension: '2d-array', aspect: 'all', format: 'r32float', mipLevelCount: 1});
+try {
+computePassEncoder167.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+commandEncoder101.copyTextureToBuffer({
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 100 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8 */
+  offset: 8,
+  buffer: buffer14,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(218).fill(190), /* required buffer size: 218 */
+{offset: 218, bytesPerRow: 55}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+document.body.append(img3);
+let bindGroup125 = device0.createBindGroup({
+  label: '\u54e0\u3786\u9e33\u32b9\u5f9c\u8bec\u06ec',
+  layout: bindGroupLayout32,
+  entries: [{binding: 36, resource: textureView203}],
+});
+let texture206 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder53.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer44, 'uint16', 72, 324);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  label: '\uc398\u{1fcf8}\u02db\udbd3\u0aa7\ue2e9\u88a8\u1a28',
+  layout: bindGroupLayout17,
+  entries: [{binding: 256, resource: {buffer: buffer19, offset: 768, size: 3188}}],
+});
+let textureView226 = texture105.createView({label: '\udbc3\u02e0\u6543\u4608\u1135\u8215\u42d7', mipLevelCount: 1});
+let computePassEncoder168 = commandEncoder101.beginComputePass({label: '\u99ad\u0087\u406e\u2b55\u0e86\u081d\u{1fd47}\u0a6b\u7d67'});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle39 = renderBundleEncoder39.finish({label: '\u07e9\u0efc\uda95\u{1fedf}'});
+let externalTexture19 = device0.importExternalTexture({label: '\uacbf\u6207\u046b\uf94e\uaf71\u6781\u{1fc86}\u0ebb', source: videoFrame3});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup125, new Uint32Array(2505), 585, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup16, new Uint32Array(1827), 201, 0);
+} catch {}
+try {
+renderPassEncoder64.end();
+} catch {}
+try {
+commandEncoder210.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1736 */
+  offset: 1736,
+  bytesPerRow: 7936,
+  rowsPerImage: 438,
+  buffer: buffer114,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData8,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer149 = device0.createBuffer({
+  label: '\ud266\u0b46\u0f41\u09b9\u63d0\ue749\u37a6\ub5ca\u03d4',
+  size: 5962,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 106});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer114, 'uint16', 1_510, 91);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer91, 1_440, 66);
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  label: '\u0226\ue7a7\u74a7\ue2df\u23e4\ue4bb\uf8dd\u7697\u{1f867}\u{1ff00}',
+  layout: bindGroupLayout13,
+  entries: [{binding: 278, resource: textureView19}],
+});
+let commandEncoder223 = device0.createCommandEncoder();
+let commandBuffer8 = commandEncoder210.finish();
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup127, new Uint32Array(567), 31, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer29 = buffer82.getMappedRange(0, 448);
+try {
+commandEncoder223.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9807 */
+  offset: 590,
+  bytesPerRow: 768,
+  rowsPerImage: 12,
+  buffer: buffer127,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 1, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule3, targets: [{format: 'r8uint', writeMask: GPUColorWrite.RED}]},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+  await promise25;
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'smpte240m'} });
+try {
+adapter0.label = '\u{1fb1d}\u08e5\u0e9f\u9395\uc057\u{1f62e}\u5706\u095c\u0676\u0b80';
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder({});
+let texture207 = device0.createTexture({
+  label: '\u{1f93d}\u{1ff01}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView227 = texture200.createView({});
+let computePassEncoder169 = commandEncoder223.beginComputePass({});
+let sampler131 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 45.09});
+try {
+computePassEncoder86.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup106);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(642);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer71, 732);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 15092, new Float32Array(3427));
+} catch {}
+document.body.prepend(canvas1);
+let texture208 = device0.createTexture({
+  size: {width: 1536},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let computePassEncoder170 = commandEncoder224.beginComputePass();
+try {
+computePassEncoder170.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup85, new Uint32Array(686), 55, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer91, 'uint32', 380, 540);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline18);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder225 = device0.createCommandEncoder();
+let texture209 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 187},
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup102, new Uint32Array(1540), 196, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup50, new Uint32Array(436), 2, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer63, 'uint16', 5_592, 752);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(1, buffer24, 1_636, 1_164);
+} catch {}
+try {
+buffer146.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(36).fill(252), /* required buffer size: 36 */
+{offset: 36}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup128 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 214, resource: textureView52}]});
+let buffer150 = device0.createBuffer({
+  label: '\u0abf\ucc28',
+  size: 5765,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder226 = device0.createCommandEncoder({});
+let sampler132 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.52,
+  lodMaxClamp: 96.11,
+});
+try {
+computePassEncoder148.setBindGroup(2, bindGroup54, new Uint32Array(2523), 160, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder29.setViewport(32.78238844293187, 0.740228909529547, 59.9219459868289, 0.20470219825469593, 0.38492775502858056, 0.8733771948573927);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer147, 472);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer141, 'uint16', 524, 642);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer76, 0, 5_700);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+commandEncoder226.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2622 */
+  offset: 2622,
+  bytesPerRow: 17408,
+  buffer: buffer50,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 462, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(92).fill(74), /* required buffer size: 92 */
+{offset: 92, bytesPerRow: 93}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder227 = device0.createCommandEncoder({});
+let computePassEncoder171 = commandEncoder226.beginComputePass({});
+let sampler133 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.788,
+  lodMaxClamp: 73.28,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder171.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(33, 2, 23, 3);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer82, 1_840, 337);
+} catch {}
+try {
+  await buffer64.mapAsync(GPUMapMode.WRITE, 0, 1004);
+} catch {}
+document.body.append(img6);
+offscreenCanvas2.width = 649;
+let computePassEncoder172 = commandEncoder227.beginComputePass({});
+let sampler134 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.26,
+  lodMaxClamp: 99.25,
+  compare: 'less',
+});
+try {
+renderPassEncoder66.setVertexBuffer(0, buffer97, 2_016);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder225.resolveQuerySet(querySet33, 27, 8, buffer55, 256);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let computePassEncoder173 = commandEncoder225.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer38, 1712, buffer46, 1016, 144);
+} catch {}
+let buffer151 = device0.createBuffer({size: 5734, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder228 = device0.createCommandEncoder({});
+try {
+device0.queue.writeBuffer(buffer123, 592, new Float32Array(550), 195);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let buffer152 = device0.createBuffer({
+  size: 4147,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder174 = commandEncoder130.beginComputePass();
+let sampler135 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.39,
+  lodMaxClamp: 60.06,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder134.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup112, new Uint32Array(1616), 20, 0);
+} catch {}
+try {
+renderPassEncoder28.draw(0, 81, 0, 367_727_183);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(18, 380, 40, -1_004_086_032, 3_870_852_425);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer15, 948);
+} catch {}
+let arrayBuffer30 = buffer64.getMappedRange(136, 188);
+let bindGroup129 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 278, resource: textureView42}]});
+try {
+computePassEncoder153.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup47, new Uint32Array(1314), 83, 0);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle23, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder28.drawIndexedIndirect(buffer152, 516);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer121, 1_164);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer99, 'uint32', 0, 317);
+} catch {}
+try {
+commandEncoder228.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 356 */
+  offset: 356,
+  rowsPerImage: 667,
+  buffer: buffer144,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 34, y: 32, z: 11},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder228.copyTextureToBuffer({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1100 */
+  offset: 1100,
+  buffer: buffer115,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder79.pushDebugGroup('\u{1faf7}');
+} catch {}
+let videoFrame23 = new VideoFrame(videoFrame0, {timestamp: 0});
+let bindGroup130 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 180, resource: textureView6}]});
+let textureView228 = texture190.createView({aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup32, new Uint32Array(409), 0, 0);
+} catch {}
+try {
+renderPassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer9);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture189,
+  mipLevel: 2,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let shaderModule22 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+var<private> vp33 = modf(vec3h());
+
+var<private> vp34: vec4u = vec4u();
+
+@group(0) @binding(144) var st10: texture_storage_3d<rgba8uint, read>;
+
+struct VertexOutput13 {
+  @builtin(position) f45: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp32 = modf(vec3h());
+
+struct FragmentOutput20 {
+  @location(3) @interpolate(linear, centroid) f0: vec2f,
+  @location(0) @interpolate(flat, centroid) f1: vec2u,
+}
+
+var<private> vp30: u32 = u32();
+
+var<private> vp31: FragmentOutput20 = FragmentOutput20();
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(190) var tex31: texture_2d_array<f32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+@vertex
+fn vertex18(@location(6) @interpolate(flat) a0: vec4h) -> VertexOutput13 {
+  var out: VertexOutput13;
+  let vf415: vec2f = quantizeToF16(vec2f(vp33.whole.gg));
+  out = VertexOutput13(vec4f(vp33.whole.rgrg));
+  vp33 = modf(vec3h(select(vec2<bool>(unconst_bool(true), unconst_bool(true)), vec2<bool>(unconst_bool(false), unconst_bool(false)), vec2<bool>(unconst_bool(true), unconst_bool(false))).ggg));
+  out.f45 *= exp(vec3f(unconst_f32(0.1544), unconst_f32(0.2984), unconst_f32(0.2431))).zyxy;
+  var vf416: vec2f = degrees(vec2f(vp32.fract.rr));
+  vp33.whole += vec3h(f16(vf416[u32(unconst_u32(127))]));
+  var vf417: vec4i = unpack4xI8(u32(vp33.fract[2]));
+  let ptr184: ptr<private, vec2f> = &vp31.f0;
+  let vf418: vec3f = sqrt(vec3f(unconst_f32(0.07228), unconst_f32(0.2650), unconst_f32(-0.3420)));
+  vp31.f1 >>= vec2u(u32(any(bool(unconst_bool(false)))));
+  var vf419: u32 = pack2x16snorm(vec2f(unconst_f32(-0.05968), unconst_f32(0.07193)));
+  let ptr185: ptr<private, vec3h> = &vp33.whole;
+  vf417 *= vec4i(vp31.f0.rggg);
+  vf419 ^= vp31.f1.y;
+  let vf420: i32 = firstTrailingBit(i32(unconst_i32(6)));
+  let vf421: vec3f = sqrt(vec3f(unconst_f32(0.3595), unconst_f32(-0.01858), unconst_f32(-0.2261)));
+  let vf422: u32 = vp31.f1[u32(vf421[2])];
+  var vf423: vec4i = unpack4xI8(u32(unconst_u32(217)));
+  let vf424: vec2f = degrees(vec2f(unconst_f32(0.4731), unconst_f32(-0.1026)));
+  let vf425: f32 = vf418[u32(unconst_u32(37))];
+  var vf426: vec3u = textureDimensions(st10);
+  let vf427: f32 = vf424[1];
+  out = VertexOutput13(vec4f(vp32.fract.yzzy));
+  return out;
+}
+
+@fragment
+fn fragment22() -> FragmentOutput20 {
+  var out: FragmentOutput20;
+  out.f0 = vec2f(f32(min(u32(unconst_u32(177)), u32(unconst_u32(158)))));
+  vp34 += vec4u(fract(vec3h(unconst_f16(801.7), unconst_f16(3787.4), unconst_f16(1249.9))).gggr);
+  var vf428: vec3h = fract(vec3h(unconst_f16(-9699.3), unconst_f16(17912.5), unconst_f16(16408.0)));
+  vp31 = FragmentOutput20(unpack2x16snorm(vp31.f1[0]), vec2u(vp31.f1[0]));
+  let vf429: i32 = countTrailingZeros(i32(unconst_i32(25)));
+  vp32 = modf(vec3h(vp31.f0.ggr));
+  var vf430: u32 = pack4x8unorm(bitcast<vec4f>(sign(bitcast<vec2i>(vp31.f0)).rgrr));
+  var vf431: vec2i = sign(bitcast<vec2i>(transpose(mat4x4h(unconst_f16(9380.9), unconst_f16(41117.8), unconst_f16(1816.2), unconst_f16(18017.8), unconst_f16(2234.6), unconst_f16(15693.6), unconst_f16(3521.9), unconst_f16(-8763.3), unconst_f16(3570.7), unconst_f16(6409.5), unconst_f16(2761.9), unconst_f16(12374.9), unconst_f16(-23955.1), unconst_f16(11102.2), unconst_f16(7822.4), unconst_f16(3624.9)))[2]));
+  var vf432: vec4h = atan(vp32.fract.yyzz);
+  vf432 -= vec4h(f16(min(u32(unconst_u32(516)), pack4xU8(vec4u(unconst_u32(146), unconst_u32(126), unconst_u32(136), unconst_u32(350))))));
+  out.f1 *= vec2u(u32(vf432[bitcast<u32>(sin(vec2h(vp34.ab)))]));
+  var vf433: vec2h = atan2(vec2h(vp31.f1), vec2h(sinh(vec2f(unconst_f32(-0.05361), unconst_f32(0.04214)))));
+  let vf434: vec2h = atan2(vec2h(unconst_f16(11891.2), unconst_f16(20177.0)), vec2h(unconst_f16(4566.9), unconst_f16(26360.2)));
+  let ptr186: ptr<private, u32> = &vp30;
+  let vf435: u32 = vp31.f1[u32(unconst_u32(471))];
+  return out;
+}
+
+@fragment
+fn fragment23(@builtin(position) a0: vec4f) -> @location(200) vec4u {
+  var out: vec4u;
+  vp33.whole = vec3h(f16(vp34[u32(abs(vec3h(unconst_f16(23770.3), unconst_f16(645.1), unconst_f16(36287.1))).b)]));
+  vp33.fract *= vp33.fract;
+  let ptr187: ptr<private, vec3h> = &vp33.whole;
+  var vf436: bool = all(bool(unconst_bool(true)));
+  var vf437: f32 = a0[u32(unconst_u32(325))];
+  out = vec4u(vp33.whole.zyzx);
+  vp30 *= u32(vf436);
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer153 = device0.createBuffer({size: 7781, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture210 = device0.createTexture({
+  label: '\u6d42\u085d\u{1f84b}\u51c1\u3936\u{1fa8d}\u0c9a',
+  size: {width: 30, height: 2, depthOrArrayLayers: 46},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView229 = texture61.createView({label: '\u9457\u0dea\u0984'});
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer32, 860, 1_496);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder228.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 852 */
+  offset: 852,
+  bytesPerRow: 3584,
+  buffer: buffer37,
+}, {
+  texture: texture201,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 22, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder228.copyTextureToBuffer({
+  texture: texture170,
+  mipLevel: 1,
+  origin: {x: 61, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 670 */
+  offset: 670,
+  bytesPerRow: 5632,
+  buffer: buffer56,
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandBuffer9 = commandEncoder103.finish({});
+let texture211 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder67 = commandEncoder228.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -779.0, g: 723.8, b: -147.2, a: 504.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder36.setIndexBuffer(buffer66, 'uint32', 0, 0);
+} catch {}
+let bindGroup131 = device0.createBindGroup({
+  label: '\u00b3\u1c40\u0efb\ubc4a\u07b9\u01ab\u0898\uf06c\u{1ffd9}\u{1fd44}',
+  layout: bindGroupLayout29,
+  entries: [{binding: 121, resource: textureView42}],
+});
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture212 = device0.createTexture({
+  size: [1536, 1, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder175 = commandEncoder229.beginComputePass({});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+renderPassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(6, buffer49, 32, 107);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup93, new Uint32Array(2298), 231, 0);
+} catch {}
+try {
+computePassEncoder79.popDebugGroup();
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f924}');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer129, 208, new BigUint64Array(5877), 370, 128);
+} catch {}
+await gc();
+let bindGroup132 = device0.createBindGroup({
+  label: '\u95a0\u{1f6ac}\u{1fda2}\u65e2\u{1f602}\ud43a',
+  layout: bindGroupLayout11,
+  entries: [{binding: 42, resource: textureView21}, {binding: 137, resource: textureView189}],
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+let querySet35 = device0.createQuerySet({label: '\u060d\u{1fc05}\u{1f63c}\u{1fc0c}\u{1ffbd}', type: 'occlusion', count: 891});
+let renderPassEncoder68 = commandEncoder230.beginRenderPass({
+  label: '\u{1fbcf}\u4220\u00db\uaeb8\uf6e2\u04a3\u0458\u{1fc12}\u{1fc3f}\u{1fe47}\u{1fe9d}',
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: 968.6, g: -217.0, b: -785.2, a: 182.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 58144279,
+});
+let renderBundle40 = renderBundleEncoder40.finish();
+let sampler136 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.48,
+  lodMaxClamp: 81.16,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup79, new Uint32Array(902), 37, 0);
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer55, 'uint16', 844, 783);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer108, 3_276, 640);
+} catch {}
+let arrayBuffer31 = buffer97.getMappedRange();
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 7},
+  aspect: 'all',
+}, new Uint8Array(6_271).fill(244), /* required buffer size: 6_271 */
+{offset: 151, bytesPerRow: 102, rowsPerImage: 60}, {width: 23, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 16, depthOrArrayLayers: 375}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer154 = device0.createBuffer({size: 36107, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder231 = device0.createCommandEncoder({});
+let texture213 = device0.createTexture({
+  label: '\u0696\uaa9d\ua246\u0de5\u04cf\u{1fd64}',
+  size: [192, 1, 52],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder75.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer83, 'uint32', 16, 1_821);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline17);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup133 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 351, resource: {buffer: buffer150, offset: 256, size: 2236}},
+    {binding: 87, resource: textureView25},
+  ],
+});
+let commandEncoder232 = device0.createCommandEncoder({});
+try {
+renderPassEncoder38.setBlendConstant({ r: 940.7, g: 922.5, b: -687.9, a: -593.8, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 136, new Int16Array(14468), 1764, 1140);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let imageData28 = new ImageData(8, 40);
+let buffer155 = device0.createBuffer({size: 10629, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture214 = gpuCanvasContext5.getCurrentTexture();
+let renderPassEncoder69 = commandEncoder232.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: 203.1, g: -819.6, b: -343.2, a: 542.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet24,
+});
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup124, []);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 57 widthInBlocks: 57 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 911 */
+  offset: 911,
+  bytesPerRow: 46080,
+  buffer: buffer11,
+}, {
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 9, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 57, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder231.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 104 */
+  offset: 104,
+  bytesPerRow: 3840,
+  buffer: buffer129,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder231.copyTextureToTexture({
+  texture: texture170,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder231.resolveQuerySet(querySet24, 2, 4, buffer61, 1024);
+} catch {}
+let buffer156 = device0.createBuffer({
+  label: '\u0521\u6ba1\u7db4\u0265\u0898\u4862',
+  size: 2243,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture215 = device0.createTexture({
+  size: [192, 1, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView230 = texture13.createView({dimension: '2d-array', aspect: 'all'});
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup131, []);
+} catch {}
+let arrayBuffer32 = buffer82.getMappedRange(448, 72);
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 43776,
+  buffer: buffer141,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 3, y: 10, z: 1},
+  aspect: 'all',
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(210).fill(52), /* required buffer size: 210 */
+{offset: 210}, {width: 108, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let querySet36 = device0.createQuerySet({label: '\u9776\u0b30\u{1f6cf}\udac5\u0ea6\u02c0', type: 'occlusion', count: 748});
+let textureView231 = texture109.createView({arrayLayerCount: 1});
+let renderPassEncoder70 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 78,
+  clearValue: { r: 543.3, g: -529.9, b: -341.9, a: -94.24, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 99239566,
+});
+try {
+renderPassEncoder39.setIndexBuffer(buffer143, 'uint16', 94, 1_518);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 14, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 76, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder233 = device0.createCommandEncoder();
+let texture216 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder71 = commandEncoder233.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: -420.9, g: 254.7, b: -629.6, a: -740.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup3, new Uint32Array(321), 145, 0);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let bindGroup134 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 42, resource: textureView169}, {binding: 137, resource: textureView31}],
+});
+let commandEncoder234 = device0.createCommandEncoder({});
+let textureView232 = texture182.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup45, new Uint32Array(255), 93, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer1, 'uint32', 428, 1_195);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder234.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 92 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6154 */
+  offset: 6154,
+  buffer: buffer67,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 92, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder234.copyTextureToTexture({
+  texture: texture186,
+  mipLevel: 1,
+  origin: {x: 10, y: 13, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture209,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 24},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 376, new Float32Array(15952), 4867, 512);
+} catch {}
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout18]});
+let commandEncoder235 = device0.createCommandEncoder();
+let texture217 = device0.createTexture({
+  size: [42, 20, 171],
+  sampleCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder176 = commandEncoder235.beginComputePass({});
+try {
+renderPassEncoder68.setBindGroup(1, bindGroup99, new Uint32Array(1194), 279, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle20, renderBundle33, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer119, 0);
+} catch {}
+try {
+commandEncoder234.copyBufferToBuffer(buffer66, 4, buffer106, 436, 0);
+} catch {}
+let textureView233 = texture117.createView({label: '\ub483\u03bd\uced4\u{1ff03}\u{1fa38}\u0e96\u03fa\u7de7\u6a49\u07c1\u98c0', mipLevelCount: 1});
+let computePassEncoder177 = commandEncoder234.beginComputePass({});
+let sampler137 = device0.createSampler({
+  label: '\u8f99\u9b91\uc4f8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.68,
+  lodMaxClamp: 92.79,
+  compare: 'less',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder169.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup130, new Uint32Array(1390), 635, 0);
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer63, 'uint16', 8, 733);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 57}
+*/
+{
+  source: imageData7,
+  origin: { x: 6, y: 1 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler138 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 87.51,
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup129, new Uint32Array(3208), 140, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u56ee\u8621\u095f\u00b4\u1bdb\u87db\u9293\u09fe\u{1f98f}\u09ae\u{1fa8a}',
+  colorFormats: ['r8uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup34, new Uint32Array(992), 302, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle1, renderBundle27, renderBundle0, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder52.setViewport(107.17652704456032, 5.29248774191061, 0.5897501217817509, 0.7444283094130373, 0.8272377465937601, 0.9140381041323975);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer110, 'uint32', 620, 87);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(6, buffer23, 0, 197);
+} catch {}
+let commandEncoder236 = device0.createCommandEncoder();
+let textureView234 = texture36.createView({dimension: '1d', baseArrayLayer: 0});
+let renderPassEncoder72 = commandEncoder236.beginRenderPass({colorAttachments: [{view: textureView70, loadOp: 'clear', storeOp: 'store'}]});
+let renderBundle41 = renderBundleEncoder41.finish({});
+try {
+computePassEncoder176.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer10, 0, 19);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let buffer157 = device0.createBuffer({
+  size: 6924,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup78, new Uint32Array(641), 185, 0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle24]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(106).fill(134), /* required buffer size: 106 */
+{offset: 106}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 91}
+*/
+{
+  source: imageData15,
+  origin: { x: 22, y: 13 },
+  flipY: true,
+}, {
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 26},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(0, buffer122);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let texture218 = gpuCanvasContext3.getCurrentTexture();
+let sampler139 = device0.createSampler({
+  label: '\u{1fb2c}\u0207\u19a6\u74c1\u5dd3\ucb07\u0436\uab6f\u3eae\u{1fee8}\ud27a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.12,
+  lodMaxClamp: 93.74,
+});
+try {
+renderPassEncoder60.executeBundles([renderBundle6, renderBundle41, renderBundle40]);
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 87, resource: textureView57},
+    {binding: 351, resource: {buffer: buffer2, offset: 512, size: 412}},
+  ],
+});
+let texture219 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 15},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder169.setBindGroup(2, bindGroup110);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer123, 'uint16', 6_552, 1_782);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(1, undefined, 166_715_872, 772_788_370);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 44, new Float32Array(5589), 139, 52);
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 150, resource: sampler30}, {binding: 69, resource: textureView14}],
+});
+let commandEncoder237 = device0.createCommandEncoder({label: '\u{1fa10}\u{1f653}'});
+let texture220 = device0.createTexture({
+  label: '\u4161\u0c79\u0ad0\u{1f8a8}\u81a6\u88c2\u0e91\u0950\u0551',
+  size: {width: 32, height: 32, depthOrArrayLayers: 18},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder178 = commandEncoder237.beginComputePass({label: '\u009a\u0405\u0155\u0f9b\u0250\ue5f4\u6c91\u8405\u078e\u055f\u{1f9a4}'});
+try {
+computePassEncoder101.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(15_135).fill(26), /* required buffer size: 15_135 */
+{offset: 55, bytesPerRow: 377, rowsPerImage: 20}, {width: 184, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder238 = device0.createCommandEncoder({});
+let computePassEncoder179 = commandEncoder238.beginComputePass({});
+try {
+computePassEncoder92.setBindGroup(1, bindGroup115);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 20, depthOrArrayLayers: 141}
+*/
+{
+  source: imageData25,
+  origin: { x: 27, y: 1 },
+  flipY: true,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 43},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 618, hasDynamicOffset: false },
+    },
+    {
+      binding: 293,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture221 = device0.createTexture({
+  label: '\u42cf\u{1fbb0}\u7838\u053f\u{1f9a0}\u537d\ucd35\u2deb\u{1f7e2}\u9ad8\u{1f7ba}',
+  size: [384, 1, 1],
+  sampleCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder180 = commandEncoder239.beginComputePass();
+try {
+computePassEncoder156.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline1);
+} catch {}
+try {
+  await buffer92.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(377_541).fill(64), /* required buffer size: 377_541 */
+{offset: 265, bytesPerRow: 200, rowsPerImage: 41}, {width: 19, height: 1, depthOrArrayLayers: 47});
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 97, resource: {buffer: buffer24, offset: 256, size: 4368}},
+    {binding: 41, resource: textureView117},
+    {binding: 120, resource: textureView197},
+  ],
+});
+let commandEncoder240 = device0.createCommandEncoder({});
+let textureView235 = texture221.createView({aspect: 'all'});
+let renderPassEncoder73 = commandEncoder240.beginRenderPass({
+  colorAttachments: [{
+  view: textureView179,
+  clearValue: { r: 907.3, g: -569.1, b: 98.64, a: 117.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler140 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 87.12,
+  lodMaxClamp: 94.54,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder178.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup123);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(3, buffer147, 664, 332);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer129, 896, new DataView(new ArrayBuffer(915)), 60, 368);
+} catch {}
+await gc();
+let buffer158 = device0.createBuffer({
+  label: '\ufb6a\u2b1b\u0aa4',
+  size: 3709,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder241 = device0.createCommandEncoder({});
+let texture222 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 1},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture223 = device0.createTexture({size: [42, 20, 46], format: 'rgb10a2unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder181 = commandEncoder241.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder150.setBindGroup(2, bindGroup120, new Uint32Array(952), 8, 0);
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup47, new Uint32Array(205), 16, 0);
+} catch {}
+let commandEncoder242 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  label: '\u0b1e\u0810\u0233\u0706\u07d8',
+  size: {width: 768, height: 1, depthOrArrayLayers: 23},
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder182 = commandEncoder242.beginComputePass();
+try {
+computePassEncoder21.setBindGroup(3, bindGroup92, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture219,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_659).fill(211), /* required buffer size: 1_659 */
+{offset: 101, bytesPerRow: 38, rowsPerImage: 41}, {width: 1, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let texture225 = device0.createTexture({
+  size: [192, 1, 229],
+  dimension: '2d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture226 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 26},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder57.setBindGroup(1, bindGroup59, new Uint32Array(2585), 905, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer63, 'uint16', 3_434, 1_012);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 244, new DataView(new ArrayBuffer(1252)), 32, 208);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = externalTexture3.label;
+} catch {}
+let buffer159 = device0.createBuffer({size: 732, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView236 = texture224.createView({baseMipLevel: 0, baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder169); computePassEncoder169.dispatchWorkgroupsIndirect(buffer152, 176); };
+} catch {}
+try {
+computePassEncoder128.end();
+} catch {}
+try {
+computePassEncoder169.end();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer44, 'uint16', 90, 208);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 66}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap5 = await createImageBitmap(videoFrame2);
+let textureView237 = texture87.createView({});
+let computePassEncoder183 = commandEncoder167.beginComputePass({});
+let renderPassEncoder74 = commandEncoder223.beginRenderPass({
+  colorAttachments: [{
+  view: textureView159,
+  clearValue: { r: -452.1, g: 537.6, b: 591.3, a: 112.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder165.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup89, new Uint32Array(1779), 313, 0);
+} catch {}
+let bindGroup138 = device0.createBindGroup({
+  layout: bindGroupLayout28,
+  entries: [{binding: 47, resource: {buffer: buffer71, offset: 1024, size: 2207}}],
+});
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle25]);
+} catch {}
+document.body.prepend(img0);
+let texture227 = device0.createTexture({
+  size: {width: 384},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView238 = texture156.createView({
+  label: '\u4702\u{1fd91}\ue78b\u3f81\u0d05\ud742\u{1fbbd}\u0e34\u7d59\u0e6e\u9ad9',
+  arrayLayerCount: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(0, bindGroup137);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup28, new Uint32Array(1066), 35, 0);
+} catch {}
+try {
+buffer117.unmap();
+} catch {}
+let sampler141 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.84,
+  lodMaxClamp: 74.61,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer34, 1_372); };
+} catch {}
+try {
+renderPassEncoder32.setViewport(6.348523046764409, 15.174968523941931, 21.578110052783074, 1.6262310337776305, 0.4009545690342303, 0.4951089851700893);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer37, 'uint32', 2_300, 1_775);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer147, 452, 1_070);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let shaderModule23 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw96: array<vec2u, 13>;
+
+@group(2) @binding(67) var<uniform> buffer162: array<array<f16, 29>, 1>;
+
+@group(1) @binding(78) var tex38: texture_2d_array<f32>;
+
+override override54: f16;
+
+@group(0) @binding(37) var<storage, read_write> buffer160: array<array<array<array<f16, 1>, 1>, 3>, 1>;
+
+struct FragmentOutput21 {
+  @location(0) @interpolate(flat, center) f0: vec4u,
+}
+
+@group(0) @binding(78) var tex34: texture_2d_array<f32>;
+
+var<workgroup> vw97: atomic<u32>;
+
+@group(0) @binding(48) var tex33: texture_depth_2d;
+
+struct VertexOutput14 {
+  @location(0) @interpolate(flat, centroid) f46: vec4u,
+  @builtin(position) f47: vec4f,
+  @location(3) @interpolate(flat, centroid) f48: u32,
+}
+
+struct T4 {
+  @align(1) @size(8) f0: i32,
+}
+
+alias vec3b = vec3<bool>;
+
+struct T3 {
+  @size(16) f0: T2,
+  @align(2) @size(44) f1: array<u32>,
+}
+
+@group(1) @binding(30) var tex36: texture_depth_2d;
+
+@group(1) @binding(37) var<storage, read_write> buffer161: array<array<f16, 3>>;
+
+fn fn0() -> array<array<bool, 1>, 13> {
+  var out: array<array<bool, 1>, 13>;
+  let ptr188: ptr<storage, f16, read_write> = &(*&buffer160)[0][2][0][0];
+  let ptr189: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer160)[0][2];
+  let ptr190: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer160[0][u32(unconst_u32(153))];
+  atomicCompareExchangeWeak(&vw97, unconst_u32(126), unconst_u32(250));
+  buffer161[pack4xU8Clamp(vw98.f0)][vw98.f0[2]] -= (*&buffer160)[0][2][0][0];
+  vw98.f0 = vec4u(bitcast<u32>(atomicLoad(&(*&vw95)[23])));
+  atomicStore(&vw97, u32(ldexp(f16(unconst_f16(-1665.2)), i32(buffer162[0][28]))));
+  return out;
+}
+
+struct T2 {
+  @align(2) @size(12) f0: i32,
+}
+
+@group(0) @binding(205) var tex35: texture_2d<f32>;
+
+override override55 = 0.1081;
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+@group(1) @binding(205) var tex39: texture_2d<f32>;
+
+@group(2) @binding(125) var tex40: texture_2d<u32>;
+
+struct T7 {
+  @size(16) f0: T2,
+}
+
+var<workgroup> vw98: FragmentOutput21;
+
+struct T1 {
+  @align(2) @size(60) f0: T0,
+}
+
+@group(0) @binding(30) var tex32: texture_depth_2d;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw95: array<atomic<i32>, 24>;
+
+override override53 = true;
+
+struct T5 {
+  @align(2) @size(16) f0: atomic<u32>,
+  @align(2) @size(44) f1: array<u32>,
+}
+
+@group(1) @binding(48) var tex37: texture_depth_2d;
+
+@group(3) @binding(180) var st11: texture_storage_2d_array<r32float, read_write>;
+
+struct T6 {
+  @align(2) @size(64) f0: array<vec2u>,
+}
+
+@vertex
+fn vertex19(@location(10) a0: vec2i) -> VertexOutput14 {
+  var out: VertexOutput14;
+  var vf438: vec2u = textureDimensions(tex37, i32(unconst_i32(24)));
+  out = VertexOutput14(vec4u(bitcast<u32>(a0[0])), vec4f(f32(a0[0])), u32(a0[0]));
+  var vf439: i32 = a0[vf438.g];
+  vf439 ^= vec2i(textureDimensions(tex40)).r;
+  var vf440: vec4u = textureLoad(tex40, vec2i(unconst_i32(181), unconst_i32(32)), bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(376), unconst_i32(534), unconst_i32(6), unconst_i32(0)))));
+  out.f46 *= textureDimensions(tex32, i32(unconst_i32(57))).grgr;
+  var vf441: f32 = override55;
+  vf441 = f32(vf438[0]);
+  var vf442: f32 = override55;
+  var vf443: vec2u = textureDimensions(tex36, i32(unconst_i32(146)));
+  let vf444: u32 = vf438[u32(unconst_u32(60))];
+  vf440 = unpack4xU8(u32(vf442));
+  out.f48 &= textureNumLevels(tex40);
+  let vf445: vec2u = textureDimensions(tex40);
+  var vf446: f32 = cos(f32(unconst_f32(0.3077)));
+  return out;
+  _ = override55;
+}
+
+@fragment
+fn fragment24(@location(15) @interpolate(flat, sample) a0: vec2i) -> FragmentOutput21 {
+  var out: FragmentOutput21;
+  let ptr191: ptr<storage, f16, read_write> = &(*&buffer161)[arrayLength(&(*&buffer161))][u32(unconst_u32(203))];
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder243 = device0.createCommandEncoder({});
+let computePassEncoder184 = commandEncoder243.beginComputePass({});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup68, new Uint32Array(2846), 208, 0);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer143, 324, new Float32Array(5762), 106, 120);
+} catch {}
+let buffer163 = device0.createBuffer({size: 2216, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder244 = device0.createCommandEncoder({});
+let texture228 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 187},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder185 = commandEncoder22.beginComputePass();
+try {
+computePassEncoder84.setBindGroup(0, bindGroup8, new Uint32Array(75), 3, 0);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup123, new Uint32Array(262), 1, 0);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(7, 1, 36, 1);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer119);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer151, 444, buffer61, 4164, 1044);
+} catch {}
+try {
+commandEncoder244.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 7, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 188 */
+  offset: 188,
+  bytesPerRow: 4864,
+  buffer: buffer25,
+}, {width: 6, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture181,
+  mipLevel: 0,
+  origin: {x: 225, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer145, 2168, 2320);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'smpte240m'} });
+try {
+globalThis.someLabel = externalTexture14.label;
+} catch {}
+let bindGroup139 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView19},
+    {binding: 4, resource: {buffer: buffer73, offset: 2560, size: 180}},
+  ],
+});
+let computePassEncoder186 = commandEncoder44.beginComputePass({});
+let sampler142 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 20.64,
+  lodMaxClamp: 90.15,
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder70.beginOcclusionQuery(84);
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(190);
+} catch {}
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let commandEncoder245 = device0.createCommandEncoder({});
+let renderPassEncoder75 = commandEncoder245.beginRenderPass({
+  colorAttachments: [{
+  view: textureView230,
+  clearValue: { r: -996.9, g: 667.1, b: -723.5, a: 641.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler143 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.520,
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 130, resource: textureView207}, {binding: 23, resource: textureView24}],
+});
+let commandEncoder246 = device0.createCommandEncoder({});
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 754});
+let computePassEncoder187 = commandEncoder246.beginComputePass({});
+let renderPassEncoder76 = commandEncoder36.beginRenderPass({colorAttachments: [{view: textureView59, depthSlice: 37, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup102, new Uint32Array(4177), 910, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup123, new Uint32Array(3435), 764, 0);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle14, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder244.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 795});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 9}
+*/
+{
+  source: img0,
+  origin: { x: 26, y: 0 },
+  flipY: false,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img10);
+let buffer164 = device0.createBuffer({
+  size: 24220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder247 = device0.createCommandEncoder({});
+let computePassEncoder188 = commandEncoder244.beginComputePass();
+try {
+computePassEncoder134.setBindGroup(2, bindGroup135);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline9);
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 69, resource: textureView10}, {binding: 150, resource: sampler30}],
+});
+let buffer165 = device0.createBuffer({
+  size: 530,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder248 = device0.createCommandEncoder();
+let sampler144 = device0.createSampler({
+  label: '\u{1fd42}\u{1f824}\u84dc\u51c1\u{1f83d}\u{1fbae}\u889a',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.65,
+  lodMaxClamp: 94.22,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup82);
+} catch {}
+try {
+computePassEncoder126.setBindGroup(0, bindGroup49, new Uint32Array(2406), 200, 0);
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer144, 'uint16', 68);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder248.copyTextureToTexture({
+  texture: texture192,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 24},
+  aspect: 'all',
+},
+{
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 34, y: 14, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup142 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 130, resource: textureView66}, {binding: 23, resource: textureView24}],
+});
+let renderPassEncoder77 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -185.7, g: 829.2, b: -796.3, a: -45.71, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 379317962,
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup43, new Uint32Array(1020), 656, 0);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup81, new Uint32Array(4314), 1_303, 0);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer149, 'uint32', 1_620, 406);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(0, buffer29, 96, 71);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise27;
+} catch {}
+let shaderModule24 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+struct T1 {
+  f0: array<u32>,
+}
+
+struct T0 {
+  @align(2) f0: array<array<vec2f, 1>, 1>,
+  @align(2) @size(28) f1: array<u32>,
+}
+
+@group(0) @binding(190) var tex41: texture_2d_array<f32>;
+
+var<workgroup> vw111: array<atomic<i32>, 22>;
+
+var<workgroup> vw101: i32;
+
+var<workgroup> vw100: vec2u;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw109: atomic<i32>;
+
+struct VertexOutput15 {
+  @location(1) @interpolate(perspective, centroid) f49: vec4h,
+  @location(6) f50: vec2h,
+  @location(7) @interpolate(flat, sample) f51: vec2i,
+  @location(10) @interpolate(perspective, center) f52: f32,
+  @builtin(position) f53: vec4f,
+  @location(8) f54: vec2u,
+  @location(9) @interpolate(flat, sample) f55: vec4i,
+}
+
+var<workgroup> vw110: mat4x2h;
+
+var<workgroup> vw104: atomic<i32>;
+
+var<workgroup> vw112: vec2h;
+
+var<workgroup> vw106: vec4f;
+
+var<workgroup> vw105: array<atomic<u32>, 3>;
+
+var<workgroup> vw107: mat2x2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp35 = modf(vec4f());
+
+@group(0) @binding(144) var st12: texture_storage_3d<rgba8uint, read>;
+
+var<private> vp36: mat3x4f = mat3x4f();
+
+var<workgroup> vw113: array<atomic<i32>, 7>;
+
+var<workgroup> vw99: array<array<atomic<i32>, 2>, 14>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw103: array<vec4u, 10>;
+
+var<workgroup> vw108: mat2x3h;
+
+var<workgroup> vw102: array<array<atomic<u32>, 1>, 22>;
+
+@vertex
+fn vertex20() -> VertexOutput15 {
+  var out: VertexOutput15;
+  out.f49 = vec4h(acos(vec3f(unconst_f32(0.09868), unconst_f32(0.5354), unconst_f32(0.4309))).gbrb);
+  out.f53 -= bitcast<vec4f>(textureDimensions(st12).zzzz);
+  out.f50 += vec2h(unpack2x16float(u32(unconst_u32(198))));
+  out.f54 >>= vec2u(refract(unpack2x16unorm(u32(unconst_u32(5))).yyyx, vec4f(f32(pack4x8unorm(vec4f(unconst_f32(0.07405), unconst_f32(0.1068), unconst_f32(0.02548), unconst_f32(0.1861))))), f32(unconst_f32(0.05032))).gb);
+  out.f52 += unpack2x16float(bitcast<u32>(tan(textureLoad(tex41, vec2i(exp2(vec3h(unconst_f16(20114.1), unconst_f16(2513.5), unconst_f16(-6861.7))).xy), i32(textureNumLayers(tex41)), vec3i(exp2(vec3h(unconst_f16(10862.6), unconst_f16(17062.8), unconst_f16(11395.4)))).r).y)))[1];
+  let ptr192: ptr<private, vec4f> = &vp35.whole;
+  out.f54 -= vec2u(unpack2x16unorm(u32(unconst_u32(9))));
+  out.f52 = saturate(tanh(vec2f(unconst_f32(0.05528), unconst_f32(0.2628)))).y;
+  vp36 -= mat3x4f(vec4f(exp2(vec3h(unconst_f16(-2239.1), unconst_f16(-6919.1), unconst_f16(4028.8))).bgbg), vec4f(exp2(vec3h(unconst_f16(-2239.1), unconst_f16(-6919.1), unconst_f16(4028.8))).bbgr), vec4f(exp2(vec3h(unconst_f16(-2239.1), unconst_f16(-6919.1), unconst_f16(4028.8))).rbbg));
+  out.f54 ^= vec2u(vp36[1].zz);
+  let vf447: vec2h = reflect(vec2h(unconst_f16(1384.5), unconst_f16(13927.6)), vec2h(unconst_f16(2764.8), unconst_f16(17238.9)));
+  out.f49 = vec4h(vp35.fract);
+  out.f49 -= bitcast<vec4h>(tanh(vec2f(unconst_f32(0.02629), unconst_f32(0.1329))));
+  var vf448: vec2f = unpack2x16unorm(bitcast<u32>(tan(f32(unconst_f32(0.01365)))));
+  vp36 = mat3x4f(vf448.gggg, vf448.yxyx, vf448.rgrr);
+  let ptr193: ptr<private, mat3x4f> = &vp36;
+  var vf449: vec2h = vf447;
+  let vf450: vec4i = unpack4xI8(u32(unconst_u32(343)));
+  let vf451: u32 = textureNumLevels(tex41);
+  let vf452: vec3h = exp2(vec3h(unconst_f16(11215.6), unconst_f16(205.4), unconst_f16(4014.7)));
+  var vf453: vec4f = quantizeToF16(vec4f(unconst_f32(0.1570), unconst_f32(0.1060), unconst_f32(0.03238), unconst_f32(0.3071)));
+  let ptr194: ptr<private, vec4f> = &(*ptr192);
+  let vf454: vec3h = vf452;
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute19() {
+  atomicStore(&vw102[21][u32(vw108[pack4xU8Clamp(textureLoad(st12, bitcast<vec3i>(vw100.rrg)))][u32(unconst_u32(448))])], u32(unconst_u32(73)));
+  vw112 -= bitcast<vec2h>(atomicLoad(&(*&vw105)[2]));
+  atomicOr(&vw99[u32(unconst_u32(17))][u32(unconst_u32(155))], i32(unconst_i32(18)));
+  var vf455: f16 = (*&vw112)[u32(unconst_u32(244))];
+  let ptr195: ptr<workgroup, array<atomic<u32>, 1>> = &vw102[21];
+  let ptr196: ptr<workgroup, array<atomic<i32>, 2>> = &(*&vw99)[13];
+  let vf456: i32 = atomicLoad(&(*&vw113)[6]);
+  var vf457: i32 = atomicExchange(&(*&vw111)[21], i32(unconst_i32(165)));
+  atomicCompareExchangeWeak(&vw111[21], unconst_i32(24), unconst_i32(66));
+  let vf458: u32 = pack4xU8(unpack4xU8(u32(vw108[0][u32(unconst_u32(57))])));
+  let ptr197: ptr<workgroup, vec4f> = &vw106;
+  textureBarrier();
+  var vf459: i32 = atomicLoad(&(*&vw111)[21]);
+  vw112 = vec2h((*&vw107)[(*&vw103)[9][3]][u32(unconst_u32(26))]);
+  vw103[u32(unconst_u32(776))] = (*&vw100).rggg;
+  let vf460: i32 = atomicExchange(&vw113[6], i32((*&vw106)[u32(unconst_u32(429))]));
+  vw106 = vec4f(f32((*&vw101)));
+  vf457 = i32((*&vw106)[u32(unconst_u32(196))]);
+  atomicCompareExchangeWeak(&vw105[u32(unconst_u32(557))], unconst_u32(61), unconst_u32(165));
+  let vf461: f32 = vp36[2][pack4x8snorm(vp36[1])];
+  vw100 = vec2u(atomicLoad(&(*&vw105)[u32(unconst_u32(94))]));
+  var vf462: u32 = atomicLoad(&(*ptr195)[0]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer166 = device0.createBuffer({
+  label: '\u{1f697}\u065c\u{1f8a8}\uf17d\u7fd6\u5540\uad9b\u8d5e\u{1f902}\u43f1',
+  size: 1512,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+});
+let computePassEncoder189 = commandEncoder248.beginComputePass({});
+let renderBundle42 = renderBundleEncoder42.finish({});
+try {
+computePassEncoder189.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup47, new Uint32Array(362), 52, 0);
+} catch {}
+try {
+renderPassEncoder70.endOcclusionQuery();
+} catch {}
+let buffer167 = device0.createBuffer({size: 2400, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture229 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 187},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler145 = device0.createSampler({
+  label: '\u08ef\u74e1\u0a8c\u057e\u0785\u9404\u{1f726}\u46f5\uee22\u{1fabc}\ufc26',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.90,
+  lodMaxClamp: 43.30,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder140.setBindGroup(3, bindGroup93, new Uint32Array(251), 2, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer66, 0);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(3, buffer0);
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 411, resource: textureView109},
+    {binding: 11, resource: {buffer: buffer1, offset: 512, size: 1214}},
+  ],
+});
+let commandEncoder249 = device0.createCommandEncoder({label: '\ua844\u0249\u0a2c\u057a\u{1fd74}\u053e\u1b1b'});
+let textureView239 = texture10.createView({label: '\u{1fe11}\u{1f6f5}\u0dce\uc4e7\u0a7f', arrayLayerCount: 2});
+let computePassEncoder190 = commandEncoder249.beginComputePass({label: '\u7fa4\ua9d0\uff4d\u0fc2\ub7a6\u13bf\u04aa\u5125\u0151'});
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup130, new Uint32Array(98), 7, 0);
+} catch {}
+try {
+renderPassEncoder66.setScissorRect(3, 0, 15, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer140, 1_888, 1_478);
+} catch {}
+let arrayBuffer33 = buffer69.getMappedRange(112, 24);
+try {
+device0.queue.writeTexture({
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 2},
+  aspect: 'all',
+}, new Uint8Array(100).fill(62), /* required buffer size: 100 */
+{offset: 100}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470m', transfer: 'bt2020_12bit'} });
+let bindGroup144 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 137, resource: textureView72},
+    {binding: 223, resource: textureView35},
+    {binding: 429, resource: {buffer: buffer58, offset: 1280, size: 112}},
+    {binding: 62, resource: textureView37},
+  ],
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout16]});
+let commandEncoder250 = device0.createCommandEncoder({});
+let querySet39 = device0.createQuerySet({label: '\u4293\u0016\u6923\u30f9\ueeac\u{1f9b4}\uf2c2', type: 'occlusion', count: 599});
+try {
+computePassEncoder188.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder61.draw(381, 170, 550_073_326, 78_705_294);
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(3, 159, 5, 325_227_398, 2_548_355_891);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer140, 3_564);
+} catch {}
+try {
+  await buffer155.mapAsync(GPUMapMode.WRITE, 408, 204);
+} catch {}
+let texture230 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 7},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup63, new Uint32Array(765), 451, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder126); computePassEncoder126.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(16, 100, 14, 13_607_097, 1_223_928_840);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer133, 0);
+} catch {}
+try {
+renderPassEncoder61.draw(29, 477, 471_388_706, 1_249_223_171);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer32, 1_092);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer158, 372);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer34, 1_900);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 124, new Int16Array(5186), 1389, 2588);
+} catch {}
+try {
+externalTexture3.label = '\u70b4\ua707\ucba4\u0074\uba5f\u1983\u{1fb31}\u0b49';
+} catch {}
+let commandEncoder251 = device0.createCommandEncoder({});
+let texture231 = device0.createTexture({
+  size: [192, 1, 1],
+  mipLevelCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+let textureView240 = texture124.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder191 = commandEncoder250.beginComputePass({});
+try {
+computePassEncoder79.setBindGroup(2, bindGroup18, [1280]);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 260 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3940 */
+  offset: 3940,
+  bytesPerRow: 6144,
+  buffer: buffer126,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas3);
+let commandEncoder252 = device0.createCommandEncoder({});
+let querySet40 = device0.createQuerySet({label: '\u0792\u095f\u3ecc\udea5\uc5ed', type: 'occlusion', count: 157});
+let computePassEncoder192 = commandEncoder252.beginComputePass({});
+try {
+computePassEncoder185.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder46.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle8, renderBundle19, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(23, 1, 43, -2_128_070_933, 140_872_333);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer40, 760);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder193 = commandEncoder251.beginComputePass({});
+try {
+computePassEncoder126.end();
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer145, 1_136);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3360 */
+  offset: 3360,
+  buffer: buffer128,
+}, {
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 2},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder165.resolveQuerySet(querySet18, 38, 27, buffer25, 2816);
+} catch {}
+try {
+computePassEncoder125.pushDebugGroup('\u5e18');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let videoFrame26 = new VideoFrame(img4, {timestamp: 0});
+try {
+globalThis.someLabel = sampler92.label;
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(48);
+} catch {}
+try {
+renderPassEncoder61.draw(190, 82, 1_592_911_940, 393_393_236);
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(37, 480, 28, 1_406_504_648, 1_185_160_263);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer152, 152);
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2591 */
+  offset: 2591,
+  bytesPerRow: 13056,
+  buffer: buffer104,
+}, {
+  texture: texture127,
+  mipLevel: 1,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 384, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder125.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder35.insertDebugMarker('\u0104');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 11},
+  aspect: 'all',
+}, new Uint8Array(89_738).fill(76), /* required buffer size: 89_738 */
+{offset: 341, bytesPerRow: 63, rowsPerImage: 129}, {width: 4, height: 0, depthOrArrayLayers: 12});
+} catch {}
+offscreenCanvas2.height = 643;
+let bindGroup145 = device0.createBindGroup({layout: bindGroupLayout26, entries: [{binding: 98, resource: textureView202}]});
+let textureView241 = texture197.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder194 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder191.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup125);
+} catch {}
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer116, 688);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer23, 0, 124);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 113});
+let textureView242 = texture225.createView({format: 'rg32float', baseMipLevel: 0, baseArrayLayer: 31, arrayLayerCount: 47});
+try {
+computePassEncoder149.setBindGroup(1, bindGroup52, new Uint32Array(3883), 594, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup96, new Uint32Array(1047), 39, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle6, renderBundle41]);
+} catch {}
+try {
+renderPassEncoder61.draw(204, 28, 365_034_660, 430_006_255);
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(11, 56, 0, 1_891_438_640, 605_180_231);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer38, 908);
+} catch {}
+let arrayBuffer34 = buffer47.getMappedRange(40, 28);
+try {
+  await promise28;
+} catch {}
+let querySet42 = device0.createQuerySet({type: 'occlusion', count: 727});
+let texture232 = device0.createTexture({
+  label: '\u4bb7\uc73a',
+  size: [120],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup97, new Uint32Array(8177), 2_434, 0);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.draw(74, 320, 1_512_619_218, 535_004_835);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer115, 92);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer36, 2_512);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4, buffer15, 0);
+} catch {}
+let videoFrame27 = new VideoFrame(videoFrame17, {timestamp: 0});
+let buffer168 = device0.createBuffer({
+  size: 2641,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder253 = device0.createCommandEncoder({});
+let computePassEncoder195 = commandEncoder253.beginComputePass();
+try {
+computePassEncoder81.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(2, bindGroup143, new Uint32Array(2803), 27, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder61.draw(245, 391, 399_316_612, 23_772_437);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer34, 1_076);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer86);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder125.setBindGroup(3, bindGroup64, new Uint32Array(1526), 207, 0);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup115, []);
+} catch {}
+try {
+renderPassEncoder70.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder61.draw(49, 34, 1_680_419_973, 144_598_410);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer99, 120);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer133, 4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 1668, new Float32Array(315));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(11).fill(131), /* required buffer size: 11 */
+{offset: 11, rowsPerImage: 72}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer169 = device0.createBuffer({
+  size: 2252,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder61.drawIndirect(buffer105, 796);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer88, 'uint16', 1_328, 378);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(5, buffer34, 2_116, 701);
+} catch {}
+let videoFrame28 = new VideoFrame(canvas4, {timestamp: 0});
+let commandEncoder254 = device0.createCommandEncoder();
+let texture233 = device0.createTexture({
+  size: {width: 60, height: 4, depthOrArrayLayers: 93},
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder196 = commandEncoder254.beginComputePass({});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder141.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup118);
+} catch {}
+try {
+renderPassEncoder61.draw(147, 105, 586_672_291, 71_806_954);
+} catch {}
+try {
+renderPassEncoder61.drawIndexed(11, 147, 11, -1_844_099_276, 1_303_258_086);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer21, 1_000);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 337, resource: {buffer: buffer86, offset: 3584, size: 688}}],
+});
+let buffer170 = device0.createBuffer({size: 16079, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder255 = device0.createCommandEncoder({});
+let texture234 = device0.createTexture({
+  size: [21, 10, 16],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView243 = texture135.createView({});
+let computePassEncoder197 = commandEncoder255.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup112);
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(0, bindGroup125, []);
+} catch {}
+try {
+renderPassEncoder70.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle29, renderBundle39, renderBundle39]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+try {
+computePassEncoder32.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer99, 252);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer108, 'uint16', 2_612, 106);
+} catch {}
+try {
+buffer170.unmap();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+document.body.prepend(img4);
+let commandEncoder256 = device0.createCommandEncoder({});
+let textureView244 = texture7.createView({dimension: '3d'});
+let renderPassEncoder78 = commandEncoder256.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 60,
+  clearValue: { r: 811.4, g: -805.2, b: -842.1, a: 577.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder197.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup44, new Uint32Array(611), 133, 0);
+} catch {}
+try {
+renderPassEncoder61.draw(58, 26, 70_071_982, 1_289_002_737);
+} catch {}
+try {
+renderPassEncoder61.drawIndexedIndirect(buffer37, 4_784);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer123, 'uint16', 4_200, 171);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline15);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let bindGroup147 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 411, resource: textureView103}, {binding: 11, resource: {buffer: buffer10, offset: 512}}],
+});
+let texture235 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture236 = device0.createTexture({
+  size: [1536],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView245 = texture110.createView({label: '\ub620\u0f64\uf602\u3d18\ub0d4\u{1f995}\u{1f96e}\ua1e4\udc59\u0258\u1faa'});
+try {
+computePassEncoder193.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroupsIndirect(buffer83, 196); };
+} catch {}
+try {
+renderPassEncoder61.end();
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -252.3, g: -375.4, b: -830.7, a: 923.4, });
+} catch {}
+try {
+commandEncoder194.copyBufferToBuffer(buffer22, 7512, buffer166, 696, 176);
+} catch {}
+let bindGroup148 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 214, resource: textureView48}]});
+let texture237 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 208},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder198 = commandEncoder194.beginComputePass({label: '\u0c81\u47c0\u{1fb06}'});
+try {
+computePassEncoder198.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup106);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer111, 'uint16', 12, 26);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer120, 0, 13_674);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let textureView246 = texture13.createView({label: '\uaa45\u{1f7ff}\u{1f98e}\u0125\u{1fb7f}', dimension: '2d-array'});
+try {
+computePassEncoder141.setBindGroup(2, bindGroup119, new Uint32Array(2102), 300, 0);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer37, 'uint16', 3_330, 320);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 2, depthOrArrayLayers: 46}
+*/
+{
+  source: imageData17,
+  origin: { x: 0, y: 18 },
+  flipY: true,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 1848});
+let textureView247 = texture235.createView({label: '\u59c8\u0759\u122c\u236d\u0775\u076b\u0d41\u93d2\udbf1\ubed3'});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup100, new Uint32Array(471), 49, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroupsIndirect(buffer1, 1_592); };
+} catch {}
+try {
+computePassEncoder141.end();
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup93, new Uint32Array(675), 99, 0);
+} catch {}
+try {
+renderPassEncoder44.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle7, renderBundle7, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(12, 0, 129, 0);
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 371, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture210,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 8, y: 6, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline20 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule4, constants: {}}});
+let texture238 = device0.createTexture({
+  size: {width: 768},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView248 = texture41.createView({format: 'rgba8unorm'});
+let renderPassEncoder79 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: 498.0, g: -807.9, b: 739.3, a: 310.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup3);
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let bindGroup149 = device0.createBindGroup({
+  label: '\u924d\u{1ff4f}\u9b85\uf4ce\u9d9d\u60f0\u{1f994}\u6e82',
+  layout: bindGroupLayout33,
+  entries: [
+    {binding: 31, resource: {buffer: buffer56, offset: 0, size: 32}},
+    {binding: 164, resource: externalTexture5},
+  ],
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let renderPassEncoder80 = commandEncoder257.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  depthSlice: 15,
+  clearValue: { r: 984.2, g: 687.3, b: -30.25, a: 475.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder144.setBindGroup(1, bindGroup136);
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(3, 0, 22, 0);
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt709', transfer: 'smpteSt4281'} });
+let commandEncoder258 = device0.createCommandEncoder();
+let textureView249 = texture171.createView({});
+let computePassEncoder199 = commandEncoder258.beginComputePass({});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup21, new Uint32Array(2737), 6, 0);
+} catch {}
+try {
+computePassEncoder199.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(0, buffer137);
+} catch {}
+let texture239 = device0.createTexture({size: {width: 60}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder146.setBindGroup(1, bindGroup58, new Uint32Array(1294), 256, 0);
+} catch {}
+try {
+renderPassEncoder44.endOcclusionQuery();
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer171 = device0.createBuffer({
+  size: 12720,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture240 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 187},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView250 = texture184.createView({});
+let sampler146 = device0.createSampler({
+  label: '\u0c76\ue36f\ud30d\u{1fe57}\u8f1d\uab15\u0b42\u3943\ufa28\u{1f9a5}\ud20d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 1.389,
+  compare: 'always',
+});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup139);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup65, new Uint32Array(204), 7, 0);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(2, buffer85, 2_580);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 206, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(196).fill(24), /* required buffer size: 196 */
+{offset: 196}, {width: 440, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let sampler147 = device0.createSampler({
+  label: '\u0dfa\u{1f97c}\u96cc\u6b1c\u{1f9dc}\u{1fb17}\u07b0\u0e20\u{1fa49}\u025e\ufc7e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 84.87,
+  lodMaxClamp: 97.99,
+  compare: 'never',
+});
+try {
+computePassEncoder112.setBindGroup(3, bindGroup7, new Uint32Array(570), 34, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle37]);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer172 = device0.createBuffer({size: 2682, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let texture241 = device0.createTexture({
+  size: {width: 168, height: 80, depthOrArrayLayers: 131},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler148 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.65,
+  lodMaxClamp: 84.07,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup140, new Uint32Array(1684), 30, 0);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(img0);
+let texture242 = device0.createTexture({
+  size: {width: 21, height: 10, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView251 = texture117.createView({mipLevelCount: 1});
+let sampler149 = device0.createSampler({
+  label: '\u07d5\u3ee3\u4cce\ud899\u0939\u04f8\u0f9a\u3b95\ubb73',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.3589,
+  lodMaxClamp: 31.09,
+});
+try {
+computePassEncoder194.setBindGroup(0, bindGroup101, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 27}
+*/
+{
+  source: img4,
+  origin: { x: 1, y: 24 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture17.label;
+} catch {}
+let bindGroup150 = device0.createBindGroup({
+  label: '\u767a\u30ec\u3e08\u{1fb29}\u012e\u8985\u686d\u43d0',
+  layout: bindGroupLayout13,
+  entries: [{binding: 278, resource: textureView10}],
+});
+let commandEncoder259 = device0.createCommandEncoder({});
+let texture243 = device0.createTexture({
+  size: [1536, 1, 104],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder200 = commandEncoder259.beginComputePass({});
+try {
+renderPassEncoder13.setViewport(8.392632039724234, 2.9789526645955826, 13.275305392020224, 0.7551901733144111, 0.8459084890841163, 0.9579807809102696);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer24, 260, 234);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let bindGroup151 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 67, resource: {buffer: buffer11, offset: 3072, size: 1914}},
+    {binding: 125, resource: textureView195},
+  ],
+});
+let texture244 = device0.createTexture({
+  size: [192, 1, 4],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler150 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.98,
+  lodMaxClamp: 23.61,
+  compare: 'not-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder199.setBindGroup(3, bindGroup136, new Uint32Array(2586), 406, 0);
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup53, []);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(7, buffer76, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout34]});
+let texture245 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 375},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView252 = texture16.createView({dimension: '2d-array', aspect: 'depth-only', baseArrayLayer: 0});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup12, new Uint32Array(2064), 305, 1);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer32, 3_156, 869);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(27_425).fill(79), /* required buffer size: 27_425 */
+{offset: 265, bytesPerRow: 44, rowsPerImage: 56}, {width: 3, height: 2, depthOrArrayLayers: 12});
+} catch {}
+let imageData29 = new ImageData(24, 84);
+let commandEncoder260 = device0.createCommandEncoder();
+let texture246 = device0.createTexture({
+  size: [84, 40, 65],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture247 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 69},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView253 = texture19.createView({arrayLayerCount: 1});
+let computePassEncoder201 = commandEncoder260.beginComputePass({});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup21, new Uint32Array(306), 127, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline16);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+document.body.append(canvas2);
+await gc();
+let bindGroup152 = device0.createBindGroup({
+  label: '\u51e2\u10ee',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 429, resource: {buffer: buffer90, offset: 0, size: 176}},
+    {binding: 137, resource: textureView5},
+    {binding: 62, resource: textureView173},
+    {binding: 223, resource: textureView35},
+  ],
+});
+let commandEncoder261 = device0.createCommandEncoder({});
+let textureView254 = texture241.createView({mipLevelCount: 1});
+let computePassEncoder202 = commandEncoder261.beginComputePass();
+let sampler151 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 94.68,
+  lodMaxClamp: 95.89,
+});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup89, new Uint32Array(157), 9, 0);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline8);
+} catch {}
+let arrayBuffer35 = buffer70.getMappedRange(488, 168);
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(img1);
+let texture248 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 100},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView255 = texture55.createView({format: 'r32float'});
+let sampler152 = device0.createSampler({
+  label: '\u3e3a\u5397\uc0ed\u0d4b\u071c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.19,
+  lodMaxClamp: 79.11,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup131);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(2, buffer112);
+} catch {}
+try {
+adapter0.label = '\ua7b9\u3c2a\u{1f989}\uc0e9\u4950\u0f41\u062f\u0976\u0e99';
+} catch {}
+let buffer173 = device0.createBuffer({size: 6704, usage: GPUBufferUsage.COPY_DST});
+let texture249 = device0.createTexture({
+  label: '\ub2e9\u060e\u556e\u7cbe\u{1f8d1}',
+  size: [84, 40, 52],
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler153 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.99,
+  lodMaxClamp: 67.64,
+  compare: 'equal',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder202.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer78, 'uint16', 2_176, 793);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 101, resource: sampler66},
+    {binding: 0, resource: {buffer: buffer65, offset: 3840, size: 1064}},
+  ],
+});
+let textureView256 = texture227.createView({});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\ua38e\u9664\u25bc\u837b\u344f\u{1fc66}\u{1fbd6}',
+  colorFormats: ['rg32float'],
+  stencilReadOnly: true,
+});
+let renderBundle43 = renderBundleEncoder43.finish({});
+try {
+computePassEncoder164.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer41, 'uint16', 1_602, 3_320);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, buffer150);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 508, new DataView(new ArrayBuffer(17007)), 95, 316);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData30 = new ImageData(108, 28);
+let commandEncoder262 = device0.createCommandEncoder({label: '\u1c43\u4dd6\u{1fb04}\u{1fc28}\u9c9b\u{1f9c3}\ubfe0\u8adc\u{1fefa}\u0c93\u0e72'});
+let computePassEncoder203 = commandEncoder262.beginComputePass({});
+let sampler154 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 82.95,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(1, bindGroup141, new Uint32Array(2393), 339, 0);
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline6);
+} catch {}
+let buffer174 = device0.createBuffer({
+  size: 11770,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture250 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 142},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer116, 584); };
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+let arrayBuffer36 = buffer82.getMappedRange(520, 48);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: img0,
+  origin: { x: 12, y: 0 },
+  flipY: false,
+}, {
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder();
+let renderPassEncoder81 = commandEncoder263.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  depthSlice: 12,
+  clearValue: { r: -781.0, g: 534.4, b: -410.2, a: 597.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 48611013,
+});
+try {
+computePassEncoder56.end();
+} catch {}
+let commandEncoder264 = device0.createCommandEncoder({});
+let computePassEncoder204 = commandEncoder68.beginComputePass();
+try {
+renderPassEncoder29.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(24, 1, 9, 0);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(5, buffer171, 0, 2_827);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+let buffer175 = device0.createBuffer({
+  size: 7941,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let computePassEncoder205 = commandEncoder264.beginComputePass({});
+try {
+computePassEncoder204.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer145, 'uint32', 3_596, 2_245);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 11768, new Int16Array(1839), 255);
+} catch {}
+let buffer176 = device0.createBuffer({
+  label: '\u356a\u1691\uec7c\u{1f76f}',
+  size: 2260,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder265 = device0.createCommandEncoder({});
+let textureView257 = texture193.createView({label: '\u{1f91e}\u25bd\u0d05\u005b', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 27});
+let renderPassEncoder82 = commandEncoder265.beginRenderPass({
+  colorAttachments: [{view: textureView130, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet8,
+});
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup117, new Uint32Array(2616), 1_182, 0);
+} catch {}
+try {
+renderPassEncoder46.beginOcclusionQuery(132);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(4, buffer85, 5_468, 1_050);
+} catch {}
+try {
+renderPassEncoder63.pushDebugGroup('\u30d0');
+} catch {}
+let imageData31 = new ImageData(8, 124);
+let sampler155 = device0.createSampler({
+  label: '\u0309\u8eba\u1808\u{1f745}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.53,
+  lodMaxClamp: 47.20,
+});
+try {
+computePassEncoder205.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer138, 520);
+} catch {}
+try {
+renderPassEncoder65.insertDebugMarker('\u6843');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(173), /* required buffer size: 26 */
+{offset: 26}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup154 = device0.createBindGroup({layout: bindGroupLayout16, entries: [{binding: 626, resource: sampler72}]});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup61, new Uint32Array(297), 25, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder74.setViewport(706.8635889455215, 0.46536152232880934, 691.206461661042, 0.0015121293553323656, 0.9090405110867895, 0.9619241745579384);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 91}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+await gc();
+let bindGroup155 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView155}]});
+let textureView258 = texture15.createView({dimension: '2d'});
+try {
+renderPassEncoder68.setBindGroup(3, bindGroup149);
+} catch {}
+let textureView259 = texture111.createView({});
+try {
+computePassEncoder147.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup130, new Uint32Array(1453), 192, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer46, 'uint16', 634, 463);
+} catch {}
+let buffer177 = device0.createBuffer({size: 19627, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView260 = texture68.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 4});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], sampleCount: 1});
+let renderBundle44 = renderBundleEncoder44.finish({label: '\u{1fe5c}\u01b1\u{1fa65}'});
+try {
+computePassEncoder47.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup150);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(182).fill(91), /* required buffer size: 182 */
+{offset: 182}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder154.setBindGroup(0, bindGroup145, new Uint32Array(1042), 271, 0);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup135, new Uint32Array(1002), 470, 0);
+} catch {}
+try {
+renderPassEncoder77.beginOcclusionQuery(351);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle27, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(4, buffer29, 0, 73);
+} catch {}
+try {
+renderPassEncoder57.insertDebugMarker('\u0e13');
+} catch {}
+let videoFrame31 = new VideoFrame(videoFrame21, {timestamp: 0});
+try {
+computePassEncoder193.setBindGroup(0, bindGroup128);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup29, new Uint32Array(319), 12, 0);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder82.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(10_596).fill(250), /* required buffer size: 10_596 */
+{offset: 310, bytesPerRow: 85, rowsPerImage: 60}, {width: 1, height: 2, depthOrArrayLayers: 3});
+} catch {}
+let imageBitmap6 = await createImageBitmap(canvas4);
+try {
+renderPassEncoder13.setScissorRect(4, 1, 7, 0);
+} catch {}
+let bindGroup156 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 180, resource: textureView217}]});
+let buffer178 = device0.createBuffer({size: 2364, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let textureView261 = texture10.createView({format: 'bgra8unorm-srgb', baseArrayLayer: 2, arrayLayerCount: 5});
+try {
+computePassEncoder168.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline17);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+renderPassEncoder63.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(165), /* required buffer size: 93 */
+{offset: 93}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer26.detached) { new Uint8Array(arrayBuffer26).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup24, new Uint32Array(227), 134, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint32', 19_456, 672);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer125, 'uint16', 204, 2);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline18);
+} catch {}
+let texture251 = device0.createTexture({
+  label: '\ub8af\uf7c2\u{1f7b6}',
+  size: {width: 84, height: 40, depthOrArrayLayers: 65},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder123.setBindGroup(2, bindGroup143, new Uint32Array(1454), 159, 0);
+} catch {}
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder68.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder53.setStencilReference(76);
+} catch {}
+try {
+renderPassEncoder75.setViewport(72.98307764062092, 7.8284289869138375, 4.471999246707368, 0.15377228151784972, 0.4360987632693232, 0.44558041597402137);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 104, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder45.insertDebugMarker('\u0844');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 16, depthOrArrayLayers: 375}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 99, y: 374 },
+  flipY: false,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 75, y: 1, z: 72},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 77, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView262 = texture98.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler156 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.63,
+  lodMaxClamp: 78.17,
+  compare: 'greater',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder106.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup156, new Uint32Array(1436), 564, 0);
+} catch {}
+try {
+renderPassEncoder69.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer165, 'uint16', 76, 181);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet2, 373, 22, buffer138, 256);
+} catch {}
+let texture252 = device0.createTexture({
+  size: [60, 4, 22],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder39.executeBundles([renderBundle39, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline17);
+} catch {}
+let texture253 = device0.createTexture({
+  label: '\u82c4\u8706\u06e9\u{1fbf5}\u67c4\ua046\ub3ae',
+  size: [240, 16, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder206 = commandEncoder45.beginComputePass({});
+let sampler157 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.99,
+  lodMaxClamp: 96.29,
+});
+try {
+computePassEncoder180.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup151);
+} catch {}
+try {
+renderPassEncoder68.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 1076, new Float32Array(7544), 860, 136);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let buffer179 = device0.createBuffer({
+  size: 839,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture254 = device0.createTexture({
+  size: {width: 84},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler158 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.64,
+  lodMaxClamp: 99.22,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup78);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1372);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer1, 'uint32', 2_868, 331);
+} catch {}
+let arrayBuffer37 = buffer47.getMappedRange(8, 0);
+let sampler159 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.47,
+  lodMaxClamp: 90.90,
+  compare: 'less-equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup131);
+} catch {}
+try {
+computePassEncoder190.setBindGroup(1, bindGroup38, new Uint32Array(2449), 862, 0);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle41]);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer82, 'uint32', 692, 2_067);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline17);
+} catch {}
+let bindGroup157 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView131}]});
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 257});
+let texture255 = gpuCanvasContext7.getCurrentTexture();
+try {
+renderPassEncoder70.executeBundles([renderBundle14, renderBundle40]);
+} catch {}
+let bindGroup158 = device0.createBindGroup({layout: bindGroupLayout16, entries: [{binding: 626, resource: sampler16}]});
+let buffer180 = device0.createBuffer({size: 8577, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture256 = device0.createTexture({size: [192], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup42, new Uint32Array(111), 5, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup38, []);
+} catch {}
+let texture257 = gpuCanvasContext7.getCurrentTexture();
+try {
+renderPassEncoder13.setIndexBuffer(buffer135, 'uint32', 17_416, 3_242);
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 4, resource: {buffer: buffer15, offset: 1280, size: 416}},
+    {binding: 42, resource: textureView193},
+  ],
+});
+let texture258 = device0.createTexture({
+  size: {width: 168, height: 80, depthOrArrayLayers: 131},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup36, new Uint32Array(1437), 166, 0);
+} catch {}
+try {
+renderPassEncoder69.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer78, 'uint32', 896, 2_081);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(1, buffer57, 84);
+} catch {}
+try {
+  await shaderModule22.getCompilationInfo();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 1016});
+try {
+computePassEncoder113.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle30, renderBundle5, renderBundle6, renderBundle26]);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline19);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise31 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule9,
+  constants: {58_066: 0, 13_754: 0, override20: 0},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}, {format: 'r32float', writeMask: 0}, {format: 'rg16float'}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex19',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 100,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x2', offset: 0, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw'},
+});
+let bindGroup160 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 278, resource: textureView42}]});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup127, new Uint32Array(1790), 455, 0);
+} catch {}
+try {
+renderPassEncoder81.setViewport(4.632462446434468, 2.5824207258444485, 20.894648756855734, 1.386805662130744, 0.048294390319060576, 0.37639243281395374);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup42, new Uint32Array(677), 38, 0);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 30 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer181 = device0.createBuffer({
+  size: 4614,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture259 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 67},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle45 = renderBundleEncoder45.finish({});
+let sampler160 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.86,
+  lodMaxClamp: 36.47,
+  maxAnisotropy: 19,
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup99, new Uint32Array(3419), 524, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer111, 'uint16', 4, 114);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer13, 0, 1_113);
+} catch {}
+try {
+renderPassEncoder38.insertDebugMarker('\ub723');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer27.detached) { new Uint8Array(arrayBuffer27).fill(0x55); };
+} catch {}
+let buffer182 = device0.createBuffer({size: 3820, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture260 = device0.createTexture({
+  size: {width: 84},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder115.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture197,
+  mipLevel: 0,
+  origin: {x: 13, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(544).fill(116), /* required buffer size: 544 */
+{offset: 544, bytesPerRow: 185}, {width: 8, height: 39, depthOrArrayLayers: 0});
+} catch {}
+let buffer183 = device0.createBuffer({
+  label: '\u057e\ua714\u{1ffd3}\u2865\u141f\uaa86\u8472',
+  size: 5000,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView263 = texture244.createView({aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer49);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup81, new Uint32Array(801), 57, 0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle40]);
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup('\u0bad');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer87, 1748, new BigUint64Array(2714), 29, 228);
+} catch {}
+let bindGroup161 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 256, resource: {buffer: buffer130, offset: 256, size: 280}}],
+});
+let textureView264 = texture233.createView({});
+try {
+computePassEncoder189.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4_294_967_295, undefined, 1_380_312_421, 1_262_097_324);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData32 = new ImageData(4, 48);
+let sampler161 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 57.73,
+  lodMaxClamp: 89.96,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup143, new Uint32Array(2685), 62, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(6, buffer24, 0, 2_432);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 248 */
+  offset: 248,
+  buffer: buffer88,
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise32;
+} catch {}
+let bindGroup162 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 50, resource: textureView218}]});
+let buffer184 = device0.createBuffer({
+  size: 3275,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture261 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder207 = commandEncoder54.beginComputePass();
+try {
+computePassEncoder113.setBindGroup(0, bindGroup81, new Uint32Array(1352), 186, 0);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline1);
+} catch {}
+try {
+  await shaderModule19.getCompilationInfo();
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  label: '\u2ad8\u0b1c\u0dd9\u0b9e\u{1fe12}\u8222',
+  layout: bindGroupLayout36,
+  entries: [{binding: 106, resource: textureView119}],
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup138, new Uint32Array(4403), 1_068, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline10);
+} catch {}
+document.body.append(img0);
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u5254\u04d1',
+  entries: [
+    {binding: 17, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 346,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let bindGroup164 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 106, resource: sampler11}]});
+let sampler162 = device0.createSampler({
+  label: '\ucfb1\ud81d\ufc7f\u9d37\u55b2\u0d26',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.80,
+  lodMaxClamp: 88.01,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup88);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer145, 2308, new Int16Array(4599), 477, 292);
+} catch {}
+await gc();
+let buffer185 = device0.createBuffer({
+  size: 10116,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler163 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.70,
+  lodMaxClamp: 90.56,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline15);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let buffer186 = device0.createBuffer({size: 414, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView265 = texture160.createView({mipLevelCount: 1});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup59, new Uint32Array(2574), 682, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let bindGroup165 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 42, resource: textureView260},
+    {binding: 4, resource: {buffer: buffer179, offset: 0, size: 304}},
+  ],
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup47, new Uint32Array(1458), 130, 0);
+} catch {}
+let buffer187 = device0.createBuffer({size: 3557, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder177.setBindGroup(2, bindGroup83, new Uint32Array(3697), 424, 0);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle27, renderBundle2, renderBundle19, renderBundle27]);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1536, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 10, y: 1 },
+  flipY: false,
+}, {
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 268, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer188 = device0.createBuffer({
+  label: '\ue658\u643a\u{1fd14}\u{1f9a3}\u38e3',
+  size: 16780,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView266 = texture133.createView({dimension: '2d'});
+try {
+computePassEncoder147.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup63, new Uint32Array(2227), 453, 0);
+} catch {}
+try {
+renderPassEncoder67.setScissorRect(1, 1, 6, 1);
+} catch {}
+try {
+renderPassEncoder16.setViewport(59.25490530842482, 4.542713980895654, 30.272237199445488, 0.42289366948926466, 0.03455063223396704, 0.8058626076567947);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer157, 'uint16', 644, 356);
+} catch {}
+let buffer189 = device0.createBuffer({
+  size: 31982,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture262 = device0.createTexture({
+  size: [1536, 1, 211],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup93, new Uint32Array(5521), 1_209, 0);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+await gc();
+let bindGroup166 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 4, resource: {buffer: buffer65, offset: 5632, size: 476}},
+    {binding: 42, resource: textureView36},
+  ],
+});
+let texture263 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 624},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler164 = device0.createSampler({
+  label: '\u077b\ud0f7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 57.38,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup38, new Uint32Array(1449), 108, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup166);
+} catch {}
+let texture264 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 62},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder142.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer150, 'uint16', 74, 29);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer145, 696);
+} catch {}
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas3);
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer190 = device0.createBuffer({
+  size: 10304,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder79.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer165, 'uint16', 34, 35);
+} catch {}
+let sampler165 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.89,
+});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder178.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle30]);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 199 widthInBlocks: 199 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3139 */
+  offset: 3139,
+  bytesPerRow: 256,
+  buffer: buffer37,
+}, {
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 199, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture156,
+  mipLevel: 0,
+  origin: {x: 18, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer92, 7680, new BigUint64Array(26482), 4900, 84);
+} catch {}
+let computePassEncoder208 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup136, new Uint32Array(104), 15, 0);
+} catch {}
+try {
+renderPassEncoder49.setViewport(5.170764870697019, 0.2549906064419081, 0.11224150574900385, 1.7417264968407984, 0.44495284089453535, 0.5995968112742687);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(0, buffer188, 0, 463);
+} catch {}
+try {
+computePassEncoder79.insertDebugMarker('\u{1fd2a}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(79).fill(128), /* required buffer size: 79 */
+{offset: 79}, {width: 127, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule25 = device0.createShaderModule({
+  label: '\u0849\ufd1f',
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw116: mat3x3h;
+
+var<private> vp37: FragmentOutput22 = FragmentOutput22(vec2u());
+
+var<workgroup> vw119: VertexOutput16;
+
+var<workgroup> vw117: VertexOutput16;
+
+@group(0) @binding(4) var<storage, read> buffer191: array<array<f16, 13>, 6>;
+
+struct T0 {
+  @size(4) f0: f16,
+}
+
+@id(51925) override override58: f16;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput16 {
+  @builtin(position) f56: vec4f,
+  @location(4) f57: vec2f,
+  @location(6) @interpolate(flat, center) f58: i32,
+  @location(1) f59: f16,
+}
+
+var<workgroup> vw114: FragmentOutput22;
+
+var<workgroup> vw118: VertexOutput16;
+
+@group(1) @binding(418) var<uniform> buffer192: array<FragmentOutput22, 2>;
+
+@group(0) @binding(42) var tex42: texture_2d<f32>;
+
+@id(46166) override override56: bool;
+
+var<workgroup> vw115: mat4x3h;
+
+@group(1) @binding(13) var tex43: texture_cube<f32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override57: f16 = 3974.6;
+
+struct FragmentOutput22 {
+  @location(0) @interpolate(flat) f0: vec2u,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex @must_use
+fn vertex21() -> VertexOutput16 {
+  var out: VertexOutput16;
+  let ptr198: ptr<storage, array<f16, 13>, read> = &(*&buffer191)[5];
+  let ptr199: ptr<storage, array<f16, 13>, read> = &(*ptr198);
+  out.f56 = vec4f(f32(pack4x8unorm(vec4f(unconst_f32(0.06729), unconst_f32(0.03073), unconst_f32(0.01940), unconst_f32(0.05433)))));
+  out.f58 *= bitcast<i32>(vp37.f0[u32(unconst_u32(203))]);
+  let ptr200: ptr<storage, array<f16, 13>, read> = &(*&buffer191)[u32((*ptr199)[12])];
+  var vf463: u32 = buffer192[1].f0[u32(buffer191[5][12])];
+  var vf464: u32 = pack4xU8Clamp(unpack4xU8(u32(buffer191[5][12])));
+  let ptr201: ptr<uniform, array<FragmentOutput22, 2>> = &(*&buffer192);
+  out.f58 ^= i32((*ptr201)[1].f0[u32(unconst_u32(49))]);
+  vf464 += buffer192[1].f0[1];
+  out.f57 = bitcast<vec2f>(vp37.f0);
+  out.f57 -= unpack2x16unorm(u32(unconst_u32(115)));
+  vf464 <<= u32(override58);
+  vf464 *= u32(abs(i32((*ptr200)[u32(unconst_u32(214))])));
+  out.f58 *= vec2i(smoothstep(vec2f(bitcast<f32>(buffer192[1].f0[u32(unconst_u32(14))])), vec2f(unconst_f32(0.1217), unconst_f32(0.1165)), vec2f(unconst_f32(0.00802), unconst_f32(0.9535))))[1];
+  let ptr202: ptr<storage, f16, read> = &(*&buffer191)[5][12];
+  out.f56 *= smoothstep(bitcast<vec2f>(firstLeadingBit(vec3i(unconst_i32(36), unconst_i32(178), unconst_i32(33))).rr), vec2f(f32((*&buffer191)[5][12])), vec2f(unconst_f32(0.06851), unconst_f32(0.04217))).rggr;
+  return out;
+  _ = override58;
+}
+
+@fragment
+fn fragment25(@builtin(sample_mask) a0: u32) -> @location(200) vec4u {
+  var out: vec4u;
+  var vf465: vec3h = fract(vec3h(unconst_f16(5357.6), unconst_f16(11475.8), unconst_f16(34555.5)));
+  var vf466: vec4u = firstLeadingBit(unpack4xU8(pack4xU8Clamp(vec4u(unconst_u32(140), unconst_u32(67), unconst_u32(13), unconst_u32(176)))));
+  vp37 = FragmentOutput22(textureDimensions(tex42));
+  var vf467: f16 = vf465[u32(unconst_u32(284))];
+  var vf468: u32 = (*&buffer192)[1].f0[0];
+  out += unpack4xU8(buffer192[1].f0[u32(unconst_u32(162))]);
+  discard;
+  let ptr203: ptr<storage, array<f16, 13>, read> = &(*&buffer191)[5];
+  return out;
+}
+
+@fragment
+fn fragment26() -> FragmentOutput22 {
+  var out: FragmentOutput22;
+  vp37.f0 &= bitcast<vec2u>(inverseSqrt(bitcast<vec4h>(textureDimensions(tex42))));
+  vp37 = (*&buffer192)[1];
+  out.f0 = vec2u(u32(buffer191[5][12]));
+  out.f0 *= bitcast<vec2u>(pow(vec4f(f32(vp37.f0[1])), vec4f(unconst_f32(0.06999), unconst_f32(0.2270), unconst_f32(0.2085), unconst_f32(0.08711))).rr);
+  let vf469: u32 = textureNumLevels(tex43);
+  let ptr204: ptr<storage, array<f16, 13>, read> = &buffer191[u32(buffer191[5][12])];
+  out = FragmentOutput22(vec2u(u32((*&buffer191)[5][12])));
+  let vf470: vec2u = textureDimensions(tex42);
+  out.f0 = (*&buffer192)[u32(unconst_u32(44))].f0;
+  out.f0 ^= vec2u(vf469);
+  out.f0 = vec2u(u32((*&buffer191)[5][12]));
+  out.f0 >>= vec2u(u32((*&buffer191)[5][bitcast<u32>(pow(vec4f(unconst_f32(-0.3855), unconst_f32(0.00788), unconst_f32(0.2721), unconst_f32(0.2182)), bitcast<vec4f>(textureDimensions(tex43).rgrg))[0])]));
+  let vf471: u32 = vp37.f0[vp37.f0[u32(unconst_u32(318))]];
+  let ptr205: ptr<uniform, FragmentOutput22> = &buffer192[1];
+  let ptr206: ptr<storage, array<array<f16, 13>, 6>, read> = &buffer191;
+  let vf472: u32 = vf470[0];
+  let vf473: vec2f = smoothstep(vec2f(f32(buffer191[5][12])), vec2f(unconst_f32(0.1907), unconst_f32(0.2226)), vec2f(f32((*ptr206)[5][12])));
+  let vf474: u32 = (*&buffer192)[1].f0[0];
+  let ptr207: ptr<uniform, vec2u> = &buffer192[1].f0;
+  out = buffer192[1];
+  let vf475: vec2u = textureDimensions(tex42);
+  out.f0 = vec2u(u32((*ptr206)[5][12]));
+  let vf476: u32 = (*ptr205).f0[0];
+  return out;
+}`,
+  sourceMap: {},
+});
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer150, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer193 = device0.createBuffer({
+  size: 17178,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView267 = texture243.createView({dimension: '3d'});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup122, new Uint32Array(1664), 369, 0);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline15);
+} catch {}
+let imageBitmap7 = await createImageBitmap(videoFrame32);
+let shaderModule26 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct VertexOutput17 {
+  @builtin(position) f60: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+@group(1) @binding(13) var tex45: texture_cube<f32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp38: mat3x2f = mat3x2f();
+
+@group(0) @binding(4) var<storage, read> buffer194: array<array<array<array<f16, 1>, 39>, 2>>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(1) @binding(31) var st13: texture_storage_1d<rgba8unorm, write>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput23 {
+  @location(0) @interpolate(linear, centroid) f0: vec2f,
+  @location(6) @interpolate(flat) f1: vec4i,
+  @builtin(sample_mask) f2: u32,
+  @location(7) @interpolate(perspective) f3: vec4f,
+}
+
+@group(0) @binding(42) var tex44: texture_2d<f32>;
+
+var<private> vp39 = array(array(modf(f16()), modf(f16())), array(modf(f16()), modf(f16())), array(modf(f16()), modf(f16())), array(modf(f16()), modf(f16())), array(modf(f16()), modf(f16())));
+
+@vertex
+fn vertex22(@location(15) a0: vec2u) -> VertexOutput17 {
+  var out: VertexOutput17;
+  let ptr208 = &vp39[4];
+  var vf477: vec2f = tan(vec2f(unconst_f32(0.06930), unconst_f32(0.1011)));
+  let ptr209: ptr<storage, array<array<array<f16, 1>, 39>, 2>, read> = &buffer194[arrayLength(&buffer194) - 1];
+  out = VertexOutput17(vec4f(f32(vp39[4][1].whole)));
+  let ptr210: ptr<storage, f16, read> = &(*ptr209)[1][38][0];
+  vp38 -= mat3x2f(bitcast<f32>(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))), f32(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))), f32(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))), bitcast<f32>(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))), bitcast<f32>(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))), bitcast<f32>(pack4xI8Clamp(vec4i(i32(buffer194[arrayLength(&buffer194)][1][u32(unconst_u32(200))][0])))));
+  return out;
+}
+
+@fragment
+fn fragment27(@location(6) a0: vec2h, @location(8) @interpolate(flat, centroid) a1: vec2u, @location(1) @interpolate(flat) a2: vec4h) -> FragmentOutput23 {
+  var out: FragmentOutput23;
+  var vf478: f32 = vp38[u32(unconst_u32(214))][u32(sign(f16(unconst_f16(299.0))))];
+  let ptr211: ptr<storage, array<f16, 1>, read> = &(*&buffer194)[arrayLength(&(*&buffer194))][1][38];
+  var vf479: vec4h = a2;
+  out.f2 <<= u32(buffer194[arrayLength(&buffer194)][1][38][0]);
+  var vf480: vec2f = fract(vec2f(unconst_f32(0.1566), unconst_f32(0.2745)));
+  vp39[4][bitcast<u32>(vf480.r)] = modf(f16(textureDimensions(tex44).g));
+  var vf481: f16 = vf479[u32(a2[2])];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute20() {
+  textureStore(st13, i32(unconst_i32(158)), vec4f(vec4f(unconst_f32(0.1835), unconst_f32(0.08923), unconst_f32(0.1379), unconst_f32(0.1617))));
+  var vf482: u32 = extractBits(textureDimensions(tex45)[1], u32(buffer194[arrayLength(&buffer194)][1][38][0]), u32(vp38[u32(unconst_u32(14))][u32(unconst_u32(6))]));
+  vp39[u32((*&buffer194)[arrayLength(&(*&buffer194))][1][u32(buffer194[arrayLength(&buffer194)][1][38][0])][0])][u32(vp39[pack4x8unorm(textureLoad(tex44, vec2i(i32((*&buffer194)[arrayLength(&(*&buffer194))][1][38][u32(unconst_u32(96))])), i32((*&buffer194)[arrayLength(&(*&buffer194)) - 1][1][38][0])))][1].whole)] = modf((*&buffer194)[arrayLength(&(*&buffer194))][1][38][0]);
+  textureStore(st13, i32(unconst_i32(5)), vec4f(vec4f(unconst_f32(0.03404), unconst_f32(0.2444), unconst_f32(0.07165), unconst_f32(0.05924))));
+  vp39[4][1].whole = f16(textureNumLevels(tex44));
+  vp38 = mat3x2f(bitcast<f32>(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))), f32(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))), f32(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))), bitcast<f32>(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))), bitcast<f32>(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))), f32(extractBits(u32(unconst_u32(5)), arrayLength(&(*&buffer194)), textureNumLevels(tex44))));
+  let ptr212: ptr<storage, array<f16, 1>, read> = &(*&buffer194)[arrayLength(&(*&buffer194))][1][u32(unconst_u32(69))];
+  var vf483: vec4h = ceil(vec4h(unconst_f16(10898.3), unconst_f16(4533.0), unconst_f16(-1478.2), unconst_f16(-1628.3)));
+  vp39[u32((*&buffer194)[arrayLength(&(*&buffer194))][1][38][0])][pack4xU8(vec4u(ceil(vec4h(unconst_f16(2604.0), unconst_f16(8096.2), unconst_f16(1409.3), unconst_f16(3190.6)))))].whole *= (*&buffer194)[arrayLength(&(*&buffer194))][1][38][0];
+  let ptr213: ptr<private, f16> = &vp39[4][1].fract;
+  let ptr214: ptr<storage, f16, read> = &(*&buffer194)[arrayLength(&(*&buffer194))][1][38][0];
+  let vf484: u32 = pack4xI8(vec4i(unconst_i32(277), unconst_i32(257), unconst_i32(203), unconst_i32(420)));
+  let vf485: vec2u = textureDimensions(tex44);
+  vf482 >>= vf485.y;
+  let ptr215: ptr<storage, f16, read> = &(*ptr212)[u32(unconst_u32(5))];
+  let vf486: vec4f = fma(vec4f(faceForward(faceForward(vec3h((*&buffer194)[arrayLength(&(*&buffer194))][1][38][0]), vec3h(unconst_f16(2823.5), unconst_f16(39774.8), unconst_f16(14770.0)), vec3h(vp39[4][1].fract)), vec3h(f16(textureNumLevels(tex44))), vec3h(unconst_f16(5814.6), unconst_f16(18754.5), unconst_f16(9557.1))).rrrb), vec4f(unconst_f32(0.00377), unconst_f32(0.9553), unconst_f32(0.07296), unconst_f32(0.1415)), vec4f(unconst_f32(0.1274), unconst_f32(-0.09239), unconst_f32(-0.3086), unconst_f32(0.2261)));
+  let ptr216 = &vp39[4][u32(vp39[4][1].whole)];
+  let ptr217: ptr<storage, f16, read> = &(*&buffer194)[arrayLength(&(*&buffer194))][1][38][0];
+}`,
+  sourceMap: {},
+});
+let sampler166 = device0.createSampler({
+  label: '\u6fa1\u086d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.74,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder142); computePassEncoder142.dispatchWorkgroupsIndirect(buffer45, 576); };
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer9, 'uint32', 212, 476);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder142); computePassEncoder142.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder9.pushDebugGroup('\u077a');
+} catch {}
+let textureView268 = texture261.createView({
+  label: '\u9872\u061f\u17b8\u19c9\u{1ff1b}\u25fb\u2b40\u{1f6f3}\u68ac',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+});
+let sampler167 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.97,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup44, new Uint32Array(192), 3, 0);
+} catch {}
+try {
+buffer173.unmap();
+} catch {}
+try {
+if (!arrayBuffer31.detached) { new Uint8Array(arrayBuffer31).fill(0x55); };
+} catch {}
+let buffer195 = device0.createBuffer({
+  label: '\u0861\u{1f9af}\u17a5\u0fa8\ucb46\u3163\u{1f703}\u8302\u09d3',
+  size: 1972,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder62.setPipeline(pipeline18);
+} catch {}
+let bindGroup167 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 223, resource: textureView151},
+    {binding: 137, resource: textureView5},
+    {binding: 429, resource: {buffer: buffer38, offset: 2048, size: 12}},
+    {binding: 62, resource: textureView37},
+  ],
+});
+try {
+computePassEncoder157.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+computePassEncoder106.setBindGroup(0, bindGroup108, new Uint32Array(1169), 112, 0);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder9.popDebugGroup();
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView269 = texture12.createView({
+  label: '\ub10f\u{1fa10}\u{1f606}\u{1feb9}\uadce\u6ae7\u5b7e\u7370\u0d36',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 40,
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup46, new Uint32Array(1213), 49, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'bt2020_10bit'} });
+try {
+globalThis.someLabel = bindGroup130.label;
+} catch {}
+let textureView270 = texture87.createView({});
+try {
+renderPassEncoder39.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer6, 'uint32', 756, 150);
+} catch {}
+let textureView271 = texture211.createView({dimension: 'cube', arrayLayerCount: 6});
+let texture265 = device0.createTexture({
+  size: [168, 80, 131],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView272 = texture109.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder142); computePassEncoder142.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline7);
+} catch {}
+document.body.prepend(img2);
+let texture266 = device0.createTexture({
+  label: '\uc6d2\u0af8\ua806\u0145\u0f7b\u0793\u01d4\u0b56',
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler168 = device0.createSampler({
+  label: '\u{1f7cf}\u0986\uee23\u0871\u{1fc32}\u3027',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.57,
+  lodMaxClamp: 82.15,
+});
+try {
+renderPassEncoder39.setScissorRect(128, 0, 101, 0);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer80, 'uint32', 3_544, 340);
+} catch {}
+await gc();
+let textureView273 = texture98.createView({dimension: 'cube'});
+let sampler169 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.38,
+  lodMaxClamp: 90.50,
+  compare: 'not-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup166);
+} catch {}
+try {
+computePassEncoder142.end();
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle27, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer133, 'uint16', 622, 619);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise33;
+} catch {}
+let img11 = await imageWithData(17, 7, '#10101010', '#20202020');
+let buffer196 = device0.createBuffer({size: 5760, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let textureView274 = texture235.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder209 = commandEncoder190.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder178); computePassEncoder178.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer0, 16, 505);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 1176, new Float32Array(1855), 283, 132);
+} catch {}
+let bindGroup168 = device0.createBindGroup({
+  layout: bindGroupLayout38,
+  entries: [{binding: 103, resource: {buffer: buffer65, offset: 512, size: 276}}],
+});
+let textureView275 = texture65.createView({});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], stencilReadOnly: true});
+let sampler170 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.87,
+  lodMaxClamp: 71.61,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder125.setBindGroup(1, bindGroup165);
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(7, buffer156, 1_216, 626);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(50).fill(242), /* required buffer size: 50 */
+{offset: 50}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView276 = texture242.createView({});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint']});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame16, colorSpace: 'display-p3'});
+try {
+computePassEncoder193.setBindGroup(2, bindGroup26, new Uint32Array(424), 52, 0);
+} catch {}
+try {
+renderPassEncoder77.beginOcclusionQuery(159);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer147, 'uint32', 540, 620);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer56, 156, 210);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView277 = texture186.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle46 = renderBundleEncoder47.finish({});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+renderPassEncoder47.setBlendConstant({ r: 26.38, g: 684.2, b: 632.5, a: -672.1, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer144, 'uint16', 26, 81);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(3, bindGroup48, []);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup21, new Uint32Array(1301), 349, 0);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer181, 'uint16', 178, 987);
+} catch {}
+let arrayBuffer38 = buffer69.getMappedRange(0, 4);
+let buffer197 = device0.createBuffer({
+  size: 10984,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture267 = device0.createTexture({
+  size: [192],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView278 = texture60.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+let renderBundle47 = renderBundleEncoder46.finish({});
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder50.setViewport(85.55846071289638, 0.38377493301704035, 16.49059277184827, 7.130204821273761, 0.18130749576695282, 0.8767397553388242);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(0, buffer103, 0, 198);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 174, resource: {buffer: buffer120, offset: 1280, size: 4616}},
+    {binding: 18, resource: {buffer: buffer58, offset: 1536, size: 100}},
+  ],
+});
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 69, resource: textureView14}, {binding: 150, resource: sampler153}],
+});
+let buffer198 = device0.createBuffer({size: 11224, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder164.setBindGroup(0, bindGroup96, new Uint32Array(131), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder178); computePassEncoder178.dispatchWorkgroups(1); };
+} catch {}
+let textureView279 = texture211.createView({
+  label: '\u5ef5\u45a3\u2d1d\ubccb\ue4a9\u0a08\u{1f8f6}',
+  dimension: 'cube',
+  aspect: 'all',
+  baseArrayLayer: 1,
+});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame20});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup84, new Uint32Array(1958), 295, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle33, renderBundle33, renderBundle21]);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 26, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData33 = new ImageData(4, 124);
+let externalTexture25 = device0.importExternalTexture({source: videoFrame10, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup57, new Uint32Array(575), 111, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup92, new Uint32Array(80), 9, 0);
+} catch {}
+let shaderModule27 = device0.createShaderModule({
+  label: '\u5c95\ube9d\ufc82',
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(27327) override override60: f16 = 265.6;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct S3 {
+  @location(14) @interpolate(flat, center) f0: u32,
+}
+
+struct T1 {
+  @align(2) @size(232) f0: array<atomic<i32>>,
+}
+
+override override59: f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput24 {
+  @location(1) @interpolate(flat, center) f0: vec4u,
+  @location(0) f1: vec2u,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0() -> FragmentOutput24 {
+  var out: FragmentOutput24;
+  var vf487: f16 = override60;
+  let vf488: vec2f = unpack2x16float(pack4x8unorm(unpack4x8unorm(pack4xU8(vec4u(unconst_u32(33), unconst_u32(593), unconst_u32(110), unconst_u32(195))))));
+  let vf489: vec2f = vf488;
+  var vf490: f32 = length(unpack2x16unorm(u32(override60)).yyxy);
+  vf487 -= f16(unpack2x16unorm(bitcast<u32>(determinant(mat3x3f(vf490, vf490, vf490, vf490, vf490, vf490, vf490, vf490, vf490))))[0]);
+  out.f1 |= vec2u(vf489);
+  var vf491: f32 = determinant(mat3x3f(max(vec4f(f32(override60)), vec4f(unconst_f32(0.08216), unconst_f32(0.04477), unconst_f32(0.06484), unconst_f32(-0.07427))).xyy, max(vec4f(f32(override60)), vec4f(unconst_f32(0.08216), unconst_f32(0.04477), unconst_f32(0.06484), unconst_f32(-0.07427))).xyx, max(vec4f(f32(override60)), vec4f(unconst_f32(0.08216), unconst_f32(0.04477), unconst_f32(0.06484), unconst_f32(-0.07427))).rgb));
+  let vf492: f32 = inverseSqrt(f32(unconst_f32(0.1017)));
+  out.f1 += vec2u(u32(vf487));
+  out.f0 >>= vec4u(atanh(vec3h(unconst_f16(1790.2), unconst_f16(3606.3), unconst_f16(2827.8))).zzyy);
+  var vf493: u32 = pack4xU8(vec4u(unconst_u32(13), unconst_u32(14), unconst_u32(282), unconst_u32(242)));
+  let vf494: f16 = override59;
+  var vf495: f32 = inverseSqrt(vf489[u32(unconst_u32(123))]);
+  var vf496: f32 = length(vec4f(unconst_f32(0.01704), unconst_f32(0.00145), unconst_f32(0.06678), unconst_f32(0.7176)));
+  vf487 = f16(vf491);
+  let ptr218: ptr<function, f16> = &vf487;
+  out.f1 |= vec2u(u32(length(vec4f(unconst_f32(-0.1158), unconst_f32(0.2665), unconst_f32(0.3405), unconst_f32(0.5018)))));
+  vf493 ^= bitcast<u32>(vf491);
+  vf487 -= f16(vf490);
+  vf491 = bitcast<vec4f>(unpack4xU8(u32(vf496)))[1];
+  return out;
+  _ = override59;
+  _ = override60;
+}
+
+@vertex
+fn vertex23(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(11) @interpolate(flat) a2: vec2u, @location(0) a3: vec2u, a4: S3) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out += bitcast<vec4f>(a3.xyxx);
+  let vf497: S3 = a4;
+  let vf498: vec4f = unpack4x8unorm(u32(unconst_u32(83)));
+  let vf499: u32 = a3[0];
+  out = vec4f(f32(a4.f0));
+  out = vec4f(cosh(bitcast<vec2h>(a3[u32(unconst_u32(351))])).ggrr);
+  out -= unpack4x8snorm(dot(vec3u(unconst_u32(223), unconst_u32(275), unconst_u32(73)), vec3u(a4.f0)));
+  var vf500: f32 = length(vec4f(unconst_f32(0.1663), unconst_f32(0.2231), unconst_f32(0.1010), unconst_f32(0.03223)));
+  let vf501: vec4i = countTrailingZeros(vec4i(unconst_i32(214), unconst_i32(357), unconst_i32(93), unconst_i32(85)));
+  var vf502: u32 = a1;
+  out = transpose(mat2x4f(vec4f(a2.yxyx), vec4f(a2.xyyx)))[0].rrrr;
+  vf500 = bitcast<f32>(unpack4xI8(u32(unconst_u32(28))).g);
+  let vf503: vec4h = mix(vec4h(unconst_f16(10134.8), unconst_f16(-25767.6), unconst_f16(1782.4), unconst_f16(9915.5)), pow(vec3h(unconst_f16(21669.4), unconst_f16(1673.3), unconst_f16(-3447.3)), cosh(vec2h(unconst_f16(4683.7), unconst_f16(16933.9))).xyy).yxyz, f16(unconst_f16(6064.5)));
+  vf500 *= bitcast<f32>(vf501[2]);
+  let vf504: vec2h = cosh(vec2h(unconst_f16(663.6), unconst_f16(31794.6)));
+  var vf505: u32 = a3[bitcast<u32>(vf498[1])];
+  let vf506: vec4h = mix(vec4h(unconst_f16(4891.7), unconst_f16(3520.2), unconst_f16(-9378.0), unconst_f16(1750.2)), vec4h(unconst_f16(14250.6), unconst_f16(15559.3), unconst_f16(13396.1), unconst_f16(56005.0)), f16(unconst_f16(14762.7)));
+  let vf507: f32 = pow(f32(unconst_f32(0.07748)), f32(a4.f0));
+  let vf508: vec4i = countTrailingZeros(vec4i(unconst_i32(91), unconst_i32(101), unconst_i32(148), unconst_i32(188)));
+  let vf509: u32 = a2[u32(vf503[u32(unconst_u32(31))])];
+  let vf510: vec4i = vf508;
+  let vf511: u32 = dot(vec3u(unconst_u32(252), unconst_u32(28), unconst_u32(29)), vec3u(unconst_u32(103), unconst_u32(271), unconst_u32(17)));
+  out += vec4f(insertBits(vec3i(unconst_i32(120), unconst_i32(444), unconst_i32(38)), vec3i(i32(override59)), u32(unconst_u32(53)), u32(unconst_u32(218))).rrbg);
+  vf505 >>= a2[1];
+  vf500 -= bitcast<f32>(vf510[u32(ceil(vec3h(unconst_f16(-1423.1), unconst_f16(7699.5), unconst_f16(5119.1))).x)]);
+  return out;
+  _ = override59;
+}
+
+@fragment
+fn fragment28(@builtin(front_facing) a0: bool, @location(10) @interpolate(flat) a1: f32, @location(15) a2: vec2f, @invariant @builtin(position) a3: vec4f, @location(4) a4: u32, @location(3) a5: f16) -> FragmentOutput24 {
+  var out: FragmentOutput24;
+  let vf512: f32 = a2[u32(unconst_u32(151))];
+  let vf513: f32 = atan2(f32(unconst_f32(0.1053)), f32(asin(f16(unconst_f16(47391.0)))));
+  out.f0 += unpack4xU8(countLeadingZeros(u32(override59)));
+  let vf514: vec2f = quantizeToF16(vec2f(unconst_f32(0.1418), unconst_f32(0.01249)));
+  fn0();
+  out = FragmentOutput24(unpack4xU8(u32(a2[1])), vec2u(u32(a2[1])));
+  out.f0 += vec4u(atan(vec3h(unconst_f16(1078.6), unconst_f16(4411.1), unconst_f16(815.0))).yyzx);
+  let vf515: f32 = atan2(f32(unconst_f32(0.1455)), vf514[u32(unconst_u32(8))]);
+  out.f0 >>= vec4u(min(vec2i(i32(vf512)), vec2i(unconst_i32(6), unconst_i32(-332))).yyxx);
+  out.f0 -= vec4u(bitcast<u32>(a2[u32(unconst_u32(3))]));
+  var vf516: vec2f = quantizeToF16(vec2f(unconst_f32(0.2326), unconst_f32(0.00385)));
+  var vf517: u32 = pack2x16unorm(vec2f(unconst_f32(-0.09292), unconst_f32(0.2402)));
+  var vf518: vec4h = faceForward(vec4h(unconst_f16(7829.9), unconst_f16(21473.9), unconst_f16(6371.0), unconst_f16(3377.6)), vec4h(unconst_f16(1638.9), unconst_f16(-11368.8), unconst_f16(3618.0), unconst_f16(10519.5)), atan(vec3h(unconst_f16(2130.3), unconst_f16(5046.0), unconst_f16(16934.4))).bbgg);
+  vf518 = vec4h(f16(vf514[1]));
+  var vf519: vec4h = faceForward(vec4h(unconst_f16(15497.1), unconst_f16(4131.5), unconst_f16(7665.6), unconst_f16(4163.8)), vec4h(unconst_f16(5611.7), unconst_f16(8105.9), unconst_f16(12175.8), unconst_f16(2352.5)), faceForward(vec4h(unconst_f16(-59564.9), unconst_f16(10785.2), unconst_f16(13996.3), unconst_f16(9894.0)), vec4h(unconst_f16(25480.9), unconst_f16(306.5), unconst_f16(16655.4), unconst_f16(11587.5)), vec4h(f16(vf516[0]))));
+  vf519 -= vec4h(f16(a0));
+  fn0();
+  let vf520: f32 = a1;
+  vf519 = vec4h(vf518[u32(unconst_u32(351))]);
+  vf516 = vec2f(bitcast<f32>(vf517));
+  return out;
+  _ = override60;
+  _ = override59;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let externalTexture26 = device0.importExternalTexture({label: '\u{1f8d8}\u1264\u14cc\u{1fb7a}\u{1f839}\u9608\u0172\u{1fcdd}', source: videoFrame14});
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle41]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(377).fill(228), /* required buffer size: 377 */
+{offset: 377}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture268 = device0.createTexture({
+  size: [42, 20, 32],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView280 = texture87.createView({aspect: 'all'});
+try {
+computePassEncoder208.setBindGroup(2, bindGroup66, new Uint32Array(66), 57, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle24, renderBundle9, renderBundle9]);
+} catch {}
+try {
+computePassEncoder55.pushDebugGroup('\u{1f8b5}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer91, 92, new BigUint64Array(4481), 71, 100);
+} catch {}
+try {
+adapter0.label = '\ua505\u42b0\ue642\uc186\u0c1f';
+} catch {}
+let texture269 = device0.createTexture({
+  label: '\u7854\uf4bb\u{1ff15}',
+  size: {width: 84, height: 40, depthOrArrayLayers: 19},
+  mipLevelCount: 7,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder207.setBindGroup(2, bindGroup150, new Uint32Array(2083), 13, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder178); computePassEncoder178.dispatchWorkgroupsIndirect(buffer152, 132); };
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer135, 'uint16', 4_090, 2_093);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+buffer195.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(173).fill(29), /* required buffer size: 173 */
+{offset: 173, bytesPerRow: 106, rowsPerImage: 38}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroupsIndirect(buffer185, 3_104); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(241).fill(142), /* required buffer size: 241 */
+{offset: 31, bytesPerRow: 10, rowsPerImage: 1}, {width: 0, height: 0, depthOrArrayLayers: 22});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView281 = texture26.createView({
+  label: '\u096e\u0b0f\u60c7\u{1f7bd}\ud5aa\u9ffc\u08bd\udda3\u02e9',
+  dimension: '2d',
+  baseArrayLayer: 1,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture243,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 48},
+  aspect: 'all',
+}, new Uint8Array(27_040).fill(128), /* required buffer size: 27_040 */
+{offset: 170, bytesPerRow: 2687, rowsPerImage: 2}, {width: 332, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroupsIndirect(buffer145, 1_064); };
+} catch {}
+try {
+  await promise34;
+} catch {}
+let texture270 = device0.createTexture({
+  size: [120, 8, 187],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder166.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(2, bindGroup88, new Uint32Array(1562), 0, 0);
+} catch {}
+try {
+computePassEncoder178.end();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer29, 332);
+} catch {}
+let imageData34 = new ImageData(56, 24);
+try {
+externalTexture6.label = '\ue6c2\ua074';
+} catch {}
+let bindGroup171 = device0.createBindGroup({
+  label: '\ud64f\u8519\u931f\u0db9\u8bd0\u{1fe53}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 190, resource: textureView230}, {binding: 144, resource: textureView107}],
+});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({label: '\u77d9\u99fe\u0b08\u027e\ua540\ub570', colorFormats: ['r8uint'], stencilReadOnly: true});
+let sampler171 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.11,
+  lodMaxClamp: 70.45,
+  compare: 'equal',
+});
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup151);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4_294_967_294, undefined, 0, 316_939_356);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(0, bindGroup113, new Uint32Array(793), 31, 0);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(1, buffer131);
+} catch {}
+try {
+commandEncoder237.clearBuffer(buffer87, 1096, 400);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(81_412).fill(74), /* required buffer size: 81_412 */
+{offset: 142, bytesPerRow: 86, rowsPerImage: 35}, {width: 10, height: 0, depthOrArrayLayers: 28});
+} catch {}
+document.body.append(img6);
+let computePassEncoder210 = commandEncoder237.beginComputePass();
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup15, new Uint32Array(3963), 131, 0);
+} catch {}
+let bindGroup172 = device0.createBindGroup({
+  layout: bindGroupLayout38,
+  entries: [{binding: 103, resource: {buffer: buffer189, offset: 2048, size: 832}}],
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame7});
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer55, 'uint16', 1_034, 363);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 1180, new BigUint64Array(19917), 4330, 384);
+} catch {}
+let texture271 = device0.createTexture({
+  label: '\u0dd1\udccb\u1861\u1a19\u8795\u{1f9d6}\u5c00\u773c\uf2d4\u297d\u1003',
+  size: [42],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder136.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder145.setBindGroup(0, bindGroup102, new Uint32Array(946), 193, 0);
+} catch {}
+try {
+renderPassEncoder72.setViewport(203.02590832056836, 0.9833177592275673, 162.32836494931206, 0.010112265274682786, 0.41471581386187206, 0.8845598042889773);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, buffer87, 2_568, 18);
+} catch {}
+try {
+  await buffer187.mapAsync(GPUMapMode.READ, 0, 1012);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(195).fill(205), /* required buffer size: 195 */
+{offset: 195, bytesPerRow: 260}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder92.setBindGroup(3, bindGroup17, [0]);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer121, 0, 1_901);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let querySet46 = device0.createQuerySet({type: 'occlusion', count: 1404});
+let sampler172 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMinClamp: 9.758, lodMaxClamp: 86.17});
+try {
+computePassEncoder149.setBindGroup(0, bindGroup114);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroupsIndirect(buffer184, 628); };
+} catch {}
+try {
+computePassEncoder202.pushDebugGroup('\u{1f7ea}');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup173 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView211}]});
+let texture272 = device0.createTexture({
+  label: '\ub370\u0e6d\u8666\u5b09\u1ede\u99af\u{1fd3b}\uac81\u0582',
+  size: [84, 40, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler173 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.73,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder155.setBindGroup(3, bindGroup115, new Uint32Array(260), 7, 0);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup157);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline18);
+} catch {}
+let texture273 = device0.createTexture({
+  label: '\u4f62\ud0cc\ud2db\u6444\u{1ff7a}\u5598\u{1f864}\uc4cc\ued6b\uda17',
+  size: {width: 384, height: 1, depthOrArrayLayers: 68},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup124);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup166, []);
+} catch {}
+try {
+renderPassEncoder14.setViewport(109.61100346637122, 10.77021917485059, 13.942142674887908, 2.089469141857479, 0.6434863990992143, 0.7369879347086913);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup157);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup148, new Uint32Array(319), 43, 0);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(7, buffer142, 616);
+} catch {}
+await gc();
+try {
+computePassEncoder143.setBindGroup(0, bindGroup132, new Uint32Array(3859), 746, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer25, 'uint16', 4_574, 2_108);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer142, 2_288, 263);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(7, buffer61);
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+let textureView282 = texture71.createView({});
+let sampler174 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 60.58,
+  lodMaxClamp: 77.52,
+});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup82, new Uint32Array(556), 156, 0);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(2, bindGroup118, []);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup122);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer1, 'uint32', 1_280, 956);
+} catch {}
+try {
+buffer125.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 988, new DataView(new ArrayBuffer(641)), 13);
+} catch {}
+let bindGroup174 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 67, resource: {buffer: buffer120, offset: 512, size: 45727}},
+    {binding: 125, resource: textureView195},
+  ],
+});
+let buffer199 = device0.createBuffer({
+  size: 319,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture274 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 375},
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder24.setIndexBuffer(buffer88, 'uint32', 684, 1_244);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup108, new Uint32Array(466), 6, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer87, 828, new Float32Array(9400), 583, 60);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture240,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 47},
+  aspect: 'all',
+}, new Uint8Array(79_129).fill(173), /* required buffer size: 79_129 */
+{offset: 249, bytesPerRow: 68, rowsPerImage: 58}, {width: 12, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let canvas6 = document.createElement('canvas');
+try {
+adapter0.label = '\u6632\ucb60\u{1fbec}\uc757\u9482\u0c75\u1cbf\uc1ac\ud0d6\u{1fc09}';
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 48, resource: textureView269},
+    {binding: 78, resource: textureView79},
+    {binding: 205, resource: textureView131},
+    {binding: 30, resource: textureView53},
+    {binding: 37, resource: {buffer: buffer6, offset: 0, size: 1048}},
+  ],
+});
+let buffer200 = device0.createBuffer({
+  size: 3517,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView283 = texture217.createView({baseArrayLayer: 55, arrayLayerCount: 14});
+let sampler175 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 44.27,
+  lodMaxClamp: 93.56,
+});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame23, colorSpace: 'display-p3'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 1, depthOrArrayLayers: 91}
+*/
+{
+  source: img2,
+  origin: { x: 16, y: 8 },
+  flipY: false,
+}, {
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer201 = device0.createBuffer({size: 6485, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder194.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup97, new Uint32Array(2464), 862, 0);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle39, renderBundle39]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer190, 'uint32', 3_772, 410);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer76, 'uint16', 1_442, 1_361);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline9);
+} catch {}
+try {
+  await buffer33.mapAsync(GPUMapMode.WRITE, 624, 140);
+} catch {}
+try {
+computePassEncoder202.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(31_590).fill(234), /* required buffer size: 31_590 */
+{offset: 0, bytesPerRow: 81, rowsPerImage: 65}, {width: 14, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let texture275 = device0.createTexture({
+  label: '\u052b\u12f9\ue090\u2149\uc925\ub6fc',
+  size: [192, 1, 39],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView284 = texture116.createView({dimension: '3d', aspect: 'all', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroupsIndirect(buffer176, 108); };
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer113, 'uint32', 1_864, 212);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer1, 'uint16', 3_120, 309);
+} catch {}
+let texture276 = gpuCanvasContext6.getCurrentTexture();
+let textureView285 = texture183.createView({label: '\u5c33\u83fd\ud425\u75f8\u6564\u8eb7\u12c8\ue675', dimension: '2d-array'});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup158, new Uint32Array(1863), 228, 0);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle9, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder48.setViewport(89.26099839444176, 4.9494884514587785, 5.518826900345612, 2.2484987525803004, 0.8577588738765833, 0.9677947547438598);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer189, 'uint16', 1_574, 830);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer133, 0);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(1, buffer197, 0, 1_371);
+} catch {}
+try {
+computePassEncoder177.pushDebugGroup('\u{1f7a0}');
+} catch {}
+let imageData35 = new ImageData(24, 32);
+let textureView286 = texture164.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup163);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup136);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline7);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(12, 19);
+let shaderModule28 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+@group(1) @binding(78) var tex52: texture_2d_array<f32>;
+
+fn fn0(a0: ptr<storage, array<T1, 1>, read>) -> mat3x2f {
+  var out: mat3x2f;
+  let ptr219: ptr<storage, f32, read> = &(*a0)[0].f0[u32(unconst_u32(258))];
+  vp41[u32(unconst_u32(6))] -= (*a0)[0].f0[1];
+  vp40.f61 = vec4f((*ptr219));
+  vp40 = VertexOutput18(vec4f(normalize(vec3h(unconst_f16(2162.7), unconst_f16(5138.0), unconst_f16(34608.9))).zxyy), vec2f(normalize(vec3h(unconst_f16(2162.7), unconst_f16(5138.0), unconst_f16(34608.9))).gg));
+  let vf521: vec2u = textureDimensions(tex48);
+  let ptr220: ptr<storage, f32, read> = &(*a0)[0].f0[1];
+  vp42[u32(unconst_u32(150))][bitcast<u32>((*a0)[0].f0[1])] = f16(vf521[pack4x8unorm(abs(vp40.f62.xyxy))]);
+  vp40.f61 -= vec4f(f32((*&buffer202)[arrayLength(&(*&buffer202))][0][2]));
+  return out;
+}
+
+var<private> vp41: array<f32, 57> = array<f32, 57>();
+
+var<private> vp40: VertexOutput18 = VertexOutput18(vec4f(), vec2f());
+
+@group(2) @binding(67) var<uniform> buffer203: array<array<f16, 1>, 29>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(3) @binding(180) var st14: texture_storage_2d_array<r32float, read_write>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput18 {
+  @builtin(position) f61: vec4f,
+  @location(9) f62: vec2f,
+}
+
+@group(0) @binding(48) var tex47: texture_depth_2d;
+
+@group(1) @binding(30) var tex50: texture_depth_2d;
+
+@group(1) @binding(48) var tex51: texture_depth_2d;
+
+struct T0 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+@group(0) @binding(205) var tex49: texture_2d<f32>;
+
+var<private> vp42: array<array<f16, 1>, 104> = array(array<f16, 1>(), array(f16()), array(f16()), array<f16, 1>(), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array<f16, 1>(f16()), array<f16, 1>(), array<f16, 1>(f16()), array<f16, 1>(), array(f16()), array<f16, 1>(), array<f16, 1>(), array<f16, 1>(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(), array<f16, 1>(f16()), array<f16, 1>(), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(), array(f16()), array<f16, 1>(), array(f16()), array(f16()), array<f16, 1>(), array<f16, 1>(f16()), array(f16()), array<f16, 1>(f16()), array<f16, 1>(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(), array(f16()), array(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(), array(f16()), array<f16, 1>(), array(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(), array<f16, 1>(), array(f16()), array(f16()), array<f16, 1>(), array<f16, 1>(f16()), array<f16, 1>(), array<f16, 1>(f16()), array<f16, 1>(f16()), array(f16()), array<f16, 1>(f16()), array<f16, 1>(), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(), array(f16()), array<f16, 1>(f16()), array<f16, 1>(f16()), array<f16, 1>(), array(f16()), array(f16()), array(f16()), array(f16()), array(f16()), array<f16, 1>(f16()), array<f16, 1>(f16()), array(f16()), array(f16()), array(f16()), array(f16()), array(f16()), array(f16()), array(f16()), array(f16()));
+
+@group(1) @binding(205) var tex53: texture_2d<f32>;
+
+fn fn1() -> array<mat2x4h, 2> {
+  var out: array<mat2x4h, 2>;
+  vp42[u32(unconst_u32(78))][u32(unconst_u32(20))] = f16(tanh(vec4f(unconst_f32(0.1370), unconst_f32(0.3056), unconst_f32(0.01545), unconst_f32(0.03508))).g);
+  let vf522: vec2u = textureDimensions(tex50, i32(smoothstep(f16(unconst_f16(13611.7)), f16(unconst_f16(6566.6)), f16(unconst_f16(14325.7)))));
+  out[textureDimensions(tex51, i32(unconst_i32(148))).y] = mat2x4h(atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r), atanh(vec3h(countTrailingZeros(vec3i(i32(smoothstep(f16(vp40.f62[u32(unconst_u32(189))]), distance(vec2h(vp42[103][0]), vec2h(vp42[103][0])), f16(atan(vp40.f62).y)))))).r));
+  var vf523: f32 = vp40.f62[u32(unconst_u32(120))];
+  vf523 = f32(vp42[103][0]);
+  let vf524: vec2u = textureDimensions(tex50);
+  vp42[u32(floor(f16(vp40.f61[pack2x16unorm(sqrt(vec2f(f32(sin(f16(unconst_f16(26710.9)))))))])))][u32(unconst_u32(210))] -= vp42[103][0];
+  vf523 = f32(vp42[103][0]);
+  var vf525: f16 = floor(f16(unconst_f16(4984.9)));
+  let vf526: vec2u = textureDimensions(tex51, i32(textureNumLevels(tex46)));
+  let ptr221: ptr<private, f32> = &vp41[56];
+  vp42[u32(tanh(vec4f(f32(vp42[103][0]))).r)][u32(unconst_u32(188))] = vp42[103][0];
+  let ptr222: ptr<private, array<f16, 1>> = &vp42[103];
+  vp41[u32(unconst_u32(107))] = vp40.f62[u32(unconst_u32(245))];
+  let vf527: u32 = textureNumLevels(tex46);
+  var vf528: u32 = insertBits(vec2u(sqrt(vec2f(unconst_f32(0.3296), unconst_f32(0.03467)))).r, u32(unconst_u32(419)), u32(unconst_u32(338)), u32(unconst_u32(107)));
+  out[u32(unconst_u32(400))] = mat2x4h(f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)), f16(textureNumLevels(tex51)));
+  vp41[u32(unconst_u32(82))] = f32(textureNumLevels(tex51));
+  let ptr223: ptr<private, f16> = &vp42[103][0];
+  var vf529: u32 = vf522[u32(unconst_u32(141))];
+  out[u32(unconst_u32(81))] = mat2x4h(f16(vf523), f16(vf523), f16(vf523), f16(vf523), f16(vf523), f16(vf523), f16(vf523), f16(vf523));
+  let vf530: u32 = vf522[1];
+  return out;
+}
+
+@group(0) @binding(78) var tex48: texture_2d_array<f32>;
+
+@group(2) @binding(125) var tex54: texture_2d<u32>;
+
+struct T1 {
+  f0: array<f32, 2>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(1) @binding(37) var<storage, read_write> buffer202: array<array<array<f16, 3>, 1>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw120: T1;
+
+@group(0) @binding(30) var tex46: texture_depth_2d;
+
+@vertex
+fn vertex24(@location(13) a0: vec2f) -> VertexOutput18 {
+  var out: VertexOutput18;
+  var vf531 = fn1();
+  fn1();
+  let vf532: vec3f = smoothstep(vec3f(f32(vf531[1][1][u32(unconst_u32(46))])), vec3f(unconst_f32(0.01741), unconst_f32(0.08393), unconst_f32(0.1449)), vec3f(bitcast<f32>(textureNumLevels(tex50))));
+  out.f62 = a0;
+  var vf533: f32 = a0[0];
+  fn1();
+  var vf534: f32 = vp40.f62[u32(unconst_u32(478))];
+  fn1();
+  vf531[u32(unconst_u32(118))] = mat2x4h(f16(vf534), f16(vf534), f16(vf534), f16(vf534), f16(vf534), f16(vf534), f16(vf534), f16(vf534));
+  vf534 -= vp40.f61[u32(unconst_u32(223))];
+  vf534 = vp40.f61[0];
+  fn1();
+  out.f62 *= vec2f(vf533);
+  var vf535 = fn1();
+  vf534 += a0[0];
+  out.f62 = vec2f(textureDimensions(tex47));
+  var vf536 = fn1();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute21() {
+  var vf537: f32 = vp40.f61[bitcast<u32>(workgroupUniformLoad(&vw120).f0[1])];
+  vp42[u32(unconst_u32(363))][textureNumLayers(tex52)] = f16((*&vw120).f0[1]);
+  let ptr224: ptr<uniform, f16> = &buffer203[28][u32(unconst_u32(50))];
+  let ptr225: ptr<uniform, array<f16, 1>> = &buffer203[u32(unconst_u32(458))];
+  let ptr226: ptr<storage, array<array<f16, 3>, 1>, read_write> = &buffer202[i32(unconst_i32(88))];
+  let vf538: vec2u = countTrailingZeros(vec2u(unconst_u32(116), unconst_u32(253)));
+  buffer202[u32(unconst_u32(4))][u32(unconst_u32(11))][u32(buffer202[arrayLength(&buffer202) - 1][0][2])] = f16(textureLoad(tex48, vec2i(unconst_i32(234), unconst_i32(79)), bitcast<i32>(vp41[56]), i32(unconst_i32(-201))).g);
+  buffer202[u32((*ptr226)[0][2])][u32((*ptr225)[u32(unconst_u32(62))])][u32(unconst_u32(44))] = buffer202[arrayLength(&buffer202)][0][2];
+  vw120 = T1(array<f32, 2>(vw120.f0[u32(buffer203[u32(unconst_u32(8))][0])], vw120.f0[u32(buffer203[u32(unconst_u32(8))][0])]));
+  vp42[pack4xI8(vec4i(unconst_i32(148), unconst_i32(71), unconst_i32(154), unconst_i32(209)))][u32(unconst_u32(698))] = (*&buffer202)[vf538[u32(unconst_u32(215))]][0][2];
+  var vf539: u32 = vf538[0];
+  let ptr227: ptr<private, f32> = &vp41[56];
+  let ptr228: ptr<storage, array<array<f16, 3>, 1>, read_write> = &buffer202[arrayLength(&buffer202) - 1];
+  vf539 <<= textureNumLayers(tex52);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture277 = device0.createTexture({
+  label: '\u5b8c\uba1b\u4652\u0ce5\u05d6\uab7b',
+  size: [21],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView287 = texture117.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundle48 = renderBundleEncoder48.finish();
+let sampler176 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 31.76,
+  lodMaxClamp: 50.48,
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup129);
+} catch {}
+try {
+computePassEncoder151.setBindGroup(2, bindGroup44, new Uint32Array(4861), 461, 0);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline0);
+} catch {}
+document.body.append(canvas3);
+let textureView288 = texture104.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup19, new Uint32Array(1633), 556, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer88, 'uint32', 436, 734);
+} catch {}
+let shaderModule29 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+override override62: i32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(42) var tex55: texture_2d<f32>;
+
+struct T1 {
+  @align(1) @size(16) f0: array<u32>,
+}
+
+@group(1) @binding(31) var st15: texture_storage_1d<rgba8unorm, write>;
+
+struct T2 {
+  @size(156) f0: array<u32>,
+}
+
+override override63: f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(1) @binding(418) var<uniform> buffer204: array<array<f16, 4>, 2>;
+
+struct T4 {
+  @align(4) f0: array<mat2x4h, 1>,
+}
+
+struct VertexOutput19 {
+  @location(10) f63: vec4f,
+  @location(14) f64: i32,
+  @location(7) @interpolate(perspective, sample) f65: vec2h,
+  @location(0) f66: vec4i,
+  @location(2) @interpolate(flat, sample) f67: i32,
+  @location(4) @interpolate(flat, sample) f68: vec4i,
+  @location(1) f69: f32,
+  @location(6) @interpolate(flat, centroid) f70: vec2h,
+  @location(3) f71: vec4f,
+  @location(13) @interpolate(perspective, centroid) f72: vec4h,
+  @invariant @builtin(position) f73: vec4f,
+  @location(11) f74: i32,
+  @location(15) @interpolate(linear) f75: vec4h,
+  @location(12) @interpolate(flat, sample) f76: f32,
+  @location(5) f77: vec2i,
+  @location(8) f78: vec4f,
+  @location(9) @interpolate(linear, sample) f79: vec2f,
+}
+
+struct T3 {
+  @size(16) f0: atomic<i32>,
+}
+
+override override61: i32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(1) @binding(13) var tex56: texture_cube<f32>;
+
+struct T0 {
+  @size(16) f0: vec2h,
+}
+
+@vertex
+fn vertex25(@location(13) @interpolate(flat) a0: vec4h, @location(3) a1: f32, @location(9) a2: vec2h) -> VertexOutput19 {
+  var out: VertexOutput19;
+  var vf540: i32 = override61;
+  out.f73 = vec4f(f32(a2[u32(unconst_u32(13))]));
+  let vf541: i32 = override62;
+  var vf542: vec2h = a2;
+  let ptr229: ptr<uniform, array<f16, 4>> = &(*&buffer204)[1];
+  let ptr230: ptr<uniform, array<f16, 4>> = &buffer204[1];
+  out.f68 = vec4i(override61);
+  let vf543: vec2h = pow(vec2h(unconst_f16(9603.1), unconst_f16(7865.9)), vec2h(unconst_f16(26701.5), unconst_f16(6005.3)));
+  out.f68 = vec4i(round(vec4f(unconst_f32(0.2252), unconst_f32(0.1310), unconst_f32(0.01104), unconst_f32(0.05234))));
+  out.f78 = round(vec4f(unconst_f32(0.01584), unconst_f32(0.4214), unconst_f32(0.1643), unconst_f32(0.08092)));
+  let ptr231: ptr<uniform, array<f16, 4>> = &(*ptr230);
+  let ptr232: ptr<uniform, f16> = &(*ptr230)[u32(unconst_u32(91))];
+  let ptr233: ptr<uniform, array<array<f16, 4>, 2>> = &buffer204;
+  var vf544: f16 = override63;
+  var vf545: f16 = a0[3];
+  let ptr234: ptr<uniform, f16> = &buffer204[1][3];
+  var vf546: i32 = vf541;
+  let vf547: f16 = vf542[u32(unconst_u32(54))];
+  let ptr235: ptr<function, i32> = &vf540;
+  out.f76 = f32((*ptr233)[1][3]);
+  let ptr236: ptr<uniform, f16> = &buffer204[1][bitcast<u32>(a1)];
+  out.f69 -= f32((*ptr233)[1][u32(unconst_u32(139))]);
+  let ptr237: ptr<uniform, f16> = &(*ptr229)[3];
+  let ptr238: ptr<uniform, f16> = &(*ptr229)[3];
+  return out;
+  _ = override63;
+  _ = override62;
+  _ = override61;
+}
+
+@fragment
+fn fragment29() -> @location(200) @interpolate(flat, center) vec4f {
+  var out: vec4f;
+  out = vec4f(f32(override63));
+  let ptr239: ptr<uniform, f16> = &buffer204[1][3];
+  let vf548: u32 = countOneBits(u32(unconst_u32(486)));
+  let vf549: u32 = countOneBits(u32(unconst_u32(31)));
+  return out;
+  _ = override63;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup176 = device0.createBindGroup({
+  label: '\u09b2\u0607\udc9f\u{1fa00}\u0c53\ua3d0\uea5a\u{1fcfe}\u{1fd22}\u{1fcff}\u{1f7f1}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 42, resource: textureView87}, {binding: 137, resource: textureView69}],
+});
+let externalTexture29 = device0.importExternalTexture({label: '\uf29f\u25b2\ua753\u0060\u{1fcf1}\u0fe3\u6333', source: videoFrame24});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup148, new Uint32Array(6423), 301, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup158);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline10);
+} catch {}
+let bindGroup177 = device0.createBindGroup({
+  label: '\u{1ff60}\u00af\ud6fd\ue346\u8463',
+  layout: bindGroupLayout26,
+  entries: [{binding: 98, resource: textureView117}],
+});
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer157, 0, 1_823);
+} catch {}
+let buffer205 = device0.createBuffer({
+  size: 2748,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup133, new Uint32Array(266), 53, 0);
+} catch {}
+try {
+renderPassEncoder38.insertDebugMarker('\uceb9');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 27}
+*/
+{
+  source: imageData24,
+  origin: { x: 3, y: 12 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 98, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler177 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.05,
+  lodMaxClamp: 89.41,
+  compare: 'always',
+  maxAnisotropy: 16,
+});
+let externalTexture30 = device0.importExternalTexture({label: '\u4862\u4c59', source: videoFrame24});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup17, [0]);
+} catch {}
+document.body.prepend(img0);
+let textureView289 = texture105.createView({mipLevelCount: 1});
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup111, new Uint32Array(1165), 56, 0);
+} catch {}
+try {
+computePassEncoder177.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup178 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 218, resource: sampler137}]});
+let texture278 = device0.createTexture({
+  label: '\u42c5\u0895\u3167\uc25f\u{1feaa}\uebf8\u00b3\u0605',
+  size: {width: 768, height: 1, depthOrArrayLayers: 34},
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder42.setVertexBuffer(6, buffer99, 360, 27);
+} catch {}
+try {
+computePassEncoder55.popDebugGroup();
+} catch {}
+let buffer206 = device0.createBuffer({
+  size: 17108,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(7, buffer74);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture279 = device0.createTexture({
+  size: {width: 30, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder158.setBindGroup(0, bindGroup123, new Uint32Array(2428), 361, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup166, new Uint32Array(315), 76, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle2, renderBundle8]);
+} catch {}
+try {
+offscreenCanvas3.getContext('webgl2');
+} catch {}
+let bindGroup179 = device0.createBindGroup({
+  layout: bindGroupLayout35,
+  entries: [{binding: 477, resource: textureView164}, {binding: 372, resource: textureView10}],
+});
+let buffer207 = device0.createBuffer({
+  size: 5879,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder164); computePassEncoder164.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder164.end();
+} catch {}
+try {
+renderPassEncoder46.setViewport(26.66908883291755, 1.8482263039019098, 2.749834901468694, 0.04776268135456199, 0.15226714817535691, 0.16341752331781428);
+} catch {}
+let gpuCanvasContext9 = canvas6.getContext('webgpu');
+let texture280 = device0.createTexture({
+  label: '\u{1fb1a}\u{1fbd0}\u44ff\u0dcc\u08e2\u9720',
+  size: {width: 768, height: 1, depthOrArrayLayers: 80},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView290 = texture217.createView({dimension: '2d', baseArrayLayer: 9});
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup167, new Uint32Array(2284), 1_106, 0);
+} catch {}
+try {
+renderPassEncoder62.setBlendConstant({ r: 8.374, g: 643.0, b: 966.8, a: -476.6, });
+} catch {}
+try {
+commandEncoder217.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 8, y: 14, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup180 = device0.createBindGroup({
+  label: '\u02d0\u08e5\u0914\u{1fb4b}\u8abb',
+  layout: bindGroupLayout37,
+  entries: [
+    {binding: 16, resource: {buffer: buffer78, offset: 1024, size: 1680}},
+    {binding: 293, resource: textureView236},
+    {binding: 73, resource: textureView247},
+  ],
+});
+try {
+renderPassEncoder80.setBindGroup(3, bindGroup86, new Uint32Array(1033), 398, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline16);
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({label: '\u00df\u0e68\u422a', bindGroupLayouts: []});
+let buffer208 = device0.createBuffer({size: 10534, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView291 = texture67.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder72.executeBundles([renderBundle11, renderBundle39]);
+} catch {}
+try {
+renderPassEncoder82.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder217.copyBufferToBuffer(buffer0, 212, buffer163, 708, 152);
+} catch {}
+try {
+commandEncoder217.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 22 */
+  offset: 22,
+  buffer: buffer104,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView292 = texture14.createView({dimension: '2d', baseArrayLayer: 4});
+let renderPassEncoder83 = commandEncoder217.beginRenderPass({
+  colorAttachments: [{
+  view: textureView160,
+  clearValue: { r: 201.3, g: -385.8, b: -604.3, a: 790.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler178 = device0.createSampler({
+  label: '\u894f\u{1f964}\ub191\u0656\u{1f764}\u7371\u7610',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.29,
+  lodMaxClamp: 96.91,
+});
+document.body.append(canvas0);
+try {
+texture72.label = '\u{1fdfd}\u5bb3\u0deb\u{1fbee}';
+} catch {}
+let bindGroup181 = device0.createBindGroup({layout: bindGroupLayout29, entries: [{binding: 121, resource: textureView36}]});
+let texture281 = device0.createTexture({
+  label: '\u{1fe35}\u0cde\uf8f2\u{1feab}\u5f01\u88aa',
+  size: {width: 84, height: 40, depthOrArrayLayers: 69},
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup91);
+} catch {}
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'smpteSt4281'} });
+let buffer209 = device0.createBuffer({size: 5271, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder66.executeBundles([renderBundle5]);
+} catch {}
+try {
+buffer169.unmap();
+} catch {}
+let imageData36 = new ImageData(12, 32);
+let texture282 = device0.createTexture({
+  size: [30, 2, 46],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup123);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(194.64498826940005, 3.693781876975807, 23.9555043557898, 12.090125162216875, 0.43445428445157186, 0.5568278804822135);
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  label: '\ue6e1\ua8b7\u{1fef6}\u{1fdcd}\u4b51\ubb68\u0388\u8c4d',
+  entries: [
+    {
+      binding: 703,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 435,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 793,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 591,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer210 = device0.createBuffer({
+  size: 4664,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder14.setPipeline(pipeline10);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let textureView293 = texture65.createView({});
+let sampler179 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 90.87,
+  lodMaxClamp: 98.72,
+});
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup149, new Uint32Array(1630), 318, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle16, renderBundle40, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer21, 'uint32', 672, 85);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, buffer45);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let buffer211 = device0.createBuffer({size: 6353, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let textureView294 = texture50.createView({baseMipLevel: 0, arrayLayerCount: 3});
+try {
+computePassEncoder181.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder163.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder195.setBindGroup(2, bindGroup12, new Uint32Array(4171), 73, 1);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+let bindGroup182 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 23, resource: textureView24}, {binding: 130, resource: textureView207}],
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup96);
+} catch {}
+try {
+renderPassEncoder80.setIndexBuffer(buffer123, 'uint16', 908, 2_449);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture219,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(61).fill(139), /* required buffer size: 61 */
+{offset: 61}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+let buffer212 = device0.createBuffer({
+  size: 7688,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder8.setIndexBuffer(buffer114, 'uint16', 276, 401);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline17);
+} catch {}
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup95);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture283 = device0.createTexture({
+  size: [192, 1, 35],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup119);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup27, new Uint32Array(4892), 406, 0);
+} catch {}
+try {
+renderPassEncoder55.insertDebugMarker('\u2ed9');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 32},
+  aspect: 'all',
+}, new Uint8Array(17_477).fill(104), /* required buffer size: 17_477 */
+{offset: 69, bytesPerRow: 32, rowsPerImage: 34}, {width: 3, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let bindGroup183 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 106, resource: sampler6}]});
+let texture284 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise36 = device0.queue.onSubmittedWorkDone();
+let buffer213 = device0.createBuffer({size: 47617, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer135, 'uint16', 10_518, 6_638);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer37);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup184 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 100, resource: textureView36}]});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup156, new Uint32Array(317), 41, 0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup81, new Uint32Array(122), 12, 0);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle5, renderBundle23, renderBundle40, renderBundle12, renderBundle16, renderBundle30, renderBundle16, renderBundle30]);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 90,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroupsIndirect(buffer105, 3_400); };
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup137, new Uint32Array(855), 145, 0);
+} catch {}
+try {
+renderPassEncoder50.insertDebugMarker('\uc29d');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(94), /* required buffer size: 19 */
+{offset: 19}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+computePassEncoder205.setBindGroup(1, bindGroup77, []);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(0, bindGroup51, new Uint32Array(309), 71, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroupsIndirect(buffer141, 44); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer44, 'uint32', 132, 308);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(260).fill(54), /* required buffer size: 260 */
+{offset: 260, bytesPerRow: 69}, {width: 26, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer214 = device0.createBuffer({size: 10459, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture285 = device0.createTexture({size: [240, 16, 375], dimension: '3d', format: 'rg32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView295 = texture147.createView({label: '\ub3a2\u{1f782}\u5152\u9dfc\u5120\ufb4b\u00bb\u0923\u{1ffc5}', mipLevelCount: 1});
+try {
+computePassEncoder108.setBindGroup(0, bindGroup173);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+adapter0.label = '\ue9a2\u0502\u{1f9f6}\u0477\u{1fffc}';
+} catch {}
+try {
+globalThis.someLabel = externalTexture7.label;
+} catch {}
+let textureView296 = texture31.createView({mipLevelCount: 1});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup100, new Uint32Array(509), 139, 0);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup123, new Uint32Array(1460), 4, 0);
+} catch {}
+let arrayBuffer39 = buffer33.getMappedRange(624, 52);
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout7]});
+let buffer215 = device0.createBuffer({size: 5440, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture286 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView297 = texture57.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder53.executeBundles([renderBundle6, renderBundle40]);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(4, buffer29, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup185 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 180, resource: textureView1}]});
+let texture287 = device0.createTexture({
+  size: [192, 1, 16],
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer36, 'uint32', 44, 465);
+} catch {}
+await gc();
+let img12 = await imageWithData(21, 39, '#10101010', '#20202020');
+let bindGroup186 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 47, resource: textureView19}]});
+try {
+computePassEncoder163.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup68, new Uint32Array(2471), 287, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle29, renderBundle39]);
+} catch {}
+let arrayBuffer40 = buffer33.getMappedRange(704, 0);
+try {
+if (!arrayBuffer31.detached) { new Uint8Array(arrayBuffer31).fill(0x55); };
+} catch {}
+let buffer216 = device0.createBuffer({
+  label: '\uf35b\u7369\u0ab2\u3f88\ud2f4\u{1f8e8}\ud06e\ud747\u5b6d',
+  size: 11576,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture288 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 65},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup42, new Uint32Array(4303), 70, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer108, 0, 1_359);
+} catch {}
+try {
+gpuCanvasContext7.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let videoFrame35 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let buffer217 = device0.createBuffer({size: 8569, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({colorFormats: ['rg32float'], depthReadOnly: true});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(3, bindGroup2, new Uint32Array(293), 56, 0);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder70.setViewport(166.91031817006672, 0.32321238252778284, 6.427161480964209, 0.17916715751021092, 0.07322291098081968, 0.8314767515037998);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(buffer76, 'uint32', 5_048, 641);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(7, buffer143, 0);
+} catch {}
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder49.setIndexBuffer(buffer83, 'uint16', 502, 2_326);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(1, buffer185);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer171, 2104, new BigUint64Array(4061), 384, 880);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData19,
+  origin: { x: 15, y: 13 },
+  flipY: true,
+}, {
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise36;
+} catch {}
+let texture289 = gpuCanvasContext1.getCurrentTexture();
+let textureView298 = texture118.createView({});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup15, new Uint32Array(4115), 542, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer0, 'uint16', 14, 302);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(3, bindGroup129);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline15);
+} catch {}
+await gc();
+let bindGroup187 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 160, resource: textureView153}]});
+let buffer218 = device0.createBuffer({
+  label: '\u09fe\u{1fe85}',
+  size: 11718,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder27.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer55, 408, 1_090);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData37 = new ImageData(8, 48);
+let buffer219 = device0.createBuffer({
+  label: '\u{1f6a8}\u{1ff1c}',
+  size: 20445,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler180 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.019,
+  lodMaxClamp: 16.75,
+  compare: 'equal',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup124);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer210, 'uint16', 1_464, 38);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup188 = device0.createBindGroup({
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 168, resource: textureView195},
+    {binding: 29, resource: {buffer: buffer0, offset: 1280, size: 2788}},
+  ],
+});
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4, bindGroupLayout12]});
+let texture290 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler181 = device0.createSampler({
+  label: '\u{1f9c9}\u0bff\u97d9\u1ca0\uc800\udb30\u3347\u4538',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.00,
+  lodMaxClamp: 96.99,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(3, bindGroup71, new Uint32Array(224), 4, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroups(3, 2, 1); };
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer37, 'uint32', 552, 1_447);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(6, buffer50, 0, 2_577);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline16);
+} catch {}
+let texture291 = device0.createTexture({
+  size: [384, 1, 15],
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup176, new Uint32Array(1735), 1_333, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(5, buffer137, 0, 316);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(1, bindGroup29);
+} catch {}
+let textureView299 = texture226.createView({dimension: '2d-array', baseArrayLayer: 2, arrayLayerCount: 2});
+let sampler182 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.28,
+});
+try {
+computePassEncoder123.end();
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(7, buffer24, 480, 351);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(buffer37, 'uint32', 988, 4_874);
+} catch {}
+try {
+commandEncoder157.copyBufferToBuffer(buffer169, 32, buffer214, 5876, 104);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer91, 64, new DataView(new ArrayBuffer(21046)), 24, 1652);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture271,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(144).fill(218), /* required buffer size: 144 */
+{offset: 144}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule15,
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex17',
+    constants: {13_552: 0, override47: 0, 30_830: 0, 39_926: 0},
+    buffers: [],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer32.detached) { new Uint8Array(arrayBuffer32).fill(0x55); };
+} catch {}
+let renderPassEncoder84 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: 443.5, g: 157.7, b: -184.7, a: 118.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler183 = device0.createSampler({
+  label: '\u{1fa9d}\u{1f970}\u06e4\u0c6c\uab03\u04b5\u{1f9bf}\udb3b\u{1fd67}\u{1fcc1}\u{1f7a5}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.50,
+  lodMaxClamp: 98.66,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup170);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup9, new Uint32Array(456), 14, 0);
+} catch {}
+try {
+renderPassEncoder81.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline0);
+} catch {}
+let texture292 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle49 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder147.setBindGroup(2, bindGroup159);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(3, bindGroup0, new Uint32Array(46), 9, 0);
+} catch {}
+try {
+renderPassEncoder46.setScissorRect(2, 0, 5, 0);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(buffer183, 'uint32', 56, 2_635);
+} catch {}
+let imageData38 = new ImageData(8, 88);
+let renderBundle50 = renderBundleEncoder49.finish({});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup127);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(0, buffer6);
+} catch {}
+let texture293 = device0.createTexture({
+  size: [120, 8, 187],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup32, new Uint32Array(1321), 55, 0);
+} catch {}
+let arrayBuffer41 = buffer64.getMappedRange(0, 4);
+try {
+computePassEncoder166.setBindGroup(3, bindGroup80);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline0);
+} catch {}
+let shaderModule30 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+struct VertexOutput21 {
+  @builtin(position) f81: vec4f,
+}
+
+var<workgroup> vw126: atomic<i32>;
+
+var<workgroup> vw132: vec4u;
+
+var<private> vp43: VertexOutput21 = VertexOutput21();
+
+var<workgroup> vw125: mat3x2h;
+
+fn fn0() -> FragmentOutput25 {
+  var out: FragmentOutput25;
+  var vf550: i32 = insertBits(insertBits(bitcast<i32>(vp44.fract.x), bitcast<vec4i>(vp43.f81).x, u32(vp46.f80[1]), max(vec2u(vp47[2]).y, u32(unconst_u32(291)))), i32(unconst_i32(169)), u32(unconst_u32(17)), u32(unconst_u32(357)));
+  out.f1 = vp44.whole;
+  let ptr240: ptr<private, vec4f> = &vp46.f80;
+  out = FragmentOutput25(u32(vf550), vec4f(f32(vf550)));
+  let vf551: u32 = max(u32(vp43.f81[1]), u32(unconst_u32(0)));
+  let ptr241: ptr<private, vec3h> = &vp45.whole;
+  let ptr242: ptr<private, vec3h> = &vp45.whole;
+  var vf552: f32 = vp43.f81[u32(unconst_u32(8))];
+  vp47 = mat3x2f(vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])], vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])], vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])], vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])], vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])], vp47[u32((*ptr242)[0])][pack2x16snorm(vp47[2])]);
+  let vf553: u32 = max(u32((*ptr241)[1]), u32(unconst_u32(199)));
+  out = FragmentOutput25(vec2u(vp47[u32((*ptr241)[u32(unconst_u32(160))])])[0], vp47[u32((*ptr241)[u32(unconst_u32(160))])].xxyx);
+  let ptr243: ptr<private, vec4f> = &vp43.f81;
+  var vf554: u32 = vf551;
+  let ptr244: ptr<private, mat3x2f> = &vp47;
+  return out;
+}
+
+@group(0) @binding(626) var sam0: sampler;
+
+var<private> vp44 = modf(vec4f());
+
+struct VertexOutput20 {
+  @builtin(position) f80: vec4f,
+}
+
+var<private> vp47: mat3x2f = mat3x2f();
+
+struct T0 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+var<workgroup> vw128: array<u32, 41>;
+
+var<workgroup> vw122: vec4h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw123: array<atomic<u32>, 57>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw131: array<atomic<i32>, 16>;
+
+var<workgroup> vw124: bool;
+
+var<workgroup> vw130: array<array<f32, 1>, 6>;
+
+var<workgroup> vw127: VertexOutput21;
+
+struct S4 {
+  @location(2) f0: vec2i,
+  @location(7) f1: f32,
+}
+
+struct FragmentOutput25 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T2 {
+  @align(2) @size(136) f0: array<u32>,
+}
+
+var<workgroup> vw129: vec2h;
+
+var<private> vp45 = modf(vec3h());
+
+var<private> vp46: VertexOutput20 = VertexOutput20(vec4f());
+
+struct T1 {
+  @size(16) f0: array<f32>,
+}
+
+var<workgroup> vw121: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex26(@location(8) a0: vec2h) -> VertexOutput20 {
+  var out: VertexOutput20;
+  let vf555: f32 = vp46.f80[0];
+  let ptr245 = &vp45;
+  var vf556: f16 = a0[0];
+  let vf557: vec2f = unpack2x16float(u32(unconst_u32(222)));
+  let vf558: vec4f = smoothstep(vec4f(f32(clamp(f16(smoothstep(vec2f(unconst_f32(0.1404), unconst_f32(-0.06028)), vp43.f81.gr, vec2f(unconst_f32(0.3006), unconst_f32(0.04544))).g), f16(unconst_f16(14197.0)), f16(unconst_f16(13750.1))))), vec4f(unconst_f32(0.2615), unconst_f32(0.04334), unconst_f32(0.1042), unconst_f32(0.00737)), vec4f(f32(dot4U8Packed(u32(unconst_u32(26)), u32(unconst_u32(373))))));
+  vf556 = f16(vp43.f81[2]);
+  let ptr246: ptr<private, vec2f> = &vp47[0];
+  out.f80 *= vec4f(pow(vec4h(vp44.whole), vec4h(unconst_f16(20734.0), unconst_f16(12600.5), unconst_f16(11142.2), unconst_f16(3560.1))));
+  out.f80 = vec4f(vp46.f80[0]);
+  var vf559: f32 = (*ptr246)[u32(a0[u32(unconst_u32(128))])];
+  vf559 = f32(a0[vec3u((*ptr245).whole)[1]]);
+  var vf560: f16 = distance(vec4h(unconst_f16(1252.4), unconst_f16(-12760.0), unconst_f16(1014.3), unconst_f16(16018.2)), vec4h(unconst_f16(-17509.4), unconst_f16(3453.9), unconst_f16(3765.7), unconst_f16(466.4)));
+  var vf561: f32 = (*ptr246)[u32(unconst_u32(81))];
+  let ptr247 = &(*ptr245);
+  out.f80 = vec4f(vp45.fract.yxzy);
+  vf556 *= f16(vp47[0][1]);
+  let vf562: f32 = vp43.f81[2];
+  vp45 = modf(vec3h(f16(pack4x8unorm(vec4f(unconst_f32(0.4865), unconst_f32(0.07669), unconst_f32(-0.02033), unconst_f32(0.2104))))));
+  let ptr248: ptr<private, vec3h> = &vp45.whole;
+  return out;
+}
+
+@vertex
+fn vertex27(a0: S4, @builtin(vertex_index) a1: u32) -> VertexOutput21 {
+  var out: VertexOutput21;
+  var vf563: u32 = pack4x8snorm(vec4f(unconst_f32(0.2368), unconst_f32(0.2884), unconst_f32(0.5383), unconst_f32(0.2675)));
+  out = VertexOutput21(vec4f(bitcast<f32>(a0.f0[0])));
+  var vf564: f16 = smoothstep(vec4h(vp46.f80).r, f16(vp47[u32(unconst_u32(105))][bitcast<u32>(vp43.f81[u32(unconst_u32(112))])]), f16(unconst_f16(2449.0)));
+  out.f81 = vp44.whole;
+  var vf565: f32 = vp43.f81[1];
+  let ptr249: ptr<function, f32> = &vf565;
+  return out;
+}
+
+@fragment
+fn fragment30() -> FragmentOutput25 {
+  var out: FragmentOutput25;
+  out.f1 += vec4f(pow(vec3h(vp44.fract.aba), vec3h(saturate(exp2(vec2f(unconst_f32(0.3070), unconst_f32(-0.00862))).rrg))).rgrg);
+  let vf566: f32 = vp46.f80[u32(unconst_u32(63))];
+  vp47 = mat3x2f(unpack4x8snorm(u32(unconst_u32(487))).xz, unpack4x8snorm(u32(unconst_u32(487))).zw, unpack4x8snorm(u32(unconst_u32(487))).ar);
+  let ptr250: ptr<private, vec4f> = &vp46.f80;
+  let vf567: f16 = floor(inverseSqrt(vec3h(unconst_f16(7575.8), unconst_f16(8705.0), unconst_f16(1606.9))).y);
+  var vf568 = fn0();
+  vp46.f80 = vec4f(pow(vp45.whole, vp45.fract).yyyx);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute22() {
+  fn0();
+  vw127.f81 = bitcast<vec4f>(workgroupUniformLoad(&vw132));
+  fn0();
+  vp46 = VertexOutput20(vec4f(vw130[5][0]));
+  let vf569: f32 = determinant(mat2x2f(f32(atomicLoad(&(*&vw131)[15])), bitcast<f32>(atomicLoad(&(*&vw131)[15])), bitcast<f32>(atomicLoad(&(*&vw131)[15])), f32(atomicLoad(&(*&vw131)[15]))));
+  let ptr251: ptr<workgroup, u32> = &(*&vw128)[atomicLoad(&(*&vw123)[56])];
+  let vf570: vec2f = unpack2x16float(bitcast<u32>(workgroupUniformLoad(&vw127).f81[1]));
+  let ptr252: ptr<workgroup, vec2h> = &(*&vw129);
+  fn0();
+  var vf571 = fn0();
+  var vf572: f32 = vp46.f80[2];
+  fn0();
+  fn0();
+  vf571 = FragmentOutput25(pack4xU8Clamp(vec4u(atanh(vec4h(unconst_f16(24757.1), unconst_f16(20068.9), unconst_f16(14367.8), unconst_f16(9093.8))))), vec4f(atanh(vec4h(unconst_f16(24757.1), unconst_f16(20068.9), unconst_f16(14367.8), unconst_f16(9093.8)))));
+  vf572 *= f32(vw125[u32(unconst_u32(41))][atomicExchange(&vw121, u32(vp47[countOneBits(vec3u(atomicExchange(&(*&vw121), bitcast<u32>(vf570[0]))))[1]].x))]);
+  fn0();
+  atomicStore(&vw123[u32(unconst_u32(6))], vf571.f0);
+  atomicAnd(&vw123[u32(unconst_u32(418))], u32(unconst_u32(174)));
+  vw129 -= vec2h(vw127.f81.gg);
+  fn0();
+  let ptr253: ptr<function, u32> = &vf571.f0;
+  var vf573: vec2h = (*&vw125)[u32(unconst_u32(54))];
+  let ptr254: ptr<private, vec3h> = &vp45.fract;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup189 = device0.createBindGroup({
+  layout: bindGroupLayout37,
+  entries: [
+    {binding: 293, resource: textureView242},
+    {binding: 73, resource: textureView247},
+    {binding: 16, resource: {buffer: buffer211, offset: 1280, size: 868}},
+  ],
+});
+let textureView300 = texture110.createView({baseMipLevel: 0});
+let sampler184 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 81.53,
+  lodMaxClamp: 98.48,
+  compare: 'less',
+});
+try {
+renderPassEncoder76.executeBundles([renderBundle41, renderBundle45, renderBundle24, renderBundle5]);
+} catch {}
+let texture294 = device0.createTexture({
+  label: '\ueed4\u9b60\u14c2\u{1f836}\u092f\u9ea6\u8dfb\u58a7\uf47d\u{1fb31}\ud4da',
+  size: {width: 1536},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder173.setBindGroup(1, bindGroup112);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup150);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup138, new Uint32Array(3786), 1_277, 0);
+} catch {}
+try {
+renderPassEncoder68.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(48, 0, 47, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+buffer152.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer150, 5764, new BigUint64Array(17846), 2267, 0);
+} catch {}
+let textureView301 = texture244.createView({label: '\u50a2\u{1f982}\u0bc2\u06f1\ufa03\u4b46\u{1fa21}\uf36e', format: 'rgba16float'});
+let sampler185 = device0.createSampler({
+  label: '\u{1ffa9}\u0ab0\u6f89\uae66\u1039',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.94,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder195.end();
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle27]);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer102, 'uint16', 36, 11);
+} catch {}
+try {
+commandEncoder253.copyBufferToTexture({
+  /* bytesInLastRow: 220 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 368 */
+  offset: 368,
+  bytesPerRow: 10752,
+  buffer: buffer127,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 55, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 3452, new Float32Array(5077), 99, 0);
+} catch {}
+let bindGroup190 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 337, resource: {buffer: buffer181, offset: 2816, size: 216}}],
+});
+let textureView302 = texture133.createView({dimension: '2d'});
+try {
+computePassEncoder88.setBindGroup(0, bindGroup148, new Uint32Array(281), 96, 0);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer61);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer143, 592, new BigUint64Array(1052), 423, 8);
+} catch {}
+let texture295 = device0.createTexture({size: [32, 32, 20], mipLevelCount: 3, format: 'rgb10a2unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder211 = commandEncoder253.beginComputePass({label: '\u4a3b\u{1f875}\u96e4\u{1fb07}\u{1f882}\u8448'});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame25, colorSpace: 'srgb'});
+try {
+renderPassEncoder69.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 168, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 17, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup190, new Uint32Array(1326), 115, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer143, 'uint16', 618, 582);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'bt2020_12bit'} });
+let bindGroup191 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 278, resource: textureView42}]});
+try {
+renderPassEncoder68.endOcclusionQuery();
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 130, resource: textureView195}, {binding: 23, resource: textureView49}],
+});
+let textureView303 = texture27.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler186 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.98,
+  lodMaxClamp: 70.10,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup101);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle45, renderBundle41, renderBundle41, renderBundle23, renderBundle6, renderBundle6, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer190, 'uint32', 1_708, 909);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer189);
+} catch {}
+let arrayBuffer42 = buffer47.getMappedRange(16, 0);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 14, y: 0 },
+  flipY: false,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap8 = await createImageBitmap(videoFrame8);
+let bindGroupLayout44 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 99,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 164, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 142,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+device0.queue.submit([]);
+} catch {}
+let texture296 = device0.createTexture({
+  size: [21],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture297 = gpuCanvasContext6.getCurrentTexture();
+try {
+computePassEncoder194.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer37, 'uint16', 20_454, 1_372);
+} catch {}
+let bindGroup193 = device0.createBindGroup({
+  label: '\u2bf3\u8371\ud966\uabf2\u0e0e\ub751\u{1fa01}\u{1ff06}\u0419\u7da5',
+  layout: bindGroupLayout44,
+  entries: [
+    {binding: 32, resource: textureView164},
+    {binding: 144, resource: textureView130},
+    {binding: 142, resource: {buffer: buffer113, offset: 512, size: 11312}},
+    {binding: 21, resource: {buffer: buffer198, offset: 256, size: 912}},
+    {binding: 43, resource: {buffer: buffer71, offset: 512, size: 138}},
+    {binding: 99, resource: sampler8},
+    {binding: 164, resource: externalTexture9},
+    {binding: 232, resource: {buffer: buffer199, offset: 0, size: 196}},
+    {binding: 203, resource: {buffer: buffer58, offset: 2048, size: 6788}},
+  ],
+});
+let textureView304 = texture82.createView({format: 'r32uint'});
+let textureView305 = texture190.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler187 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 98.42,
+  lodMaxClamp: 98.44,
+});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup157, new Uint32Array(402), 91, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup152, new Uint32Array(337), 76, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder84.setViewport(75.86484977245752, 1.99970046553692, 16.799170079824684, 2.357668027149166, 0.26092810060638416, 0.7136696016259304);
+} catch {}
+try {
+computePassEncoder120.insertDebugMarker('\u0fbf');
+} catch {}
+let texture298 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler188 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'repeat'});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup161);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline19);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer220 = device0.createBuffer({size: 16307, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture299 = gpuCanvasContext1.getCurrentTexture();
+let textureView306 = texture151.createView({
+  label: '\u0be2\u6460\u0499\u0982\u{1f89f}\ubf75\ud6a4\ufeef\ucc7c\u2d66\u{1fc43}',
+  dimension: '2d',
+  baseArrayLayer: 3,
+});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup184);
+} catch {}
+try {
+renderPassEncoder83.executeBundles([renderBundle30, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer23, 'uint16', 312, 1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(212), /* required buffer size: 8 */
+{offset: 8, rowsPerImage: 11}, {width: 139, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let bindGroup194 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 41, resource: textureView117},
+    {binding: 97, resource: {buffer: buffer8, offset: 512, size: 1292}},
+    {binding: 120, resource: textureView164},
+  ],
+});
+let textureView307 = texture7.createView({});
+let sampler189 = device0.createSampler({
+  label: '\u0e3f\ub17a\u45e1\u{1f9c3}\u{1f908}\ubcaa\u32b2',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.06,
+  lodMaxClamp: 89.54,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup176);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup181, new Uint32Array(1764), 1_089, 0);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline21);
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+try {
+textureView95.label = '\u1e23\u9ba9\ua5ec\u{1f8f1}\u00d5\u38b7\u0edc\u1a7f\u10f3';
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer221 = device0.createBuffer({
+  label: '\u7c04\u{1f8c4}\u{1ffb5}\ub3ca\u2c16\u0f77',
+  size: 1222,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture300 = device0.createTexture({
+  size: [30, 2, 46],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView308 = texture23.createView({baseArrayLayer: 0});
+try {
+computePassEncoder209.setBindGroup(0, bindGroup192);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup169, new Uint32Array(2945), 21, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle8, renderBundle27, renderBundle2, renderBundle49, renderBundle49]);
+} catch {}
+let arrayBuffer43 = buffer155.getMappedRange(408, 48);
+document.body.append(canvas6);
+let imageData39 = new ImageData(12, 96);
+let videoFrame37 = new VideoFrame(videoFrame29, {timestamp: 0});
+let sampler190 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.43,
+  lodMaxClamp: 40.25,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder210.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup181);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline21);
+} catch {}
+let imageBitmap9 = await createImageBitmap(imageData25);
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'unspecified'} });
+let shaderModule31 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S5 {
+  @builtin(instance_index) f0: u32,
+  @builtin(vertex_index) f1: u32,
+  @location(10) @interpolate(linear, centroid) f2: vec4h,
+  @location(15) @interpolate(perspective) f3: f32,
+  @location(2) @interpolate(perspective, centroid) f4: f32,
+  @location(7) @interpolate(flat, sample) f5: vec4i,
+  @location(12) @interpolate(flat) f6: vec4i,
+  @location(13) @interpolate(flat) f7: vec4u,
+  @location(3) @interpolate(flat) f8: u32,
+  @location(8) f9: vec4f,
+  @location(14) @interpolate(flat, sample) f10: vec2u,
+  @location(1) f11: f32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(18) var<storage, read> buffer222: array<mat2x3h>;
+
+struct VertexOutput22 {
+  @location(2) @interpolate(flat, sample) f82: vec2f,
+  @invariant @builtin(position) f83: vec4f,
+  @location(13) f84: f16,
+  @location(14) f85: i32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput26 {
+  @location(0) @interpolate(flat) f0: vec2u,
+  @location(1) f1: vec4u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex28(@location(9) a0: vec2f, @location(6) @interpolate(flat, center) a1: i32, a2: S5, @location(0) a3: vec4i) -> VertexOutput22 {
+  var out: VertexOutput22;
+  let vf574: i32 = a2.f6[3];
+  var vf575: vec4i = a3;
+  vf575 = vec4i(i32(any(vec3<bool>(bool(a2.f8)))));
+  out.f84 -= vec2h(trunc(vec2f(f32(vf575[u32(a2.f9[2])])))).y;
+  let vf576: vec4i = a2.f5;
+  out.f84 = f16(a2.f5[0]);
+  return out;
+}
+
+@fragment
+fn fragment31() -> FragmentOutput26 {
+  var out: FragmentOutput26;
+  out.f1 = vec4u(buffer222[arrayLength(&buffer222)][0].xxzy);
+  var vf577: f16 = buffer222[arrayLength(&buffer222)][1][2];
+  var vf578: vec3h = buffer222[arrayLength(&buffer222)][countTrailingZeros(vec2u(u32(buffer222[arrayLength(&buffer222)][1][u32((*&buffer222)[arrayLength(&(*&buffer222))][0].y)])))[0]];
+  out.f1 *= vec4u(buffer222[arrayLength(&buffer222)][0].rggr);
+  discard;
+  let vf579: f32 = saturate(f32(unconst_f32(0.1685)));
+  var vf580: f16 = (*&buffer222)[arrayLength(&(*&buffer222))][u32(unconst_u32(686))][u32(unconst_u32(266))];
+  let vf581: vec4i = select(vec4i(unconst_i32(25), unconst_i32(214), unconst_i32(30), unconst_i32(9)), vec4i(i32((*&buffer222)[arrayLength(&(*&buffer222))][u32(unconst_u32(117))][vec3u((*&buffer222)[arrayLength(&(*&buffer222)) - 1][0]).r])), bool(unconst_bool(false)));
+  vf580 = vf578[u32(unconst_u32(54))];
+  let vf582: vec4i = select(vec4i(unconst_i32(254), unconst_i32(400), unconst_i32(66), unconst_i32(135)), vec4i(unconst_i32(159), unconst_i32(76), unconst_i32(359), unconst_i32(205)), bool(unconst_bool(true)));
+  return out;
+}
+
+@compute @workgroup_size(2, 2, 1)
+fn compute23() {
+  let vf583: u32 = pack2x16snorm(vec2f(unconst_f32(0.02880), unconst_f32(0.1122)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup195 = device0.createBindGroup({layout: bindGroupLayout26, entries: [{binding: 98, resource: textureView202}]});
+let buffer223 = device0.createBuffer({
+  size: 4696,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView309 = texture75.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 4});
+try {
+renderPassEncoder84.setPipeline(pipeline17);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder85.setBindGroup(0, bindGroup17, [256]);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup128);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle21, renderBundle22, renderBundle33, renderBundle4, renderBundle37, renderBundle37, renderBundle4, renderBundle7, renderBundle33, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer156, 'uint32', 740, 113);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline18);
+} catch {}
+let bindGroup196 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 120, resource: textureView164},
+    {binding: 97, resource: {buffer: buffer119, offset: 512}},
+    {binding: 41, resource: textureView202},
+  ],
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup142);
+} catch {}
+try {
+renderPassEncoder70.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder70.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(2, buffer90, 0, 19);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 9},
+  aspect: 'all',
+}, new Uint8Array(746_766).fill(250), /* required buffer size: 746_766 */
+{offset: 137, bytesPerRow: 727, rowsPerImage: 79}, {width: 176, height: 0, depthOrArrayLayers: 14});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder125.setBindGroup(3, bindGroup8);
+} catch {}
+let textureView310 = texture235.createView({});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup46, new Uint32Array(13), 3, 0);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle4, renderBundle4, renderBundle33, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(6, buffer216, 0);
+} catch {}
+try {
+gpuCanvasContext9.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let buffer224 = device0.createBuffer({size: 38803, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let texture301 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder47.setStencilReference(85);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(3, buffer133, 332, 23);
+} catch {}
+document.body.prepend(canvas2);
+let textureView311 = texture164.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup91, new Uint32Array(2666), 1_328, 0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup104);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder35.pushDebugGroup('\u{1ff95}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+computePassEncoder71.setBindGroup(2, bindGroup0, new Uint32Array(1283), 273, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(145).fill(28), /* required buffer size: 145 */
+{offset: 145}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer225 = device0.createBuffer({
+  size: 39093,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+buffer29.unmap();
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup197 = device0.createBindGroup({
+  layout: bindGroupLayout38,
+  entries: [{binding: 103, resource: {buffer: buffer170, offset: 8960, size: 132}}],
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(0, bindGroup166, new Uint32Array(679), 99, 0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup104);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(1043);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer123, 2_704);
+} catch {}
+try {
+computePassEncoder171.setBindGroup(0, bindGroup168, new Uint32Array(2302), 261, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup80, new Uint32Array(3122), 261, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer169, 'uint16', 232, 545);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline21);
+} catch {}
+try {
+computePassEncoder140.insertDebugMarker('\u037f');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroupLayout45 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 114,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup198 = device0.createBindGroup({layout: bindGroupLayout26, entries: [{binding: 98, resource: textureView115}]});
+let buffer226 = device0.createBuffer({size: 241, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let querySet47 = device0.createQuerySet({type: 'occlusion', count: 1182});
+let textureView312 = texture263.createView({mipLevelCount: 1});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup183, []);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer81, 'uint16', 378, 269);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer122, 0);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+try {
+renderPassEncoder35.popDebugGroup();
+} catch {}
+try {
+computePassEncoder181.label = '\u31bf\u56f1\u8839\u{1fde1}\u0dbe\u44a2\u7084\ua1fb';
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 78, resource: textureView177},
+    {binding: 48, resource: textureView14},
+    {binding: 37, resource: {buffer: buffer96, offset: 768, size: 668}},
+    {binding: 30, resource: textureView77},
+    {binding: 205, resource: textureView193},
+  ],
+});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup146);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup28, new Uint32Array(2698), 39, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup114, new Uint32Array(3808), 192, 0);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer9, 'uint16', 330, 1_890);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(6, buffer50, 0);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer42.detached) { new Uint8Array(arrayBuffer42).fill(0x55); };
+} catch {}
+try {
+  await promise37;
+} catch {}
+let textureView313 = texture263.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture32 = device0.importExternalTexture({source: videoFrame30});
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup73, []);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline0);
+} catch {}
+let bindGroup200 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 351, resource: {buffer: buffer198, offset: 1536}}, {binding: 87, resource: textureView57}],
+});
+let textureView314 = texture26.createView({dimension: '2d', baseArrayLayer: 20});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({label: '\u{1fcfb}\u189a\u{1fde0}\u0d65\ucb6b\u0df6', colorFormats: ['rg8uint']});
+let renderBundle51 = renderBundleEncoder51.finish({});
+let sampler191 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 30.84,
+  lodMaxClamp: 54.99,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup0, new Uint32Array(3806), 793, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(4, buffer9, 220, 1_761);
+} catch {}
+let querySet48 = device0.createQuerySet({type: 'occlusion', count: 1025});
+let texture302 = device0.createTexture({
+  size: {width: 60, height: 4, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler192 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 90.86,
+  lodMaxClamp: 96.17,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+computePassEncoder167.setBindGroup(0, bindGroup31, new Uint32Array(2088), 52, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let bindGroup201 = device0.createBindGroup({
+  layout: bindGroupLayout38,
+  entries: [{binding: 103, resource: {buffer: buffer189, offset: 2816, size: 1328}}],
+});
+let texture303 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler193 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.84,
+  lodMaxClamp: 87.19,
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle33]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer125, 'uint16', 200, 518);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline9);
+} catch {}
+let img13 = await imageWithData(75, 16, '#10101010', '#20202020');
+let textureView315 = texture271.createView({});
+try {
+computePassEncoder69.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup106, new Uint32Array(413), 283, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer23, 'uint32', 788, 289);
+} catch {}
+try {
+buffer154.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture298,
+  mipLevel: 1,
+  origin: {x: 18, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(296).fill(167), /* required buffer size: 296 */
+{offset: 296, rowsPerImage: 5}, {width: 57, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas4);
+let bindGroup202 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 999, resource: {buffer: buffer78, offset: 0, size: 2912}}],
+});
+let buffer227 = device0.createBuffer({
+  size: 10456,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture304 = device0.createTexture({
+  size: [60, 4, 93],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let externalTexture33 = device0.importExternalTexture({
+  label: '\u9f28\u{1f736}\u{1fe4b}\ue6a0\u{1fa3c}\u{1fe93}\u7bdc\u6f1b\u0eed\u{1f8ff}',
+  source: videoFrame19,
+});
+try {
+computePassEncoder109.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer181, 'uint32', 816, 786);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer74, 0, 1_910);
+} catch {}
+document.body.prepend(canvas4);
+let querySet49 = device0.createQuerySet({type: 'occlusion', count: 424});
+let sampler194 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'repeat', lodMinClamp: 54.58, lodMaxClamp: 58.86});
+try {
+renderPassEncoder24.setIndexBuffer(buffer110, 'uint16', 124, 1_252);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer34, 280, 307);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup203 = device0.createBindGroup({
+  label: '\u6e32\u{1fd0b}\u05e0\u{1f82c}\uaae3',
+  layout: bindGroupLayout8,
+  entries: [{binding: 47, resource: textureView19}],
+});
+let textureView316 = texture265.createView({});
+try {
+renderPassEncoder79.setPipeline(pipeline21);
+} catch {}
+let texture305 = gpuCanvasContext1.getCurrentTexture();
+let textureView317 = texture227.createView({});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint']});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup17, [0]);
+} catch {}
+try {
+renderPassEncoder79.draw(95, 0, 648_269_245, 674_175_608);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer77, 'uint16', 1_372, 1_281);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(1, buffer97, 0);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer23, 'uint32', 212, 800);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+document.body.prepend(img6);
+offscreenCanvas2.width = 2510;
+let textureView318 = texture162.createView({dimension: '2d', baseArrayLayer: 11});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup101, new Uint32Array(431), 7, 0);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(0, buffer6, 0, 2_429);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+sampler97.label = '\u0289\u{1fae4}\ucf75\u061d\u5923\u63f2';
+} catch {}
+let bindGroup204 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [
+    {binding: 418, resource: {buffer: buffer101, offset: 6144, size: 8101}},
+    {binding: 13, resource: textureView209},
+    {binding: 31, resource: textureView227},
+  ],
+});
+let textureView319 = texture112.createView({dimension: '2d-array'});
+try {
+renderPassEncoder79.draw(16, 501, 174_895_297, 46_729_247);
+} catch {}
+try {
+renderPassEncoder79.drawIndexed(1, 223, 0, 44_710_889, 83_969_169);
+} catch {}
+try {
+renderPassEncoder79.drawIndirect(buffer178, 1_448);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer200, 'uint32', 120, 34);
+} catch {}
+let textureView320 = texture143.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundle52 = renderBundleEncoder52.finish({});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup146);
+} catch {}
+try {
+computePassEncoder113.setBindGroup(2, bindGroup151, new Uint32Array(1291), 399, 0);
+} catch {}
+try {
+renderPassEncoder79.draw(84, 233, 626_601_450, 29_529_317);
+} catch {}
+try {
+renderPassEncoder79.drawIndexed(0, 156, 3, 60_600_194, 72_407_165);
+} catch {}
+try {
+renderPassEncoder79.drawIndirect(buffer225, 3_116);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer28, 564, 382);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105).fill(185), /* required buffer size: 105 */
+{offset: 105}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({label: '\ub7e6\u{1f8bf}\u46a1\uf50f', colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup185, new Uint32Array(838), 151, 0);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(81, 0, 7, 0);
+} catch {}
+try {
+renderPassEncoder79.draw(97, 46, 1_097_904_596, 167_634_081);
+} catch {}
+try {
+renderPassEncoder79.drawIndexed(0, 90, 6, 705_863_930, 537_457_717);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer210, 'uint16', 768, 1_374);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup44);
+} catch {}
+let arrayBuffer44 = buffer187.getMappedRange(48, 40);
+try {
+computePassEncoder42.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup202, new Uint32Array(654), 233, 0);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -81.13, g: 602.1, b: -532.7, a: 671.3, });
+} catch {}
+try {
+renderPassEncoder79.draw(182, 489, 147_657_225, 778_954_077);
+} catch {}
+try {
+renderPassEncoder79.drawIndirect(buffer61, 2_576);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer221, 'uint16', 72, 56);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, undefined, 0, 15_165_602);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(1, buffer189, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule28}});
+let bindGroup205 = device0.createBindGroup({
+  label: '\u125d\u0729\u573f\ufd2e\u{1fe88}\u{1fe01}\ua17a',
+  layout: bindGroupLayout26,
+  entries: [{binding: 98, resource: textureView115}],
+});
+try {
+renderPassEncoder75.setBindGroup(0, bindGroup198);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer210, 240);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup144, new Uint32Array(11), 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 64, new BigUint64Array(37013), 248, 504);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 1},
+  aspect: 'all',
+}, new Uint8Array(2_755_864).fill(174), /* required buffer size: 2_755_864 */
+{offset: 18, bytesPerRow: 287, rowsPerImage: 34}, {width: 18, height: 15, depthOrArrayLayers: 283});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute1', constants: {53_740: 0}},
+});
+document.body.prepend(img5);
+let bindGroup206 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [
+    {binding: 13, resource: textureView271},
+    {binding: 31, resource: textureView158},
+    {binding: 418, resource: {buffer: buffer46, offset: 1792, size: 1886}},
+  ],
+});
+let buffer228 = device0.createBuffer({
+  size: 8332,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture306 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder81.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder79.draw(450, 261, 25_205_824, 182_903_248);
+} catch {}
+try {
+renderPassEncoder79.drawIndirect(buffer83, 484);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer57, 'uint16', 14, 167);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(3, bindGroup166, new Uint32Array(681), 95, 0);
+} catch {}
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'unspecified', transfer: 'linear'} });
+try {
+computePassEncoder20.setBindGroup(0, bindGroup119);
+} catch {}
+try {
+renderPassEncoder70.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder70.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder79.draw(17, 377, 23_099_474, 685_094_329);
+} catch {}
+try {
+renderPassEncoder79.drawIndirect(buffer176, 44);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer157, 'uint32', 444, 2_980);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderBundleEncoder53.draw(0, 221, 0, 922_556_008);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer68, 316);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer91, 'uint32', 344, 1_121);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer20, 0, 1_532);
+} catch {}
+try {
+computePassEncoder151.setBindGroup(0, bindGroup145, new Uint32Array(1385), 129, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup50, new Uint32Array(783), 93, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle29, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder79.draw(84, 152, 1_210_357_000, 4_496_103);
+} catch {}
+try {
+renderPassEncoder79.drawIndexed(7, 113, 0, 258_519_359, 404_541_200);
+} catch {}
+try {
+renderPassEncoder79.drawIndexedIndirect(buffer133, 572);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(0, buffer55);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(3, bindGroup178, []);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup37, new Uint32Array(175), 36, 0);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer83, 220);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer25, 'uint16', 416, 1_646);
+} catch {}
+try {
+buffer224.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler195 = device0.createSampler({
+  label: '\u{1ffb6}\u521c\u879b\ub42b\uaef7\ue2f2\ue93a\u0325',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.02,
+  lodMaxClamp: 91.32,
+});
+try {
+renderPassEncoder79.drawIndexed(0, 137, 0, 53_452_576, 434_435_203);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup184, new Uint32Array(995), 211, 0);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(5, 163, 23, 174_846_055, 673_910_131);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer95, 1_908);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(2, buffer13, 8);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup207 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 130, resource: textureView0}, {binding: 23, resource: textureView126}],
+});
+try {
+renderPassEncoder79.end();
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(7, buffer188, 3_452);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(3, 330, 10, 1_026_008_585, 1_054_763_376);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline14);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 84, height: 40, depthOrArrayLayers: 65}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 5 },
+  flipY: false,
+}, {
+  texture: texture251,
+  mipLevel: 0,
+  origin: {x: 5, y: 8, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer229 = device0.createBuffer({size: 11350, usage: GPUBufferUsage.MAP_WRITE});
+let renderPassEncoder85 = commandEncoder189.beginRenderPass({
+  label: '\ud933\ud980\u{1fc92}\u{1f8ff}\u{1fa26}',
+  colorAttachments: [{
+  view: textureView207,
+  clearValue: { r: -642.9, g: -552.3, b: -975.4, a: -996.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet27,
+  maxDrawCount: 25897588,
+});
+let renderBundle53 = renderBundleEncoder53.finish({});
+try {
+computePassEncoder149.setBindGroup(1, bindGroup90, new Uint32Array(1258), 226, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder167); computePassEncoder167.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(7, buffer199);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer184, 'uint16', 2_268, 13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 2156, new Float32Array(16663), 451, 160);
+} catch {}
+let bindGroup208 = device0.createBindGroup({
+  layout: bindGroupLayout33,
+  entries: [
+    {binding: 164, resource: externalTexture22},
+    {binding: 31, resource: {buffer: buffer118, offset: 256, size: 460}},
+  ],
+});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'r32float', 'rg16float'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder144.setBindGroup(1, bindGroup120, new Uint32Array(530), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder42); computePassEncoder42.dispatchWorkgroupsIndirect(buffer96, 472); };
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(4_294_967_295, undefined, 0, 338_998_339);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let texture307 = device0.createTexture({
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder137.setBindGroup(0, bindGroup190);
+} catch {}
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(1, buffer49);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 23296,
+  buffer: buffer74,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture308 = device0.createTexture({size: [240, 16, 1], format: 'rg32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder212 = commandEncoder50.beginComputePass({});
+let renderBundle54 = renderBundleEncoder55.finish({});
+try {
+computePassEncoder212.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup27, new Uint32Array(424), 1, 0);
+} catch {}
+try {
+renderPassEncoder11.setViewport(205.03617078380637, 0.8198390330134018, 20.40779847383131, 3.590798082597047, 0.2079278554435785, 0.9336232847220627);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer71);
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+try {
+textureView262.label = '\u0e5a\u95b7\uebf8\uf07b\u{1fe50}\ud214\u{1f66a}\u{1f9b1}\u{1ff35}';
+} catch {}
+let textureView321 = texture257.createView({});
+let sampler196 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.18,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup195);
+} catch {}
+try {
+computePassEncoder182.pushDebugGroup('\u0be2');
+} catch {}
+let sampler197 = device0.createSampler({
+  label: '\u0b96\u827d\u{1f68a}\ub228\u{1faab}\u0f9b\u0191\uc8bf\u05d2\u0426',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.83,
+  lodMaxClamp: 99.19,
+});
+try {
+renderPassEncoder17.setPipeline(pipeline18);
+} catch {}
+let promise39 = shaderModule20.getCompilationInfo();
+try {
+renderPassEncoder37.insertDebugMarker('\u{1f996}');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle55 = renderBundleEncoder54.finish({});
+let sampler198 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.867,
+  lodMaxClamp: 46.93,
+});
+try {
+renderPassEncoder29.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer166, 44, new DataView(new ArrayBuffer(30670)), 5982, 60);
+} catch {}
+document.body.prepend(canvas4);
+let buffer230 = device0.createBuffer({
+  label: '\u660e\u{1f956}\u0502\ubae5\ud230',
+  size: 6966,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let sampler199 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 8.079,
+  lodMaxClamp: 85.58,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer108, 'uint16', 56, 564);
+} catch {}
+try {
+  await promise38;
+} catch {}
+let videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'unspecified', transfer: 'unspecified'} });
+let texture309 = device0.createTexture({
+  label: '\u06ff\uec2e\u098e\u081b\u9eed\ucb9b\ue819',
+  size: [168, 80, 247],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler200 = device0.createSampler({
+  label: '\ubfa2\uf640\ue932\u{1fac6}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.38,
+  lodMaxClamp: 57.99,
+  compare: 'less',
+  maxAnisotropy: 5,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder167); computePassEncoder167.dispatchWorkgroupsIndirect(buffer111, 12); };
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup96, new Uint32Array(2009), 116, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let bindGroup209 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 337, resource: {buffer: buffer193, offset: 9472, size: 348}}],
+});
+let texture310 = device0.createTexture({
+  label: '\u{1f967}\uefd7\u2d7f\uef20\u02fc\u03a2\u9dc5\u07fa\u0b1f\u{1f8ba}',
+  size: [21, 10, 40],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder78.executeBundles([renderBundle40, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer165, 'uint16', 66, 24);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(0, buffer223, 0, 112);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet50 = device0.createQuerySet({type: 'occlusion', count: 1430});
+let textureView322 = texture72.createView({});
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup88, []);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer83, 'uint32', 768, 104);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(3, buffer57);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 18}
+*/
+{
+  source: canvas0,
+  origin: { x: 5, y: 100 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas2);
+let texture311 = device0.createTexture({
+  size: {width: 168},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({colorFormats: ['rg32float'], depthReadOnly: true, stencilReadOnly: true});
+let externalTexture34 = device0.importExternalTexture({label: '\u392a\ua8e8\u7f0f\u90a3\u{1fb4e}\u777c\u3daf', source: videoFrame18, colorSpace: 'srgb'});
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setViewport(74.28775930619521, 5.16063413888885, 21.80200705570588, 0.7901438065010292, 0.7573530304267306, 0.8548419842139734);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(4, buffer86);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let buffer231 = device0.createBuffer({
+  size: 21055,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder57 = device0.createRenderBundleEncoder({colorFormats: ['rg32float']});
+let sampler201 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.79,
+  lodMaxClamp: 71.03,
+});
+try {
+renderPassEncoder81.setBindGroup(2, bindGroup113, new Uint32Array(853), 468, 0);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(2, buffer56, 0);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup183, new Uint32Array(599), 177, 0);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+adapter0.label = '\u22e8\u1cb7\u0d4d\u{1f897}\u010f\u{1f81d}\u{1fad3}';
+} catch {}
+let shaderModule32 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+var<workgroup> vw134: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw133: mat2x3f;
+
+@group(0) @binding(180) var st16: texture_storage_2d_array<r32float, read_write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  f0: array<f16, 1>,
+}
+
+struct VertexOutput23 {
+  @builtin(position) f86: vec4f,
+}
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  out = vec2h(firstTrailingBit(vec4u(unconst_u32(32), unconst_u32(7), unconst_u32(17), unconst_u32(5))).aa);
+  out = vec2h(log(vec3f(unconst_f32(0.1588), unconst_f32(-0.04194), unconst_f32(-0.00539))).gr);
+  let vf584: vec4f = unpack4x8snorm(u32(unconst_u32(180)));
+  out -= bitcast<vec2h>(vp48.f86[bitcast<vec4u>(vp48.f86).a]);
+  out -= vec2h(vp48.f86.gg);
+  out *= vec2h(atan2(vec2f(unconst_f32(0.3994), unconst_f32(0.3527)), vec2f(unconst_f32(-0.03941), unconst_f32(0.1922))));
+  let vf585: f32 = vf584[3];
+  var vf586: vec2i = reverseBits(vec2i(log(vec3f(f32(distance(f16(unconst_f16(11826.4)), f16(unconst_f16(3202.6)))))).rg));
+  var vf587: vec2i = reverseBits(vec2i(unconst_i32(237), unconst_i32(340)));
+  let vf588: f32 = vf584[3];
+  let vf589: vec3u = extractBits(vec3u(unconst_u32(30), unconst_u32(60), unconst_u32(28)), u32(vf588), pack2x16unorm(atan2(vec2f(unconst_f32(-0.04131), unconst_f32(0.05926)), unpack4x8unorm(u32(unconst_u32(365))).br)));
+  vf587 = vec2i(i32(vf588));
+  let vf590: vec2h = tanh(vec2h(unconst_f16(1107.5), unconst_f16(-7424.3)));
+  let ptr255: ptr<function, vec2i> = &vf586;
+  out = bitcast<vec2h>((*ptr255)[1]);
+  let vf591: vec2i = reverseBits(vec2i(unconst_i32(350), unconst_i32(100)));
+  out = bitcast<vec2h>(vp48.f86[2]);
+  let vf592: f16 = distance(vec4h(vf584)[1], f16(unconst_f16(2185.2)));
+  var vf593: f32 = pow(vp48.f86[3], vp48.f86.w);
+  vf586 = vec2i(i32(vf590[0]));
+  let vf594: i32 = vf587[1];
+  return out;
+}
+
+var<workgroup> vw135: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp48: VertexOutput23 = VertexOutput23();
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T2 {
+  f0: array<vec2h>,
+}
+
+@vertex
+fn vertex29(@location(14) @interpolate(flat, sample) a0: f16) -> VertexOutput23 {
+  var out: VertexOutput23;
+  var vf595: vec2h = ldexp(vec2h(unconst_f16(6033.4), unconst_f16(18141.3)), vec2i(unconst_i32(122), unconst_i32(32)));
+  out = VertexOutput23(unpack4x8snorm(pack4x8unorm(vec4f(unconst_f32(-0.02400), unconst_f32(0.04786), unconst_f32(0.00953), unconst_f32(0.06557)))));
+  let ptr256: ptr<function, vec2h> = &vf595;
+  out.f86 *= vec4f(bitcast<f32>(pack4x8unorm(vp48.f86)));
+  fn0();
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer232 = device0.createBuffer({size: 4383, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler202 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.38,
+  lodMaxClamp: 59.66,
+  compare: 'less-equal',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder8.setViewport(134.17802477694732, 0.5870881477667931, 34.71858472331707, 0.25697820623534057, 0.8662225780542612, 0.8880445812930651);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(1, bindGroup156);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(6, buffer147, 100, 872);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(244).fill(195), /* required buffer size: 244 */
+{offset: 244, bytesPerRow: 43, rowsPerImage: 29}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup210 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 84, resource: textureView75}]});
+let texture312 = device0.createTexture({
+  size: {width: 84, height: 40, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer21, 'uint16', 80, 2_532);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline9);
+} catch {}
+let textureView323 = texture310.createView({baseArrayLayer: 0, arrayLayerCount: 3});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup90, new Uint32Array(1274), 193, 0);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle5, renderBundle41, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer82, 'uint32', 928, 1_000);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroup211 = device0.createBindGroup({
+  label: '\u05c4\u773b\u{1fd52}\u00a6\u0084\u024e\ufbdc\u{1f869}\u7eb0\uf929',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 174, resource: {buffer: buffer90, offset: 0, size: 40}},
+    {binding: 18, resource: {buffer: buffer219, offset: 1280, size: 184}},
+  ],
+});
+let querySet51 = device0.createQuerySet({type: 'occlusion', count: 334});
+let textureView324 = texture257.createView({dimension: '2d', baseArrayLayer: 0});
+let sampler203 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.71,
+  lodMaxClamp: 26.65,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder167.end();
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(1, bindGroup181, new Uint32Array(2997), 114, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder222.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2284 */
+  offset: 2284,
+  buffer: buffer22,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker('\u46ca');
+} catch {}
+let texture313 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder213 = commandEncoder222.beginComputePass({});
+let sampler204 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.78,
+  lodMaxClamp: 97.36,
+  compare: 'less-equal',
+  maxAnisotropy: 13,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame38, colorSpace: 'display-p3'});
+try {
+computePassEncoder213.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer117, 260, 817);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup83);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer165, 28, new BigUint64Array(7671), 452, 0);
+} catch {}
+let buffer233 = device0.createBuffer({
+  size: 682,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle56 = renderBundleEncoder56.finish({label: '\u{1fb93}\u029f\udda2\u{1f917}\u27bb\u{1fa74}\uf337\u1356\u13ec'});
+try {
+renderPassEncoder29.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(3, bindGroup173, new Uint32Array(58), 12, 0);
+} catch {}
+try {
+computePassEncoder182.popDebugGroup();
+} catch {}
+let imageData40 = new ImageData(40, 60);
+let renderBundle57 = renderBundleEncoder57.finish({});
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup99, new Uint32Array(1525), 317, 0);
+} catch {}
+try {
+renderPassEncoder76.executeBundles([renderBundle41]);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer156, 'uint16', 312, 159);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let imageData41 = new ImageData(136, 216);
+let bindGroup212 = device0.createBindGroup({
+  label: '\ub015\u74c6\uf9c6\u{1f7c1}\u7270\ucafc\u0e61\ud890\uc586\u1758\u0745',
+  layout: bindGroupLayout25,
+  entries: [{binding: 23, resource: textureView49}, {binding: 130, resource: textureView232}],
+});
+let texture314 = device0.createTexture({
+  size: {width: 768},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup118, new Uint32Array(1801), 315, 0);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline7);
+} catch {}
+let bindGroup213 = device0.createBindGroup({
+  label: '\u027f\u{1febd}\u0ffc',
+  layout: bindGroupLayout22,
+  entries: [{binding: 160, resource: textureView153}],
+});
+let buffer234 = device0.createBuffer({
+  size: 16470,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet52 = device0.createQuerySet({type: 'occlusion', count: 74});
+let sampler205 = device0.createSampler({
+  label: '\u{1fcde}\u7fc7\u{1faca}\uc2d6\ufe9e\u008f\u0d1c\u085f\u66c2\u0e1e\ua408',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 90.89,
+  lodMaxClamp: 98.97,
+});
+try {
+renderPassEncoder45.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 233,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 41, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 504,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 295,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup214 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 137, resource: textureView242}, {binding: 42, resource: textureView36}],
+});
+let textureView325 = texture271.createView({});
+let texture315 = device0.createTexture({
+  size: [120, 8, 187],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup144);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup121, new Uint32Array(749), 8, 0);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer219, 'uint16', 4_112, 901);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline21);
+} catch {}
+let bindGroup215 = device0.createBindGroup({
+  label: '\u1b77\u{1fea7}\ub966\uc7b6\u39bf\ubd33',
+  layout: bindGroupLayout14,
+  entries: [{binding: 50, resource: textureView304}],
+});
+let texture316 = device0.createTexture({
+  size: [120, 8, 1],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView326 = texture243.createView({});
+let sampler206 = device0.createSampler({
+  label: '\u30a2\u0f88\u07ff\u{1ff34}\u9581\u0c83',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.79,
+  lodMaxClamp: 97.71,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder202.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder165.setBindGroup(3, bindGroup18, new Uint32Array(1628), 84, 1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup190, new Uint32Array(999), 27, 0);
+} catch {}
+document.body.prepend(img4);
+let textureView327 = texture108.createView({label: '\u4428\u08c6\u5a7c\udb54', baseMipLevel: 0});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder111.setBindGroup(2, bindGroup148, new Uint32Array(1302), 152, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup114, new Uint32Array(282), 27, 0);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer66, 'uint32', 0, 1);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer45 = buffer70.getMappedRange(328, 32);
+let bindGroupLayout47 = device0.createBindGroupLayout({
+  label: '\u0167\u890c\u20cf',
+  entries: [
+    {
+      binding: 803,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 220,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 100, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let texture317 = device0.createTexture({
+  size: {width: 120, height: 8, depthOrArrayLayers: 71},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler207 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.30,
+  lodMaxClamp: 64.65,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup133, new Uint32Array(806), 2, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder168.insertDebugMarker('\u{1f777}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer235 = device0.createBuffer({
+  size: 4708,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture318 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 20},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView328 = texture22.createView({});
+let sampler208 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 44.07,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup208, new Uint32Array(839), 61, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup0, new Uint32Array(3797), 1_102, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(0, bindGroup79, new Uint32Array(2083), 532, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise40 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  constants: {13_754: 0, override20: 0},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: 0}, {format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule28,
+    buffers: [
+      {
+        arrayStride: 1380,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 476, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', unclippedDepth: false},
+});
+document.body.prepend(img10);
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'unspecified', transfer: 'hlg'} });
+let textureView329 = texture318.createView({baseArrayLayer: 1, arrayLayerCount: 4});
+let texture319 = device0.createTexture({
+  size: {width: 1536, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder17.setBlendConstant({ r: -658.7, g: 239.6, b: -253.7, a: 440.3, });
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer235, 'uint16', 400, 236);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(0, buffer6, 132, 173);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline18);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 16, depthOrArrayLayers: 375}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture245,
+  mipLevel: 0,
+  origin: {x: 29, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'linear'} });
+let bindGroupLayout48 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 45, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture320 = gpuCanvasContext7.getCurrentTexture();
+let textureView330 = texture36.createView({});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup171, new Uint32Array(1735), 511, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer29, 'uint16', 58, 36);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(7, buffer164, 11_572);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline7);
+} catch {}
+let bindGroup216 = device0.createBindGroup({
+  label: '\u4a6e\u2753\u0ffa\u4c4f\ufebd\u0641\u5ba1\u08d0\u31ba',
+  layout: bindGroupLayout19,
+  entries: [{binding: 144, resource: textureView108}, {binding: 190, resource: textureView91}],
+});
+let buffer236 = device0.createBuffer({
+  size: 16768,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let textureView331 = texture9.createView({dimension: '2d', baseArrayLayer: 0});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup140, new Uint32Array(199), 31, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle20, renderBundle33, renderBundle4, renderBundle20, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer216, 'uint32', 1_728, 350);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup122);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData42 = new ImageData(20, 4);
+let bindGroup217 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 337, resource: {buffer: buffer8, offset: 0, size: 488}}],
+});
+let buffer237 = device0.createBuffer({size: 8247, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup91, new Uint32Array(446), 36, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer68, 'uint32', 396, 288);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer157, 640, 1_088);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer216, 'uint16', 1_882, 139);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline7);
+} catch {}
+try {
+buffer105.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer185, 756, new Float32Array(34694), 7598, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup218 = device0.createBindGroup({
+  label: '\u692d\u{1fabd}',
+  layout: bindGroupLayout28,
+  entries: [{binding: 47, resource: {buffer: buffer22, offset: 2048, size: 406}}],
+});
+try {
+computePassEncoder181.setBindGroup(2, bindGroup0, new Uint32Array(1877), 151, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer164);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(3, buffer90, 28, 41);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture321 = device0.createTexture({
+  label: '\u3a76\u7e15\uc5bb',
+  size: {width: 21, height: 10, depthOrArrayLayers: 23},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder62.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder81.setViewport(2.2636620825511478, 0.2381126948415977, 30.44300269568815, 1.3253633916312657, 0.21903202467325167, 0.610503271484492);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(2, buffer103);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup17, [0]);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup218, new Uint32Array(1920), 90, 0);
+} catch {}
+document.body.prepend(canvas2);
+let imageData43 = new ImageData(48, 8);
+let buffer238 = device0.createBuffer({
+  size: 9583,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup123, new Uint32Array(253), 15, 0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup31, new Uint32Array(602), 226, 0);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(2, buffer45);
+} catch {}
+let bindGroupLayout49 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 393,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer239 = device0.createBuffer({size: 573, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView332 = texture293.createView({dimension: '3d'});
+let renderBundle58 = renderBundleEncoder58.finish({});
+let sampler209 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 94.00,
+});
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup197, new Uint32Array(717), 30, 0);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(47);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.setViewport(119.42687548502946, 1.9454338029672282, 77.76803351987843, 11.068685022091328, 0.520447127169676, 0.8823410782723728);
+} catch {}
+let texture322 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 48},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder70.setIndexBuffer(buffer169, 'uint32', 528, 361);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture193,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(70_647).fill(42), /* required buffer size: 70_647 */
+{offset: 135, bytesPerRow: 113, rowsPerImage: 12}, {width: 2, height: 0, depthOrArrayLayers: 53});
+} catch {}
+let buffer240 = device0.createBuffer({
+  size: 8689,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView333 = texture9.createView({dimension: '2d'});
+let texture323 = device0.createTexture({
+  size: {width: 1536},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView334 = texture234.createView({});
+try {
+computePassEncoder183.setBindGroup(0, bindGroup49, []);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup164, new Uint32Array(1517), 254, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer238, 1496, new Int16Array(45631), 12000, 948);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 3},
+  aspect: 'all',
+}, new Uint8Array(3_496).fill(96), /* required buffer size: 3_496 */
+{offset: 107, bytesPerRow: 69, rowsPerImage: 4}, {width: 8, height: 2, depthOrArrayLayers: 13});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let externalTexture37 = device0.importExternalTexture({source: videoFrame26});
+try {
+renderPassEncoder50.setIndexBuffer(buffer216, 'uint32', 84, 1_836);
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+let bindGroup219 = device0.createBindGroup({
+  layout: bindGroupLayout35,
+  entries: [{binding: 477, resource: textureView109}, {binding: 372, resource: textureView93}],
+});
+let texture324 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 13},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup162);
+} catch {}
+try {
+renderPassEncoder76.setBlendConstant({ r: 606.5, g: 237.9, b: 113.9, a: 331.5, });
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt470bg', transfer: 'pq'} });
+let texture325 = device0.createTexture({
+  label: '\u{1fd18}\u751d\uf824',
+  size: {width: 384, height: 1, depthOrArrayLayers: 28},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup163, new Uint32Array(652), 103, 0);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(32);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer165, 'uint16', 284, 11);
+} catch {}
+let arrayBuffer46 = buffer82.getMappedRange(568, 56);
+document.body.append(canvas2);
+let imageData44 = new ImageData(72, 56);
+let buffer241 = device0.createBuffer({size: 8079, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let texture326 = device0.createTexture({
+  label: '\ucef1\u1fc3\u0472',
+  size: [168],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture38 = device0.importExternalTexture({
+  label: '\u0f8e\u{1fe61}\u6a9d\uaea3\ue679\ue984\u072b',
+  source: videoFrame21,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder205.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+computePassEncoder193.setBindGroup(1, bindGroup111, new Uint32Array(1313), 164, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup213, new Uint32Array(1633), 631, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer29, 0, 48);
+} catch {}
+let bindGroup220 = device0.createBindGroup({
+  label: '\ud374\u059d\u0996\u614a\u{1fc74}\u07da\u{1fd46}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 218, resource: sampler204}],
+});
+let buffer242 = device0.createBuffer({
+  label: '\u0c82\u0831\u38fe\u001b\u6b0f',
+  size: 13653,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView335 = texture279.createView({dimension: '2d', baseArrayLayer: 0});
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup128);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(5, buffer188);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 3240, new Float32Array(56079), 72, 280);
+} catch {}
+let bindGroup221 = device0.createBindGroup({
+  layout: bindGroupLayout37,
+  entries: [
+    {binding: 293, resource: textureView236},
+    {binding: 16, resource: {buffer: buffer179, offset: 0, size: 692}},
+    {binding: 73, resource: textureView310},
+  ],
+});
+let texture327 = device0.createTexture({
+  size: [84, 40, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup157);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup51, new Uint32Array(2211), 101, 0);
+} catch {}
+let arrayBuffer47 = buffer187.getMappedRange(88, 628);
+try {
+buffer169.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup222 = device0.createBindGroup({
+  layout: bindGroupLayout47,
+  entries: [
+    {binding: 26, resource: textureView329},
+    {binding: 100, resource: {buffer: buffer89, offset: 0, size: 167}},
+    {binding: 63, resource: textureView10},
+    {binding: 76, resource: textureView86},
+    {binding: 220, resource: {buffer: buffer181, offset: 0, size: 1572}},
+    {binding: 803, resource: {buffer: buffer226, offset: 0, size: 23}},
+  ],
+});
+let sampler210 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 6.066,
+  lodMaxClamp: 83.97,
+});
+try {
+computePassEncoder171.setBindGroup(0, bindGroup213, new Uint32Array(761), 218, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer0, 'uint16', 474, 971);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture291,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(42_100).fill(148), /* required buffer size: 42_100 */
+{offset: 19, bytesPerRow: 507, rowsPerImage: 83}, {width: 102, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let textureView336 = texture161.createView({label: '\u{1fa9c}\u6e66\ufb93\u1402\u{1f622}\uf7fb\u{1f70f}\u3755\u1867'});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup73, new Uint32Array(493), 66, 0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle29]);
+} catch {}
+let arrayBuffer48 = buffer69.getMappedRange(304, 600);
+try {
+computePassEncoder179.pushDebugGroup('\u{1ff17}');
+} catch {}
+try {
+renderBundle0.label = '\u0fb5\u{1ffdd}\u00d4\u02b0';
+} catch {}
+let shaderModule33 = device0.createShaderModule({
+  label: '\uaaee\u{1f844}\ub956\u{1ff20}\u0865',
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+var<workgroup> vw136: atomic<u32>;
+
+@group(0) @binding(11) var<uniform> buffer243: vec2h;
+
+struct T0 {
+  @align(2) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp52: array<mat2x2h, 1> = array<mat2x2h, 1>(mat2x2h());
+
+var<private> vp50 = modf(f16());
+
+var<private> vp49: mat4x2f = mat4x2f();
+
+struct T1 {
+  @align(2) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(411) var st17: texture_storage_2d<r32sint, read_write>;
+
+var<private> vp51: vec2u = vec2u();
+
+struct VertexOutput24 {
+  @builtin(position) f87: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@vertex
+fn vertex30() -> VertexOutput24 {
+  var out: VertexOutput24;
+  vp49 = mat4x2f(vec2f(vp52[0][0]), vec2f(vp52[0][0]), vec2f(vp52[0][0]), vec2f(vp52[0][0]));
+  vp49 = mat4x2f(bitcast<vec2f>(unpack4xU8(u32(unconst_u32(104))).zx), bitcast<vec2f>(unpack4xU8(u32(unconst_u32(104))).wz), vec2f(unpack4xU8(u32(unconst_u32(104))).ag), bitcast<vec2f>(unpack4xU8(u32(unconst_u32(104))).yy));
+  let vf596: f16 = (*&buffer243)[u32(unconst_u32(882))];
+  vp50 = modf(f16(vp49[u32(unconst_u32(65))][1]));
+  let ptr257: ptr<private, vec2u> = &vp51;
+  vp50.whole += exp2(bitcast<vec2h>(vp49[0][1])).g;
+  vp51 *= vec2u(buffer243);
+  var vf597: u32 = (*ptr257)[1];
+  vp49 -= mat4x2f(f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]), f32(vp52[0][u32(unconst_u32(86))][pack4xU8(vec4u(log(vec4h(unconst_f16(5007.0), unconst_f16(6357.3), unconst_f16(2941.2), unconst_f16(2885.9)))))]));
+  return out;
+}
+
+@fragment
+fn fragment32() -> @location(200) @interpolate(flat, centroid) vec4f {
+  var out: vec4f;
+  vp51 <<= vec2u(sinh(vec2f(unconst_f32(0.1500), unconst_f32(-0.2031))));
+  let ptr258: ptr<private, mat2x2h> = &vp52[0];
+  let vf598: vec2f = sinh(atan2(vec4f(unconst_f32(0.2855), unconst_f32(0.02237), unconst_f32(0.08827), unconst_f32(-0.1341)), quantizeToF16(vec4f(unconst_f32(0.2918), unconst_f32(0.01484), unconst_f32(0.00371), unconst_f32(0.07933)))).wz);
+  let vf599: vec3f = tan(vec3f(unconst_f32(0.1663), unconst_f32(0.1894), unconst_f32(0.1064)));
+  let ptr259: ptr<private, vec2h> = &(*ptr258)[0];
+  vp52[0] += mat2x2h(vp50.fract, vp50.fract, vp50.fract, vp50.fract);
+  let vf600: vec4f = atan2(vec4f(f32(buffer243[u32((*ptr258)[u32(unconst_u32(180))][u32(unconst_u32(291))])])), vec4f(unconst_f32(0.01213), unconst_f32(0.04055), unconst_f32(-0.3647), unconst_f32(0.04839)));
+  textureStore(st17, vec2i(vp49[1]), vec4i(vec4i(unconst_i32(-314), unconst_i32(148), unconst_i32(108), unconst_i32(43))));
+  let vf601: f32 = vf600[u32((*ptr258)[0][u32((*ptr258)[u32(dot(vec2i(unconst_i32(1), unconst_i32(180)), vec2i((*ptr259))))][u32(unconst_u32(12))])])];
+  vp52[u32(unconst_u32(93))] = mat2x2h(buffer243, buffer243);
+  var vf602: vec4i = textureLoad(st17, vec2i(unconst_i32(13), unconst_i32(17)));
+  let ptr260: ptr<private, vec2f> = &vp49[1];
+  vp52[bitcast<u32>(vp52[u32(unconst_u32(16))][0])] -= mat2x2h(f16(vf600[0]), f16(vf600[0]), f16(vf600[0]), f16(vf600[0]));
+  vp51 ^= vec2u(u32(vp52[0][0][u32(unconst_u32(393))]));
+  var vf603: f16 = (*&buffer243)[u32(unconst_u32(28))];
+  let ptr261: ptr<uniform, vec2h> = &buffer243;
+  var vf604: vec2f = sinh(vec2f(unconst_f32(0.01031), unconst_f32(0.00959)));
+  discard;
+  var vf605: vec4i = textureLoad(st17, vec2i(i32((*ptr258)[bitcast<u32>((*ptr258)[u32(unconst_u32(158))])][bitcast<u32>(vp52[0][0])])));
+  out = vec4f(bitcast<f32>(vf602[2]));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute24() {
+  textureStore(st17, vec2i(unconst_i32(16), unconst_i32(44)), vec4i(bitcast<vec4i>(vp49[1].xxxx)));
+  vp52[0] += mat2x2h(f16(atomicLoad(&(*&vw136))), f16(atomicLoad(&(*&vw136))), f16(atomicLoad(&(*&vw136))), f16(atomicLoad(&(*&vw136))));
+  var vf606: vec2f = vp49[u32(unconst_u32(125))];
+  let ptr262: ptr<private, mat2x2h> = &vp52[0];
+  let vf607: f16 = (*ptr262)[u32(unconst_u32(439))][u32(unconst_u32(31))];
+  let ptr263: ptr<private, vec2f> = &vp49[1];
+  vp49 = mat4x2f((*ptr263), (*ptr263), (*ptr263), (*ptr263));
+  vp52[bitcast<u32>((*ptr262)[1])] = mat2x2h(vec2h(vp49[u32(unconst_u32(99))]), vec2h(vp49[u32(unconst_u32(99))]));
+}`,
+  sourceMap: {},
+});
+let textureView337 = texture12.createView({aspect: 'depth-only', baseArrayLayer: 27, arrayLayerCount: 2});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup55, new Uint32Array(3260), 153, 0);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle40, renderBundle40]);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+  await promise39;
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -102,6 +102,9 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
             continue;
 
         auto& texture = fromAPI(attachment.view);
+        if (texture.isDestroyed())
+            m_parentEncoder->makeSubmitInvalid();
+
         texture.setPreviouslyCleared();
         addResourceToActiveResources(texture, BindGroupEntryUsage::Attachment);
         m_rasterSampleCount = texture.sampleCount();


### PR DESCRIPTION
#### d14a13b3119708e4ecbb8beb7afd443cba48c28c
<pre>
[WebGPU] Destroyed canvas backing shouldn&apos;t be allowed as a render target
<a href="https://bugs.webkit.org/show_bug.cgi?id=281614">https://bugs.webkit.org/show_bug.cgi?id=281614</a>
<a href="https://rdar.apple.com/137965520">rdar://137965520</a>

Reviewed by Tadeu Zagallo.

Renders to destroyed canvas backing should be rejected.

* LayoutTests/fast/webgpu/nocrash/fuzz-281614-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-281614.html: Added.
Add canvas backing.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):

Canonical link: <a href="https://commits.webkit.org/285417@main">https://commits.webkit.org/285417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc69c4f81de8af1f457e77c78a3b61f3989f6256

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19617 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64624 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6485 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->