### PR TITLE
[scroll-animations] play-animation.html, reverse-animation.html and updating-the-finished-state.html WPT tests under scroll-animations/scroll-timelines are crashes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7418,6 +7418,8 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-wit
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/cancel-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/pause-animation.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline.html [ Skip ]
@@ -7426,6 +7428,7 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeli
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/update-playback-rate.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 
 # webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-multiple.html [ Pass Failure ]
@@ -7465,13 +7468,10 @@ imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.
 
 # webkit.org/b/281481 [scroll-animations] some WPT tests are crashing
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 
 # webkit.org/b/281482 [scroll-animations] some WPT reftests can't find their reference
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-update-reversed-animation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
@@ -1,20 +1,18 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Playing an animations aligns the start time with the start of the active range Test timed out
-NOTRUN Playing an animations with a negative playback rate aligns the start time with the end of the active range
-NOTRUN Start time set while play pending is preserved.
-NOTRUN Current time set while play pending is preserved.
-NOTRUN Playing a running animation resets a sticky start time
-NOTRUN Playing a finished animation restarts the animation aligned at the start
-NOTRUN Playing a finished and reversed animation restarts the animation aligned at the end
-NOTRUN Playing a pause-pending but previously finished animation realigns with the scroll position
-NOTRUN Playing a finished animation clears the start time
-NOTRUN The ready promise should be replaced if the animation is not already pending
-NOTRUN A pending ready promise should be resolved and not replaced when the animation enters the running state
-NOTRUN Resuming an animation from paused realigns with scroll position.
-NOTRUN If a pause operation is interrupted, the ready promise is reused
-NOTRUN A pending playback rate is used when determining timeline range alignment
-NOTRUN Playing a canceled animation sets the start time
-NOTRUN Playing a canceled animation backwards sets the start time
+PASS Playing an animations aligns the start time with the start of the active range
+PASS Playing an animations with a negative playback rate aligns the start time with the end of the active range
+FAIL Start time set while play pending is preserved. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Current time set while play pending is preserved. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Playing a running animation resets a sticky start time promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Playing a finished animation restarts the animation aligned at the start assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got 100
+FAIL Playing a finished and reversed animation restarts the animation aligned at the end promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Playing a pause-pending but previously finished animation realigns with the scroll position assert_approx_equals: values do not match for "After aborting a pause when finished, the start time should no longer be sticky" expected 0 +/- 0.125 but got -50
+FAIL Playing a finished animation clears the start time assert_approx_equals: values do not match for "start time is zero" expected 0 +/- 0.125 but got -100
+PASS The ready promise should be replaced if the animation is not already pending
+PASS A pending ready promise should be resolved and not replaced when the animation enters the running state
+FAIL Resuming an animation from paused realigns with scroll position. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS If a pause operation is interrupted, the ready promise is reused
+FAIL A pending playback rate is used when determining timeline range alignment promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Playing a canceled animation sets the start time
+PASS Playing a canceled animation backwards sets the start time
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
@@ -1,15 +1,13 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Setting current time while reverse-pending preserves currentTime promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-TIMEOUT Reversing an animation inverts the playback rate Test timed out
-NOTRUN Reversing an animation resets a sticky start time.
-NOTRUN Reversing an animation does not cause it to leave the pending state
-NOTRUN Reversing an animation does not cause it to resolve the ready promise
-NOTRUN Reversing an animation with a negative playback rate should cause the animation to play in a forward direction
-NOTRUN Reversing when when playbackRate == 0 should preserve the playback rate
-NOTRUN Reversing an idle animation aligns startTime with the rangeEnd boundary
-NOTRUN Reversing an animation without an active timeline throws an InvalidStateError
-NOTRUN Reversing an animation plays a pausing animation
-NOTRUN Reversing should use the negative pending playback rate
+FAIL Setting current time while reverse-pending preserves currentTime promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Reversing an animation inverts the playback rate promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Reversing an animation resets a sticky start time. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Reversing an animation does not cause it to leave the pending state
+PASS Reversing an animation does not cause it to resolve the ready promise
+PASS Reversing an animation with a negative playback rate should cause the animation to play in a forward direction
+FAIL Reversing when when playbackRate == 0 should preserve the playback rate promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Reversing an idle animation aligns startTime with the rangeEnd boundary assert_approx_equals: values do not match for "animation.startTime should be at its effect end" expected 100 +/- 0.125 but got -100
+PASS Reversing an animation without an active timeline throws an InvalidStateError
+FAIL Reversing an animation plays a pausing animation promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Reversing should use the negative pending playback rate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state-expected.txt
@@ -1,12 +1,12 @@
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT Updating the finished state when seeking past end Test timed out
-NOTRUN Updating the finished state when playing exactly to end
-NOTRUN Updating the finished state when seeking exactly to end
-NOTRUN Updating the finished state when playing in reverse past zero
-NOTRUN Updating the finished state when seeking a reversed animation past zero
-NOTRUN Updating the finished state when playing  a reversed animation exactly to zero
+FAIL Updating the finished state when seeking past end promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Updating the finished state when playing exactly to end
+FAIL Updating the finished state when seeking exactly to end promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Updating the finished state when playing in reverse past zero promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Updating the finished state when seeking a reversed animation past zero promise_test: Unhandled rejection with value: object "TypeError: Type error"
+TIMEOUT Updating the finished state when playing  a reversed animation exactly to zero Test timed out
 NOTRUN Updating the finished state when seeking a reversed animation exactly to zero
 NOTRUN Updating the finished state when seeking before end
 NOTRUN Updating the finished state when seeking a reversed animation before end
@@ -22,8 +22,8 @@ NOTRUN Finish notification steps run when the animation seeks past finish
 NOTRUN Finish notification steps run when the animation completes with .finish(), even if we then seek away
 NOTRUN Animation finished promise is replaced after seeking back to start
 NOTRUN Animation finished promise is replaced after replaying from start
-TIMEOUT Animation finish event is fired again after seeking back to start Test timed out
+PASS Animation finish event is fired again after seeking back to start
 TIMEOUT Animation finish event is fired again after replaying from start Test timed out
-TIMEOUT finish event is not fired at the end of the active interval when the endDelay has not expired Test timed out
-TIMEOUT finish event is fired after the endDelay has expired Test timed out
+PASS finish event is not fired at the end of the active interval when the endDelay has not expired
+PASS finish event is fired after the endDelay has expired
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -732,7 +732,7 @@ auto WebAnimation::playState() const -> PlayState
     // animation's effective playback rate > 0 and current time ≥ target effect end; or
     // animation's effective playback rate < 0 and current time ≤ 0,
     // → finished
-    if (animationCurrentTime && ((effectivePlaybackRate() > 0 && (*animationCurrentTime + timeEpsilon()) >= effectEndTime()) || (effectivePlaybackRate() < 0 && (*animationCurrentTime - timeEpsilon()) <= 0_s)))
+    if (animationCurrentTime && ((effectivePlaybackRate() > 0 && (*animationCurrentTime + timeEpsilon()) >= effectEndTime()) || (effectivePlaybackRate() < 0 && (*animationCurrentTime - timeEpsilon()) <= zeroTime())))
         return PlayState::Finished;
 
     // Otherwise → running
@@ -998,16 +998,16 @@ void WebAnimation::updateFinishedState(DidSeek didSeek, SynchronouslyNotify sync
                 m_holdTime = endTime;
             else
                 m_holdTime = std::max(m_previousCurrentTime.value(), endTime);
-        } else if (m_playbackRate < 0 && unconstrainedCurrentTime <= 0_s) {
+        } else if (m_playbackRate < 0 && unconstrainedCurrentTime <= zeroTime()) {
             // If animation playback rate < 0 and unconstrained current time is less than or equal to 0,
             // If did seek is true, let the hold time be the value of unconstrained current time.
             if (didSeek == DidSeek::Yes)
                 m_holdTime = unconstrainedCurrentTime;
             // If did seek is false, let the hold time be the minimum value of previous current time and zero. If the previous current time is unresolved, let the hold time be zero.
             else if (!m_previousCurrentTime)
-                m_holdTime = 0_s;
+                m_holdTime = zeroTime();
             else
-                m_holdTime = std::min(m_previousCurrentTime.value(), CSSNumberishTime { 0_s });
+                m_holdTime = std::min(m_previousCurrentTime.value(), zeroTime());
         } else if (m_playbackRate && m_timeline && m_timeline->currentTime()) {
             // If animation playback rate ≠ 0, and animation is associated with an active timeline,
             // Perform the following steps:


### PR DESCRIPTION
#### c25e4c092278e9c55184431fe7a941bf61a431b9
<pre>
[scroll-animations] play-animation.html, reverse-animation.html and updating-the-finished-state.html WPT tests under scroll-animations/scroll-timelines are crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281660">https://bugs.webkit.org/show_bug.cgi?id=281660</a>
<a href="https://rdar.apple.com/138102638">rdar://138102638</a>

Reviewed by Anne van Kesteren.

Ensure we always use compatible times to compare with 0.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::playState const):
(WebCore::WebAnimation::updateFinishedState):

Canonical link: <a href="https://commits.webkit.org/285353@main">https://commits.webkit.org/285353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23f6e2580190b3e42289d42ab1155c2caf339101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23370 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62300 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19771 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21898 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78195 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71593 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19265 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62318 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6605 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11104 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47558 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->