### PR TITLE
[TZone] Update TZone debugging code

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -93,7 +93,8 @@ struct TZoneHeapBase {
     {
         bmalloc_type type = BMALLOC_TYPE_INITIALIZER((unsigned)roundUpToMulipleOf8(differentSize), roundUpToMulipleOf8(alignof(LibPasBmallocHeapType)), __PRETTY_FUNCTION__);
 
-        TZONE_LOG_DEBUG("Unannotated TZone type %s:%d:%s\n", __FILE__, __LINE__, __PRETTY_FUNCTION__);
+        TZONE_LOG_DEBUG("Unannotated TZone type %s:%d\n", __FILE__, __LINE__);
+        TZONE_LOG_DEBUG("  Super Class: %s\n", __PRETTY_FUNCTION__);
 
         //  &&&& Should we figure out a way to cache this different sized heap?
         return *TZoneHeapManager::singleton().heapRefForTZoneType(&type);

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -27,6 +27,7 @@
 
 #if BUSE(TZONE)
 
+#include "BCompiler.h"
 #include "BPlatform.h"
 #include "ProcessCheck.h"
 #include "Sizes.h"
@@ -45,6 +46,8 @@
 namespace bmalloc { namespace api {
 
 TZoneHeapManager* TZoneHeapManager::theTZoneHeapManager = nullptr;
+
+static constexpr bool verbose = false;
 
 static const char base64Chars[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -70,9 +73,9 @@ static_assert(sizeof(TypeNameTemplate) == typeNameLen);
 
 static TypeNameTemplate typeNameTemplate;
 
-static void dumpRegisterdTypesAtExit(void)
+static void dumpRegisteredTypesAtExit(void)
 {
-    TZoneHeapManager::singleton().dumpRegisterdTypes();
+    TZoneHeapManager::singleton().dumpRegisteredTypes();
 }
 
 void TZoneHeapManager::init()
@@ -99,13 +102,12 @@ void TZoneHeapManager::init()
     }
     primordialSeed = timeValue.tv_sec * 1000 * 1000 + timeValue.tv_usec;
 
-    if constexpr (verbose)
-        TZONE_LOG_DEBUG("primordialSeed: 0x%llx\n", primordialSeed);
-
     const char* procName = processNameString();
 
-    if constexpr (verbose)
+    if constexpr (verbose) {
+        TZONE_LOG_DEBUG("primordialSeed: 0x%llx\n", primordialSeed);
         TZONE_LOG_DEBUG("Process Name: \"%s\"\n", procName);
+    }
 
     unsigned byteIdx = 0;
 
@@ -122,6 +124,21 @@ void TZoneHeapManager::init()
 
     for (; byteIdx < rawSeedLength; byteIdx++)
         rawSeed[byteIdx] = 'Q' - (byteIdx & 0xf);
+
+    if constexpr (verbose) {
+        TZONE_LOG_DEBUG("rawSeed (len %zu): 0x", rawSeedLength);
+        size_t i = 0;
+        while (true) {
+            TZONE_LOG_DEBUG("%02x", rawSeed[i]);
+            if (++i >= rawSeedLength)
+                break;
+            if (!(i % 32)) {
+                TZONE_LOG_DEBUG("\n");
+                TZONE_LOG_DEBUG("                 ... ");
+            }
+        }
+        TZONE_LOG_DEBUG("\n");
+    }
 
     (void)CC_SHA256(&rawSeed, rawSeedLength, (unsigned char*)&m_tzoneKey.seed);
 #else // OS(DARWIN) => !OS(DARWIN)
@@ -141,7 +158,8 @@ void TZoneHeapManager::init()
 
     m_state = TZoneHeapManager::Seeded;
 
-    atexit(dumpRegisterdTypesAtExit);
+    if (verbose)
+        atexit(dumpRegisteredTypesAtExit);
 }
 
 bool TZoneHeapManager::isReady()
@@ -189,7 +207,7 @@ static char* nameForTypeUpdateIndex(UniqueLockHolder&, unsigned index)
     return &typeNameTemplate.string[0];
 }
 
-void TZoneHeapManager::dumpRegisterdTypes()
+void TZoneHeapManager::dumpRegisteredTypes()
 {
     if (verbose && m_state >= TZoneHeapManager::Seeded) {
         if (!m_typeSizes.size())
@@ -201,27 +219,44 @@ void TZoneHeapManager::dumpRegisterdTypes()
         Vector<unsigned> bucketCountHistogram;
         unsigned totalTypeCount = 0;
         unsigned totalUseBucketCount = 0;
+        unsigned largestSizeClassCount = 0;
+
+        SizeAndAlign largestSizeClass;
 
         TZONE_LOG_DEBUG("TZoneHeap registered size classes: %zu\n", m_typeSizes.size());
-        TZONE_LOG_DEBUG("        Size      Align    Buckets    TypeCnt   UsedBkts\n");
-        TZONE_LOG_DEBUG("    --------   --------   --------   --------   --------\n");
+
+        TZONE_LOG_DEBUG("      Size  Align  Bckts  Types  Inuse ");
+        for (unsigned i = 0; i < largestBucketCount; i++)
+            TZONE_LOG_DEBUG("  %sBkt%u", i < 10 ? " " : "", i);
+        TZONE_LOG_DEBUG("\n");
+
+        TZONE_LOG_DEBUG("    ------  -----  -----  -----  ----- ");
+        for (unsigned i = 0; i < largestBucketCount; i++)
+            TZONE_LOG_DEBUG("  -----");
+        TZONE_LOG_DEBUG("\n");
+
         for (auto iter = m_typeSizes.begin(); iter < typeSizesEnd; iter++) {
             SizeAndAlign typeSizeAlign = *iter;
-
-            auto typeCount = m_typeCountBySizeAndAlignment.get(typeSizeAlign);
-            totalTypeCount += typeCount;
+            unsigned numBucketsThisSizeClass = bucketCountForSizeClass(typeSizeAlign);
 
             TZoneTypeBuckets* bucketsForSize = m_heapRefsBySizeAndAlignment.get(typeSizeAlign);
+            unsigned typeCount = bucketsForSize->numberOfTypesThisSizeClass;
+            totalTypeCount += bucketsForSize->numberOfTypesThisSizeClass;
+
             unsigned usedBuckets = 0;
 
             for (unsigned bucket = 0; bucket < bucketsForSize->numberOfBuckets; ++bucket) {
-                if (bucketsForSize->usedBucketBitmap & 1<<bucket)
+                if (bucketsForSize->bucketUseCounts[bucket])
                     usedBuckets++;
             }
 
             totalUseBucketCount += usedBuckets;
 
-            TZONE_LOG_DEBUG("    %8u   %8u   %8u   %8u   %8u\n", typeSizeAlign.size(), typeSizeAlign.alignment(), bucketCountForSizeClass(typeSizeAlign), typeCount, usedBuckets);
+            TZONE_LOG_DEBUG("    %6u  %5u  %5u  %5u  %5u ", typeSizeAlign.size(), typeSizeAlign.alignment(), numBucketsThisSizeClass, typeCount, usedBuckets);
+
+            for (unsigned bucket = 0; bucket < bucketsForSize->numberOfBuckets; ++bucket)
+                TZONE_LOG_DEBUG("  %5u", bucketsForSize->bucketUseCounts[bucket]);
+            TZONE_LOG_DEBUG("\n");
 
             auto bucketCount = bucketCountForSizeClass(typeSizeAlign);
 
@@ -231,7 +266,7 @@ void TZoneHeapManager::dumpRegisterdTypes()
             bucketCountHistogram[bucketCount] = bucketCountHistogram[bucketCount] + 1;
             if (typeCount > largestSizeClassCount) {
                 largestSizeClassCount = typeCount;
-                m_largestSizeClass = typeSizeAlign;
+                largestSizeClass = typeSizeAlign;
             }
         }
 
@@ -244,7 +279,7 @@ void TZoneHeapManager::dumpRegisterdTypes()
         }
         TZONE_LOG_DEBUG("\n");
 
-        TZONE_LOG_DEBUG("    Most populated size class:  size: %u alignment %u type count: %u\n", m_largestSizeClass.size(), m_largestSizeClass.alignment(), largestSizeClassCount);
+        TZONE_LOG_DEBUG("    Most populated size class:  size: %u alignment %u type count: %u\n", largestSizeClass.size(), largestSizeClass.alignment(), largestSizeClassCount);
     }
 }
 
@@ -260,6 +295,40 @@ void TZoneHeapManager::ensureSingleton()
     );
 };
 
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+BINLINE unsigned TZoneHeapManager::tzoneBucketForKey(UniqueLockHolder&, bmalloc_type* type, unsigned bucketCountForSize)
+{
+    static constexpr bool verboseBucketSelection = false;
+
+    SHA256ResultAsUnsigned sha256Result;
+
+    m_tzoneKey.className = type->name;
+    m_tzoneKey.sizeOfType = type->size;
+    m_tzoneKey.alignmentOfType = type->alignment;
+
+    (void)CC_SHA256(&m_tzoneKey, sizeof(TZoneHeapRandomizeKey), (unsigned char*)&sha256Result);
+
+    unsigned bucket = sha256Result[3] % bucketCountForSize;
+
+    if constexpr (verboseBucketSelection) {
+        TZONE_LOG_DEBUG("Choosing Bucket name: %p  size: %u  align: %u  ", m_tzoneKey.className, m_tzoneKey.sizeOfType, m_tzoneKey.alignmentOfType);
+        TZONE_LOG_DEBUG(" seed { ");
+        for (unsigned i = 0; i < CC_SHA1_DIGEST_LENGTH; ++i)
+            TZONE_LOG_DEBUG("%02x",  m_tzoneKey.seed[i]);
+        TZONE_LOG_DEBUG(" }\n");
+
+        TZONE_LOG_DEBUG("Result: {");
+        for (unsigned i = 0; i < 4; ++i)
+            TZONE_LOG_DEBUG(" %02llx",  sha256Result[i]);
+        TZONE_LOG_DEBUG(" }  bucket: %u\n", bucket);
+    }
+
+    return bucket;
+}
+
+BCOMPILER_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 TZoneHeapManager::TZoneTypeBuckets* TZoneHeapManager::populateBucketsForSizeClass(UniqueLockHolder& lock, SizeAndAlign typeSizeAlign)
 {
     RELEASE_BASSERT(m_state >= TZoneHeapManager::Seeded);
@@ -267,15 +336,18 @@ TZoneHeapManager::TZoneTypeBuckets* TZoneHeapManager::populateBucketsForSizeClas
 
     auto bucketCount = bucketCountForSizeClass(typeSizeAlign);
 
-    if (verbose) {
-        m_typeSizes.push(typeSizeAlign);
+    if constexpr (verbose) {
+        if (bucketCount > largestBucketCount)
+            largestBucketCount = bucketCount;
 
-        m_typeCountBySizeAndAlignment.set(typeSizeAlign, 1);
+        m_typeSizes.push(typeSizeAlign);
     }
 
     TZoneTypeBuckets* buckets = static_cast<TZoneTypeBuckets*>(zeroedMalloc(SIZE_TZONE_TYPE_BUCKETS(bucketCount), CompactAllocationMode::NonCompact));
 
     buckets->numberOfBuckets = bucketCount;
+    buckets->numberOfTypesThisSizeClass = 0;
+    buckets->bucketUseCounts.resize(bucketCount);
 
     for (unsigned i = 0; i < bucketCount; ++i) {
         char* typeName = !i ? nameForType(lock, typeSizeAlign.size(), typeSizeAlign.alignment(), i) : nameForTypeUpdateIndex(lock, i);
@@ -305,21 +377,20 @@ pas_heap_ref* TZoneHeapManager::heapRefForTZoneType(bmalloc_type* classType)
 
     TZoneTypeBuckets* bucketsForSize = nullptr;
 
-    if (m_heapRefsBySizeAndAlignment.contains(typeSizeAlign)) {
+    if (m_heapRefsBySizeAndAlignment.contains(typeSizeAlign))
         bucketsForSize = m_heapRefsBySizeAndAlignment.get(typeSizeAlign);
-        if (verbose) {
-            unsigned count = m_typeCountBySizeAndAlignment.get(typeSizeAlign);
-            m_typeCountBySizeAndAlignment.set(typeSizeAlign, ++count);
-        }
-    } else
+    else
         bucketsForSize = populateBucketsForSizeClass(lock, typeSizeAlign);
 
     unsigned bucket = tzoneBucketForKey(lock, classType, bucketsForSize->numberOfBuckets);
 
-    if (verbose) {
+    if constexpr (verbose) {
+        bucketsForSize->numberOfTypesThisSizeClass++;
+        bucketsForSize->bucketUseCounts[bucket]++;
+
         bucketsForSize->usedBucketBitmap |= 1 << bucket;
-        if (!(++registerHeapCount % 5))
-            dumpRegisterdTypes();
+        if (!(++registerHeapCount % 10))
+            dumpRegisteredTypes();
     }
 
     return &bucketsForSize->buckets[bucket].heapref;


### PR DESCRIPTION
#### 7098ad895d64acbb6fae3637fbc72cc53f777300
<pre>
[TZone] Update TZone debugging code
<a href="https://bugs.webkit.org/show_bug.cgi?id=281641">https://bugs.webkit.org/show_bug.cgi?id=281641</a>
<a href="https://rdar.apple.com/138083630">rdar://138083630</a>

Reviewed by Yijia Huang.

Added various debugging improvements to the TZone manager and allocation path for unannotated subclasses.
The changes for &quot;verbose&quot; compilation mode include:
 * Adding bucket counts for each size class.
 * Simplifying the data needed for statistics.
 * Using a separate verbose flag for the dump of bucket selection.
 * Moving all debug code to a .cpp file to speed up compilation when changing debug flags.

For the unannotated subclass allocation path, split the debug info into two lines so that the info isn’t truncated in the OS log.
Also fixed the spelling of the method dumpRegisteredTypes.

* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::TZoneHeapBase::provideHeap):
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::dumpRegisteredTypesAtExit):
(bmalloc::api::TZoneHeapManager::init):
(bmalloc::api::TZoneHeapManager::dumpRegisteredTypes):
(bmalloc::api::TZoneHeapManager::tzoneBucketForKey):
(bmalloc::api::TZoneHeapManager::populateBucketsForSizeClass):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
(bmalloc::api::dumpRegisterdTypesAtExit): Deleted.
(bmalloc::api::TZoneHeapManager::dumpRegisterdTypes): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
(bmalloc::api::TZoneHeapManager::tzoneBucketForKey): Deleted.

Canonical link: <a href="https://commits.webkit.org/285355@main">https://commits.webkit.org/285355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3603fd44b47a6442c50693b72d617bb9b065013

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23443 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15443 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21793 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65363 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78079 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71488 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64666 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6532 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93269 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47453 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20530 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->