### PR TITLE
Make it possible to get a raster image fro, an SVG image data

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -535,7 +535,8 @@ CheckedRef<BackForwardController> Page::checkedBackForward()
 
 void Page::firstTimeInitialization()
 {
-    platformStrategies()->loaderStrategy()->addOnlineStateChangeListener(&networkStateChanged);
+    if (auto loaderStrategy = platformStrategies()->loaderStrategy())
+        loaderStrategy->addOnlineStateChangeListener(&networkStateChanged);
 
     FontCache::registerFontCacheInvalidationCallback([] {
         updateStyleForAllPagesAfterGlobalChangeInEnvironment();

--- a/Source/WebCore/platform/PlatformStrategies.h
+++ b/Source/WebCore/platform/PlatformStrategies.h
@@ -39,6 +39,9 @@ class PushStrategy;
 
 class PlatformStrategies {
 public:
+    PlatformStrategies() = default;
+    virtual ~PlatformStrategies() = default;
+
     LoaderStrategy* loaderStrategy()
     {
         if (!m_loaderStrategy)
@@ -77,18 +80,11 @@ public:
     }
 #endif
 
-protected:
-    PlatformStrategies() = default;
-
-    virtual ~PlatformStrategies()
-    {
-    }
-
 private:
-    virtual LoaderStrategy* createLoaderStrategy() = 0;
-    virtual PasteboardStrategy* createPasteboardStrategy() = 0;
-    virtual MediaStrategy* createMediaStrategy() = 0;
-    virtual BlobRegistry* createBlobRegistry() = 0;
+    virtual LoaderStrategy* createLoaderStrategy() { return nullptr; }
+    virtual PasteboardStrategy* createPasteboardStrategy() { return nullptr; }
+    virtual MediaStrategy* createMediaStrategy() { return nullptr; }
+    virtual BlobRegistry* createBlobRegistry() { return nullptr; }
 
     LoaderStrategy* m_loaderStrategy { };
     PasteboardStrategy* m_pasteboardStrategy { };
@@ -97,7 +93,7 @@ private:
     BlobRegistry* m_blobRegistry { };
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    virtual PushStrategy* createPushStrategy() = 0;
+    virtual PushStrategy* createPushStrategy() { return nullptr; }
     PushStrategy* m_pushStrategy { };
 #endif
 };

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -96,7 +96,7 @@ RefPtr<Image> Image::create(ImageObserver& observer)
 
     auto mimeType = observer.mimeType();
     if (mimeType == "image/svg+xml"_s)
-        return SVGImage::create(observer);
+        return SVGImage::create(&observer);
 
     auto url = observer.sourceUrl();
     if (isPDFResource(mimeType, url)) {

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -42,6 +42,7 @@
 #include "ElementTextDirection.h"
 #include "HTMLElement.h"
 #include "HTMLSlotElement.h"
+#include "Page.h"
 #include "SVGElement.h"
 #include "SelectorCheckerTestFunctions.h"
 #include "SelectorCompiler.h"
@@ -499,11 +500,12 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
 #if ENABLE(CSS_SELECTOR_JIT)
     auto& compiledSelector = ruleData.compiledSelector();
+    bool canUseCompiledSelector = Page::nonUtilityPageCount();
 
-    if (compiledSelector.status == SelectorCompilationStatus::NotCompiled)
+    if (canUseCompiledSelector && compiledSelector.status == SelectorCompilationStatus::NotCompiled)
         SelectorCompiler::compileSelector(compiledSelector, ruleData.selector(), SelectorCompiler::SelectorContext::RuleCollector);
 
-    if (compiledSelector.status == SelectorCompilationStatus::SimpleSelectorChecker) {
+    if (canUseCompiledSelector && compiledSelector.status == SelectorCompilationStatus::SimpleSelectorChecker) {
         compiledSelector.wasUsed();
 
 #if !ASSERT_MSG_DISABLED
@@ -533,7 +535,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     bool selectorMatches;
 #if ENABLE(CSS_SELECTOR_JIT)
-    if (compiledSelector.status == SelectorCompilationStatus::SelectorCheckerWithCheckingContext) {
+    if (canUseCompiledSelector && compiledSelector.status == SelectorCompilationStatus::SelectorCheckerWithCheckingContext) {
         compiledSelector.wasUsed();
         selectorMatches = SelectorCompiler::ruleCollectorSelectorCheckerWithCheckingContext(compiledSelector, &element(), &context, &specificity);
     } else

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1305,8 +1305,10 @@ PostResolutionCallbackDisabler::PostResolutionCallbackDisabler(Document& documen
 {
     ++resolutionNestingDepth;
 
-    if (resolutionNestingDepth == 1)
-        platformStrategies()->loaderStrategy()->suspendPendingRequests();
+    if (resolutionNestingDepth == 1) {
+        if (auto loaderStrategy = platformStrategies()->loaderStrategy())
+            loaderStrategy->suspendPendingRequests();
+    }
 
     // FIXME: It's strange to build this into the disabler.
     suspendMemoryCacheClientCalls(document);
@@ -1330,7 +1332,8 @@ PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler()
         }
         queue.clear();
 
-        platformStrategies()->loaderStrategy()->resumePendingRequests();
+        if (auto loaderStrategy = platformStrategies()->loaderStrategy())
+            loaderStrategy->resumePendingRequests();
     }
 
     --resolutionNestingDepth;

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -118,7 +118,6 @@ void SMILTimeContainer::begin()
     if (isStarted())
         return;
 
-    ASSERT(Page::nonUtilityPageCount());
     if (!Page::nonUtilityPageCount())
         return;
 

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -68,8 +68,8 @@
 
 namespace WebCore {
 
-SVGImage::SVGImage(ImageObserver& observer)
-    : Image(&observer)
+SVGImage::SVGImage(ImageObserver* observer)
+    : Image(observer)
     , m_startAnimationTimer(*this, &SVGImage::startAnimationTimerFired)
 {
 }
@@ -187,7 +187,6 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
         return ImageDrawResult::DidNothing;
 
     RefPtr observer = imageObserver();
-    ASSERT(observer);
 
     // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
     setImageObserver(nullptr);

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -42,7 +42,7 @@ class SVGImageForContainer;
 
 class SVGImage final : public Image {
 public:
-    static Ref<SVGImage> create(ImageObserver& observer) { return adoptRef(*new SVGImage(observer)); }
+    static Ref<SVGImage> create(ImageObserver* observer = nullptr) { return adoptRef(*new SVGImage(observer)); }
 
     RenderBox* embeddedContentBox() const;
     LocalFrameView* frameView() const;
@@ -68,6 +68,7 @@ public:
 
     Page* internalPage() { return m_page.get(); }
     WEBCORE_EXPORT RefPtr<SVGSVGElement> rootElement() const;
+    WEBCORE_EXPORT RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) final;
 
 private:
     friend class SVGImageChromeClient;
@@ -90,11 +91,9 @@ private:
     // FIXME: Implement this to be less conservative.
     bool currentFrameKnownToBeOpaque() const final { return false; }
 
-    RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) final;
-
     void startAnimationTimerFired();
 
-    WEBCORE_EXPORT explicit SVGImage(ImageObserver&);
+    WEBCORE_EXPORT explicit SVGImage(ImageObserver*);
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
     ImageDrawResult drawForContainer(GraphicsContext&, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
     void drawPatternForContainer(GraphicsContext&, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect&, ImagePaintingOptions = { });


### PR DESCRIPTION
#### 07f8a0c62b6850167f968f7fdd6448c9b740926d
<pre>
Make it possible to get a raster image fro, an SVG image data
<a href="https://bugs.webkit.org/show_bug.cgi?id=281638">https://bugs.webkit.org/show_bug.cgi?id=281638</a>
<a href="https://rdar.apple.com/138081516">rdar://138081516</a>

Reviewed by NOBODY (OOPS!).

Change the SVGImage interface such that it can be initialized with an observer.

Make it possible to crate a Page outside WebCore and without a WebProcess.

Disable the CSS compiler JIT for this case since it requires certain features to
be enabled.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::firstTimeInitialization):
* Source/WebCore/platform/PlatformStrategies.h:
(WebCore::PlatformStrategies::createLoaderStrategy):
(WebCore::PlatformStrategies::createPasteboardStrategy):
(WebCore::PlatformStrategies::createMediaStrategy):
(WebCore::PlatformStrategies::createBlobRegistry):
(WebCore::PlatformStrategies::createPushStrategy):
(WebCore::PlatformStrategies::~PlatformStrategies): Deleted.
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::create):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::PostResolutionCallbackDisabler::PostResolutionCallbackDisabler):
(WebCore::Style::PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler):
* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::begin):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::SVGImage):
(WebCore::SVGImage::drawForContainer):
* Source/WebCore/svg/graphics/SVGImage.h:
* Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp:
(TestWebKitAPI::TEST(SVGImageCasts, SVGImageForContainerIsNotSVGImage)):
(TestWebKitAPI::TEST(SVGImageCasts, SVGImageDataToNativeImage)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07f8a0c62b6850167f968f7fdd6448c9b740926d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56940 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19676 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21790 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65353 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65399 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64662 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6530 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2234 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->