### PR TITLE
Use of Options::enableStrongRefTracker() breaks testapi in the Debug build.

### DIFF
--- a/Source/JavaScriptCore/heap/Strong.h
+++ b/Source/JavaScriptCore/heap/Strong.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,13 @@ namespace JSC {
 
 class VM;
 
-REFTRACKER_DECL(StrongRefTracker);
+#if ENABLE(REFTRACKER)
+void initializeSystemForStrongRefTracker();
+#endif
+
+REFTRACKER_DECL(StrongRefTracker, {
+    initializeSystemForStrongRefTracker();
+});
 
 // A strongly referenced handle that prevents the object it points to from being garbage collected.
 template <typename T, ShouldStrongDestructorGrabLock shouldStrongDestructorGrabLock> class Strong final : public Handle<T> {

--- a/Source/JavaScriptCore/heap/StrongInlines.h
+++ b/Source/JavaScriptCore/heap/StrongInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,10 @@
 #include "JSCJSValueInlines.h"
 #include "VM.h"
 
+#if ENABLE(REFTRACKER)
+#include "InitializeThreading.h"
+#endif
+
 namespace JSC {
 
 template <typename T, ShouldStrongDestructorGrabLock shouldStrongDestructorGrabLock>
@@ -51,5 +55,16 @@ inline void Strong<T, shouldStrongDestructorGrabLock>::set(VM& vm, ExternalType 
         setSlot(vm.heap.handleSet()->allocate());
     set(value);
 }
+
+#if ENABLE(REFTRACKER)
+inline void initializeSystemForStrongRefTracker()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        WTF::initializeMainThread();
+        JSC::initialize();
+    });
+}
+#endif // ENABLE(REFTRACKER)
 
 } // namespace JSC

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -114,9 +114,12 @@ struct RefTrackerMixin final {
     RefTrackerMixin* originalThis = nullptr;
 };
 
-#define REFTRACKER_DECL(T) \
+#define REFTRACKER_DECL(T, initializer) \
     struct T final { \
-        inline static bool enabled() { return Options::enable ## T(); } \
+        inline static bool enabled() { \
+            initializer \
+            return Options::enable ## T(); \
+        } \
         WTF_EXPORT_PRIVATE static WTF::RefTracker& refTrackerSingleton(); \
     };
 
@@ -137,7 +140,7 @@ struct RefTrackerMixin final {
 
 #else // ENABLE(REFTRACKER)
 
-#define REFTRACKER_DECL(_)
+#define REFTRACKER_DECL(_, initializer)
 #define REFTRACKER_MEMBERS(_)
 #define REFTRACKER_IMPL(_)
 


### PR DESCRIPTION
#### 49e3e247239519e79fed18eda8016a3464d6830e
<pre>
Use of Options::enableStrongRefTracker() breaks testapi in the Debug build.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281626">https://bugs.webkit.org/show_bug.cgi?id=281626</a>
<a href="https://rdar.apple.com/138066602">rdar://138066602</a>

Reviewed by David Degazio.

284791@main causes an ASSERT failure:
ASSERTION FAILED: g_jscConfig.options.allowUnfinalizedAccess || g_jscConfig.options.isFinalized

The reason is that StrongRefTracker::enabled() is assuming that JSC Options are initialized when
they may not be.

The fix is to make StrongRefTracker::enabled() initialize JSC if needed.

* Source/JavaScriptCore/heap/Strong.h:
(JSC::REFTRACKER_DECL):
* Source/JavaScriptCore/heap/StrongInlines.h:
(JSC::initializeSystemForStrongRefTracker):
* Source/WTF/wtf/RefTrackerMixin.h:

Canonical link: <a href="https://commits.webkit.org/285304@main">https://commits.webkit.org/285304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffc70dfa2c6b60221045b4a287c68a14b767a4d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62181 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21760 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65330 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78046 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71455 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19172 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62205 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6514 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93236 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11079 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47420 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20524 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->