### PR TITLE
[GTK] Honor GtkSettings:gtk-font-rendering setting

### DIFF
--- a/Source/WebCore/platform/glib/SystemSettings.cpp
+++ b/Source/WebCore/platform/glib/SystemSettings.cpp
@@ -64,6 +64,9 @@ void SystemSettings::updateSettings(const SystemSettings::State& state)
     if (state.xftDPI)
         m_state.xftDPI = state.xftDPI;
 
+    if (state.followFontSystemSettings)
+        m_state.followFontSystemSettings = state.followFontSystemSettings;
+
     if (state.cursorBlink)
         m_state.cursorBlink = state.cursorBlink;
 

--- a/Source/WebCore/platform/glib/SystemSettings.h
+++ b/Source/WebCore/platform/glib/SystemSettings.h
@@ -44,6 +44,7 @@ struct SystemSettingsState {
     std::optional<String> xftHintStyle;
     std::optional<String> xftRGBA;
     std::optional<int> xftDPI;
+    std::optional<bool> followFontSystemSettings;
     std::optional<bool> cursorBlink;
     std::optional<int> cursorBlinkTime;
     std::optional<bool> primaryButtonWarpsSlider;
@@ -72,6 +73,7 @@ public:
     std::optional<bool> cursorBlink() const { return m_state.cursorBlink; }
     std::optional<int> cursorBlinkTime() const { return m_state.cursorBlinkTime; }
     std::optional<int> xftDPI() const { return m_state.xftDPI; }
+    std::optional<bool> followFontSystemSettings() const { return m_state.followFontSystemSettings; }
     std::optional<bool> overlayScrolling() const { return m_state.overlayScrolling; }
     std::optional<bool> primaryButtonWarpsSlider() const { return m_state.primaryButtonWarpsSlider; }
     std::optional<bool> enableAnimations() const { return m_state.enableAnimations; }

--- a/Source/WebCore/platform/graphics/FontRenderOptions.h
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.h
@@ -39,6 +39,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
+#if PLATFORM(GTK) && !USE(GTK4)
+static constexpr bool s_followSystemSettingsDefault = true;
+#else
+static constexpr bool s_followSystemSettingsDefault = false;
+#endif
+
 namespace WebCore {
 
 class FontRenderOptions {
@@ -70,15 +76,16 @@ public:
     void setHinting(std::optional<Hinting>);
     void setAntialias(std::optional<Antialias>);
     void setSubpixelOrder(std::optional<SubpixelOrder>);
+    void setFollowSystemSettings(std::optional<bool> followSystemSettings) { m_followSystemSettings = followSystemSettings.value_or(s_followSystemSettingsDefault); }
 
 #if USE(CAIRO)
     const cairo_font_options_t* fontOptions() const { return m_fontOptions.get(); }
 #elif USE(SKIA)
-    SkFontHinting hinting() const { return m_hinting; }
-    SkFont::Edging antialias() const { return m_antialias; }
-    SkPixelGeometry subpixelOrder() const { return m_subpixelOrder; }
+    SkFontHinting hinting() const;
+    SkFont::Edging antialias() const;
+    SkPixelGeometry subpixelOrder() const;
     void setUseSubpixelPositioning(bool enable) { m_useSubpixelPositioning = enable; }
-    bool useSubpixelPositioning() const { return m_useSubpixelPositioning; }
+    bool useSubpixelPositioning() const;
 #endif
 
     WEBCORE_EXPORT void disableHintingForTesting();
@@ -96,6 +103,7 @@ private:
     SkPixelGeometry m_subpixelOrder { kUnknown_SkPixelGeometry };
     bool m_useSubpixelPositioning { false };
 #endif
+    bool m_followSystemSettings { s_followSystemSettingsDefault };
     bool m_isHintingDisabledForTesting { false };
 };
 

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -63,7 +63,7 @@ FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, boo
     bool forceSubpixel = !FontRenderOptions::singleton().isHintingDisabledForTesting() && m_font.getHinting() != SkFontHinting::kFull;
     m_font.setSubpixel(forceSubpixel || useSubpixelPositioning);
 
-    m_font.setLinearMetrics(useSubpixelPositioning);
+    m_font.setLinearMetrics(m_font.getHinting() == SkFontHinting::kNone && m_font.isSubpixel());
 
     m_hbFont = SkiaHarfBuzzFont::getOrCreate(*m_font.getTypeface());
 

--- a/Source/WebKit/Shared/glib/SystemSettings.serialization.in
+++ b/Source/WebKit/Shared/glib/SystemSettings.serialization.in
@@ -30,6 +30,7 @@ headers: <WebCore/SystemSettings.h>
     std::optional<String> xftHintStyle;
     std::optional<String> xftRGBA;
     std::optional<int> xftDPI;
+    std::optional<bool> followFontSystemSettings;
     std::optional<bool> cursorBlink;
     std::optional<int> cursorBlinkTime;
     std::optional<bool> primaryButtonWarpsSlider;

--- a/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp
@@ -78,6 +78,11 @@ int SystemSettingsManagerProxy::xftDPI() const
     return -1;
 }
 
+bool SystemSettingsManagerProxy::followFontSystemSettings() const
+{
+    return false;
+}
+
 bool SystemSettingsManagerProxy::cursorBlink() const
 {
     return true;
@@ -112,7 +117,7 @@ void SystemSettingsManagerProxy::initialize()
 
 void SystemSettingsManagerProxy::settingsDidChange()
 {
-    auto& oldState = SystemSettings::singleton().settingsState();
+    const auto& oldState = SystemSettings::singleton().settingsState();
     SystemSettings::State changedState;
 
     auto themeName = this->themeName();
@@ -146,6 +151,10 @@ void SystemSettingsManagerProxy::settingsDidChange()
     auto xftRGBA = this->xftRGBA();
     if (oldState.xftRGBA != xftRGBA)
         changedState.xftRGBA = xftRGBA;
+
+    auto followFontSystemSettings = this->followFontSystemSettings();
+    if (oldState.followFontSystemSettings != followFontSystemSettings)
+        changedState.followFontSystemSettings = followFontSystemSettings;
 
     auto cursorBlink = this->cursorBlink();
     if (oldState.cursorBlink != cursorBlink)

--- a/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h
+++ b/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h
@@ -59,6 +59,7 @@ private:
     String xftHintStyle() const;
     String xftRGBA() const;
     int xftDPI() const;
+    bool followFontSystemSettings() const;
     bool cursorBlink() const;
     int cursorBlinkTime() const;
     bool primaryButtonWarpsSlider() const;

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -110,6 +110,21 @@ int SystemSettingsManagerProxy::xftDPI() const
     return dpiSetting;
 }
 
+bool SystemSettingsManagerProxy::followFontSystemSettings() const
+{
+#if USE(GTK4)
+#if GTK_CHECK_VERSION(4, 16, 0)
+    GtkFontRendering fontRendering;
+    g_object_get(m_settings, "gtk-font-rendering", &fontRendering, nullptr);
+    return fontRendering == GTK_FONT_RENDERING_MANUAL;
+#else
+    return false;
+#endif
+#endif
+
+    return true;
+}
+
 bool SystemSettingsManagerProxy::cursorBlink() const
 {
     gboolean cursorBlinkSetting;
@@ -159,6 +174,9 @@ SystemSettingsManagerProxy::SystemSettingsManagerProxy()
     g_signal_connect_swapped(m_settings, "notify::gtk-xft-hinting", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-xft-hintstyle", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-xft-rgba", G_CALLBACK(settingsChangedCallback), this);
+#if GTK_CHECK_VERSION(4, 16, 0)
+    g_signal_connect_swapped(m_settings, "notify::gtk-font-rendering", G_CALLBACK(settingsChangedCallback), this);
+#endif
     g_signal_connect_swapped(m_settings, "notify::gtk-cursor-blink", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-cursor-blink-time", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-primary-button-warps-slider", G_CALLBACK(settingsChangedCallback), this);

--- a/Source/WebKit/WebProcess/glib/SystemSettingsManager.cpp
+++ b/Source/WebKit/WebProcess/glib/SystemSettingsManager.cpp
@@ -63,10 +63,13 @@ SystemSettingsManager::SystemSettingsManager(WebProcess& process)
             fontRenderOptions.setAntialias(systemSettings.antialiasMode());
         }
 
+        if (state.followFontSystemSettings)
+            fontRenderOptions.setFollowSystemSettings(systemSettings.followFontSystemSettings());
+
         if (state.overlayScrolling || state.themeName)
             ScrollbarTheme::theme().themeChanged();
 
-        if (themeDidChange || antialiasSettingsDidChange || hintingSettingsDidChange)
+        if (themeDidChange || antialiasSettingsDidChange || hintingSettingsDidChange || state.followFontSystemSettings)
             Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment();
     }, this);
 }


### PR DESCRIPTION
#### 3172ac2bd7ab8d25a76213d488e515ef0b45baf7
<pre>
[GTK] Honor GtkSettings:gtk-font-rendering setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=281665">https://bugs.webkit.org/show_bug.cgi?id=281665</a>

Reviewed by Adrian Perez de Castro.

And ignore the font system settings when rendering mode is set to automatic.

* Source/WebCore/platform/glib/SystemSettings.cpp:
(WebCore::SystemSettings::updateSettings):
* Source/WebCore/platform/glib/SystemSettings.h:
(WebCore::SystemSettings::followFontSystemSettings const):
* Source/WebCore/platform/graphics/FontRenderOptions.h:
(WebCore::FontRenderOptions::setFollowSystemSettings):
(WebCore::FontRenderOptions::hinting const): Deleted.
(WebCore::FontRenderOptions::antialias const): Deleted.
(WebCore::FontRenderOptions::subpixelOrder const): Deleted.
* Source/WebCore/platform/graphics/skia/FontRenderOptionsSkia.cpp:
(WebCore::FontRenderOptions::hinting const):
(WebCore::FontRenderOptions::antialias const):
(WebCore::FontRenderOptions::subpixelOrder const):
* Source/WebKit/Shared/glib/SystemSettings.serialization.in:
* Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp:
(WebKit::SystemSettingsManagerProxy::settingsDidChange):
* Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h:
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::followFontSystemSettings const):
(WebKit::SystemSettingsManagerProxy::SystemSettingsManagerProxy):
* Source/WebKit/WebProcess/glib/SystemSettingsManager.cpp:
(WebKit::SystemSettingsManager::SystemSettingsManager):

Canonical link: <a href="https://commits.webkit.org/285502@main">https://commits.webkit.org/285502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19bbf55a6b352ef7558d946ca07e1919481b8b8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57300 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15786 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22434 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65018 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6990 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2881 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->