### PR TITLE
AX: AXIsolatedTree::{collectNodeChangesForSubtree, removeSubtreeFromNodeMap} modify m_nodeMap children IDs when they shouldn't

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -417,6 +417,9 @@ public:
         // object from the nodemap, and rely on the normal updateChildren flow to repair parent relationships
         // as needed.
         m_nodeMap.remove(axID);
+        // Any queued parent updates no longer need to happen (and if we do try to process them, we'll crash,
+        // since this object is no longer in the node map).
+        m_needsParentUpdate.remove(axID);
     }
 #endif // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 
@@ -500,7 +503,7 @@ private:
     RefPtr<AXIsolatedTree> m_replacingTree;
     RefPtr<AccessibilityObject> m_rootOfSubtreeBeingUpdated;
 
-    // Stores the parent ID and children IDS for a given IsolatedObject.
+    // Stores the parent ID and children IDs for a given IsolatedObject.
     struct ParentChildrenIDs {
         Markable<AXID> parentID;
         Vector<AXID> childrenIDs;


### PR DESCRIPTION
#### 2206f4c04ec44388ffa00a53bc87fbe00d975c59
<pre>
AX: AXIsolatedTree::{collectNodeChangesForSubtree, removeSubtreeFromNodeMap} modify m_nodeMap children IDs when they shouldn&apos;t
<a href="https://bugs.webkit.org/show_bug.cgi?id=281642">https://bugs.webkit.org/show_bug.cgi?id=281642</a>
<a href="https://rdar.apple.com/138083925">rdar://138083925</a>

Reviewed by Chris Fleizach.

A key component of AXIsolatedTree::updateChildren is comparing the &quot;old&quot; children (what is in the node map) for an
object vs. it&apos;s new children (the result of AccessibilityObject::children()). This makes AXIsolatedTree::{collectNodeChangesForSubtree, removeSubtreeFromNodeMap}&apos;s
behavior of modifying the children IDs for existing entries in the node map problematic, as that can happen before we&apos;ve
had a chance to call `updateChildren`, thus making the old and new children &quot;match&quot; even though they have actually changed
since we last ran `updateChildren`. This means we won&apos;t create a new node change for this object, resulting in stale
properties and missing children.

Address this by changing collectNodeChangesForSubtree to only modify children IDs in the node map for new entries,
and removing this behavior outright from `removeSubtreeFromNodeMap`. In both cases, the children IDs will be corrected
as necessary when `updateChildren` does run. This is also more efficient -- we are doing strictly less work.

This change is required to fix a test (changing-aria-hidden-with-display-none-parent.html) in an upcoming patch, which
exposes this bug. The specific sequence in this case is that `removeSubtreeFromNodeMap` modifies the node map for an
object right before we call `updateChildren` for it, making the `updateChildren` do the incorrect thing.

* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::objectBecameIgnored):

Canonical link: <a href="https://commits.webkit.org/285352@main">https://commits.webkit.org/285352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575feb6b43dc022241a435713f2b900068124f9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56938 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64667 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6537 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2241 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48526 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->