### PR TITLE
[Navigation] Fix sandboxing tests in navigation-methods

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
@@ -1,4 +1,6 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://localhost:8800/navigation-api/navigation-methods/sandboxing-back-parent.html#end' from frame with URL 'http://localhost:8800/navigation-api/navigation-methods/resources/navigation-back.html'. The frame attempting navigation of the top-level window is sandboxed, but the 'allow-top-navigation' flag is not set.
 
 
-FAIL A sandboxed iframe cannot navigate its parent via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
+
+PASS A sandboxed iframe cannot navigate its parent via its own navigation object by using back()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
@@ -1,4 +1,6 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://localhost:8800/navigation-api/navigation-methods/sandboxing-back-sibling.html' from frame with URL 'http://localhost:8800/navigation-api/navigation-methods/resources/navigation-back.html'. The frame attempting navigation of the top-level window is sandboxed, but the 'allow-top-navigation' flag is not set.
 
 
-FAIL A sandboxed iframe cannot navigate its sibling via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
+
+PASS A sandboxed iframe cannot navigate its sibling via its own navigation object by using back()
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -430,6 +430,13 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
     if (!window()->protectedDocument()->isFullyActive() || window()->document()->unloadCounter())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
+    auto entry = findEntryByKey(key);
+    if (!entry)
+        createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::AbortError, "Navigation aborted"_s);
+
+    if (!frame()->isMainFrame() && !window()->protectedDocument()->canNavigate(&frame()->page()->mainFrame()))
+        return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::SecurityError, "Invalid state"_s);
+
     RefPtr current = currentEntry();
     if (current->key() == key) {
         committed->resolve<IDLInterface<NavigationHistoryEntry>>(*current.get());


### PR DESCRIPTION
#### c38e8f3bcf8a056f2cf79efcabe5d10508cb8286
<pre>
[Navigation] Fix sandboxing tests in navigation-methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=281679">https://bugs.webkit.org/show_bug.cgi?id=281679</a>

Reviewed by Alex Christensen.

Fix sandboxing tests in navigation-methods by checking whether the subframes are sandboxed and throwing an
exception if so [1].

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal">https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal</a> (Step 12.6)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::performTraversal):

Canonical link: <a href="https://commits.webkit.org/285384@main">https://commits.webkit.org/285384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/688aea14d55e0b7de5ad0f211493af1200913476

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19796 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21934 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65468 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64736 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6627 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2379 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->