### PR TITLE
[Tools][GTK][WPE] generate-bundle test suite fails to run on a non-interactive TTY

### DIFF
--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_docker_start_test.sh
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_docker_start_test.sh
@@ -13,6 +13,8 @@ else
     exit 1
 fi
 
+export PYTHONUNBUFFERED=1
+
 # Install needed packages
 case "${CURRENT_DISTRO}" in
     alpine)

--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh
@@ -55,7 +55,7 @@ I=0
 for DISTRO in ${DISTROS_TO_TEST[@]}; do
     echo "[INFO] Start testing on distro: ${DISTRO}"
     docker pull "${DISTRO}"
-    docker run -it --rm \
+    docker run --init --rm \
                 -v "${MYDIR}:/testdata:ro" \
                 -v "${FBUNDLE}:/testbundle.tar.xz:ro" \
                 -v "/tmp/.X11-unix:/tmp/.X11-unix" \


### PR DESCRIPTION
#### d8d506d2a783b828797e6cb6cf0c3b39bf9687a7
<pre>
[Tools][GTK][WPE] generate-bundle test suite fails to run on a non-interactive TTY
<a href="https://bugs.webkit.org/show_bug.cgi?id=281661">https://bugs.webkit.org/show_bug.cgi?id=281661</a>

Unreviewed follow-up fix after 285014@main

On the bots the test suite fails to run with error: &quot;the input device is not a TTY&quot;.
Fix that by running the docker command non interactively, and also disable stdout
buffering for the python webdriver tests so they print status as they are executed.

* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_docker_start_test.sh:
* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh:

Canonical link: <a href="https://commits.webkit.org/285324@main">https://commits.webkit.org/285324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/630c45e62d8960cae45635a068c386bc361224a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25094 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75373 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/71813 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21865 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20099 "Build is in progress. Recent messages:") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16547 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16594 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11090 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47525 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->