### PR TITLE
[scroll-animations] make `Animation.timeline` return `ScrollTimeline` and `ViewTimeline` instances

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -4,8 +4,8 @@ PASS scroll-timeline-name is referenceable in animation-timeline on that element
 FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "100px"
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
-FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object AnimationTimeline]"
-FAIL Timeline lookup updates candidate when closer match available. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.timeline.source.id')"
+FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"
+PASS Timeline lookup updates candidate when closer match available.
 FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "50px" but got "none"
 FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "0"
 FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "0"

--- a/Source/WebCore/bindings/js/JSAnimationTimelineCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAnimationTimelineCustom.cpp
@@ -31,6 +31,10 @@
 #include "DocumentTimeline.h"
 #include "JSDOMBinding.h"
 #include "JSDocumentTimeline.h"
+#include "JSScrollTimeline.h"
+#include "JSViewTimeline.h"
+#include "ScrollTimeline.h"
+#include "ViewTimeline.h"
 
 using namespace JSC;
 
@@ -40,6 +44,11 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<A
 {
     if (value->isDocumentTimeline())
         return createWrapper<DocumentTimeline>(globalObject, WTFMove(value));
+    if (value->isViewTimeline())
+        return createWrapper<ViewTimeline>(globalObject, WTFMove(value));
+    if (value->isScrollTimeline())
+        return createWrapper<ScrollTimeline>(globalObject, WTFMove(value));
+    ASSERT_NOT_REACHED();
     return createWrapper<AnimationTimeline>(globalObject, WTFMove(value));
 }
 


### PR DESCRIPTION
#### e367a94d5ace381debe2045be82380cd4cac13c2
<pre>
[scroll-animations] make `Animation.timeline` return `ScrollTimeline` and `ViewTimeline` instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=281684">https://bugs.webkit.org/show_bug.cgi?id=281684</a>
<a href="https://rdar.apple.com/138135049">rdar://138135049</a>

Reviewed by Chris Dumez and Anne van Kesteren.

Getting the `timeline` property of a style-originated animation associated with a progress-based
timeline returns an `AnimationTimeline` instance instead of either `ScrollTimeline` or `ViewTimeline`.
We now return the right wrapper based on the various `AnimationTimeline` subclasses and ensure we
don&apos;t ever return an `AnimationTimeline` itself with an assertion.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSAnimationTimelineCustom.cpp:
(WebCore::toJSNewlyCreated):

Canonical link: <a href="https://commits.webkit.org/285377@main">https://commits.webkit.org/285377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afb0e24c02c03979e0b5ec63a9ff652738ea2e87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62339 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19300 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64750 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6636 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11123 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2390 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->