### PR TITLE
Pass the current point to SVGPathSource segment parsing functions

### DIFF
--- a/Source/WebCore/rendering/style/BasicShapesShape.cpp
+++ b/Source/WebCore/rendering/style/BasicShapesShape.cpp
@@ -84,7 +84,7 @@ private:
         return SVGPathSegType::MoveToAbs;
     }
 
-    std::optional<MoveToSegment> parseMoveToSegment() override
+    std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) override
     {
         if (!m_nextIndex)
             return MoveToSegment { floatPointForLengthPoint(m_start, m_boxSize) };
@@ -93,25 +93,25 @@ private:
         return MoveToSegment { floatPointForLengthPoint(moveSegment.offset(), m_boxSize) };
     }
 
-    std::optional<LineToSegment> parseLineToSegment() override
+    std::optional<LineToSegment> parseLineToSegment(FloatPoint) override
     {
         auto& lineSegment = currentValue<ShapeLineSegment>();
         return LineToSegment { floatPointForLengthPoint(lineSegment.offset(), m_boxSize) };
     }
 
-    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment() override
+    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) override
     {
         auto& lineSegment = currentValue<ShapeHorizontalLineSegment>();
         return LineToHorizontalSegment { floatValueForLength(lineSegment.length(), m_boxSize.width()) };
     }
 
-    std::optional<LineToVerticalSegment> parseLineToVerticalSegment() override
+    std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) override
     {
         auto& lineSegment = currentValue<ShapeVerticalLineSegment>();
         return LineToVerticalSegment { floatValueForLength(lineSegment.length(), m_boxSize.height()) };
     }
 
-    std::optional<CurveToCubicSegment> parseCurveToCubicSegment() override
+    std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint) override
     {
         auto& curveSegment = currentValue<ShapeCurveSegment>();
         ASSERT(curveSegment.controlPoint2());
@@ -122,7 +122,7 @@ private:
         };
     }
 
-    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment() override
+    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment(FloatPoint) override
     {
         auto& curveSegment = currentValue<ShapeCurveSegment>();
         ASSERT(!curveSegment.controlPoint2());
@@ -132,7 +132,7 @@ private:
         };
     }
 
-    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment() override
+    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment(FloatPoint) override
     {
         auto& smoothSegment = currentValue<ShapeSmoothSegment>();
         ASSERT(smoothSegment.intermediatePoint());
@@ -142,13 +142,13 @@ private:
         };
     }
 
-    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() override
+    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment(FloatPoint) override
     {
         auto& smoothSegment = currentValue<ShapeSmoothSegment>();
         return CurveToQuadraticSmoothSegment { floatPointForLengthPoint(smoothSegment.offset(), m_boxSize) };
     }
 
-    std::optional<ArcToSegment> parseArcToSegment() override
+    std::optional<ArcToSegment> parseArcToSegment(FloatPoint) override
     {
         auto& arcSegment = currentValue<ShapeArcSegment>();
         auto radius = floatSizeForLengthSize(arcSegment.ellipseSize(), m_boxSize);

--- a/Source/WebCore/svg/SVGPathBlender.cpp
+++ b/Source/WebCore/svg/SVGPathBlender.cpp
@@ -120,19 +120,19 @@ FloatPoint SVGPathBlender::blendAnimatedFloatPoint(const FloatPoint& fromPoint, 
     return animatedPoint;
 }
 
-template<typename Function> using InvokeResult = typename std::invoke_result_t<Function, SVGPathSource>::value_type;
+template<typename Function> using InvokeResult = typename std::invoke_result_t<Function, SVGPathSource, FloatPoint>::value_type;
 template<typename Function> using ResultPair = std::pair<InvokeResult<Function>, InvokeResult<Function>>;
-template<typename Function> static std::optional<ResultPair<Function>> pullFromSources(SVGPathSource& fromSource, SVGPathSource& toSource, Function&& function)
+template<typename Function> static std::optional<ResultPair<Function>> pullFromSources(SVGPathSource& fromSource, SVGPathSource& toSource, Function&& function, FloatPoint currentPoint)
 {
     InvokeResult<Function> fromResult;
     if (fromSource.hasMoreData()) {
-        auto parsedFrom = std::invoke(function, fromSource);
+        auto parsedFrom = std::invoke(function, fromSource, currentPoint);
         if (!parsedFrom)
             return std::nullopt;
         fromResult = WTFMove(*parsedFrom);
     }
 
-    auto parsedTo = std::invoke(std::forward<Function>(function), toSource);
+    auto parsedTo = std::invoke(std::forward<Function>(function), toSource, currentPoint);
     if (!parsedTo)
         return std::nullopt;
 
@@ -141,7 +141,7 @@ template<typename Function> static std::optional<ResultPair<Function>> pullFromS
 
 bool SVGPathBlender::blendMoveToSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseMoveToSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseMoveToSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -162,7 +162,7 @@ bool SVGPathBlender::blendMoveToSegment(float progress)
 
 bool SVGPathBlender::blendLineToSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -179,7 +179,7 @@ bool SVGPathBlender::blendLineToSegment(float progress)
 
 bool SVGPathBlender::blendLineToHorizontalSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToHorizontalSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToHorizontalSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -196,7 +196,7 @@ bool SVGPathBlender::blendLineToHorizontalSegment(float progress)
 
 bool SVGPathBlender::blendLineToVerticalSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToVerticalSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseLineToVerticalSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -213,7 +213,7 @@ bool SVGPathBlender::blendLineToVerticalSegment(float progress)
 
 bool SVGPathBlender::blendCurveToCubicSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToCubicSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToCubicSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -233,7 +233,7 @@ bool SVGPathBlender::blendCurveToCubicSegment(float progress)
 
 bool SVGPathBlender::blendCurveToCubicSmoothSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToCubicSmoothSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToCubicSmoothSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -252,7 +252,7 @@ bool SVGPathBlender::blendCurveToCubicSmoothSegment(float progress)
 
 bool SVGPathBlender::blendCurveToQuadraticSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToQuadraticSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToQuadraticSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -271,7 +271,7 @@ bool SVGPathBlender::blendCurveToQuadraticSegment(float progress)
 
 bool SVGPathBlender::blendCurveToQuadraticSmoothSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToQuadraticSmoothSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseCurveToQuadraticSmoothSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 
@@ -288,7 +288,7 @@ bool SVGPathBlender::blendCurveToQuadraticSmoothSegment(float progress)
 
 bool SVGPathBlender::blendArcToSegment(float progress)
 {
-    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseArcToSegment);
+    auto result = pullFromSources(m_fromSource, m_toSource, &SVGPathSource::parseArcToSegment, m_fromCurrentPoint);
     if (!result)
         return false;
 

--- a/Source/WebCore/svg/SVGPathByteStreamSource.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.cpp
@@ -43,35 +43,35 @@ std::optional<SVGPathSegType> SVGPathByteStreamSource::parseSVGSegmentType()
     return readSVGSegmentType();
 }
 
-std::optional<SVGPathSource::MoveToSegment> SVGPathByteStreamSource::parseMoveToSegment()
+std::optional<SVGPathSource::MoveToSegment> SVGPathByteStreamSource::parseMoveToSegment(FloatPoint)
 {
     MoveToSegment segment;
     segment.targetPoint = readFloatPoint();
     return segment;
 }
 
-std::optional<SVGPathSource::LineToSegment> SVGPathByteStreamSource::parseLineToSegment()
+std::optional<SVGPathSource::LineToSegment> SVGPathByteStreamSource::parseLineToSegment(FloatPoint)
 {
     LineToSegment segment;
     segment.targetPoint = readFloatPoint();
     return segment;
 }
 
-std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathByteStreamSource::parseLineToHorizontalSegment()
+std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathByteStreamSource::parseLineToHorizontalSegment(FloatPoint)
 {
     LineToHorizontalSegment segment;
     segment.x = readFloat();
     return segment;
 }
 
-std::optional<SVGPathSource::LineToVerticalSegment> SVGPathByteStreamSource::parseLineToVerticalSegment()
+std::optional<SVGPathSource::LineToVerticalSegment> SVGPathByteStreamSource::parseLineToVerticalSegment(FloatPoint)
 {
     LineToVerticalSegment segment;
     segment.y = readFloat();
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToCubicSegment> SVGPathByteStreamSource::parseCurveToCubicSegment()
+std::optional<SVGPathSource::CurveToCubicSegment> SVGPathByteStreamSource::parseCurveToCubicSegment(FloatPoint)
 {
     CurveToCubicSegment segment;
     segment.point1 = readFloatPoint();
@@ -80,7 +80,7 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathByteStreamSource::parse
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathByteStreamSource::parseCurveToCubicSmoothSegment()
+std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathByteStreamSource::parseCurveToCubicSmoothSegment(FloatPoint)
 {
     CurveToCubicSmoothSegment segment;
     segment.point2 = readFloatPoint();
@@ -88,7 +88,7 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathByteStreamSource:
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathByteStreamSource::parseCurveToQuadraticSegment()
+std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathByteStreamSource::parseCurveToQuadraticSegment(FloatPoint)
 {
     CurveToQuadraticSegment segment;
     segment.point1 = readFloatPoint();
@@ -96,14 +96,14 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathByteStreamSource::p
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathByteStreamSource::parseCurveToQuadraticSmoothSegment()
+std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathByteStreamSource::parseCurveToQuadraticSmoothSegment(FloatPoint)
 {
     CurveToQuadraticSmoothSegment segment;
     segment.targetPoint = readFloatPoint();
     return segment;
 }
 
-std::optional<SVGPathSource::ArcToSegment> SVGPathByteStreamSource::parseArcToSegment()
+std::optional<SVGPathSource::ArcToSegment> SVGPathByteStreamSource::parseArcToSegment(FloatPoint)
 {
     ArcToSegment segment;
     segment.rx = readFloat();

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -35,15 +35,15 @@ private:
     SVGPathSegType nextCommand(SVGPathSegType) final;
 
     std::optional<SVGPathSegType> parseSVGSegmentType() final;
-    std::optional<MoveToSegment> parseMoveToSegment() final;
-    std::optional<LineToSegment> parseLineToSegment() final;
-    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment() final;
-    std::optional<LineToVerticalSegment> parseLineToVerticalSegment() final;
-    std::optional<CurveToCubicSegment> parseCurveToCubicSegment() final;
-    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment() final;
-    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment() final;
-    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() final;
-    std::optional<ArcToSegment> parseArcToSegment() final;
+    std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) final;
+    std::optional<LineToSegment> parseLineToSegment(FloatPoint) final;
+    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) final;
+    std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) final;
+    std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint) final;
+    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment(FloatPoint) final;
+    std::optional<ArcToSegment> parseArcToSegment(FloatPoint) final;
 
 #if COMPILER(MSVC)
 #pragma warning(disable: 4701)

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -75,7 +75,7 @@ void SVGPathParser::parseClosePathSegment()
 
 bool SVGPathParser::parseMoveToSegment()
 {
-    auto result = m_source->parseMoveToSegment();
+    auto result = m_source->parseMoveToSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -94,7 +94,7 @@ bool SVGPathParser::parseMoveToSegment()
 
 bool SVGPathParser::parseLineToSegment()
 {
-    auto result = m_source->parseLineToSegment();
+    auto result = m_source->parseLineToSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -111,7 +111,7 @@ bool SVGPathParser::parseLineToSegment()
 
 bool SVGPathParser::parseLineToHorizontalSegment()
 {
-    auto result = m_source->parseLineToHorizontalSegment();
+    auto result = m_source->parseLineToHorizontalSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -128,7 +128,7 @@ bool SVGPathParser::parseLineToHorizontalSegment()
 
 bool SVGPathParser::parseLineToVerticalSegment()
 {
-    auto result = m_source->parseLineToVerticalSegment();
+    auto result = m_source->parseLineToVerticalSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -145,7 +145,7 @@ bool SVGPathParser::parseLineToVerticalSegment()
 
 bool SVGPathParser::parseCurveToCubicSegment()
 {
-    auto result = m_source->parseCurveToCubicSegment();
+    auto result = m_source->parseCurveToCubicSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -166,7 +166,7 @@ bool SVGPathParser::parseCurveToCubicSegment()
 
 bool SVGPathParser::parseCurveToCubicSmoothSegment()
 {
-    auto result = m_source->parseCurveToCubicSmoothSegment();
+    auto result = m_source->parseCurveToCubicSmoothSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -196,7 +196,7 @@ bool SVGPathParser::parseCurveToCubicSmoothSegment()
 
 bool SVGPathParser::parseCurveToQuadraticSegment()
 {
-    auto result = m_source->parseCurveToQuadraticSegment();
+    auto result = m_source->parseCurveToQuadraticSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -226,7 +226,7 @@ bool SVGPathParser::parseCurveToQuadraticSegment()
 
 bool SVGPathParser::parseCurveToQuadraticSmoothSegment()
 {
-    auto result = m_source->parseCurveToQuadraticSmoothSegment();
+    auto result = m_source->parseCurveToQuadraticSmoothSegment(m_currentPoint);
     if (!result)
         return false;
 
@@ -260,7 +260,7 @@ bool SVGPathParser::parseCurveToQuadraticSmoothSegment()
 
 bool SVGPathParser::parseArcToSegment()
 {
-    auto result = m_source->parseArcToSegment();
+    auto result = m_source->parseArcToSegment(m_currentPoint);
     if (!result)
         return false;
 

--- a/Source/WebCore/svg/SVGPathSegListSource.cpp
+++ b/Source/WebCore/svg/SVGPathSegListSource.cpp
@@ -55,7 +55,7 @@ std::optional<SVGPathSegType> SVGPathSegListSource::parseSVGSegmentType()
     return pathSegType;
 }
 
-std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSegment()
+std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::MoveToAbs || m_segment->pathSegType() == SVGPathSegType::MoveToRel);
@@ -66,7 +66,7 @@ std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSeg
     return segment;
 }
 
-std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSegment()
+std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToAbs || m_segment->pathSegType() == SVGPathSegType::LineToRel);
@@ -77,7 +77,7 @@ std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSeg
     return segment;
 }
 
-std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::parseLineToHorizontalSegment()
+std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::parseLineToHorizontalSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToHorizontalAbs || m_segment->pathSegType() == SVGPathSegType::LineToHorizontalRel);
@@ -88,7 +88,7 @@ std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::pars
     return segment;
 }
 
-std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseLineToVerticalSegment()
+std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseLineToVerticalSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToVerticalAbs || m_segment->pathSegType() == SVGPathSegType::LineToVerticalRel);
@@ -99,7 +99,7 @@ std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseL
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCurveToCubicSegment()
+std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCurveToCubicSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicRel);
@@ -112,7 +112,7 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCur
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::parseCurveToCubicSmoothSegment()
+std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::parseCurveToCubicSmoothSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothRel);
@@ -124,7 +124,7 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::pa
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::parseCurveToQuadraticSegment()
+std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::parseCurveToQuadraticSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticRel);
@@ -136,7 +136,7 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::pars
     return segment;
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource::parseCurveToQuadraticSmoothSegment()
+std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource::parseCurveToQuadraticSmoothSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothRel);
@@ -147,7 +147,7 @@ std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource
     return segment;
 }
 
-std::optional<SVGPathSource::ArcToSegment> SVGPathSegListSource::parseArcToSegment()
+std::optional<SVGPathSource::ArcToSegment> SVGPathSegListSource::parseArcToSegment(FloatPoint)
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::ArcAbs || m_segment->pathSegType() == SVGPathSegType::ArcRel);

--- a/Source/WebCore/svg/SVGPathSegListSource.h
+++ b/Source/WebCore/svg/SVGPathSegListSource.h
@@ -40,15 +40,15 @@ private:
     SVGPathSegType nextCommand(SVGPathSegType) final;
 
     std::optional<SVGPathSegType> parseSVGSegmentType() final;
-    std::optional<MoveToSegment> parseMoveToSegment() final;
-    std::optional<LineToSegment> parseLineToSegment() final;
-    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment() final;
-    std::optional<LineToVerticalSegment> parseLineToVerticalSegment() final;
-    std::optional<CurveToCubicSegment> parseCurveToCubicSegment() final;
-    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment() final;
-    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment() final;
-    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() final;
-    std::optional<ArcToSegment> parseArcToSegment() final;
+    std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) final;
+    std::optional<LineToSegment> parseLineToSegment(FloatPoint) final;
+    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) final;
+    std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) final;
+    std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint) final;
+    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment(FloatPoint) final;
+    std::optional<ArcToSegment> parseArcToSegment(FloatPoint) final;
 
     SingleThreadWeakRef<const SVGPathSegList> m_pathSegList;
     RefPtr<SVGPathSeg> m_segment;

--- a/Source/WebCore/svg/SVGPathSource.h
+++ b/Source/WebCore/svg/SVGPathSource.h
@@ -51,46 +51,46 @@ public:
     struct MoveToSegment {
         FloatPoint targetPoint;
     };
-    virtual std::optional<MoveToSegment> parseMoveToSegment() = 0;
+    virtual std::optional<MoveToSegment> parseMoveToSegment(FloatPoint currentPoint) = 0;
 
     struct LineToSegment {
         FloatPoint targetPoint;
     };
-    virtual std::optional<LineToSegment> parseLineToSegment() = 0;
+    virtual std::optional<LineToSegment> parseLineToSegment(FloatPoint currentPoint) = 0;
 
     struct LineToHorizontalSegment {
         float x = 0;
     };
-    virtual std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment() = 0;
+    virtual std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint currentPoint) = 0;
 
     struct LineToVerticalSegment {
         float y = 0;
     };
-    virtual std::optional<LineToVerticalSegment> parseLineToVerticalSegment() = 0;
+    virtual std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint currentPoint) = 0;
 
     struct CurveToCubicSegment {
         FloatPoint point1;
         FloatPoint point2;
         FloatPoint targetPoint;
     };
-    virtual std::optional<CurveToCubicSegment> parseCurveToCubicSegment() = 0;
+    virtual std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint currentPoint) = 0;
 
     struct CurveToCubicSmoothSegment {
         FloatPoint point2;
         FloatPoint targetPoint;
     };
-    virtual std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment() = 0;
+    virtual std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment(FloatPoint currentPoint) = 0;
 
     struct CurveToQuadraticSegment {
         FloatPoint point1;
         FloatPoint targetPoint;
     };
-    virtual std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment() = 0;
+    virtual std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment(FloatPoint currentPoint) = 0;
 
     struct CurveToQuadraticSmoothSegment {
         FloatPoint targetPoint;
     };
-    virtual std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() = 0;
+    virtual std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment(FloatPoint currentPoint) = 0;
 
     struct ArcToSegment {
         float rx = 0;
@@ -100,7 +100,7 @@ public:
         bool sweep = false;
         FloatPoint targetPoint;
     };
-    virtual std::optional<ArcToSegment> parseArcToSegment() = 0;
+    virtual std::optional<ArcToSegment> parseArcToSegment(FloatPoint currentPoint) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathStringViewSource.cpp
+++ b/Source/WebCore/svg/SVGPathStringViewSource.cpp
@@ -136,7 +136,7 @@ std::optional<SVGPathSegType> SVGPathStringViewSource::parseSVGSegmentType()
     });
 }
 
-std::optional<SVGPathSource::MoveToSegment> SVGPathStringViewSource::parseMoveToSegment()
+std::optional<SVGPathSource::MoveToSegment> SVGPathStringViewSource::parseMoveToSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<MoveToSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -149,7 +149,7 @@ std::optional<SVGPathSource::MoveToSegment> SVGPathStringViewSource::parseMoveTo
     });
 }
 
-std::optional<SVGPathSource::LineToSegment> SVGPathStringViewSource::parseLineToSegment()
+std::optional<SVGPathSource::LineToSegment> SVGPathStringViewSource::parseLineToSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<LineToSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -162,7 +162,7 @@ std::optional<SVGPathSource::LineToSegment> SVGPathStringViewSource::parseLineTo
     });
 }
 
-std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringViewSource::parseLineToHorizontalSegment()
+std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringViewSource::parseLineToHorizontalSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<LineToHorizontalSegment> {
         auto x = parseNumber(buffer);
@@ -175,7 +175,7 @@ std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringViewSource::p
     });
 }
 
-std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringViewSource::parseLineToVerticalSegment()
+std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringViewSource::parseLineToVerticalSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<LineToVerticalSegment> {
         auto y = parseNumber(buffer);
@@ -188,7 +188,7 @@ std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringViewSource::par
     });
 }
 
-std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringViewSource::parseCurveToCubicSegment()
+std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringViewSource::parseCurveToCubicSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<CurveToCubicSegment> {
         auto point1 = parseFloatPoint(buffer);
@@ -211,7 +211,7 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringViewSource::parse
     });
 }
 
-std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringViewSource::parseCurveToCubicSmoothSegment()
+std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringViewSource::parseCurveToCubicSmoothSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<CurveToCubicSmoothSegment> {
         auto point2 = parseFloatPoint(buffer);
@@ -229,7 +229,7 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringViewSource:
     });
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringViewSource::parseCurveToQuadraticSegment()
+std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringViewSource::parseCurveToQuadraticSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<CurveToQuadraticSegment> {
         auto point1 = parseFloatPoint(buffer);
@@ -247,7 +247,7 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringViewSource::p
     });
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringViewSource::parseCurveToQuadraticSmoothSegment()
+std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringViewSource::parseCurveToQuadraticSmoothSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<CurveToQuadraticSmoothSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -260,7 +260,7 @@ std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringViewSou
     });
 }
 
-std::optional<SVGPathSource::ArcToSegment> SVGPathStringViewSource::parseArcToSegment()
+std::optional<SVGPathSource::ArcToSegment> SVGPathStringViewSource::parseArcToSegment(FloatPoint)
 {
     return parse([](auto& buffer) -> std::optional<ArcToSegment> {
         auto rx = parseNumber(buffer);

--- a/Source/WebCore/svg/SVGPathStringViewSource.h
+++ b/Source/WebCore/svg/SVGPathStringViewSource.h
@@ -36,15 +36,15 @@ private:
     SVGPathSegType nextCommand(SVGPathSegType previousCommand) final;
 
     std::optional<SVGPathSegType> parseSVGSegmentType() final;
-    std::optional<MoveToSegment> parseMoveToSegment() final;
-    std::optional<LineToSegment> parseLineToSegment() final;
-    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment() final;
-    std::optional<LineToVerticalSegment> parseLineToVerticalSegment() final;
-    std::optional<CurveToCubicSegment> parseCurveToCubicSegment() final;
-    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment() final;
-    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment() final;
-    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() final;
-    std::optional<ArcToSegment> parseArcToSegment() final;
+    std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) final;
+    std::optional<LineToSegment> parseLineToSegment(FloatPoint) final;
+    std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) final;
+    std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) final;
+    std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint) final;
+    std::optional<CurveToCubicSmoothSegment> parseCurveToCubicSmoothSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSegment> parseCurveToQuadraticSegment(FloatPoint) final;
+    std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment(FloatPoint) final;
+    std::optional<ArcToSegment> parseArcToSegment(FloatPoint) final;
 
     template<typename Function> decltype(auto) parse(Function&&);
 


### PR DESCRIPTION
#### 75438506e981119be69203a2c709d2e02a8c5215
<pre>
Pass the current point to SVGPathSource segment parsing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=281645">https://bugs.webkit.org/show_bug.cgi?id=281645</a>
<a href="https://rdar.apple.com/138088365">rdar://138088365</a>

Reviewed by Alan Baradlay.

The CSS `shape()` function is getting start/end-relative control points[1] and so its SVGPathSource
implementation will need to know the current path point. So pass the current point to all SVGPathSource
functions that create non-trivial segments.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773">https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773</a>

* Source/WebCore/rendering/style/BasicShapesShape.cpp:
* Source/WebCore/svg/SVGPathBlender.cpp:
(WebCore::pullFromSources):
(WebCore::SVGPathBlender::blendMoveToSegment):
(WebCore::SVGPathBlender::blendLineToSegment):
(WebCore::SVGPathBlender::blendLineToHorizontalSegment):
(WebCore::SVGPathBlender::blendLineToVerticalSegment):
(WebCore::SVGPathBlender::blendCurveToCubicSegment):
(WebCore::SVGPathBlender::blendCurveToCubicSmoothSegment):
(WebCore::SVGPathBlender::blendCurveToQuadraticSegment):
(WebCore::SVGPathBlender::blendCurveToQuadraticSmoothSegment):
(WebCore::SVGPathBlender::blendArcToSegment):
* Source/WebCore/svg/SVGPathByteStreamSource.cpp:
(WebCore::SVGPathByteStreamSource::parseMoveToSegment):
(WebCore::SVGPathByteStreamSource::parseLineToSegment):
(WebCore::SVGPathByteStreamSource::parseLineToHorizontalSegment):
(WebCore::SVGPathByteStreamSource::parseLineToVerticalSegment):
(WebCore::SVGPathByteStreamSource::parseCurveToCubicSegment):
(WebCore::SVGPathByteStreamSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathByteStreamSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathByteStreamSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathByteStreamSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathByteStreamSource.h:
* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::SVGPathParser::parseMoveToSegment):
(WebCore::SVGPathParser::parseLineToSegment):
(WebCore::SVGPathParser::parseLineToHorizontalSegment):
(WebCore::SVGPathParser::parseLineToVerticalSegment):
(WebCore::SVGPathParser::parseCurveToCubicSegment):
(WebCore::SVGPathParser::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathParser::parseCurveToQuadraticSegment):
(WebCore::SVGPathParser::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathParser::parseArcToSegment):
* Source/WebCore/svg/SVGPathSegListSource.cpp:
(WebCore::SVGPathSegListSource::parseMoveToSegment):
(WebCore::SVGPathSegListSource::parseLineToSegment):
(WebCore::SVGPathSegListSource::parseLineToHorizontalSegment):
(WebCore::SVGPathSegListSource::parseLineToVerticalSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathSegListSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathSegListSource.h:
* Source/WebCore/svg/SVGPathSource.h:
* Source/WebCore/svg/SVGPathStringViewSource.cpp:
(WebCore::SVGPathStringViewSource::parseMoveToSegment):
(WebCore::SVGPathStringViewSource::parseLineToSegment):
(WebCore::SVGPathStringViewSource::parseLineToHorizontalSegment):
(WebCore::SVGPathStringViewSource::parseLineToVerticalSegment):
(WebCore::SVGPathStringViewSource::parseCurveToCubicSegment):
(WebCore::SVGPathStringViewSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathStringViewSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathStringViewSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathStringViewSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathStringViewSource.h:

Canonical link: <a href="https://commits.webkit.org/285347@main">https://commits.webkit.org/285347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d73f5211040b160814056cfde5c343d78dbd3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23284 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15455 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21812 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78098 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19205 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62247 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6544 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2256 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->