### PR TITLE
Add more smart pointers to ComplexTextController

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -323,10 +323,10 @@ void ComplexTextController::collectComplexTextRuns()
     unsigned currentIndex = 0;
     unsigned indexOfFontTransition = 0;
 
-    const Font* font = nullptr;
-    const Font* nextFont = nullptr;
-    const Font* synthesizedFont = nullptr;
-    const Font* smallSynthesizedFont = nullptr;
+    RefPtr<const Font> font;
+    RefPtr<const Font> nextFont;
+    RefPtr<const Font> synthesizedFont;
+    RefPtr<const Font> smallSynthesizedFont;
 
     CachedTextBreakIterator graphemeClusterIterator(m_run.text(), { }, TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
 
@@ -342,7 +342,7 @@ void ComplexTextController::collectComplexTextRuns()
     bool nextIsSmallCaps = false;
 
     auto capitalizedBase = capitalized(baseCharacter);
-    if (shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont, baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
+    if (shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
         synthesizedFont = &nextFont->noSynthesizableFeaturesFont();
         smallSynthesizedFont = synthesizedFont->smallCapsFont(m_font.fontDescription());
         char32_t characterToWrite = capitalizedBase ? capitalizedBase.value() : baseOfString[0];
@@ -379,7 +379,7 @@ void ComplexTextController::collectComplexTextRuns()
         nextFont = m_font.fontForCombiningCharacterSequence(baseOfString.subspan(previousIndex, currentIndex - previousIndex));
 
         capitalizedBase = capitalized(baseCharacter);
-        if (!synthesizedFont && shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont, baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
+        if (!synthesizedFont && shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
             // Rather than synthesize each character individually, we should synthesize the entire "run" if any character requires synthesis.
             synthesizedFont = &nextFont->noSynthesizableFeaturesFont();
             smallSynthesizedFont = synthesizedFont->smallCapsFont(m_font.fontDescription());
@@ -394,11 +394,11 @@ void ComplexTextController::collectComplexTextRuns()
                 unsigned itemStart = indexOfFontTransition;
                 if (synthesizedFont) {
                     if (isSmallCaps)
-                        collectComplexTextRunsForCharacters(m_smallCapsBuffer.subspan(itemStart, itemLength), itemStart, smallSynthesizedFont);
+                        collectComplexTextRunsForCharacters(m_smallCapsBuffer.subspan(itemStart, itemLength), itemStart, smallSynthesizedFont.get());
                     else
-                        collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, synthesizedFont);
+                        collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, synthesizedFont.get());
                 } else
-                    collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, font);
+                    collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, font.get());
                 if (nextFont != font) {
                     synthesizedFont = nullptr;
                     smallSynthesizedFont = nullptr;
@@ -415,11 +415,11 @@ void ComplexTextController::collectComplexTextRuns()
         unsigned itemStart = indexOfFontTransition;
         if (synthesizedFont) {
             if (nextIsSmallCaps)
-                collectComplexTextRunsForCharacters(m_smallCapsBuffer.subspan(itemStart, itemLength), itemStart, smallSynthesizedFont);
+                collectComplexTextRunsForCharacters(m_smallCapsBuffer.subspan(itemStart, itemLength), itemStart, smallSynthesizedFont.get());
             else
-                collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, synthesizedFont);
+                collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, synthesizedFont.get());
         } else
-            collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, nextFont);
+            collectComplexTextRunsForCharacters(baseOfString.subspan(itemStart, itemLength), itemStart, nextFont.get());
     }
 
     if (!m_run.ltr())


### PR DESCRIPTION
#### a2bb61cfed57d3f23c2d9022536ecc9379df74eb
<pre>
Add more smart pointers to ComplexTextController
<a href="https://bugs.webkit.org/show_bug.cgi?id=281621">https://bugs.webkit.org/show_bug.cgi?id=281621</a>
<a href="https://rdar.apple.com/138062967">rdar://138062967</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::collectComplexTextRuns):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2bb61cfed57d3f23c2d9022536ecc9379df74eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75252 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46763 "Found 21 new test failures: editing/deleting/delete-emoji-1.html fast/dom/DOMImplementation/createDocument-namespace-err.html fast/dom/Document/createAttributeNS-namespace-err.html fast/dom/Document/createElement-valid-names.html fast/dom/Document/createElementNS-namespace-err.html fast/dom/Element/setAttributeNS-namespace-err.html fast/parser/entities-in-xhtml.xhtml fast/text/combining-character-sequence-fallback-crash.html fast/text/combining-enclosing-keycap.html fast/text/complex-initial-advance.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37349 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43424 "Found 27 new test failures: imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-1.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-004.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-style-property-010Cf.html imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-line-break-baspglwj-082.html imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-line-break-baspglwj-123.html imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-012.html imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-021.html imported/w3c/web-platform-tests/css/css-text/shaping/shaping-arabic-diacritics-001.html imported/w3c/web-platform-tests/css/css-ui/text-overflow-022.html imported/w3c/web-platform-tests/dom/nodes/DOMImplementation-createDocument.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19635 "Found 60 new test failures: editing/deleting/delete-emoji-1.html editing/mac/deleting/backward-delete.html editing/selection/move-by-character-brute-force.html fast/dom/DOMImplementation/createDocument-namespace-err.html fast/dom/Document/createAttributeNS-namespace-err.html fast/dom/Document/createElement-valid-names.html fast/dom/Document/createElementNS-namespace-err.html fast/dom/Element/setAttributeNS-namespace-err.html fast/parser/entities-in-xhtml.xhtml fast/text/cjk-multi-codepoint-cluster-vertical.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65328 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19995 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html editing/deleting/delete-emoji-1.html editing/mac/deleting/backward-delete.html editing/selection/move-by-character-brute-force.html fast/dom/DOMImplementation/createDocument-namespace-err.html fast/dom/Document/createAttributeNS-namespace-err.html fast/dom/Document/createElement-valid-names.html fast/dom/Document/createElementNS-namespace-err.html fast/dom/Element/setAttributeNS-namespace-err.html fast/parser/entities-in-xhtml.xhtml ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78030 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16426 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19164 "Found 60 new test failures: editing/deleting/delete-emoji-1.html editing/mac/deleting/backward-delete.html editing/selection/move-by-character-brute-force.html fast/dom/DOMImplementation/createDocument-namespace-err.html fast/dom/Document/createAttributeNS-namespace-err.html fast/dom/Document/createElement-valid-names.html fast/dom/Document/createElementNS-namespace-err.html fast/dom/Element/setAttributeNS-namespace-err.html fast/parser/entities-in-xhtml.xhtml fast/text/cjk-multi-codepoint-cluster-vertical.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64642 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12855 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6500 "Found 60 new test failures: editing/deleting/delete-emoji-1.html editing/mac/deleting/backward-delete.html editing/selection/move-by-character-brute-force.html fast/dom/DOMImplementation/createDocument-namespace-err.html fast/dom/Document/createAttributeNS-namespace-err.html fast/dom/Document/createElement-valid-names.html fast/dom/Document/createElementNS-namespace-err.html fast/dom/Element/setAttributeNS-namespace-err.html fast/forms/input-placeholder-paint-order-2.html fast/parser/entities-in-xhtml.xhtml ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2188 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->