### PR TITLE
Enhanced <input type=color>: make a11y code account for alpha

### DIFF
--- a/LayoutTests/accessibility/color-well-legacy-expected.txt
+++ b/LayoutTests/accessibility/color-well-legacy-expected.txt
@@ -1,9 +1,9 @@
-This test checks the role of ColorWellRolean input with type=color
+This test checks the role of ColorWellRole on an input with type=color
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-Role of input type=color is: AXRole: AXButton
+Role of input type=color is: AXRole: AXColorWell
 Value of empty color well: AXValue: rgb 0.00000 0.00000 0.00000 1
 Value of good color well: AXValue: rgb 1.00000 0.00000 0.00000 1
 Value of bad color well: AXValue: rgb 0.00000 0.00000 0.00000 1

--- a/LayoutTests/accessibility/color-well-legacy.html
+++ b/LayoutTests/accessibility/color-well-legacy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ InputTypeColorEnhancementsEnabled=false ] -->
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<input id="empty_colorwell" type="color">
+<input id="good_colorwell" type="color" value="#ff0000">
+<input id="bad_colorwell" type="color" value="purple">
+
+<script>
+    description("This test checks the role of ColorWellRole on an input with type=color");
+
+    if (window.accessibilityController) {
+        let axColorwell = accessibilityController.accessibleElementById("empty_colorwell");
+        debug("Role of input type=color is: " + axColorwell.role);
+        debug("Value of empty color well: " + axColorwell.stringValue);
+
+        axColorwell = accessibilityController.accessibleElementById("good_colorwell");
+        debug("Value of good color well: " + axColorwell.stringValue);
+
+        axColorwell = accessibilityController.accessibleElementById("bad_colorwell");
+        debug("Value of bad color well: " + axColorwell.stringValue);
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/color-well.html
+++ b/LayoutTests/accessibility/color-well.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!doctype html><!-- webkit-test-runner [ InputTypeColorEnhancementsEnabled=true ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
@@ -8,23 +8,32 @@
 
 <input id="empty_colorwell" type="color">
 <input id="good_colorwell" type="color" value="#ff0000">
-<input id="bad_colorwell" type="color" value="purple">
-    
+<input id="bad_colorwell" type="color" value="not a color">
+<input id="alpha_colorwell" type="color" alpha value="color(srgb .23 .234 .23 / .4)">
+<input id="p3_colorwell" type="color" alpha colorspace="display-p3" value="#ff449942">
+
 <script>
-    description("This test checks the role of ColorWellRolean input with type=color");
+let output = "This test checks the role of ColorWellRole on an input with type=color\n\n";
 
-    if (window.accessibilityController) {
-        let axColorwell = accessibilityController.accessibleElementById("empty_colorwell");
-        debug("Role of input type=color is: " + axColorwell.role);
-        debug("Value of empty color well: " + axColorwell.stringValue);
+if (window.accessibilityController) {
+    let axColorwell = accessibilityController.accessibleElementById("empty_colorwell");
+    output += `Role of input type=color is: ${axColorwell.role}\n`;
+    output += `Value of empty color well: ${axColorwell.stringValue}\n`;
 
-        axColorwell = accessibilityController.accessibleElementById("good_colorwell");
-        debug("Value of good color well: " + axColorwell.stringValue);
+    axColorwell = accessibilityController.accessibleElementById("good_colorwell");
+    output += `Value of good color well: ${axColorwell.stringValue}\n`;
 
-        axColorwell = accessibilityController.accessibleElementById("bad_colorwell");
-        debug("Value of bad color well: " + axColorwell.stringValue);
-    }
+    axColorwell = accessibilityController.accessibleElementById("bad_colorwell");
+    output += `Value of bad color well: ${axColorwell.stringValue}\n`;
+
+    axColorwell = accessibilityController.accessibleElementById("alpha_colorwell");
+    output += `Value of alpha color well: ${axColorwell.stringValue}\n`;
+
+    axColorwell = accessibilityController.accessibleElementById("p3_colorwell");
+    output += `Value of p3 color well: ${axColorwell.stringValue}\n`;
+
+    debug(output);
+}
 </script>
 </body>
 </html>
-

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -160,6 +160,7 @@ fast/multicol/multicol-with-child-renderLayer-for-input.html [ Pass ]
 # Enhanced <input type=color>
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html [ Skip ]
+accessibility/color-well.html [ Skip ]
 
 # permessage-deflate WebSocket extension.
 http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-comp-bit-onoff.html [ Pass ]

--- a/LayoutTests/platform/gtk/accessibility/color-well-legacy-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/color-well-legacy-expected.txt
@@ -1,12 +1,12 @@
 This test checks the role of ColorWellRole on an input with type=color
 
-Role of input type=color is: AXRole: AXColorWell
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Role of input type=color is: AXRole: AXButton
 Value of empty color well: AXValue: rgb 0.00000 0.00000 0.00000 1
 Value of good color well: AXValue: rgb 1.00000 0.00000 0.00000 1
 Value of bad color well: AXValue: rgb 0.00000 0.00000 0.00000 1
-Value of alpha color well: AXValue: rgb 0.231373 0.235294 0.231373 0.400000
-Value of p3 color well: AXValue: rgb 1.00000 0.266667 0.600000 0.258824
-
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1113,6 +1113,7 @@ http/tests/security/contentSecurityPolicy/navigate-self-to-data-url.html [ Skip 
 
 # Color well is turned off.
 accessibility/color-well.html [ Skip ]
+accessibility/color-well-legacy.html [ Skip ]
 accessibility/color-input-value-changes.html [ Skip ]
 accessibility/mac/media-query-values-change.html [ Skip ]
 editing/pasteboard/drag-and-drop-color-input-events.html [ Skip ]

--- a/LayoutTests/platform/wpe/accessibility/color-well-legacy-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/color-well-legacy-expected.txt
@@ -1,4 +1,4 @@
-This test checks the role of ColorWellRolean input with type=color
+This test checks the role of ColorWellRole on an input with type=color
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -298,7 +298,7 @@ AXCoreObject::AXValue AXCoreObject::value()
 
     if (isColorWell()) {
         auto color = convertColor<SRGBA<float>>(colorValue()).resolved();
-        return makeString("rgb "_s, String::numberToStringFixedPrecision(color.red, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.green, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.blue, 6, TrailingZerosPolicy::Keep), " 1"_s);
+        return makeString("rgb "_s, String::numberToStringFixedPrecision(color.red, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.green, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.blue, 6, TrailingZerosPolicy::Keep), ' ', color.alpha == 1.0f ? "1"_s : String::numberToStringFixedPrecision(color.alpha, 6, TrailingZerosPolicy::Keep));
     }
 
     return stringValue();

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2559,11 +2559,11 @@ DateComponentsType AccessibilityObject::dateTimeComponentsType() const
 SRGBA<uint8_t> AccessibilityNodeObject::colorValue() const
 {
     if (!isColorWell())
-        return Color::transparentBlack;
+        return Color::black;
 
     RefPtr input = dynamicDowncast<HTMLInputElement>(node());
     if (!input)
-        return Color::transparentBlack;
+        return Color::black;
 
     return input->valueAsColor().toColorTypeLossy<SRGBA<uint8_t>>();
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2869,7 +2869,7 @@ bool AccessibilityObject::hasHighlighting() const
 
 SRGBA<uint8_t> AccessibilityObject::colorValue() const
 {
-    return Color::transparentBlack;
+    return Color::black;
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1851,7 +1851,7 @@ Color HTMLInputElement::valueAsColor() const
     if (auto* colorInputType = dynamicDowncast<ColorInputType>(*m_inputType))
         return colorInputType->valueAsColor();
 #endif
-    return Color::transparentBlack;
+    return Color::black;
 }
 
 void HTMLInputElement::selectColor(StringView color)


### PR DESCRIPTION
#### 4cb42b8c9386d435841b39b4864d920ee9416c03
<pre>
Enhanced &lt;input type=color&gt;: make a11y code account for alpha
<a href="https://bugs.webkit.org/show_bug.cgi?id=281283">https://bugs.webkit.org/show_bug.cgi?id=281283</a>
<a href="https://rdar.apple.com/137734496">rdar://137734496</a>

Reviewed by Tyler Wilcock.

Change the fallback color from transparent black to opaque black to
preserve how it is exposed today in accessibility. This also happens to
match the fallback color used by the control itself. It is not entirely
clear why transparent black was used before.

And start serializing the alpha component of the color in
AXCoreObject::value() when it is not 1. As all existing code paths can
only hit it when it is 1 there is no preference guard here.

* LayoutTests/accessibility/color-well-expected.txt:
* LayoutTests/accessibility/color-well-legacy-expected.txt: Copied from LayoutTests/accessibility/color-well-expected.txt.
* LayoutTests/accessibility/color-well-legacy.html: Copied from LayoutTests/accessibility/color-well.html.
* LayoutTests/accessibility/color-well.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/accessibility/color-well-legacy-expected.txt: Renamed from LayoutTests/platform/gtk/accessibility/color-well-expected.txt.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wpe/accessibility/color-well-legacy-expected.txt: Renamed from LayoutTests/platform/wpe/accessibility/color-well-expected.txt.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::value):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::colorValue const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::colorValue const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::valueAsColor const):

Canonical link: <a href="https://commits.webkit.org/285395@main">https://commits.webkit.org/285395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b287aae6c6262b2fa6123b885c4ba855becab37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62371 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37472 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19335 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65489 "Found 4 new test failures: fast/editing/document-leak-altered-text-field.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-float.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgba16f-rgba-float.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64755 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6663 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11131 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2433 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->