### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for CtapDriver

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -74,7 +74,7 @@ CcidService::~CcidService()
 void CcidService::didConnectTag()
 {
     auto connection = m_connection;
-    getInfo(WTF::makeUnique<CtapCcidDriver>(connection.releaseNonNull(), m_connection->contactless() ? WebCore::AuthenticatorTransport::Nfc : WebCore::AuthenticatorTransport::SmartCard));
+    getInfo(CtapCcidDriver::create(connection.releaseNonNull(), m_connection->contactless() ? WebCore::AuthenticatorTransport::Nfc : WebCore::AuthenticatorTransport::SmartCard));
 }
 
 void CcidService::startDiscoveryInternal()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -99,7 +99,7 @@ Ref<HidConnection> HidService::createHidConnection(IOHIDDeviceRef device) const
 void HidService::deviceAdded(IOHIDDeviceRef device)
 {
 #if HAVE(SECURITY_KEY_API)
-    getInfo(WTF::makeUnique<CtapHidDriver>(createHidConnection(device)));
+    getInfo(CtapHidDriver::create(createHidConnection(device)));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
@@ -66,7 +66,7 @@ void NfcService::didConnectTag()
 #if HAVE(NEAR_FIELD)
     auto connection = m_connection;
     ASSERT(connection);
-    getInfo(WTF::makeUnique<CtapNfcDriver>(connection.releaseNonNull()));
+    getInfo(CtapNfcDriver::create(connection.releaseNonNull()));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -81,7 +81,7 @@ void VirtualService::startDiscoveryInternal()
         case WebCore::AuthenticatorTransport::Nfc:
         case WebCore::AuthenticatorTransport::Ble:
         case WebCore::AuthenticatorTransport::Usb:
-            observer()->authenticatorAdded(CtapAuthenticator::create(WTF::makeUnique<CtapHidDriver>(VirtualHidConnection::create(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
+            observer()->authenticatorAdded(CtapAuthenticator::create(CtapHidDriver::create(VirtualHidConnection::create(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
             break;
         case WebCore::AuthenticatorTransport::Internal:
             observer()->authenticatorAdded(LocalAuthenticator::create(makeUniqueRef<VirtualLocalConnection>(config)));

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -104,7 +104,7 @@ bool isPinError(const CtapDeviceResponseCode& error)
 
 } // namespace
 
-CtapAuthenticator::CtapAuthenticator(std::unique_ptr<CtapDriver>&& driver, AuthenticatorGetInfoResponse&& info)
+CtapAuthenticator::CtapAuthenticator(Ref<CtapDriver>&& driver, AuthenticatorGetInfoResponse&& info)
     : FidoAuthenticator(WTFMove(driver))
     , m_info(WTFMove(info))
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -47,13 +47,13 @@ class CtapDriver;
 
 class CtapAuthenticator final : public FidoAuthenticator {
 public:
-    static Ref<CtapAuthenticator> create(std::unique_ptr<CtapDriver>&& driver, fido::AuthenticatorGetInfoResponse&& info)
+    static Ref<CtapAuthenticator> create(Ref<CtapDriver>&& driver, fido::AuthenticatorGetInfoResponse&& info)
     {
         return adoptRef(*new CtapAuthenticator(WTFMove(driver), WTFMove(info)));
     }
 
 private:
-    explicit CtapAuthenticator(std::unique_ptr<CtapDriver>&&, fido::AuthenticatorGetInfoResponse&&);
+    explicit CtapAuthenticator(Ref<CtapDriver>&&, fido::AuthenticatorGetInfoResponse&&);
 
     void makeCredential() final;
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -36,6 +36,11 @@ namespace WebKit {
 using namespace apdu;
 using namespace fido;
 
+Ref<CtapCcidDriver> CtapCcidDriver::create(Ref<CcidConnection>&& connection, WebCore::AuthenticatorTransport transport)
+{
+    return adoptRef(*new CtapCcidDriver(WTFMove(connection), transport));
+}
+
 CtapCcidDriver::CtapCcidDriver(Ref<CcidConnection>&& connection, WebCore::AuthenticatorTransport transport)
     : CtapDriver(transport)
     , m_connection(WTFMove(connection))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
@@ -35,13 +35,15 @@ namespace WebKit {
 
 // The following implements the CTAP NFC protocol:
 // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc
-class CtapCcidDriver : public CtapDriver {
+class CtapCcidDriver final : public CtapDriver {
 public:
-    explicit CtapCcidDriver(Ref<CcidConnection>&&, WebCore::AuthenticatorTransport);
+    static Ref<CtapCcidDriver> create(Ref<CcidConnection>&&, WebCore::AuthenticatorTransport);
 
     void transact(Vector<uint8_t>&& data, ResponseCallback&&) final;
 
 private:
+    explicit CtapCcidDriver(Ref<CcidConnection>&&, WebCore::AuthenticatorTransport);
+
     void respondAsync(ResponseCallback&&, Vector<uint8_t>&& response) const;
 
     Ref<CcidConnection> m_connection;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
@@ -32,21 +32,12 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class CtapDriver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CtapDriver> : std::true_type { };
-}
 
 namespace WebKit {
 
-class CtapDriver : public CanMakeWeakPtr<CtapDriver> {
+class CtapDriver : public RefCountedAndCanMakeWeakPtr<CtapDriver> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(CtapDriver);
     WTF_MAKE_NONCOPYABLE(CtapDriver);
 public:
@@ -63,8 +54,9 @@ public:
     virtual void cancel() { };
 
 protected:
-    CtapDriver(WebCore::AuthenticatorTransport transport)
-        : m_transport(transport) { }
+    explicit CtapDriver(WebCore::AuthenticatorTransport transport)
+        : m_transport(transport)
+    { }
 
 private:
     fido::ProtocolVersion m_protocol { fido::ProtocolVersion::kCtap };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -163,6 +163,11 @@ void CtapHidDriverWorker::cancel(fido::FidoHidMessage&& requestMessage)
     connection->sendSync(requestMessage.popNextPacket());
 }
 
+Ref<CtapHidDriver> CtapHidDriver::create(Ref<HidConnection>&& connection)
+{
+    return adoptRef(*new CtapHidDriver(WTFMove(connection)));
+}
+
 CtapHidDriver::CtapHidDriver(Ref<HidConnection>&& connection)
     : CtapDriver(WebCore::AuthenticatorTransport::Usb)
     , m_worker(makeUniqueRef<CtapHidDriverWorker>(WTFMove(connection)))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
@@ -34,13 +34,11 @@
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
-class CtapHidDriver;
 class CtapHidDriverWorker;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CtapHidDriver> : std::true_type { };
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CtapHidDriverWorker> : std::true_type { };
 }
 
@@ -95,12 +93,14 @@ public:
         Busy
     };
 
-    explicit CtapHidDriver(Ref<HidConnection>&&);
+    static Ref<CtapHidDriver> create(Ref<HidConnection>&&);
 
     void transact(Vector<uint8_t>&& data, ResponseCallback&&) final;
     void cancel() final;
 
 private:
+    explicit CtapHidDriver(Ref<HidConnection>&&);
+
     void continueAfterChannelAllocated(std::optional<fido::FidoHidMessage>&&);
     void continueAfterResponseReceived(std::optional<fido::FidoHidMessage>&&);
     void returnResponse(Vector<uint8_t>&&);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
@@ -36,6 +36,11 @@ namespace WebKit {
 using namespace apdu;
 using namespace fido;
 
+Ref<CtapNfcDriver> CtapNfcDriver::create(Ref<NfcConnection>&& connection)
+{
+    return adoptRef(*new CtapNfcDriver(WTFMove(connection)));
+}
+
 CtapNfcDriver::CtapNfcDriver(Ref<NfcConnection>&& connection)
     : CtapDriver(WebCore::AuthenticatorTransport::Nfc)
     , m_connection(WTFMove(connection))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
@@ -35,13 +35,15 @@ namespace WebKit {
 
 // The following implements the CTAP NFC protocol:
 // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc
-class CtapNfcDriver : public CtapDriver {
+class CtapNfcDriver final : public CtapDriver {
 public:
-    explicit CtapNfcDriver(Ref<NfcConnection>&&);
+    static Ref<CtapNfcDriver> create(Ref<NfcConnection>&&);
 
     void transact(Vector<uint8_t>&& data, ResponseCallback&&) final;
 
 private:
+    explicit CtapNfcDriver(Ref<NfcConnection>&&);
+
     void respondAsync(ResponseCallback&&, Vector<uint8_t>&& response) const;
 
     Ref<NfcConnection> m_connection;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-FidoAuthenticator::FidoAuthenticator(std::unique_ptr<CtapDriver>&& driver)
+FidoAuthenticator::FidoAuthenticator(Ref<CtapDriver>&& driver)
     : m_driver(WTFMove(driver))
 {
     ASSERT(m_driver);
@@ -41,8 +41,8 @@ FidoAuthenticator::FidoAuthenticator(std::unique_ptr<CtapDriver>&& driver)
 
 FidoAuthenticator::~FidoAuthenticator()
 {
-    if (m_driver)
-        m_driver->cancel();
+    if (RefPtr driver = m_driver)
+        driver->cancel();
 }
 
 CtapDriver& FidoAuthenticator::driver() const
@@ -51,10 +51,10 @@ CtapDriver& FidoAuthenticator::driver() const
     return *m_driver;
 }
 
-std::unique_ptr<CtapDriver> FidoAuthenticator::releaseDriver()
+Ref<CtapDriver> FidoAuthenticator::releaseDriver()
 {
     ASSERT(m_driver);
-    return WTFMove(m_driver);
+    return m_driver.releaseNonNull();
 }
 
 String FidoAuthenticator::transportForDebugging() const

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -35,18 +35,18 @@ class CtapDriver;
 
 class FidoAuthenticator : public Authenticator {
 public:
-    ~FidoAuthenticator() override;
+    ~FidoAuthenticator();
 
 protected:
-    explicit FidoAuthenticator(std::unique_ptr<CtapDriver>&&);
+    explicit FidoAuthenticator(Ref<CtapDriver>&&);
 
     CtapDriver& driver() const;
-    std::unique_ptr<CtapDriver> releaseDriver();
+    Ref<CtapDriver> releaseDriver();
 
     String transportForDebugging() const;
 
 private:
-    std::unique_ptr<CtapDriver> m_driver;
+    RefPtr<CtapDriver> m_driver;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
@@ -42,13 +42,13 @@ public:
 
 protected:
     explicit FidoService(AuthenticatorTransportServiceObserver&);
-    void getInfo(std::unique_ptr<CtapDriver>&&);
+    void getInfo(Ref<CtapDriver>&&);
 
 private:
     void continueAfterGetInfo(WeakPtr<CtapDriver>&&, Vector<uint8_t>&& info);
 
     // Keeping drivers alive when they are getting info from devices.
-    HashSet<std::unique_ptr<CtapDriver>> m_drivers;
+    HashSet<Ref<CtapDriver>> m_drivers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -49,7 +49,7 @@ namespace {
 const unsigned retryTimeOutValueMs = 200;
 }
 
-U2fAuthenticator::U2fAuthenticator(std::unique_ptr<CtapDriver>&& driver)
+U2fAuthenticator::U2fAuthenticator(Ref<CtapDriver>&& driver)
     : FidoAuthenticator(WTFMove(driver))
     , m_retryTimer(RunLoop::main(), this, &U2fAuthenticator::retryLastCommand)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
@@ -40,13 +40,13 @@ class CtapDriver;
 
 class U2fAuthenticator final : public FidoAuthenticator {
 public:
-    static Ref<U2fAuthenticator> create(std::unique_ptr<CtapDriver>&& driver)
+    static Ref<U2fAuthenticator> create(Ref<CtapDriver>&& driver)
     {
         return adoptRef(*new U2fAuthenticator(WTFMove(driver)));
     }
 
 private:
-    explicit U2fAuthenticator(std::unique_ptr<CtapDriver>&&);
+    explicit U2fAuthenticator(Ref<CtapDriver>&&);
 
     void makeCredential() final;
     void checkExcludeList(size_t index);


### PR DESCRIPTION
#### a67d4444756aeea139c5212aeae603e35425d7f0
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for CtapDriver
<a href="https://bugs.webkit.org/show_bug.cgi?id=281670">https://bugs.webkit.org/show_bug.cgi?id=281670</a>

Reviewed by Geoffrey Garen and Ryosuke Niwa.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::didConnectTag):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
(WebKit::HidService::deviceAdded):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm:
(WebKit::NfcService::didConnectTag):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::VirtualService::startDiscoveryInternal):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::CtapAuthenticator):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp:
(WebKit::CtapCcidDriver::create):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h:
(WebKit::CtapDriver::CtapDriver):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriver::create):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp:
(WebKit::CtapNfcDriver::create):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp:
(WebKit::FidoAuthenticator::FidoAuthenticator):
(WebKit::FidoAuthenticator::~FidoAuthenticator):
(WebKit::FidoAuthenticator::releaseDriver):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp:
(WebKit::FidoService::getInfo):
(WebKit::FidoService::continueAfterGetInfo):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::U2fAuthenticator):
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/285402@main">https://commits.webkit.org/285402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ce4b4196e81ef844875bfc565e006deb27edd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15573 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43620 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19360 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65502 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64769 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13049 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6692 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->