### PR TITLE
Make [JSManagedValue initWithValue:] more robust against clients using it from non-main threads

### DIFF
--- a/Source/JavaScriptCore/heap/WeakSetInlines.h
+++ b/Source/JavaScriptCore/heap/WeakSetInlines.h
@@ -33,6 +33,7 @@ namespace JSC {
 inline WeakImpl* WeakSet::allocate(JSValue jsValue, WeakHandleOwner* weakHandleOwner, void* context)
 {
     CellContainer container = jsValue.asCell()->cellContainer();
+    ASSERT(container.vm().currentThreadIsHoldingAPILock());
     WeakSet& weakSet = container.weakSet();
     WeakBlock::FreeCell* allocator = weakSet.m_allocator;
     if (UNLIKELY(!allocator))

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -55,6 +55,9 @@ class VM;
 class JSGlobalObject;
 class JSLock;
 
+// FIXME: We should either have a specialization of WTF::Locker for JSLock or only allow using JSLockHolder.
+// It's weird that WTF::Locker<JSLock> doesn't ref() the VM for the lifetime of the lock and it's unclear
+// there's any noticable performance difference.
 class JSLockHolder {
 public:
     JS_EXPORT_PRIVATE JSLockHolder(VM*);


### PR DESCRIPTION
#### 529254aff8b25ff25e6d2f196512de5c82b45fe4
<pre>
Make [JSManagedValue initWithValue:] more robust against clients using it from non-main threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=281648">https://bugs.webkit.org/show_bug.cgi?id=281648</a>
<a href="https://rdar.apple.com/138037948">rdar://138037948</a>

Reviewed by NOBODY (OOPS!).

[JSManagedValue initWithValue:] does not currently acquire the JS API lock because it expects to
only be called on the JS main thread.  However, it&apos;s easy for clients to make mistakes can call
it from different threads.  We should make [JSManagedValue initWithValue:] more robust by simply
making it acquire the JS API lock for its VM.

Also change [JSManagedValue value:] to not acquire the JS API lock twice.  It was first acquiring
the lock with a WTF::Locker, and subsequently with a JSC::JSLockHolder.  The only added value of
the JSC::JSLockHolder is that it refs the VM using a RefPtr.  So, instead of using the
JSC::JSLockHolder, we can just use a RefPtr to store the VM instead of the raw VM* it was using
before.  With that, the use of the JSC::JSLockHolder becomes completely redundant.

This issue is caught by existing tests now that WeakSet::allocate asserts currentThreadIsHoldingAPILock

* Source/JavaScriptCore/API/JSManagedValue.mm:
(-[JSManagedValue initWithValue:]):
(-[JSManagedValue value]):
* Source/JavaScriptCore/heap/WeakSetInlines.h:
(JSC::WeakSet::allocate):
* Source/JavaScriptCore/runtime/JSLock.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/529254aff8b25ff25e6d2f196512de5c82b45fe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24336 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/309 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57453 "Failure limit exceed. At least found 498 new test failures: accessibility/accessibility-crash-focused-element-change.html accessibility/aria-activedescendant-crash.html accessibility/aria-checkbox-sends-notification.html accessibility/aria-hidden-crash.html accessibility/aria-switch-sends-notification.html accessibility/crash-table-recursive-layout.html accessibility/heading-title-includes-links.html accessibility/image-map-update-parent-crash.html accessibility/img-with-svg-source.html accessibility/list-detection2.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62915 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37869 "Found 55 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestFrame:/webkit/WebKitFrame/main-frame, /WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal, /WPE/TestResources:/webkit/WebKitWebResource/suggested-filename, /WPE/TestLoaderClient:/webkit/WebKitWebView/user-agent, /TestJSC:/jsc/weak-value, /WPE/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestResources:/webkit/WebKitWebResource/mime-type, /TestWebKit:WebKit.OnDeviceChangeCrash ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22665 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66233 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72355 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/511 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Running apply-patch; Running checkout-pull-request; Running compile-webkit; Running compile-webkit-without-change") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20 "Found 60 new test failures: accessibility/accessibility-crash-focused-element-change.html accessibility/aria-activedescendant-crash.html accessibility/aria-hidden-crash.html accessibility/mac/canvas.html accessibility/mac/display-contents-relative-frame.html accessibility/mac/dynamic-transform-relative-frame.html accessibility/text-marker/character-offset-visible-position-conversion-hang.html animations/animation-controller-drt-api.html animations/animation-hit-test-transform.html animations/animation-hit-test.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65176 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7165 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/376 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20703 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/405 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->