### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make more WebAuthentication classes RefCounted

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
@@ -33,13 +33,13 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
-class HidConnection {
-    WTF_MAKE_TZONE_ALLOCATED(HidConnection);
+class HidConnection : public RefCountedAndCanMakeWeakPtr<HidConnection> {
     WTF_MAKE_NONCOPYABLE(HidConnection);
 public:
     enum class DataSent : bool { No, Yes };
@@ -47,7 +47,7 @@ public:
     using DataSentCallback = CompletionHandler<void(DataSent)>;
     using DataReceivedCallback = Function<void(Vector<uint8_t>&&)>;
 
-    explicit HidConnection(IOHIDDeviceRef);
+    static Ref<HidConnection> create(IOHIDDeviceRef);
     virtual ~HidConnection();
 
     // Overrided by MockHidConnection.
@@ -63,6 +63,7 @@ public:
     void receiveReport(Vector<uint8_t>&&);
 
 protected:
+    explicit HidConnection(IOHIDDeviceRef);
     bool isInitialized() const { return m_isInitialized; }
     void setIsInitialized(bool isInitialized) { m_isInitialized = isInitialized; }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -59,7 +59,10 @@ static void reportReceived(void* context, IOReturn status, void*, IOHIDReportTyp
 }
 #endif // HAVE(SECURITY_KEY_API)
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(HidConnection);
+Ref<HidConnection> HidConnection::create(IOHIDDeviceRef device)
+{
+    return adoptRef(*new HidConnection(device));
+}
 
 HidConnection::HidConnection(IOHIDDeviceRef device)
     : m_device(device)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
@@ -30,7 +30,6 @@
 #include "FidoService.h"
 #include <pal/spi/cocoa/IOKitSPI.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/UniqueRef.h>
 
 namespace WebKit {
 
@@ -48,7 +47,7 @@ private:
 
     // Overrided by MockHidService.
     virtual void platformStartDiscovery();
-    virtual UniqueRef<HidConnection> createHidConnection(IOHIDDeviceRef) const;
+    virtual Ref<HidConnection> createHidConnection(IOHIDDeviceRef) const;
 
     RetainPtr<IOHIDManagerRef> m_manager;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -86,9 +86,9 @@ void HidService::platformStartDiscovery()
 #endif
 }
 
-UniqueRef<HidConnection> HidService::createHidConnection(IOHIDDeviceRef device) const
+Ref<HidConnection> HidService::createHidConnection(IOHIDDeviceRef device) const
 {
-    return makeUniqueRef<HidConnection>(device);
+    return HidConnection::create(device);
 }
 
 void HidService::deviceAdded(IOHIDDeviceRef device)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -44,6 +44,11 @@ using namespace WebCore;
 using namespace cbor;
 using namespace fido;
 
+Ref<MockHidConnection> MockHidConnection::create(IOHIDDeviceRef device, const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockHidConnection(device, configuration));
+}
+
 MockHidConnection::MockHidConnection(IOHIDDeviceRef device, const MockWebAuthenticationConfiguration& configuration)
     : HidConnection(device)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
@@ -33,15 +33,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class MockHidConnection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::MockHidConnection> : std::true_type { };
-}
-
-namespace WebKit {
 
 // The following basically simulates an external HID token that:
 //    1. Supports only one protocol, either CTAP2 or U2F.
@@ -52,11 +43,14 @@ namespace WebKit {
 // There are indefinite stages for each U2F request:
 // FSM: Info::Init => Info::Msg => [Request::Init => Request::Msg]+
 // According to different combinations of error and stages, error will manifest differently.
-class MockHidConnection final : public CanMakeWeakPtr<MockHidConnection>, public HidConnection {
+class MockHidConnection final : public HidConnection {
 public:
-    MockHidConnection(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockHidConnection> create(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
+    virtual ~MockHidConnection() = default;
 
 private:
+    MockHidConnection(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
+
     // HidConnection
     void initialize() final;
     void terminate() final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
@@ -48,9 +48,9 @@ void MockHidService::platformStartDiscovery()
     LOG_ERROR("No hid authenticators is available.");
 }
 
-UniqueRef<HidConnection> MockHidService::createHidConnection(IOHIDDeviceRef device) const
+Ref<HidConnection> MockHidService::createHidConnection(IOHIDDeviceRef device) const
 {
-    return makeUniqueRef<MockHidConnection>(device, m_configuration);
+    return MockHidConnection::create(device, m_configuration);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
@@ -38,7 +38,7 @@ public:
 
 private:
     void platformStartDiscovery() final;
-    UniqueRef<HidConnection> createHidConnection(IOHIDDeviceRef) const final;
+    Ref<HidConnection> createHidConnection(IOHIDDeviceRef) const final;
 
     WebCore::MockWebAuthenticationConfiguration m_configuration;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
@@ -45,6 +45,11 @@ using namespace WebCore;
 
 const size_t CtapChannelIdSize = 4;
 
+Ref<VirtualHidConnection> VirtualHidConnection::create(const String& authenticatorId, const VirtualAuthenticatorConfiguration& configuration, const WeakPtr<VirtualAuthenticatorManager>& manager)
+{
+    return adoptRef(*new VirtualHidConnection(authenticatorId, configuration, manager));
+}
+
 VirtualHidConnection::VirtualHidConnection(const String& authenticatorId, const VirtualAuthenticatorConfiguration& configuration, const WeakPtr<VirtualAuthenticatorManager>& manager)
     : HidConnection(nullptr)
     , m_manager(manager)

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.h
@@ -33,23 +33,17 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class VirtualHidConnection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::VirtualHidConnection> : std::true_type { };
-}
-
-namespace WebKit {
 struct VirtualAuthenticatorConfiguration;
 class VirtualAuthenticatorManager;
 
-class VirtualHidConnection final : public CanMakeWeakPtr<VirtualHidConnection>, public HidConnection {
+class VirtualHidConnection final : public HidConnection {
 public:
-    explicit VirtualHidConnection(const String& authenticatorId, const VirtualAuthenticatorConfiguration&, const WeakPtr<VirtualAuthenticatorManager>&);
+    static Ref<VirtualHidConnection> create(const String& authenticatorId, const VirtualAuthenticatorConfiguration&, const WeakPtr<VirtualAuthenticatorManager>&);
+    virtual ~VirtualHidConnection() = default;
 
 private:
+    explicit VirtualHidConnection(const String& authenticatorId, const VirtualAuthenticatorConfiguration&, const WeakPtr<VirtualAuthenticatorManager>&);
+
     void initialize() final;
     void terminate() final;
     DataSent sendSync(const Vector<uint8_t>& data) final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -73,7 +73,7 @@ void VirtualService::startDiscoveryInternal()
         case WebCore::AuthenticatorTransport::Nfc:
         case WebCore::AuthenticatorTransport::Ble:
         case WebCore::AuthenticatorTransport::Usb:
-            observer()->authenticatorAdded(CtapAuthenticator::create(WTF::makeUnique<CtapHidDriver>(makeUniqueRef<VirtualHidConnection>(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
+            observer()->authenticatorAdded(CtapAuthenticator::create(WTF::makeUnique<CtapHidDriver>(VirtualHidConnection::create(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
             break;
         case WebCore::AuthenticatorTransport::Internal:
             observer()->authenticatorAdded(LocalAuthenticator::create(makeUniqueRef<VirtualLocalConnection>(config)));

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -42,15 +42,15 @@ using namespace fido;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CtapHidDriverWorker);
 
-CtapHidDriverWorker::CtapHidDriverWorker(UniqueRef<HidConnection>&& connection)
+CtapHidDriverWorker::CtapHidDriverWorker(Ref<HidConnection>&& connection)
     : m_connection(WTFMove(connection))
 {
-    m_connection->initialize();
+    protectedConnection()->initialize();
 }
 
 CtapHidDriverWorker::~CtapHidDriverWorker()
 {
-    m_connection->terminate();
+    protectedConnection()->terminate();
 }
 
 void CtapHidDriverWorker::transact(fido::FidoHidMessage&& requestMessage, MessageCallback&& callback)
@@ -62,8 +62,9 @@ void CtapHidDriverWorker::transact(fido::FidoHidMessage&& requestMessage, Messag
     m_callback = WTFMove(callback);
 
     // HidConnection could hold data from other applications, and thereofore invalidate it before each transaction.
-    m_connection->invalidateCache();
-    m_connection->send(m_requestMessage->popNextPacket(), [weakThis = WeakPtr { *this }](HidConnection::DataSent sent) mutable {
+    Ref connection = m_connection;
+    connection->invalidateCache();
+    connection->send(m_requestMessage->popNextPacket(), [weakThis = WeakPtr { *this }](HidConnection::DataSent sent) mutable {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -83,7 +84,7 @@ void CtapHidDriverWorker::write(HidConnection::DataSent sent)
 
     if (!m_requestMessage->numPackets()) {
         m_state = State::Read;
-        m_connection->registerDataReceivedCallback([weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) mutable {
+        protectedConnection()->registerDataReceivedCallback([weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) mutable {
             ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
@@ -92,7 +93,7 @@ void CtapHidDriverWorker::write(HidConnection::DataSent sent)
         return;
     }
 
-    m_connection->send(m_requestMessage->popNextPacket(), [weakThis = WeakPtr { *this }](HidConnection::DataSent sent) mutable {
+    protectedConnection()->send(m_requestMessage->popNextPacket(), [weakThis = WeakPtr { *this }](HidConnection::DataSent sent) mutable {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -144,7 +145,7 @@ void CtapHidDriverWorker::returnMessage()
 
 void CtapHidDriverWorker::reset()
 {
-    m_connection->unregisterDataReceivedCallback();
+    protectedConnection()->unregisterDataReceivedCallback();
     m_callback = nullptr;
     m_responseMessage = std::nullopt;
     m_requestMessage = std::nullopt;
@@ -156,12 +157,13 @@ void CtapHidDriverWorker::reset()
 void CtapHidDriverWorker::cancel(fido::FidoHidMessage&& requestMessage)
 {
     reset();
-    m_connection->invalidateCache();
+    Ref connection = m_connection;
+    connection->invalidateCache();
     ASSERT(requestMessage.numPackets() == 1);
-    m_connection->sendSync(requestMessage.popNextPacket());
+    connection->sendSync(requestMessage.popNextPacket());
 }
 
-CtapHidDriver::CtapHidDriver(UniqueRef<HidConnection>&& connection)
+CtapHidDriver::CtapHidDriver(Ref<HidConnection>&& connection)
     : CtapDriver(WebCore::AuthenticatorTransport::Usb)
     , m_worker(makeUniqueRef<CtapHidDriverWorker>(WTFMove(connection)))
     , m_nonce(kHidInitNonceLength)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
@@ -61,7 +61,7 @@ public:
         Read
     };
 
-    explicit CtapHidDriverWorker(UniqueRef<HidConnection>&&);
+    explicit CtapHidDriverWorker(Ref<HidConnection>&&);
     ~CtapHidDriverWorker();
 
     void transact(fido::FidoHidMessage&&, MessageCallback&&);
@@ -73,7 +73,9 @@ private:
     void returnMessage();
     void reset();
 
-    UniqueRef<HidConnection> m_connection;
+    Ref<HidConnection> protectedConnection() { return m_connection; }
+
+    Ref<HidConnection> m_connection;
     State m_state { State::Idle };
     std::optional<fido::FidoHidMessage> m_requestMessage;
     std::optional<fido::FidoHidMessage> m_responseMessage;
@@ -93,7 +95,7 @@ public:
         Busy
     };
 
-    explicit CtapHidDriver(UniqueRef<HidConnection>&&);
+    explicit CtapHidDriver(Ref<HidConnection>&&);
 
     void transact(Vector<uint8_t>&& data, ResponseCallback&&) final;
     void cancel() final;


### PR DESCRIPTION
#### 4de859dce063802780052a99ac2045701e391853
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make more WebAuthentication classes RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281637">https://bugs.webkit.org/show_bug.cgi?id=281637</a>

Reviewed by Chris Dumez.

HidConnection class and its subclasses in WebAuthentication are managed as WeakPtr so they should be ref counted.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::HidConnection::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
(WebKit::HidService::createHidConnection const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::create):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp:
(WebKit::MockHidService::createHidConnection const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp:
(WebKit::VirtualHidConnection::create):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::VirtualService::startDiscoveryInternal):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriverWorker::CtapHidDriverWorker):
(WebKit::CtapHidDriverWorker::~CtapHidDriverWorker):
(WebKit::CtapHidDriverWorker::transact):
(WebKit::CtapHidDriverWorker::write):
(WebKit::CtapHidDriverWorker::reset):
(WebKit::CtapHidDriverWorker::cancel):
(WebKit::CtapHidDriver::CtapHidDriver):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h:
(WebKit::CtapHidDriverWorker::protectedConnection):

Canonical link: <a href="https://commits.webkit.org/285345@main">https://commits.webkit.org/285345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae8dd2721583f56463730ccd8a8b0bde3ca649e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43451 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78073 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16469 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19191 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 10 flakes 2 failures; Uploaded test results; 13 flakes 1 failures; Compiled WebKit (warnings); layout-tests; Found 1 new test failure: http/wpt/mediarecorder/pause-recording.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64661 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6529 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2231 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48516 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->