### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from ScrollingTreeScrollingNodeDelegateIOS

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -40,15 +40,6 @@
 @class WKBEScrollView;
 @class WKScrollingNodeScrollViewDelegate;
 
-namespace WebKit {
-class ScrollingTreeScrollingNodeDelegateIOS;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ScrollingTreeScrollingNodeDelegateIOS> : std::true_type { };
-}
-
 namespace WebCore {
 
 class FloatPoint;
@@ -60,8 +51,9 @@ class ScrollingTreeScrollingNode;
 
 namespace WebKit {
 
-class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate, public CanMakeWeakPtr<ScrollingTreeScrollingNodeDelegateIOS> {
+class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate, public CanMakeWeakPtr<ScrollingTreeScrollingNodeDelegateIOS>, public CanMakeCheckedPtr<ScrollingTreeScrollingNodeDelegateIOS> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeScrollingNodeDelegateIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollingTreeScrollingNodeDelegateIOS);
 public:
     
     enum class AllowOverscrollToPreventScrollPropagation : bool { No, Yes };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -73,32 +73,35 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
-    _scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
+    scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
     _inUserInteraction = YES;
 
     if (scrollView.panGestureRecognizer.state == UIGestureRecognizerStateBegan)
-        _scrollingTreeNodeDelegate->scrollViewWillStartPanGesture();
-    _scrollingTreeNodeDelegate->scrollWillStart();
+        scrollingTreeNodeDelegate->scrollViewWillStartPanGesture();
+    scrollingTreeNodeDelegate->scrollWillStart();
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
     if (![scrollView isZooming]) {
         auto touchActions = _scrollingTreeNodeDelegate->activeTouchActions();
-        _scrollingTreeNodeDelegate->clearActiveTouchActions();
+        scrollingTreeNodeDelegate->clearActiveTouchActions();
         
         if (touchActions && !touchActions.containsAny({ WebCore::TouchAction::Auto, WebCore::TouchAction::Manipulation })) {
             auto axesToPreventMomentumScrolling = dynamic_objc_cast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
@@ -109,61 +112,64 @@
         }
     }
 
-    std::optional<unsigned> originalHorizontalSnapPosition = _scrollingTreeNodeDelegate->scrollingNode().currentHorizontalSnapPointIndex();
-    std::optional<unsigned> originalVerticalSnapPosition = _scrollingTreeNodeDelegate->scrollingNode().currentVerticalSnapPointIndex();
+    std::optional<unsigned> originalHorizontalSnapPosition = scrollingTreeNodeDelegate->scrollingNode().currentHorizontalSnapPointIndex();
+    std::optional<unsigned> originalVerticalSnapPosition = scrollingTreeNodeDelegate->scrollingNode().currentVerticalSnapPointIndex();
 
     WebCore::FloatSize viewportSize(static_cast<float>(CGRectGetWidth([scrollView bounds])), static_cast<float>(CGRectGetHeight([scrollView bounds])));
     const auto& snapOffsetsInfo = _scrollingTreeNodeDelegate->scrollingNode().snapOffsetsInfo();
     if (!snapOffsetsInfo.horizontalSnapOffsets.isEmpty()) {
         auto [potentialSnapPosition, index] = snapOffsetsInfo.closestSnapOffset(WebCore::ScrollEventAxis::Horizontal, viewportSize, WebCore::FloatPoint(*targetContentOffset), velocity.x, scrollView.contentOffset.x);
-        _scrollingTreeNodeDelegate->scrollingNode().setCurrentHorizontalSnapPointIndex(index);
+        scrollingTreeNodeDelegate->scrollingNode().setCurrentHorizontalSnapPointIndex(index);
         if (targetContentOffset->x >= 0 && targetContentOffset->x <= scrollView.contentSize.width)
             targetContentOffset->x = potentialSnapPosition;
     }
 
     if (!snapOffsetsInfo.verticalSnapOffsets.isEmpty()) {
         auto [potentialSnapPosition, index] = snapOffsetsInfo.closestSnapOffset(WebCore::ScrollEventAxis::Vertical, viewportSize, WebCore::FloatPoint(*targetContentOffset), velocity.y, scrollView.contentOffset.y);
-        _scrollingTreeNodeDelegate->scrollingNode().setCurrentVerticalSnapPointIndex(index);
+        scrollingTreeNodeDelegate->scrollingNode().setCurrentVerticalSnapPointIndex(index);
         if (targetContentOffset->y >= 0 && targetContentOffset->y <= scrollView.contentSize.height)
             targetContentOffset->y = potentialSnapPosition;
     }
 
     if (originalHorizontalSnapPosition != _scrollingTreeNodeDelegate->scrollingNode().currentHorizontalSnapPointIndex()
         || originalVerticalSnapPosition != _scrollingTreeNodeDelegate->scrollingNode().currentVerticalSnapPointIndex()) {
-        _scrollingTreeNodeDelegate->currentSnapPointIndicesDidChange(_scrollingTreeNodeDelegate->scrollingNode().currentHorizontalSnapPointIndex(), _scrollingTreeNodeDelegate->scrollingNode().currentVerticalSnapPointIndex());
+        scrollingTreeNodeDelegate->currentSnapPointIndicesDidChange(_scrollingTreeNodeDelegate->scrollingNode().currentHorizontalSnapPointIndex(), scrollingTreeNodeDelegate->scrollingNode().currentVerticalSnapPointIndex());
     }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)willDecelerate
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
     if (_inUserInteraction && !willDecelerate) {
         _inUserInteraction = NO;
-        _scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
-        _scrollingTreeNodeDelegate->scrollDidEnd();
+        scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
+        scrollingTreeNodeDelegate->scrollDidEnd();
     }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
     if (_inUserInteraction) {
         _inUserInteraction = NO;
-        _scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
-        _scrollingTreeNodeDelegate->scrollDidEnd();
+        scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
+        scrollingTreeNodeDelegate->scrollDidEnd();
     }
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
-    _scrollingTreeNodeDelegate->scrollDidEnd();
+    scrollingTreeNodeDelegate->scrollDidEnd();
 }
 
 - (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(UIView *)view
@@ -173,23 +179,25 @@
 
 - (void)cancelPointersForGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
-    _scrollingTreeNodeDelegate->cancelPointersForGestureRecognizer(gestureRecognizer);
+    scrollingTreeNodeDelegate->cancelPointersForGestureRecognizer(gestureRecognizer);
 }
 
 #pragma mark - WKBaseScrollViewDelegate
 
 - (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return UIAxisNeither;
 
     auto panGestureRecognizer = scrollView.panGestureRecognizer;
-    _scrollingTreeNodeDelegate->computeActiveTouchActionsForGestureRecognizer(panGestureRecognizer);
+    scrollingTreeNodeDelegate->computeActiveTouchActionsForGestureRecognizer(panGestureRecognizer);
 
-    auto touchActions = _scrollingTreeNodeDelegate->activeTouchActions();
+    auto touchActions = scrollingTreeNodeDelegate->activeTouchActions();
     if (!touchActions) {
         [self cancelPointersForGestureRecognizer:panGestureRecognizer];
         return UIAxisNeither;
@@ -216,11 +224,12 @@
 
 - (WKBEScrollView *)parentScrollViewForScrollView:(WKBEScrollView *)scrollView
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return nil;
 
     // An "acting parent" is a non-ancestor scrolling parent. We tell this to UIKit so it can propagate scrolls correctly.
-    return dynamic_objc_cast<WKBEScrollView>(_scrollingTreeNodeDelegate->findActingScrollParent(scrollView));
+    return dynamic_objc_cast<WKBEScrollView>(scrollingTreeNodeDelegate->findActingScrollParent(scrollView));
 }
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
@@ -236,10 +245,11 @@
 
 - (void)scrollView:(WKBaseScrollView *)scrollView handleScrollUpdate:(WKBEScrollViewScrollUpdate *)update completion:(void (^)(BOOL handled))completion
 {
-    if (UNLIKELY(!_scrollingTreeNodeDelegate))
+    CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
+    if (UNLIKELY(!scrollingTreeNodeDelegate))
         return;
 
-    _scrollingTreeNodeDelegate->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
+    scrollingTreeNodeDelegate->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
 }
 
 #endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)


### PR DESCRIPTION
#### a1a55dd06121be86c1451581f2f60a6f675f57cf
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from ScrollingTreeScrollingNodeDelegateIOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=281635">https://bugs.webkit.org/show_bug.cgi?id=281635</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewDidScroll:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillBeginDragging:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDragging:willDecelerate:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDecelerating:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndScrollingAnimation:]):
(-[WKScrollingNodeScrollViewDelegate cancelPointersForGestureRecognizer:]):
(-[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]):
(-[WKScrollingNodeScrollViewDelegate parentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollUpdate:completion:]):

Canonical link: <a href="https://commits.webkit.org/285312@main">https://commits.webkit.org/285312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6360b17418be563b5ce02b3d02f9b5d51a3556df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62188 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43442 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78062 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19181 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62212 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12871 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11085 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2220 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->