### PR TITLE
[visionOS] Relax criteria for Panoramic images to delegate fullscreen to Quick Look

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -711,18 +711,13 @@ bool ImageDecoderCG::canDecodeType(const String& mimeType)
 }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-bool ImageDecoderCG::isPanoramic() const
+bool ImageDecoderCG::isMaybePanoramic() const
 {
     auto imageSize = FloatSize(frameSizeAtIndex(0));
     auto aspectRatio = imageSize.aspectRatio();
 
     constexpr float panoramicImageAspectRatioThreshold = 2.0;
-    if (aspectRatio <= panoramicImageAspectRatioThreshold)
-        return false;
-
-    constexpr float panoramicImageMinDimension = 800;
-    constexpr float panoramicImageMaxDimension = 30000;
-    return imageSize.minDimension() > panoramicImageMinDimension && imageSize.maxDimension() < panoramicImageMaxDimension;
+    return aspectRatio > panoramicImageAspectRatioThreshold;
 }
 
 bool ImageDecoderCG::isSpatial() const
@@ -736,7 +731,7 @@ bool ImageDecoderCG::isSpatial() const
 
 bool ImageDecoderCG::shouldUseQuickLookForFullscreen() const
 {
-    return isPanoramic() || isSpatial();
+    return isMaybePanoramic() || isSpatial();
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -85,7 +85,7 @@ private:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool isSpatial() const;
-    bool isPanoramic() const;
+    bool isMaybePanoramic() const;
     bool shouldUseQuickLookForFullscreen() const;
 #endif
 


### PR DESCRIPTION
#### 42e1ee204fc91f5c75dcef4dc8d764e9e70f2ba8
<pre>
[visionOS] Relax criteria for Panoramic images to delegate fullscreen to Quick Look
<a href="https://bugs.webkit.org/show_bug.cgi?id=281632">https://bugs.webkit.org/show_bug.cgi?id=281632</a>
&lt;<a href="https://rdar.apple.com/136329595">rdar://136329595</a>&gt;

Reviewed by Said Abou-Hallawa.

On visionOS, delegate element fullscreen to Quick Look for any image
that is wide enough to be a Panoramic image, even if it isn&apos;t large
enough. That way, if `srcset` switches the image source to one large
enough to be a Panoramic image after going fullscreen, Quick Look
will already be open to display it.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::isMaybePanoramic const):
(WebCore::ImageDecoderCG::shouldUseQuickLookForFullscreen const):
(WebCore::ImageDecoderCG::isPanoramic const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
Loosen the criteria for panorama detection.

Canonical link: <a href="https://commits.webkit.org/285388@main">https://commits.webkit.org/285388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f12527b646bc06060c486d35ea3f82adc2c32e31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64648 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12866 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6516 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47425 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->