### PR TITLE
REGRESSION(284010@main): White area around YouTube autocomplete popup

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -64,7 +64,7 @@ template<typename TargetType> TargetType fromCSSValue(const CSSValue& value)
 
 class TypeDeducingCSSValueMapper {
 public:
-    TypeDeducingCSSValueMapper(Style::BuilderState& builderState, const CSSValue& value)
+    TypeDeducingCSSValueMapper(const Style::BuilderState& builderState, const CSSValue& value)
         : m_builderState { builderState }
         , m_value { value }
     {
@@ -113,11 +113,11 @@ private:
         return value;
     }
 
-    Style::BuilderState& m_builderState;
+    const Style::BuilderState& m_builderState;
     const CSSValue& m_value;
 };
 
-inline TypeDeducingCSSValueMapper fromCSSValueDeducingType(Style::BuilderState& builderState, const CSSValue& value)
+inline TypeDeducingCSSValueMapper fromCSSValueDeducingType(const Style::BuilderState& builderState, const CSSValue& value)
 {
     return { builderState, value };
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9243,6 +9243,7 @@
         },
         "scrollbar-width": {
             "codegen-properties": {
+                "converter": "ScrollbarWidth",
                 "parser-grammar": "auto | thin | none",
                 "settings-flag": "cssScrollbarWidthEnabled"
             },

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -656,15 +656,16 @@ bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 }
 
 // youtube.com rdar://135886305
-bool Quirks::needsYouTubeDarkModeQuirk() const
+// NOTE: Also remove `BuilderConverter::convertScrollbarWidth` and related code when removing this quirk.
+bool Quirks::needsScrollbarWidthThinDisabledQuirk() const
 {
     if (!needsQuirks())
         return false;
 
-    if (!m_needsYouTubeDarkModeQuirk)
-        m_needsYouTubeDarkModeQuirk = isDomain("youtube.com"_s);
+    if (!m_needsScrollbarWidthThinDisabledQuirk)
+        m_needsScrollbarWidthThinDisabledQuirk = isDomain("youtube.com"_s);
 
-    return *m_needsYouTubeDarkModeQuirk;
+    return *m_needsScrollbarWidthThinDisabledQuirk;
 }
 
 // gizmodo.com rdar://102227302

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -113,7 +113,7 @@ public:
 
     bool needsPrimeVideoUserSelectNoneQuirk() const;
 
-    bool needsYouTubeDarkModeQuirk() const;
+    bool needsScrollbarWidthThinDisabledQuirk() const;
 
     bool shouldOpenAsAboutBlank(const String&) const;
 
@@ -276,7 +276,7 @@ private:
     mutable std::optional<bool> m_shouldDisableElementFullscreen;
     mutable std::optional<bool> m_shouldIgnorePlaysInlineRequirementQuirk;
     mutable std::optional<bool> m_needsRelaxedCorsMixedContentCheckQuirk;
-    mutable std::optional<bool> m_needsYouTubeDarkModeQuirk;
+    mutable std::optional<bool> m_needsScrollbarWidthThinDisabledQuirk;
     mutable std::optional<bool> m_needsPrimeVideoUserSelectNoneQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -991,17 +991,6 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
     }
 #endif
 #endif
-
-#if ENABLE(DARK_MODE_CSS)
-    if (m_document->quirks().needsYouTubeDarkModeQuirk()) {
-        // Sets color-scheme to dark if dark attribute is applied to root element.
-        if (m_element && m_element == m_document->documentElement()) {
-            static MainThreadNeverDestroyed<const AtomString> darkMode("dark"_s);
-            if (m_element->hasAttribute(darkMode))
-                style.setColorScheme(StyleColorScheme(ColorScheme::Dark, true));
-        }
-    }
-#endif
 }
 
 void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -64,6 +64,7 @@
 #include "GridPositionsResolver.h"
 #include "LineClampValue.h"
 #include "LocalFrame.h"
+#include "Quirks.h"
 #include "QuotesData.h"
 #include "RenderStyleInlines.h"
 #include "SVGElementTypeHelpers.h"
@@ -152,6 +153,8 @@ public:
     static ScrollSnapStop convertScrollSnapStop(const BuilderState&, const CSSValue&);
     static std::optional<ScrollbarColor> convertScrollbarColor(const BuilderState&, const CSSValue&);
     static ScrollbarGutter convertScrollbarGutter(const BuilderState&, const CSSValue&);
+    // scrollbar-width converter is only needed for quirking.
+    static ScrollbarWidth convertScrollbarWidth(const BuilderState&, const CSSValue&);
     static GridTrackSize convertGridTrackSize(const BuilderState&, const CSSValue&);
     static Vector<GridTrackSize> convertGridTrackSizeList(const BuilderState&, const CSSValue&);
     static std::optional<GridTrackList> convertGridTrackList(const BuilderState&, const CSSValue&);
@@ -1191,6 +1194,15 @@ inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(const BuilderSta
     gutter.bothEdges = true;
 
     return gutter;
+}
+
+inline ScrollbarWidth BuilderConverter::convertScrollbarWidth(const BuilderState& builderState, const CSSValue& value)
+{
+    ScrollbarWidth scrollbarWidth = fromCSSValueDeducingType(builderState, value);
+    if (scrollbarWidth == ScrollbarWidth::Thin && builderState.document().quirks().needsScrollbarWidthThinDisabledQuirk())
+        return ScrollbarWidth::Auto;
+
+    return scrollbarWidth;
 }
 
 inline GridLength BuilderConverter::createGridTrackBreadth(const BuilderState& builderState, const CSSPrimitiveValue& primitiveValue)


### PR DESCRIPTION
#### 53c5612fe347798118ba5ed646fc15b1cd5b4b50
<pre>
REGRESSION(284010@main): White area around YouTube autocomplete popup
<a href="https://bugs.webkit.org/show_bug.cgi?id=281652">https://bugs.webkit.org/show_bug.cgi?id=281652</a>
<a href="https://rdar.apple.com/137387751">rdar://137387751</a>

Reviewed by Simon Fraser.

284010@main forced the CSS color-scheme of YouTube to dark when YouTube in dark mode, to ensure
the natively drawn scrollbars (triggered by `scrollbar-width: thin`) don&apos;t draw with a
light color scheme looking out of place.

Unfortunately, setting the CSS color-scheme to dark has the side-effect of adding a white background
to iframes with mismatching color-scheme. That is visible with the iframe that appears behind the
YouTube search autocomplete popup.

Fix the original issue in 284010@main by disabling `scrollbar-width: thin` on YouTube, so custom
drawn scrollbars styled using `::-webkit-scrollbar` pseudo-elements are used once again.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::TypeDeducingCSSValueMapper::TypeDeducingCSSValueMapper):
(WebCore::fromCSSValueDeducingType):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsScrollbarWidthThinDisabledQuirk const):
(WebCore::Quirks::needsYouTubeDarkModeQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertScrollbarWidth):

Canonical link: <a href="https://commits.webkit.org/285343@main">https://commits.webkit.org/285343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/023c5fe2ced704cdfea3cc0f6e6c9a206f4f8e89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23330 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15476 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62256 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19231 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62279 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12936 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2302 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48587 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->