### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AuthenticatorTransportService and subclasses

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -411,7 +411,7 @@ void AuthenticatorManager::cancelRequest()
     m_requestTimeOutTimer.stop();
 }
 
-UniqueRef<AuthenticatorTransportService> AuthenticatorManager::createService(AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
+Ref<AuthenticatorTransportService> AuthenticatorManager::createService(AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
 {
     return AuthenticatorTransportService::create(transport, observer);
 }
@@ -430,7 +430,7 @@ void AuthenticatorManager::startDiscovery(const TransportSet& transports)
     ASSERT(RunLoop::isMain());
     ASSERT(m_services.isEmpty() && transports.size() <= maxTransportNumber);
     m_services = WTF::map(transports, [this](auto& transport) {
-        auto service = createService(transport, *this);
+        Ref service = createService(transport, *this);
         service->startDiscovery();
         return service;
     });

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -109,7 +109,7 @@ private:
     void cancelRequest() final;
 
     // Overriden by MockAuthenticatorManager.
-    virtual UniqueRef<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const;
+    virtual Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const;
     // Overriden to return every exception for tests to confirm.
     virtual void respondReceivedInternal(Respond&&) { }
     virtual void filterTransports(TransportSet&) const;
@@ -127,7 +127,7 @@ private:
     RunLoop::Timer m_requestTimeOutTimer;
     RefPtr<AuthenticatorPresenterCoordinator> m_presenter;
 
-    Vector<UniqueRef<AuthenticatorTransportService>> m_services;
+    Vector<Ref<AuthenticatorTransportService>> m_services;
     HashSet<Ref<Authenticator>> m_authenticators;
 
     Mode m_mode { Mode::Compatible };

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
@@ -37,43 +37,43 @@
 #include "MockNfcService.h"
 #include "NfcService.h"
 #include <wtf/RunLoop.h>
-#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorTransportService);
 
-UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::create(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer)
+Ref<AuthenticatorTransportService> AuthenticatorTransportService::create(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer)
 {
     switch (transport) {
     case WebCore::AuthenticatorTransport::Internal:
-        return makeUniqueRef<LocalService>(observer);
+        return LocalService::create(observer);
     case WebCore::AuthenticatorTransport::Usb:
-        return makeUniqueRef<HidService>(observer);
+        return HidService::create(observer);
     case WebCore::AuthenticatorTransport::Nfc:
-        return makeUniqueRef<NfcService>(observer);
+        return NfcService::create(observer);
     case WebCore::AuthenticatorTransport::SmartCard:
-        return makeUniqueRef<CcidService>(observer);
+        return CcidService::create(observer);
     default:
         ASSERT_NOT_REACHED();
-        return makeUniqueRef<LocalService>(observer);
+        return LocalService::create(observer);
     }
 }
 
-UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::createMock(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+Ref<AuthenticatorTransportService> AuthenticatorTransportService::createMock(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
 {
     switch (transport) {
     case WebCore::AuthenticatorTransport::Internal:
-        return makeUniqueRef<MockLocalService>(observer, configuration);
+        return MockLocalService::create(observer, configuration);
     case WebCore::AuthenticatorTransport::Usb:
-        return makeUniqueRef<MockHidService>(observer, configuration);
+        return MockHidService::create(observer, configuration);
     case WebCore::AuthenticatorTransport::Nfc:
-        return makeUniqueRef<MockNfcService>(observer, configuration);
+        return MockNfcService::create(observer, configuration);
     case WebCore::AuthenticatorTransport::SmartCard:
-        return makeUniqueRef<MockCcidService>(observer, configuration);
+        return MockCcidService::create(observer, configuration);
     default:
         ASSERT_NOT_REACHED();
-        return makeUniqueRef<MockLocalService>(observer, configuration);
+        return MockLocalService::create(observer, configuration);
     }
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
@@ -29,20 +29,10 @@
 
 #include "WebAuthenticationFlags.h"
 #include <WebCore/AuthenticatorTransport.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class AuthenticatorTransportService;
-class AuthenticatorTransportServiceObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AuthenticatorTransportService> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AuthenticatorTransportServiceObserver> : std::true_type { };
-}
 
 namespace WebCore {
 struct MockWebAuthenticationConfiguration;
@@ -52,20 +42,23 @@ namespace WebKit {
 
 class Authenticator;
 
-class AuthenticatorTransportServiceObserver : public CanMakeWeakPtr<AuthenticatorTransportServiceObserver> {
+class AuthenticatorTransportServiceObserver : public AbstractRefCountedAndCanMakeWeakPtr<AuthenticatorTransportServiceObserver> {
 public:
     virtual ~AuthenticatorTransportServiceObserver() = default;
 
     virtual void authenticatorAdded(Ref<Authenticator>&&) = 0;
     virtual void serviceStatusUpdated(WebAuthenticationStatus) = 0;
+
+protected:
+    AuthenticatorTransportServiceObserver() = default;
 };
 
-class AuthenticatorTransportService : public CanMakeWeakPtr<AuthenticatorTransportService> {
+class AuthenticatorTransportService : public AbstractRefCountedAndCanMakeWeakPtr<AuthenticatorTransportService> {
     WTF_MAKE_TZONE_ALLOCATED(AuthenticatorTransportService);
     WTF_MAKE_NONCOPYABLE(AuthenticatorTransportService);
 public:
-    static UniqueRef<AuthenticatorTransportService> create(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&);
-    static UniqueRef<AuthenticatorTransportService> createMock(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<AuthenticatorTransportService> create(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&);
+    static Ref<AuthenticatorTransportService> createMock(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
     virtual ~AuthenticatorTransportService() = default;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
@@ -38,21 +38,12 @@ OBJC_CLASS _WKSmartCardSlotObserver;
 OBJC_CLASS _WKSmartCardSlotStateObserver;
 
 namespace WebKit {
-class CcidService;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CcidService> : std::true_type { };
-}
-
-namespace WebKit {
 
 class CcidConnection;
 
 class CcidService : public FidoService {
 public:
-    explicit CcidService(AuthenticatorTransportServiceObserver&);
+    static Ref<CcidService> create(AuthenticatorTransportServiceObserver&);
     ~CcidService();
 
     static bool isAvailable();
@@ -61,6 +52,9 @@ public:
 
     void updateSlots(NSArray *slots);
     void onValidCard(RetainPtr<TKSmartCard>&&);
+
+protected:
+    explicit CcidService(AuthenticatorTransportServiceObserver&);
 
 private:
     void startDiscoveryInternal() final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -55,6 +55,11 @@
 
 namespace WebKit {
 
+Ref<CcidService> CcidService::create(AuthenticatorTransportServiceObserver& observer)
+{
+    return adoptRef(*new CcidService(observer));
+}
+
 CcidService::CcidService(AuthenticatorTransportServiceObserver& observer)
     : FidoService(observer)
     , m_restartTimer(RunLoop::main(), this, &CcidService::platformStartDiscovery)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
@@ -37,10 +37,13 @@ class HidConnection;
 
 class HidService : public FidoService {
 public:
-    explicit HidService(AuthenticatorTransportServiceObserver&);
+    static Ref<HidService> create(AuthenticatorTransportServiceObserver&);
     ~HidService();
 
     void deviceAdded(IOHIDDeviceRef);
+
+protected:
+    explicit HidService(AuthenticatorTransportServiceObserver&);
 
 private:
     void startDiscoveryInternal() final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -50,6 +50,11 @@ static void deviceRemovedCallback(void* context, IOReturn, void*, IOHIDDeviceRef
 }
 #endif // HAVE(SECURITY_KEY_API)
 
+Ref<HidService> HidService::create(AuthenticatorTransportServiceObserver& observer)
+{
+    return adoptRef(*new HidService(observer));
+}
+
 HidService::HidService(AuthenticatorTransportServiceObserver& observer)
     : FidoService(observer)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
@@ -33,11 +33,18 @@ namespace WebKit {
 
 class LocalConnection;
 
-class LocalService : public AuthenticatorTransportService {
+class LocalService : public AuthenticatorTransportService, public RefCounted<LocalService> {
+    WTF_MAKE_TZONE_ALLOCATED(LocalService);
 public:
-    explicit LocalService(AuthenticatorTransportServiceObserver&);
+    static Ref<LocalService> create(AuthenticatorTransportServiceObserver&);
 
     static bool isAvailable();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+protected:
+    explicit LocalService(AuthenticatorTransportServiceObserver&);
 
 private:
     void startDiscoveryInternal() final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
@@ -30,9 +30,7 @@
 
 #import "LocalAuthenticator.h"
 #import "LocalConnection.h"
-
-#import "AppAttestInternalSoftLink.h"
-#import "LocalAuthenticationSoftLink.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/LocalServiceAdditions.h>
@@ -40,7 +38,17 @@
 #define LOCAL_SERVICE_ADDITIONS
 #endif
 
+#import "AppAttestInternalSoftLink.h"
+#import "LocalAuthenticationSoftLink.h"
+
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalService);
+
+Ref<LocalService> LocalService::create(AuthenticatorTransportServiceObserver& observer)
+{
+    return adoptRef(*new LocalService(observer));
+}
 
 LocalService::LocalService(AuthenticatorTransportServiceObserver& observer)
     : AuthenticatorTransportService(observer)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -105,7 +105,8 @@ void NfcConnection::stop() const
 
 void NfcConnection::didDetectTags(NSArray *tags)
 {
-    if (!m_service || !tags.count)
+    RefPtr service = m_service.get();
+    if (!service || !tags.count)
         return;
 
     // A physical NFC tag could have multiple interfaces.
@@ -114,7 +115,7 @@ void NfcConnection::didDetectTags(NSArray *tags)
     for (NFTag *tag : tags) {
         if ([tagID isEqualToData:tag.tagID])
             continue;
-        m_service->didDetectMultipleTags();
+        service->didDetectMultipleTags();
         restartPolling();
         return;
     }
@@ -130,7 +131,7 @@ void NfcConnection::didDetectTags(NSArray *tags)
             continue;
         }
 
-        m_service->didConnectTag();
+        service->didConnectTag();
         return;
     }
     restartPolling();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
@@ -33,21 +33,12 @@
 OBJC_CLASS NFReaderSession;
 
 namespace WebKit {
-class NfcService;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::NfcService> : std::true_type { };
-}
-
-namespace WebKit {
 
 class NfcConnection;
 
 class NfcService : public FidoService {
 public:
-    explicit NfcService(AuthenticatorTransportServiceObserver&);
+    static Ref<NfcService> create(AuthenticatorTransportServiceObserver&);
     ~NfcService();
 
     static bool isAvailable();
@@ -56,8 +47,10 @@ public:
     void didConnectTag();
     void didDetectMultipleTags() const;
 
-#if HAVE(NEAR_FIELD)
 protected:
+    explicit NfcService(AuthenticatorTransportServiceObserver&);
+
+#if HAVE(NEAR_FIELD)
     void setConnection(Ref<NfcConnection>&&); // For MockNfcConnection
 #endif
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
@@ -39,15 +39,18 @@
 
 namespace WebKit {
 
+Ref<NfcService> NfcService::create(AuthenticatorTransportServiceObserver& observer)
+{
+    return adoptRef(*new NfcService(observer));
+}
+
 NfcService::NfcService(AuthenticatorTransportServiceObserver& observer)
     : FidoService(observer)
     , m_restartTimer(RunLoop::main(), this, &NfcService::platformStartDiscovery)
 {
 }
 
-NfcService::~NfcService()
-{
-}
+NfcService::~NfcService() = default;
 
 bool NfcService::isAvailable()
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
@@ -40,7 +40,7 @@ MockAuthenticatorManager::MockAuthenticatorManager(WebCore::MockWebAuthenticatio
 {
 }
 
-UniqueRef<AuthenticatorTransportService> MockAuthenticatorManager::createService(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
+Ref<AuthenticatorTransportService> MockAuthenticatorManager::createService(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
 {
     return AuthenticatorTransportService::createMock(transport, observer, m_testConfiguration);
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
@@ -42,7 +42,7 @@ public:
 private:
     explicit MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&&);
 
-    UniqueRef<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
+    Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
     void respondReceivedInternal(Respond&&) final;
     void filterTransports(TransportSet&) const;
     void runPresenterInternal(const TransportSet&) final { }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
@@ -33,23 +33,16 @@
 OBJC_CLASS NSData;
 
 namespace WebKit {
-class MockCcidService;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::MockCcidService> : std::true_type { };
-}
-
-namespace WebKit {
 
 class MockCcidService final : public CcidService {
 public:
-    MockCcidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockCcidService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
     RetainPtr<NSData> nextReply();
 
 private:
+    MockCcidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+
     void platformStartDiscovery() final;
 
     WebCore::MockWebAuthenticationConfiguration m_configuration;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -60,12 +60,17 @@
 
 - (void)transmitRequest:(NSData *)request reply:(void(^)(NSData * response, NSError * error))reply
 {
-    reply(m_service->nextReply().get(), nil);
+    reply(Ref { *m_service }->nextReply().get(), nil);
 }
 
 @end
 
 namespace WebKit {
+
+Ref<MockCcidService> MockCcidService::create(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockCcidService(observer, configuration));
+}
 
 MockCcidService::MockCcidService(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : CcidService(observer)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
@@ -33,6 +33,11 @@
 
 namespace WebKit {
 
+Ref<MockHidService> MockHidService::create(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockHidService(observer, configuration));
+}
+
 MockHidService::MockHidService(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : HidService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
@@ -34,9 +34,11 @@ namespace WebKit {
 
 class MockHidService final : public HidService {
 public:
-    MockHidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockHidService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
 private:
+    MockHidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+
     void platformStartDiscovery() final;
     Ref<HidConnection> createHidConnection(IOHIDDeviceRef) const final;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
@@ -34,9 +34,11 @@ namespace WebKit {
 
 class MockLocalService final : public LocalService {
 public:
-    MockLocalService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockLocalService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
 private:
+    MockLocalService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+
     bool platformStartDiscovery() const final;
     UniqueRef<LocalConnection> createLocalConnection() const final;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
@@ -40,6 +40,11 @@
 
 namespace WebKit {
 
+Ref<MockLocalService> MockLocalService::create(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockLocalService(observer, configuration));
+}
+
 MockLocalService::MockLocalService(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : LocalService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
@@ -33,25 +33,18 @@
 OBJC_CLASS NSData;
 
 namespace WebKit {
-class MockNfcService;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::MockNfcService> : std::true_type { };
-}
-
-namespace WebKit {
 
 class MockNfcService final : public NfcService {
 public:
-    MockNfcService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockNfcService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
     NSData* transceive();
     void receiveStopPolling();
     void receiveStartPolling();
 
 private:
+    MockNfcService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+
     void platformStartDiscovery() final;
 
     void detectTags() const;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -187,6 +187,11 @@ static NSData* NFReaderSessionTransceive(id, SEL, NSData *)
 
 #endif // HAVE(NEAR_FIELD)
 
+Ref<MockNfcService> MockNfcService::create(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockNfcService(observer, configuration));
+}
+
 MockNfcService::MockNfcService(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : NfcService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
@@ -73,7 +73,7 @@ Vector<VirtualCredential> VirtualAuthenticatorManager::credentialsMatchingList(c
     return matching;
 }
 
-UniqueRef<AuthenticatorTransportService> VirtualAuthenticatorManager::createService(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
+Ref<AuthenticatorTransportService> VirtualAuthenticatorManager::createService(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer) const
 {
     Vector<std::pair<String, VirtualAuthenticatorConfiguration>> configs;
     for (auto& id : m_virtualAuthenticators.keys()) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
@@ -64,7 +64,7 @@ protected:
 private:
     VirtualAuthenticatorManager();
 
-    UniqueRef<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
+    Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
     void runPanel() override;
     void filterTransports(TransportSet&) const override { };
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.h
@@ -30,18 +30,26 @@
 #include "AuthenticatorTransportService.h"
 #include "VirtualAuthenticatorConfiguration.h"
 #include "VirtualCredential.h"
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class VirtualAuthenticatorManager;
 
-class VirtualService : public AuthenticatorTransportService {
+class VirtualService final: public AuthenticatorTransportService, public RefCounted<VirtualService> {
+    WTF_MAKE_TZONE_ALLOCATED(VirtualService);
 public:
+    static Ref<VirtualService> create(AuthenticatorTransportServiceObserver&, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>&);
+
+    static Ref<AuthenticatorTransportService> createVirtual(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>&);
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
     explicit VirtualService(AuthenticatorTransportServiceObserver&, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>&);
 
-    static UniqueRef<AuthenticatorTransportService> createVirtual(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>&);
-private:
     void startDiscoveryInternal() final;
 
     Vector<std::pair<String, VirtualAuthenticatorConfiguration>> m_authenticators;

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -36,6 +36,7 @@
 #import "VirtualLocalConnection.h"
 #import <WebCore/FidoConstants.h>
 #import <WebCore/WebAuthenticationConstants.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/text/WTFString.h>
 
@@ -43,14 +44,21 @@ namespace WebKit {
 using namespace fido;
 using namespace WebCore;
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VirtualService);
+
+Ref<VirtualService> VirtualService::create(AuthenticatorTransportServiceObserver& observer, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>& configuration)
+{
+    return adoptRef(*new VirtualService(observer, configuration));
+}
+
 VirtualService::VirtualService(AuthenticatorTransportServiceObserver& observer, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>& authenticators)
     : AuthenticatorTransportService(observer), m_authenticators(authenticators)
 {
 }
 
-UniqueRef<AuthenticatorTransportService> VirtualService::createVirtual(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>& authenticators)
+Ref<AuthenticatorTransportService> VirtualService::createVirtual(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>& authenticators)
 {
-    return makeUniqueRef<VirtualService>(observer, authenticators);
+    return VirtualService::create(observer, authenticators);
 }
 
 static AuthenticatorGetInfoResponse authenticatorInfoForConfig(const VirtualAuthenticatorConfiguration& config)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -36,10 +36,13 @@
 #include <WebCore/FidoConstants.h>
 #include <WebCore/FidoHidMessage.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 
 namespace WebKit {
 using namespace fido;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FidoService);
 
 FidoService::FidoService(AuthenticatorTransportServiceObserver& observer)
     : AuthenticatorTransportService(observer)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
@@ -33,21 +33,15 @@
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
-class FidoService;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::FidoService> : std::true_type { };
-}
-
-namespace WebKit {
-
-class FidoService : public AuthenticatorTransportService {
+class FidoService : public AuthenticatorTransportService, public RefCounted<FidoService> {
+    WTF_MAKE_TZONE_ALLOCATED(FidoService);
 public:
-    explicit FidoService(AuthenticatorTransportServiceObserver&);
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 protected:
+    explicit FidoService(AuthenticatorTransportServiceObserver&);
     void getInfo(std::unique_ptr<CtapDriver>&&);
 
 private:


### PR DESCRIPTION
#### fdab054758b2f649404c8e1449707b4138502c57
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AuthenticatorTransportService and subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=281646">https://bugs.webkit.org/show_bug.cgi?id=281646</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::createService const):
(WebKit::AuthenticatorManager::startDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp:
(WebKit::AuthenticatorTransportService::create):
(WebKit::AuthenticatorTransportService::createMock):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
(WebKit::HidService::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm:
(WebKit::LocalService::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm:
(WebKit::NfcService::create):
(WebKit::NfcService::~NfcService): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp:
(WebKit::MockAuthenticatorManager::createService const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm:
(WebKit::MockCcidService::create):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm:
(WebKit::MockLocalService::create):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::create):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp:
(WebKit::VirtualAuthenticatorManager::createService const):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.h:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::VirtualService::create):
(WebKit::VirtualService::createVirtual):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h:

Canonical link: <a href="https://commits.webkit.org/285371@main">https://commits.webkit.org/285371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e13c38831e68ebce7a6b379a9c684fa7e0d47bfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23549 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23371 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62301 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43531 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78187 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16581 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19266 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65452 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64720 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6606 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11119 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2343 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->