### PR TITLE
[Skia] Enable text subpixel positioning when not running tests and not full hinting

### DIFF
--- a/Source/WebCore/platform/graphics/FontRenderOptions.h
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.h
@@ -80,6 +80,7 @@ public:
 #endif
 
     WEBCORE_EXPORT void disableHintingForTesting();
+    bool isHintingDisabledForTesting() const { return m_isHintingDisabledForTesting; }
 
 private:
     FontRenderOptions();

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -47,7 +47,14 @@ FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, boo
     m_font.setEmbolden(m_syntheticBold);
     m_font.setSkewX(m_syntheticOblique ? -SK_Scalar1 / 4 : 0);
     m_font.setEdging(FontRenderOptions::singleton().antialias());
-    m_font.setHinting(FontRenderOptions::singleton().hinting());
+    if (m_font.getEdging() == SkFont::Edging::kAlias) {
+        // Force full hinting when antialiasing is disabled like Cairo does.
+        m_font.setHinting(SkFontHinting::kFull);
+    } else
+        m_font.setHinting(FontRenderOptions::singleton().hinting());
+
+    // Force subpixel positioning when not running tests and full hinting was not requested.
+    m_font.setSubpixel(!FontRenderOptions::singleton().isHintingDisabledForTesting() && m_font.getHinting() != SkFontHinting::kFull);
 
     m_hbFont = SkiaHarfBuzzFont::getOrCreate(*m_font.getTypeface());
 


### PR DESCRIPTION
#### 9ebeefe8a6b07044fc8cd624ac88f7451bab82e1
<pre>
[Skia] Enable text subpixel positioning when not running tests and not full hinting
<a href="https://bugs.webkit.org/show_bug.cgi?id=281664">https://bugs.webkit.org/show_bug.cgi?id=281664</a>

Reviewed by Adrian Perez de Castro.

This matches chromium behavior and improves the kerning when hinting is
not disabled or slight. Also force full hinting when antialias is
disabled, which also matches chromium and Cairo.

* Source/WebCore/platform/graphics/FontRenderOptions.h:
(WebCore::FontRenderOptions::isHintingDisabledForTesting const):
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::FontPlatformData):

Canonical link: <a href="https://commits.webkit.org/285378@main">https://commits.webkit.org/285378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/209a8d4f82a7e91f297b71eaa30907d433254324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56984 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21875 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78162 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65441 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64708 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6588 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2319 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->