### PR TITLE
[text-box] Make `text-box-edge` inherited per spec update

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Property text-box-edge has initial value auto
-PASS Property text-box-edge does not inherit
+PASS Property text-box-edge inherits
 PASS Property text-box-trim has initial value none
 PASS Property text-box-trim does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance.html
@@ -9,6 +9,6 @@
   <div id="target"></div>
 </div>
 <script>
-assert_not_inherited('text-box-edge', 'auto', 'cap');
+assert_inherited('text-box-edge', 'auto', 'cap');
 assert_not_inherited('text-box-trim', 'none', 'trim-start');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-accumulation-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-accumulation-001.html
@@ -17,6 +17,7 @@
 }
 .target {
   font: 100px/2 MetricsTestFont;
+  text-box-edge: auto;
 }
 .target, .outer {
   text-box-trim: trim-start;

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -670,7 +670,7 @@
             }
         },
         "text-box-edge": {
-            "inherited": false,
+            "inherited": true,
             "values": [
                 "auto",
                 "text",

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -878,9 +878,6 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.textBoxTrim != second.textBoxTrim)
         return true;
 
-    if (first.textBoxEdge != second.textBoxEdge)
-        return true;
-
     if (first.maxLines != second.maxLines)
         return true;
 
@@ -898,6 +895,7 @@ static bool rareInheritedDataChangeRequiresLayout(const StyleRareInheritedData& 
         || first.textAlignLast != second.textAlignLast
         || first.textJustify != second.textJustify
         || first.textIndentLine != second.textIndentLine
+        || first.textBoxEdge != second.textBoxEdge
         || first.lineFitEdge != second.lineFitEdge
         || first.usedZoom != second.usedZoom
         || first.textZoom != second.textZoom
@@ -1946,8 +1944,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyScrollSnapStop);
         if (first.scrollSnapType != second.scrollSnapType)
             changingProperties.m_properties.set(CSSPropertyScrollSnapType);
-        if (first.textBoxEdge != second.textBoxEdge)
-            changingProperties.m_properties.set(CSSPropertyTextBoxEdge);
         if (first.maxLines != second.maxLines)
             changingProperties.m_properties.set(CSSPropertyMaxLines);
         if (first.overflowContinue != second.overflowContinue)
@@ -2081,6 +2077,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyImageRendering);
         if (first.textAlignLast != second.textAlignLast)
             changingProperties.m_properties.set(CSSPropertyTextAlignLast);
+        if (first.textBoxEdge != second.textBoxEdge)
+            changingProperties.m_properties.set(CSSPropertyTextBoxEdge);
         if (first.lineFitEdge != second.lineFitEdge)
             changingProperties.m_properties.set(CSSPropertyLineFitEdge);
         if (first.textJustify != second.textJustify)
@@ -3766,12 +3764,12 @@ bool RenderStyle::hasSnapPosition() const
 
 TextEdge RenderStyle::textBoxEdge() const
 {
-    return m_nonInheritedData->rareData->textBoxEdge;
+    return m_rareInheritedData->textBoxEdge;
 }
 
-void RenderStyle::setTextBoxEdge(TextEdge textBoxEdgeValue)
+void RenderStyle::setTextBoxEdge(TextEdge value)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, textBoxEdge, textBoxEdgeValue);
+    SET_VAR(m_rareInheritedData, textBoxEdge, value);
 }
 
 TextEdge RenderStyle::initialTextBoxEdge()
@@ -3784,9 +3782,9 @@ TextEdge RenderStyle::lineFitEdge() const
     return m_rareInheritedData->lineFitEdge;
 }
 
-void RenderStyle::setLineFitEdge(TextEdge lineFitEdgeValue)
+void RenderStyle::setLineFitEdge(TextEdge value)
 {
-    SET_VAR(m_rareInheritedData, lineFitEdge, lineFitEdgeValue);
+    SET_VAR(m_rareInheritedData, lineFitEdge, value);
 }
 
 TextEdge RenderStyle::initialLineFitEdge()

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -87,6 +87,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , indent(RenderStyle::initialTextIndent())
     , usedZoom(RenderStyle::initialZoom())
     , textUnderlineOffset(RenderStyle::initialTextUnderlineOffset())
+    , textBoxEdge(RenderStyle::initialTextBoxEdge())
     , lineFitEdge(RenderStyle::initialLineFitEdge())
     , miterLimit(RenderStyle::initialStrokeMiterLimit())
     , customProperties(StyleCustomPropertyData::create())
@@ -182,6 +183,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , indent(o.indent)
     , usedZoom(o.usedZoom)
     , textUnderlineOffset(o.textUnderlineOffset)
+    , textBoxEdge(o.textBoxEdge)
     , lineFitEdge(o.lineFitEdge)
     , miterLimit(o.miterLimit)
     , customProperties(o.customProperties)
@@ -295,6 +297,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && indent == o.indent
         && usedZoom == o.usedZoom
         && textUnderlineOffset == o.textUnderlineOffset
+        && textBoxEdge == o.textBoxEdge
         && lineFitEdge == o.lineFitEdge
         && wordSpacing == o.wordSpacing
         && miterLimit == o.miterLimit

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -96,6 +96,7 @@ public:
 
     TextUnderlineOffset textUnderlineOffset;
 
+    TextEdge textBoxEdge;
     TextEdge lineFitEdge;
     
     Length wordSpacing;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -101,7 +101,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , pseudoElementNameArgument(nullAtom())
     , anchorNames(RenderStyle::initialAnchorNames())
     , positionAnchor(RenderStyle::initialPositionAnchor())
-    , textBoxEdge(RenderStyle::initialTextBoxEdge())
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
@@ -200,7 +199,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , pseudoElementNameArgument(o.pseudoElementNameArgument)
     , anchorNames(o.anchorNames)
     , positionAnchor(o.positionAnchor)
-    , textBoxEdge(o.textBoxEdge)
     , blockStepSize(o.blockStepSize)
     , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
@@ -330,7 +328,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && containIntrinsicHeightType == o.containIntrinsicHeightType
         && containerType == o.containerType
         && textBoxTrim == o.textBoxTrim
-        && textBoxEdge == o.textBoxEdge
         && overflowAnchor == o.overflowAnchor
         && viewTransitionClasses == o.viewTransitionClasses
         && viewTransitionName == o.viewTransitionName

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -207,8 +207,6 @@ public:
     Vector<AtomString> anchorNames;
     AtomString positionAnchor;
 
-    TextEdge textBoxEdge;
-
     std::optional<Length> blockStepSize;
     unsigned blockStepInsert : 1; // BlockStepInsert
 


### PR DESCRIPTION
#### 3996476d1f4930e53d90b0e9b55bc9c9b8341c31
<pre>
[text-box] Make `text-box-edge` inherited per spec update
<a href="https://bugs.webkit.org/show_bug.cgi?id=281590">https://bugs.webkit.org/show_bug.cgi?id=281590</a>
<a href="https://rdar.apple.com/138049359">rdar://138049359</a>

Reviewed by NOBODY (OOPS!).

See <a href="https://github.com/w3c/csswg-drafts/issues/10904">https://github.com/w3c/csswg-drafts/issues/10904</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/parsing/inheritance.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-accumulation-001.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):
(WebCore::rareInheritedDataChangeRequiresLayout):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::textBoxEdge const):
(WebCore::RenderStyle::setTextBoxEdge):
(WebCore::RenderStyle::setLineFitEdge):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3996476d1f4930e53d90b0e9b55bc9c9b8341c31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15474 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65434 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64700 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6567 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2297 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->