### PR TITLE
[GTK][WPE] Use std::array to store GObject signal and property identifiers

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp
@@ -75,9 +75,7 @@ struct _WebKitAuthenticationRequestPrivate {
     std::optional<bool> canSaveCredentials;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitAuthenticationRequest, webkit_authentication_request, G_TYPE_OBJECT, GObject)
 
@@ -499,9 +497,7 @@ void webkit_authentication_request_cancel(WebKitAuthenticationRequest* request)
     request->priv->acceptedCredential = std::nullopt;
     request->priv->handledRequest = true;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(request, signals[CANCELLED], 0);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -61,9 +61,7 @@ struct _WebKitBackForwardListPrivate {
     BackForwardListItemsMap itemsMap;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitBackForwardList, webkit_back_forward_list, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -100,9 +100,7 @@ struct _WebKitCookieManagerPrivate {
     RefPtr<CookieStoreObserver> m_observer;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitCookieManager, webkit_cookie_manager, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
@@ -36,8 +36,6 @@
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebKit;
 using namespace WebCore;
 
@@ -72,7 +70,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitDownloadPrivate {
     ~_WebKitDownloadPrivate()
@@ -101,7 +99,7 @@ struct _WebKitDownloadPrivate {
     bool allowOverwrite;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitDownload, webkit_download, G_TYPE_OBJECT, GObject)
 
@@ -233,7 +231,7 @@ static void webkit_download_class_init(WebKitDownloadClass* downloadClass)
             FALSE,
             WEBKIT_PARAM_READWRITE);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitDownload::received-data:
@@ -727,5 +725,3 @@ void webkit_download_set_allow_overwrite(WebKitDownload* download, gboolean allo
     download->priv->allowOverwrite = allowed;
     g_object_notify_by_pspec(G_OBJECT(download), sObjProperties[PROP_ALLOW_OVERWRITE]);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -52,9 +52,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitEditorStatePrivate {
     WebPageProxy* page;
@@ -66,9 +64,7 @@ struct _WebKitEditorStatePrivate {
     unsigned isRedoAvailable : 1;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitEditorState, webkit_editor_state, G_TYPE_OBJECT, GObject)
 
@@ -106,7 +102,7 @@ static void webkit_editor_state_class_init(WebKitEditorStateClass* editorStateCl
             0, G_MAXUINT, 0,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitEditorState::changed:
@@ -132,10 +128,7 @@ static void webkitEditorStateSetTypingAttributes(WebKitEditorState* editorState,
         return;
 
     editorState->priv->typingAttributes = typingAttributes;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(editorState), sObjProperties[PROP_TYPING_ATTRIBUTES]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 WebKitEditorState* webkitEditorStateCreate(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -40,8 +40,6 @@
 #include <WebCore/RefPtrCairo.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebKit;
 using namespace WebCore;
 
@@ -67,7 +65,7 @@ enum {
     LAST_SIGNAL
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 struct _WebKitFaviconDatabasePrivate {
     RefPtr<IconDatabase> iconDatabase;
@@ -183,11 +181,13 @@ void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase* database, co
         return;
     }
 
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (g_str_has_prefix(pageURI, "about:")) {
         g_task_report_new_error(database, callback, userData, 0,
             WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_NOT_FOUND, _("Page %s does not have a favicon"), pageURI);
         return;
     }
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     GRefPtr<GTask> task = adoptGRef(g_task_new(database, cancellable, callback, userData));
     WebKitFaviconDatabasePrivate* priv = database->priv;
@@ -321,5 +321,3 @@ void webkit_favicon_database_clear(WebKitFaviconDatabase* database)
 
     database->priv->iconDatabase->clear([] { });
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp
@@ -54,9 +54,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     PREEDIT_STARTED,
@@ -144,9 +142,7 @@ struct _WebKitInputMethodContextPrivate {
     WebKitInputHints hints;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_ABSTRACT_TYPE(WebKitInputMethodContext, webkit_input_method_context, G_TYPE_OBJECT)
 
@@ -254,7 +250,7 @@ static void webkit_input_method_context_class_init(WebKitInputMethodContextClass
             WEBKIT_INPUT_HINT_NONE,
             WEBKIT_PARAM_READWRITE);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitInputMethodContext::preedit-started:
@@ -551,10 +547,7 @@ void webkit_input_method_context_set_input_purpose(WebKitInputMethodContext* con
         return;
 
     context->priv->purpose = purpose;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(context), sObjProperties[PROP_INPUT_PURPOSE]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -591,8 +584,5 @@ void webkit_input_method_context_set_input_hints(WebKitInputMethodContext* conte
         return;
 
     context->priv->hints = hints;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(context), sObjProperties[PROP_INPUT_HINTS]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -65,9 +65,7 @@ enum {
     N_PROPERTIES
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     DOWNLOAD_STARTED,
@@ -75,9 +73,7 @@ enum {
     LAST_SIGNAL
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 struct _WebKitNetworkSessionPrivate {
     _WebKitNetworkSessionPrivate()
@@ -201,7 +197,7 @@ static void webkit_network_session_class_init(WebKitNetworkSessionClass* session
             FALSE,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitNetworkSession::download-started:
@@ -224,9 +220,7 @@ static void webkit_network_session_class_init(WebKitNetworkSessionClass* session
 
 void webkitNetworkSessionDownloadStarted(WebKitNetworkSession* session, WebKitDownload* download)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(session, signals[DOWNLOAD_STARTED], 0, download);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 static gpointer createDefaultNetworkSession(gpointer)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp
@@ -58,9 +58,7 @@ struct _WebKitNotificationPrivate {
     guint64 id;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitNotification, webkit_notification, G_TYPE_OBJECT, GObject)
 
@@ -287,10 +285,7 @@ const gchar* webkit_notification_get_tag(WebKitNotification* notification)
 void webkit_notification_close(WebKitNotification* notification)
 {
     g_return_if_fail(WEBKIT_IS_NOTIFICATION(notification));
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(notification, signals[CLOSED], 0);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -307,8 +302,5 @@ void webkit_notification_close(WebKitNotification* notification)
 void webkit_notification_clicked(WebKitNotification* notification)
 {
     g_return_if_fail(WEBKIT_IS_NOTIFICATION(notification));
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(notification, signals[CLICKED], 0);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
@@ -61,9 +61,7 @@ enum {
     LAST_SIGNAL
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitOptionMenu, webkit_option_menu, G_TYPE_OBJECT, GObject)
 
@@ -211,9 +209,7 @@ void webkit_option_menu_close(WebKitOptionMenu* menu)
 {
     g_return_if_fail(WEBKIT_IS_OPTION_MENU(menu));
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(menu, signals[CLOSE], 0, nullptr);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -57,8 +57,6 @@
 
 #define FEATURE_DEFAULT(featureName) ((DEFAULT_VALUE_FOR_ ## featureName) ? TRUE : FALSE)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebKit;
 
 struct _WebKitSettingsPrivate {
@@ -194,7 +192,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void webKitSettingsDispose(GObject* object)
 {
@@ -1717,7 +1715,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         nullptr, // A null string forces the default value.
         readWriteConstructParamFlags);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 WebPreferences* webkitSettingsGetPreferences(WebKitSettings* settings)
@@ -4301,6 +4299,8 @@ WebKitFeatureList* webkit_settings_get_development_features(void)
  */
 gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile* keyFile, const gchar* groupName, GError** error)
 {
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
     g_return_val_if_fail(keyFile, FALSE);
     g_return_val_if_fail(groupName, FALSE);
@@ -4398,6 +4398,8 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
 
     g_object_setv(G_OBJECT(settings), propertyNames->len, const_cast<const char**>(reinterpret_cast<char**>(propertyNames->pdata)), reinterpret_cast<GValue*>(values->data));
     return TRUE;
+
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -4447,5 +4449,3 @@ webkit_settings_set_webrtc_udp_ports_range(WebKitSettings* settings, const gchar
     UNUSED_PARAM(udpPortsRange);
 #endif
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp
@@ -33,9 +33,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 using namespace WebKit;
 using namespace WebCore;
@@ -121,7 +119,7 @@ static void webkit_uri_scheme_response_class_init(WebKitURISchemeResponseClass* 
             -1, INT64_MAX, -1,
             static_cast<GParamFlags>(WEBKIT_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 // Private getters

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -77,9 +77,7 @@ enum {
     LAST_SIGNAL
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 static void webkit_user_content_manager_class_init(WebKitUserContentManagerClass* klass)
 {
@@ -410,14 +408,10 @@ public:
     {
 #if ENABLE(2022_GLIB_API)
         GRefPtr<JSCValue> value = API::SerializedScriptValue::deserialize(serializedScriptValue);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         g_signal_emit(m_manager, signals[SCRIPT_MESSAGE_RECEIVED], m_handlerName, value.get());
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #else
         WebKitJavascriptResult* jsResult = webkitJavascriptResultCreate(serializedScriptValue);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         g_signal_emit(m_manager, signals[SCRIPT_MESSAGE_RECEIVED], m_handlerName, jsResult);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         webkit_javascript_result_unref(jsResult);
 #endif
     }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -118,8 +118,6 @@
 #include "WebKitJavascriptResultPrivate.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebKit;
 using namespace WebCore;
 
@@ -243,7 +241,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 class PageLoadStateObserver final : public RefCounted<PageLoadStateObserver>, public PageLoadState::Observer {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PageLoadStateObserver);
@@ -422,7 +420,7 @@ struct _WebKitWebViewPrivate {
     bool isWebProcessResponsive;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 #if PLATFORM(GTK)
 WEBKIT_DEFINE_TYPE(WebKitWebView, webkit_web_view, WEBKIT_TYPE_WEB_VIEW_BASE)
@@ -1696,7 +1694,7 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
         nullptr,
         static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitWebView::load-changed:
@@ -5491,8 +5489,10 @@ void webkit_web_view_set_cors_allowlist(WebKitWebView* webView, const gchar* con
 
     Vector<String> allowListVector;
     if (allowList) {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (auto str = allowList; *str; ++str)
             allowListVector.append(String::fromUTF8(*str));
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     getPage(webView).setCORSDisablingPatterns(WTFMove(allowListVector));
@@ -5738,5 +5738,3 @@ webkit_web_view_get_default_content_security_policy(WebKitWebView* webView)
 
     return webView->priv->defaultContentSecurityPolicy.data();
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
@@ -29,8 +29,6 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebCore;
 
 /**
@@ -108,7 +106,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitWindowPropertiesPrivate {
 #if PLATFORM(GTK)
@@ -305,7 +303,7 @@ static void webkit_window_properties_class_init(WebKitWindowPropertiesClass* req
             FALSE,
             paramFlags);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 WebKitWindowProperties* webkitWindowPropertiesCreate()
@@ -534,5 +532,3 @@ gboolean webkit_window_properties_get_fullscreen(WebKitWindowProperties* windowP
 
     return windowProperties->priv->fullscreen;
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
@@ -63,9 +63,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     FINISHED,
@@ -81,9 +79,7 @@ struct _WebKitColorChooserRequestPrivate {
     bool handled;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitColorChooserRequest, webkit_color_chooser_request, G_TYPE_OBJECT, GObject)
 
@@ -142,7 +138,7 @@ static void webkit_color_chooser_request_class_init(WebKitColorChooserRequestCla
             GDK_TYPE_RGBA,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitColorChooserRequest::finished:
@@ -184,10 +180,7 @@ void webkit_color_chooser_request_set_rgba(WebKitColorChooserRequest* request, c
         return;
 
     request->priv->rgba = *rgba;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(request), sObjProperties[PROP_RGBA]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -250,10 +243,7 @@ void webkit_color_chooser_request_finish(WebKitColorChooserRequest* request)
         return;
 
     request->priv->handled = true;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(request, signals[FINISHED], 0);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -280,10 +270,7 @@ void webkit_color_chooser_request_cancel(WebKitColorChooserRequest* request)
 #if ENABLE(INPUT_TYPE_COLOR)
     request->priv->colorChooser->cancel();
 #endif // ENABLE(INPUT_TYPE_COLOR)
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_signal_emit(request, signals[FINISHED], 0);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #if ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -69,9 +69,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     FINISHED,
@@ -106,9 +104,7 @@ struct _WebKitPrintOperationPrivate {
     guint signalId { 0 };
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitPrintOperation, webkit_print_operation, G_TYPE_OBJECT, GObject)
 
@@ -202,7 +198,7 @@ static void webkit_print_operation_class_init(WebKitPrintOperationClass* printOp
             GTK_TYPE_PAGE_SETUP,
             WEBKIT_PARAM_READWRITE);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitPrintOperation::finished:
@@ -763,10 +759,7 @@ void webkit_print_operation_set_print_settings(WebKitPrintOperation* printOperat
         return;
 
     printOperation->priv->printSettings = printSettings;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(printOperation), sObjProperties[PROP_PRINT_SETTINGS]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -807,10 +800,7 @@ void webkit_print_operation_set_page_setup(WebKitPrintOperation* printOperation,
         return;
 
     printOperation->priv->pageSetup = pageSetup;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_object_notify_by_pspec(G_OBJECT(printOperation), sObjProperties[PROP_PAGE_SETUP]);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -77,9 +77,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitWebInspectorPrivate {
     ~_WebKitWebInspectorPrivate()
@@ -95,9 +93,7 @@ struct _WebKitWebInspectorPrivate {
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebInspector, webkit_web_inspector, G_TYPE_OBJECT, GObject)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 static void webkitWebInspectorGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {
@@ -161,7 +157,7 @@ static void webkit_web_inspector_class_init(WebKitWebInspectorClass* findClass)
             FALSE,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitWebInspector::open-window:
@@ -295,8 +291,6 @@ public:
     }
 
 private:
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     bool openWindow(WebInspectorUIProxy&) override
     {
         gboolean returnValue;
@@ -358,8 +352,6 @@ private:
         m_inspector->priv->canAttach = available;
         g_object_notify_by_pspec(G_OBJECT(m_inspector), sObjProperties[PROP_CAN_ATTACH]);
     }
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     WebKitWebInspector* m_inspector;
 };


### PR DESCRIPTION
#### 9d3358a6d868c44ea21571cf773d5a4ab1bf4852
<pre>
[GTK][WPE] Use std::array to store GObject signal and property identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=281667">https://bugs.webkit.org/show_bug.cgi?id=281667</a>

Reviewed by Carlos Garcia Campos.

Replace usage of raw arrays with std::array for GObject signal
and property identifiers. This allows removing a number of
WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} opt-outs, or in a few
files narrowing them down to a few lines of code only.

* Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp:
(webkit_authentication_request_cancel):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(webkit_download_class_init):
(webkit_download_set_allow_overwrite):
* Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp:
(webkit_editor_state_class_init):
(webkitEditorStateSetTypingAttributes):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseGetFaviconInternal):
(webkit_favicon_database_clear):
* Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp:
(webkit_input_method_context_class_init):
(webkit_input_method_context_set_input_purpose):
(webkit_input_method_context_set_input_hints):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_class_init):
(webkitNetworkSessionDownloadStarted):
* Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp:
(webkit_notification_close):
(webkit_notification_clicked):
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp:
(webkit_option_menu_close):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_class_init):
(webkit_settings_apply_from_key_file):
(webkit_settings_set_webrtc_udp_ports_range):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp:
(webkit_uri_scheme_response_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp:
(webkit_window_properties_class_init):
(webkit_window_properties_get_fullscreen):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp:
(webkit_color_chooser_request_class_init):
(webkit_color_chooser_request_set_rgba):
(webkit_color_chooser_request_finish):
(webkit_color_chooser_request_cancel):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkit_print_operation_class_init):
(webkit_print_operation_set_print_settings):
(webkit_print_operation_set_page_setup):
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp:
(webkit_web_inspector_class_init):

Canonical link: <a href="https://commits.webkit.org/285400@main">https://commits.webkit.org/285400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30c2fcbbf9e3e3b11f03e27cc912f184f07a0013

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25337 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59774 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23580 "Failed to checkout and rebase branch from PR 35361") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75616 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22108 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16790 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/23580 "Failed to checkout and rebase branch from PR 35361") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16838 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/13114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11134 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47768 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->