### PR TITLE
[scroll-animations] WPT test `scroll-animations/scroll-timelines/finish-animation.html` is a crash

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7415,6 +7415,7 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-wit
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/cancel-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/pause-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation.html [ Skip ]
@@ -7465,7 +7466,6 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animation
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]
 
 # webkit.org/b/281481 [scroll-animations] some WPT tests are crashing
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation-expected.txt
@@ -1,25 +1,23 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Finishing an animation with a zero playback rate throws
-FAIL Finishing an animation seeks to the end time assert_equals: 'actual' unit type must be 'percent' for "After finishing, the currentTime should be set to the end of the active duration" expected (string) "percent" but got (undefined) undefined
+PASS Finishing an animation seeks to the end time
 FAIL Finishing an animation with a current time past the effect end jumps back to the end promise_test: Unhandled rejection with value: object "TypeError: Type error"
-TIMEOUT Finishing a reversed animation jumps to zero time Test timed out
-NOTRUN Finishing a reversed animation with a current time less than zero makes it jump back to zero
-NOTRUN Finishing an animation while play-pending resolves the pending task immediately
-NOTRUN Finishing an animation attached to inactive timeline while play-pending doesn't resolves the pending task
-NOTRUN Finishing an animation resolves the finished promise synchronously
-NOTRUN A pending ready promise is resolved and not replaced when the animation is finished
-NOTRUN Finishing an animation fires finish event on orphaned element
-NOTRUN Finishing a canceled animation sets the current and start times
-NOTRUN Finishing idle animation produces correct state and fires finish event.
-NOTRUN Finishing idle animation attached to inactive timeline pauses the animation.
-NOTRUN Finishing running animation produces correct state and fires finish event.
-NOTRUN Finishing running animation attached to inactive timeline pauses the animation.
-NOTRUN Finishing a paused animation resolves the start time
-NOTRUN Finishing a pause-pending animation resolves the pending task immediately and update the start time
-NOTRUN Finishing a pause-pending animation with negative playback rate resolves the pending task immediately
-NOTRUN Finishing an animation during an aborted pause makes it finished immediately
-NOTRUN A pending playback rate should be applied immediately when an animation is finished
-NOTRUN An exception should be thrown if the effective playback rate is zero
+PASS Finishing a reversed animation jumps to zero time
+FAIL Finishing a reversed animation with a current time less than zero makes it jump back to zero promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Finishing an animation while play-pending resolves the pending task immediately
+PASS Finishing an animation attached to inactive timeline while play-pending doesn't resolves the pending task
+PASS Finishing an animation resolves the finished promise synchronously
+PASS A pending ready promise is resolved and not replaced when the animation is finished
+PASS Finishing an animation fires finish event on orphaned element
+PASS Finishing a canceled animation sets the current and start times
+PASS Finishing idle animation produces correct state and fires finish event.
+PASS Finishing idle animation attached to inactive timeline pauses the animation.
+PASS Finishing running animation produces correct state and fires finish event.
+PASS Finishing running animation attached to inactive timeline pauses the animation.
+PASS Finishing a paused animation resolves the start time
+PASS Finishing a pause-pending animation resolves the pending task immediately and update the start time
+PASS Finishing a pause-pending animation with negative playback rate resolves the pending task immediately
+PASS Finishing an animation during an aborted pause makes it finished immediately
+PASS A pending playback rate should be applied immediately when an animation is finished
+PASS An exception should be thrown if the effective playback rate is zero
 

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -95,7 +95,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
             // Set unlimited current time based on the first matching condition:
             // - start time is resolved: (timeline time - start time) × playback rate
             // - Otherwise: animation's current time
-            ASSERT(data.timelineTime);
+            ASSERT_IMPLIES(data.startTime, data.timelineTime);
             auto unlimitedCurrentTime = data.startTime ? (*data.timelineTime - *data.startTime) * data.playbackRate : *data.localTime;
             // Let effective timeline time be unlimited current time / animation’s playback rate + effective start time
             auto effectiveTimelineTime = unlimitedCurrentTime / data.playbackRate + effectiveStartTime;

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -131,6 +131,13 @@ CSSNumberishTime CSSNumberishTime::matchingZero() const
     return { m_type, 0 };
 }
 
+CSSNumberishTime CSSNumberishTime::matchingEpsilon() const
+{
+    if (m_type == Type::Percentage)
+        return CSSNumberishTime::fromPercentage(0.000001);
+    return { WebCore::timeEpsilon };
+}
+
 bool CSSNumberishTime::approximatelyEqualTo(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -49,6 +49,7 @@ public:
     bool isZero() const;
 
     CSSNumberishTime matchingZero() const;
+    CSSNumberishTime matchingEpsilon() const;
 
     bool approximatelyEqualTo(const CSSNumberishTime&) const;
     bool approximatelyLessThan(const CSSNumberishTime&) const;

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -209,7 +209,6 @@ private:
     double effectivePlaybackRate() const;
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
-    CSSNumberishTime timeEpsilon() const;
     void autoAlignStartTime();
 
     // ActiveDOMObject.


### PR DESCRIPTION
#### e6cfe393428767b92d32bbe3b1007160371c8419
<pre>
[scroll-animations] WPT test `scroll-animations/scroll-timelines/finish-animation.html` is a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=281685">https://bugs.webkit.org/show_bug.cgi?id=281685</a>
<a href="https://rdar.apple.com/138136777">rdar://138136777</a>

Reviewed by Dean Jackson, Matt Woodrow, and Ryosuke Niwa.

Fix three issues that caused assertion failures in `scroll-animations/scroll-timelines/finish-animation.html`:

1. a mistaken assertion in `AnimationEffectTiming::getBasicTiming()`,
2. incompatible time operations with the epsilon value,
3. incompatible time operations with the 0 value.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/finish-animation-expected.txt:
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const): We incorrectly asserted that `timelineTime` would always
be resolved, but this is only expected if `startTime` also is.
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::matchingEpsilon const): Introduce a new method to get the matching epsilon value
for a given time value such that an operation between the two can be safely conducted.
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::playState const):
(WebCore::WebAnimation::zeroTime const): Ensure we return a percentage 0 value not only if the animation is
associated with a progress-based timeline, but also if we have a percentage value for the start time or the
hold time.
(WebCore::WebAnimation::play):
(WebCore::WebAnimation::timeEpsilon const): Deleted.
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/285380@main">https://commits.webkit.org/285380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac2c8a44b1f805522516d3cdc5e9a029e6d0d150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25294 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23537 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75573 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22065 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16795 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/13080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47725 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->