### PR TITLE
Adding a Test to check if Swift refcounting is really working.

### DIFF
--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -46,8 +46,12 @@ class RefCountedBase {
 public:
     WTF_EXPORT_PRIVATE static void logRefDuringDestruction(const void*);
     WTF_EXPORT_PRIVATE static void printRefDuringDestructionLogAndCrash [[noreturn]] (const void*);
-
+#ifndef __swift__
     void ref() const
+#else
+    // FIXME: swift is not importing const methods.
+    void ref()
+#endif
     {
         applyRefDerefThreadingCheck();
         applyRefDuringDestructionCheck();

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -478,12 +478,11 @@ void Buffer::indirectBufferInvalidated()
 void Buffer::copy(const std::span<const uint8_t> data, const size_t offset)
 {
     auto buffer = getBufferContents();
-    RELEASE_ASSERT(buffer);
     auto endOffset = checkedSum<size_t>(offset, data.size());
-    RELEASE_ASSERT(!(endOffset.hasOverflowed() || endOffset.value() > currentSize()));
-    auto checkSize = checkedSum<size_t>(currentSize());
+    RELEASE_ASSERT(!(endOffset.hasOverflowed() || endOffset.value() > buffer.size()));
+    auto checkSize = checkedSum<size_t>(buffer.size());
     RELEASE_ASSERT(!checkSize.hasOverflowed());
-    auto destination = std::span<uint8_t> { buffer + offset, static_cast<size_t>(currentSize()) - offset };
+    auto destination = std::span<uint8_t> { buffer.data() + offset, buffer.size() - offset };
     WebGPU::copySpan(destination, data);
 }
 #endif

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -166,6 +166,7 @@ WGPU_EXPORT void wgpuDeviceClearUncapturedErrorCallback(WGPUDevice device) WGPU_
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 
 #if defined(ENABLE_WEBGPU_SWIFT) && ENABLE_WEBGPU_SWIFT && defined(__WEBGPU__)
+#include <Metal/Metal.h>
 #include "Buffer.h"
 #include "CommandEncoder.h"
 #include "CommandsMixin.h"

--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -117,6 +117,8 @@ def parse_args(args):
                              help='Only check and run TestWebCore.exe (Windows only)'),
         optparse.make_option('--webkit-legacy-only', action='store_const', const='TestWebKitLegacy', dest='api_binary',
                              help='Only check and run TestWebKitLegacy.exe (Windows only)'),
+        optparse.make_option('--webgpu-only', action='store_const', const='TestWebGPU', dest='api_binary',
+                             help='Only check and run TestWebGPU (Darwin ports only)'),
         optparse.make_option('--wgsl-only', action='store_const', const='TestWGSL', dest='api_binary',
                              help='Only check and run TestWGSL (Darwin ports only)'),
         optparse.make_option('-d', '--dump', action='store_true', default=False,

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -42,7 +42,7 @@ class DarwinPort(ApplePort):
     CURRENT_VERSION = None
     SDK = None
 
-    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']
+    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL', 'TestWebGPU']
 
     def __init__(self, host, port_name, **kwargs):
         ApplePort.__init__(self, host, port_name, **kwargs)

--- a/Tools/TestWebKitAPI/Configurations/TestWebGPU.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebGPU.xcconfig
@@ -1,0 +1,39 @@
+// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+PRODUCT_NAME = TestWebGPU;
+
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) ENABLE_WEBGPU_SWIFT;
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/Tests/WebGPU;
+
+DEFINES_MODULE = YES;
+MODULEMAP_FILE = $(SRCROOT)/Tests/WebGPU/TestWebGPU.modulemap;
+
+SWIFT_OBJC_INTERFACE_HEADER_NAME = TestWebGPUSwift-Generated.h;
+SWIFT_VERSION = 5.0;
+SWIFT_OBJC_INTEROP_MODE = objcxx;
+
+SWIFT_INSTALL_OBJC_HEADER = NO;
+
+OTHER_SWIFT_FLAGS = -Xcc -std=c++20 -Xcc $(SRCROOT)/Tests/WebGPU;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
@@ -24,14 +24,14 @@
 
 GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) GTEST_API_=
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) GTEST_API_= $(GCC_PREPROCESSOR_DEFINITIONS_$(ENABLE_WEBGPU_SWIFT))
+GCC_PREPROCESSOR_DEFINITIONS_ENABLE_WEBGPU_SWIFT = ENABLE_WEBGPU_SWIFT;
 
 FRAMEWORK_SEARCH_PATHS = $(FRAMEWORK_SEARCH_PATHS_$(WK_COCOA_TOUCH));
 FRAMEWORK_SEARCH_PATHS_ = $(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks $(SYSTEM_LIBRARY_DIR)/Frameworks/WebKit.framework/Versions/A/Frameworks;
 FRAMEWORK_SEARCH_PATHS_cocoatouch = $(inherited);
 
 PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform $(SRCROOT)/../../Source/WebKit/Platform/IPC $(SRCROOT)/../../Source/WebKit/Platform/IPC/darwin $(SRCROOT)/../../Source/WebKit/Platform/IPC/cocoa $(SRCROOT)/../../Source/WebKit/Shared $(SRCROOT)/../../Source/WebKit/Shared/Cocoa $(SRCROOT)/../../Source/WebKit/Shared/cf $(SRCROOT)/../../Source/WebKit/Shared/API/C $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit $(inherited);
-
 WK_APPSERVERSUPPORT_LDFLAGS[sdk=iphone*] = -framework AppServerSupport
 WK_APPSERVERSUPPORT_LDFLAGS[sdk=xr*] = -framework AppServerSupport
 
@@ -126,7 +126,7 @@ WK_WRITING_TOOLS_UI_LDFLAGS_MACOS_SINCE_1500 = -weak_framework WritingToolsUI;
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) $(GTEST_LDFLAGS) -lxml2 -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework CoreText -framework IOKit -lboringssl -licucore -lWebKitPlatform -framework LocalAuthentication -framework QuartzCore -framework Security $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(WK_WRITING_TOOLS_LDFLAGS) $(WK_WRITING_TOOLS_UI_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) $(GTEST_LDFLAGS) -lxml2 -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework CoreText -framework IOKit -lboringssl -licucore -lWebKitPlatform -framework LocalAuthentication -framework QuartzCore -framework Security $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(WK_WRITING_TOOLS_LDFLAGS) $(WK_WRITING_TOOLS_UI_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) -framework WebGPU;
 
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 				537CF84822EFD72000C6EBB3 /* Check .xcfilelists */,
 			);
 			dependencies = (
+				94E0F7CC2CC328700007B54B /* PBXTargetDependency */,
 				3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */,
 				7B9FC58828A26D83007570E7 /* PBXTargetDependency */,
 				7C83E0301D0A5E1B00FEBCF3 /* PBXTargetDependency */,
@@ -599,7 +600,14 @@
 		93F56DA71E5F9174003EDE84 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0331D0A5F2700FEBCF3 /* libicucore.dylib */; };
 		93F7E86F14DC8E5C00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */; };
 		93FCDB34263631560046DD7D /* SortedArrayMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93FCDB33263631560046DD7D /* SortedArrayMap.cpp */; };
+		940E06BC2CD9417B008EDD95 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E0F7AA2CC2F4B90007B54B /* Tests.swift */; };
+		940E06C82CD94937008EDD95 /* TestWebGPU.h in Sources */ = {isa = PBXBuildFile; fileRef = 940E06C72CD948D9008EDD95 /* TestWebGPU.h */; };
 		946422142BC83114001B42B3 /* SerializedScriptValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */; };
+		94E0F7B72CC2F7CD0007B54B /* RefCountTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94E0F7AB2CC2F6890007B54B /* RefCountTests.cpp */; };
+		94E0F7B82CC2F7CD0007B54B /* TestWebGPU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94E0F7A52CC2F16E0007B54B /* TestWebGPU.cpp */; };
+		94E0F7B92CC2F80A0007B54B /* libgtest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDF3A83728930475005920CF /* libgtest.a */; };
+		94E0F7BB2CC2F8210007B54B /* WebGPU.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E0F7BA2CC2F8210007B54B /* WebGPU.framework */; };
+		94E0F7C92CC324110007B54B /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E0F7C82CC324110007B54B /* libWTF.a */; };
 		9528E5FD279A0341008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */; };
 		95C52729275F35E100DA7E40 /* FontShadowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95C52728275F35E100DA7E40 /* FontShadowTests.cpp */; };
 		9B0786A51C5885C300D159E3 /* InjectedBundleMakeAllShadowRootsOpen_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B0786A41C5885C300D159E3 /* InjectedBundleMakeAllShadowRootsOpen_Bundle.cpp */; };
@@ -1414,6 +1422,20 @@
 			remoteGlobalIDString = 7CCE7E8B1A41144E00447C4C;
 			remoteInfo = TestWebKitAPILibrary;
 		};
+		940E06BA2CD9340F008EDD95 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDF3A82928930475005920CF /* gtest.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D07F2BC0486CC7A007CD1D0;
+			remoteInfo = "gtest-framework";
+		};
+		94E0F7CB2CC328700007B54B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 94E0F7AF2CC2F79C0007B54B;
+			remoteInfo = TestWebGPU;
+		};
 		A13EBBB21B87441900097110 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -1550,6 +1572,15 @@
 			);
 			name = "Product Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94E0F7AE2CC2F79C0007B54B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 		A17C464B2C98E4520023F3C7 /* Copy Resources */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -3148,7 +3179,16 @@
 		93F7E86B14DC8E4D00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewFirstVisuallyNonEmptyLayoutFrames.cpp; sourceTree = "<group>"; };
 		93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp; sourceTree = "<group>"; };
 		93FCDB33263631560046DD7D /* SortedArrayMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SortedArrayMap.cpp; sourceTree = "<group>"; };
+		940E06C72CD948D9008EDD95 /* TestWebGPU.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = TestWebGPU.h; sourceTree = "<group>"; };
 		9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SerializedScriptValue.cpp; sourceTree = "<group>"; };
+		94E0F7A52CC2F16E0007B54B /* TestWebGPU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestWebGPU.cpp; sourceTree = "<group>"; };
+		94E0F7A62CC2F1A30007B54B /* TestWebGPU.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestWebGPU.xcconfig; sourceTree = "<group>"; };
+		94E0F7A72CC2F47C0007B54B /* TestWebGPU.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = TestWebGPU.modulemap; sourceTree = "<group>"; };
+		94E0F7AA2CC2F4B90007B54B /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		94E0F7AB2CC2F6890007B54B /* RefCountTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCountTests.cpp; sourceTree = "<group>"; };
+		94E0F7B02CC2F79C0007B54B /* TestWebGPU */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestWebGPU; sourceTree = BUILT_PRODUCTS_DIR; };
+		94E0F7BA2CC2F8210007B54B /* WebGPU.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebGPU.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		94E0F7C82CC324110007B54B /* libWTF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWTF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		95095F1F262FFFA50000D920 /* SampledPageTopColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SampledPageTopColor.mm; sourceTree = "<group>"; };
 		950E4CC0252E75230071659F /* iOSStylusSupport.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = iOSStylusSupport.mm; sourceTree = "<group>"; };
 		95194CBF28A580E900343FDE /* red.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = red.html; sourceTree = "<group>"; };
@@ -3942,6 +3982,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		94E0F7AD2CC2F79C0007B54B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94E0F7B92CC2F80A0007B54B /* libgtest.a in Frameworks */,
+				94E0F7C92CC324110007B54B /* libWTF.a in Frameworks */,
+				94E0F7BB2CC2F8210007B54B /* WebGPU.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A1798B7D22431D18000764BD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -4170,6 +4220,7 @@
 				A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */,
 				A17C58022C9AA12F009DD0B5 /* TestWebKitAPI.app */,
 				A17C582E2C9B3EAD009DD0B5 /* TestWebKitAPIBundle.xctest */,
+				94E0F7B02CC2F79C0007B54B /* TestWebGPU */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4903,6 +4954,7 @@
 				7B9FC5A928A38F2E007570E7 /* libWebKitIPC.a */,
 				7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */,
 				3A5DDB2028D54269004DA950 /* libwgsl.a */,
+				94E0F7C82CC324110007B54B /* libWTF.a */,
 				7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */,
 				578CBD66204FB2C70083B9F2 /* LocalAuthentication.framework */,
 				516281282325C45400BB7E42 /* PDFKit.framework */,
@@ -4910,6 +4962,7 @@
 				574F55D0204D471C002948C6 /* Security.framework */,
 				A17C58242C9AAA25009DD0B5 /* UIKit.framework */,
 				7B9FC5B628A52236007570E7 /* WebCore.framework */,
+				94E0F7BA2CC2F8210007B54B /* WebGPU.framework */,
 				2B648DBA28C1C1F700791F2B /* WebKit.framework */,
 				A17C58452C9BF45A009DD0B5 /* XCTest.framework */,
 			);
@@ -4930,6 +4983,18 @@
 				37C7CC2B1EA4146B007BD956 /* WeakLinking.cpp */,
 			);
 			path = darwin;
+			sourceTree = "<group>";
+		};
+		94E0F79D2CC2F1570007B54B /* WebGPU */ = {
+			isa = PBXGroup;
+			children = (
+				94E0F7AB2CC2F6890007B54B /* RefCountTests.cpp */,
+				94E0F7AA2CC2F4B90007B54B /* Tests.swift */,
+				94E0F7A52CC2F16E0007B54B /* TestWebGPU.cpp */,
+				940E06C72CD948D9008EDD95 /* TestWebGPU.h */,
+				94E0F7A72CC2F47C0007B54B /* TestWebGPU.modulemap */,
+			);
+			path = WebGPU;
 			sourceTree = "<group>";
 		};
 		9BD5111A1FE8E10200D2B630 /* mac */ = {
@@ -5422,6 +5487,7 @@
 				BC90957F12554CF900083756 /* DebugRelease.xcconfig */,
 				BC575AE2126E88B1006F0F12 /* InjectedBundle.xcconfig */,
 				7B9FC58628A2682E007570E7 /* TestIPC.xcconfig */,
+				94E0F7A62CC2F1A30007B54B /* TestWebGPU.xcconfig */,
 				5735F0251F3A4EA6000EE801 /* TestWebKitAPI-iOS.entitlements */,
 				51EB125324C66BCB000CB030 /* TestWebKitAPI-macOS-internal.entitlements */,
 				7AB0173923FB2BF0002F8366 /* TestWebKitAPI-macOS.entitlements */,
@@ -5876,6 +5942,7 @@
 				7B774903267CCE38009873B4 /* Misc */,
 				C08587F913FEC39B001EF4E5 /* TestWebKitAPI */,
 				440A1D3614A01000008A66F2 /* WebCore */,
+				94E0F79D2CC2F1570007B54B /* WebGPU */,
 				BC9096411255616000083756 /* WebKit */,
 				1ABC3DEC1899BE55004F0626 /* WebKit Cocoa */,
 				BC3C4C6F14575B1D0025FB62 /* WebKit Objective-C */,
@@ -6310,6 +6377,25 @@
 			productReference = 8DD76FA10486AA7600D96B5E /* TestWebKitAPI */;
 			productType = "com.apple.product-type.tool";
 		};
+		94E0F7AF2CC2F79C0007B54B /* TestWebGPU */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 94E0F7B42CC2F79C0007B54B /* Build configuration list for PBXNativeTarget "TestWebGPU" */;
+			buildPhases = (
+				94E0F7AC2CC2F79C0007B54B /* Sources */,
+				94E0F7AD2CC2F79C0007B54B /* Frameworks */,
+				94E0F7AE2CC2F79C0007B54B /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				940E06BB2CD9340F008EDD95 /* PBXTargetDependency */,
+			);
+			name = TestWebGPU;
+			productInstallPath = "$(HOME)/bin";
+			productName = TestWebKitAPI;
+			productReference = 94E0F7B02CC2F79C0007B54B /* TestWebGPU */;
+			productType = "com.apple.product-type.tool";
+		};
 		A13EBB481B87339E00097110 /* WebProcessPlugIn */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A13EBB4C1B87339E00097110 /* Build configuration list for PBXNativeTarget "WebProcessPlugIn" */;
@@ -6420,6 +6506,9 @@
 					8DD76F960486AA7600D96B5E = {
 						ProvisioningStyle = Manual;
 					};
+					94E0F7AF2CC2F79C0007B54B = {
+						CreatedOnToolsVersion = 16.0;
+					};
 					A13EBB481B87339E00097110 = {
 						CreatedOnToolsVersion = 7.0;
 						ProvisioningStyle = Manual;
@@ -6471,6 +6560,7 @@
 				BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */,
 				A13EBB481B87339E00097110 /* WebProcessPlugIn */,
 				537CF84322EFD64100C6EBB3 /* Apply Configuration to XCFileLists */,
+				94E0F7AF2CC2F79C0007B54B /* TestWebGPU */,
 			);
 		};
 /* End PBXProject section */
@@ -7323,6 +7413,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		94E0F7AC2CC2F79C0007B54B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94E0F7B72CC2F7CD0007B54B /* RefCountTests.cpp in Sources */,
+				940E06BC2CD9417B008EDD95 /* Tests.swift in Sources */,
+				94E0F7B82CC2F7CD0007B54B /* TestWebGPU.cpp in Sources */,
+				940E06C82CD94937008EDD95 /* TestWebGPU.h in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A13EBB451B87339E00097110 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -7484,6 +7585,16 @@
 			isa = PBXTargetDependency;
 			target = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;
 			targetProxy = 7CCE7F501A4124DB00447C4C /* PBXContainerItemProxy */;
+		};
+		940E06BB2CD9340F008EDD95 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "gtest-framework";
+			targetProxy = 940E06BA2CD9340F008EDD95 /* PBXContainerItemProxy */;
+		};
+		94E0F7CC2CC328700007B54B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 94E0F7AF2CC2F79C0007B54B /* TestWebGPU */;
+			targetProxy = 94E0F7CB2CC328700007B54B /* PBXContainerItemProxy */;
 		};
 		A13EBBB31B87441900097110 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -7675,6 +7786,20 @@
 			};
 			name = Release;
 		};
+		94E0F7B52CC2F79C0007B54B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 94E0F7A62CC2F1A30007B54B /* TestWebGPU.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		94E0F7B62CC2F79C0007B54B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 94E0F7A62CC2F1A30007B54B /* TestWebGPU.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		A13EBB4D1B87339E00097110 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A13EBB521B87346600097110 /* WebProcessPlugIn.xcconfig */;
@@ -7834,6 +7959,15 @@
 			buildConfigurations = (
 				7CCE7E9D1A41144E00447C4C /* Debug */,
 				7CCE7E9E1A41144E00447C4C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		94E0F7B42CC2F79C0007B54B /* Build configuration list for PBXNativeTarget "TestWebGPU" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				94E0F7B52CC2F79C0007B54B /* Debug */,
+				94E0F7B62CC2F79C0007B54B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebGPU.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebGPU.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "94E0F7AF2CC2F79C0007B54B"
+               BuildableName = "TestWebGPU"
+               BlueprintName = "TestWebGPU"
+               ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      internalIOSLaunchStyle = "3"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94E0F7AF2CC2F79C0007B54B"
+            BuildableName = "TestWebGPU"
+            BlueprintName = "TestWebGPU"
+            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94E0F7AF2CC2F79C0007B54B"
+            BuildableName = "TestWebGPU"
+            BlueprintName = "TestWebGPU"
+            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Tools/TestWebKitAPI/Tests/WebGPU/RefCountTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebGPU/RefCountTests.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "TestWebGPU.h"
+
+#if ENABLE(WEBGPU_SWIFT)
+TEST(TestWebGPU, ReferenceCounting)
+{
+    Ref obj = Cpp::CppRefCounted::create();
+    EXPECT_EQ(2u, obj->getSwiftRefCount());
+}
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWebGPU.h"
+
+#ifndef __swift__
+#include "TestWebGPUSwift-Generated.h"
+unsigned Cpp::CppRefCounted::getSwiftRefCount()
+{
+    return TestWebGPU::getRefCount(this);
+}
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.h
+++ b/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <vector>
+#include <wtf/Platform.h>
+#include <wtf/PlatformEnable.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <swift/bridging>
+
+namespace Cpp {
+
+using VectorUInt8 = std::vector<uint8_t>;
+class CppRefCounted: public RefCounted<CppRefCounted> {
+public:
+    static Ref<CppRefCounted> create() { return adoptRef(*new CppRefCounted()); }
+    unsigned getSwiftRefCount();
+} SWIFT_SHARED_REFERENCE(refCpp, derefCpp);
+
+}
+
+inline void refCpp(Cpp::CppRefCounted* obj)
+{
+    WTF::retainRefCounted(obj);
+}
+
+inline void derefCpp(Cpp::CppRefCounted* obj)
+{
+    WTF::releaseRefCounted(obj);
+}

--- a/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.modulemap
+++ b/Tools/TestWebKitAPI/Tests/WebGPU/TestWebGPU.modulemap
@@ -1,0 +1,5 @@
+module TestWebGPU {
+    header "TestWebGPU.h"
+    export *
+    module * { export * }
+}

--- a/Tools/TestWebKitAPI/Tests/WebGPU/Tests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebGPU/Tests.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public func getRefCount(obj: Cpp.CppRefCounted) -> UInt32 {
+    // Just an API call to ensure swift does not optimize this out.
+    let refCount = obj.refCount()
+    let _ = "The ref count is \(refCount)"
+    return refCount
+}


### PR DESCRIPTION
#### 39d68c46d92e77d3a7a19c86d3fd8bc15c666c4f
<pre>
Adding a Test to check if Swift refcounting is really working.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281608">https://bugs.webkit.org/show_bug.cgi?id=281608</a>
<a href="https://rdar.apple.com/problem/138056283">rdar://problem/138056283</a>

Reviewed by NOBODY (OOPS!).

Check that reference count is getting incremented in swift.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/TestPlumbing.swift: Added.
(getRefCount(_:)):
* Source/WebGPU/WebGPU/WebGPU.h:
(retainCpp):
(releaseCpp):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebGPU/WebGPU/WebGPUSwift.mm: Added.
(WebGPUTest::CppRefCounted::getSwiftRefCount):
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebGPUSwift.mm: Added.
(TEST(WebGPUSwiftTest, CppReferenceCounting)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b70bf0f2dfeaea58d4a792b1b3598eeb7100971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74865 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54295 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76982 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63431 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2080 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58806 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17080 "Found 3 new test failures: webgl/2.0.0/conformance/textures/canvas_sub_rectangle/tex-2d-rgb-rgb-unsigned_byte.html webgl/2.0.y/conformance/context/context-release-with-workers.html webgl/2.0.y/conformance/rendering/canvas-alpha-bug.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77932 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/63431 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39199 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/74373 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/63431 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68002 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/63431 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80779 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74123 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2183 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/2080 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2332 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66351 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/27682 "Hash 1b70bf0f for PR 35368 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96394 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2148 "Hash 1b70bf0f for PR 35368 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21071 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2176 "Hash 1b70bf0f for PR 35368 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3097 "Hash 1b70bf0f for PR 35368 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2183 "Hash 1b70bf0f for PR 35368 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->