### PR TITLE
[scroll-animations] scroll timelines should clamp their current time between `0%` and `100%`.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8152,3 +8152,7 @@ imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-mutable-prototy
 # Below tests give `Error fetching /interfaces/webidl.idl` in test output
 imported/w3c/web-platform-tests/WebIDL/idlharness.any.html [ Skip ]
 imported/w3c/web-platform-tests/WebIDL/idlharness.any.worker.html [ Skip ]
+
+# Platform-specific tests enabled on macOS and iOS separately.
+webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html [ Skip ]
+webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7500,3 +7500,5 @@ webkit.org/b/257011 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphena
 
 webkit.org/b/281238 compositing/tiling/tile-cache-zoomed.html [ Failure ]
 
+# Platform-specific test enabled on macOS and iOS separately.
+webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2436,3 +2436,6 @@ webkit.org/b/280792 inspector/worker/debugger-pause-subworker.html [ Skip ]
 
 # webkit.org/b/281523 [macOS arm64] Flaky test - imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failed in EWS)
 [ arm64 ] imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html [ Pass Failure ]
+
+# Platform-specific test enabled on macOS and iOS separately.
+webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html [ Pass ]

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios-expected.txt
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The current time of a scroll timeline remains within the 0% to 100% range.
+

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+</style>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script>
+
+promise_test(async () => {
+    const unconstrained = true;
+
+    window.scrollTo(0, 0);
+    await UIHelper.renderingUpdate();
+
+    const scrollTimeline = new ScrollTimeline({ source: document.documentElement });
+    assert_equals(scrollTimeline.currentTime.toString(), "0%");
+
+    await UIHelper.scrollTo(0, -100, unconstrained);
+    await UIHelper.renderingUpdate();
+
+    assert_equals(scrollTimeline.currentTime.toString(), "0%");
+
+    await UIHelper.scrollTo(0, 2100, unconstrained);
+    await UIHelper.renderingUpdate();
+
+    assert_equals(scrollTimeline.currentTime.toString(), "100%");
+}, "The current time of a scroll timeline remains within the 0% to 100% range.");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac-expected.txt
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The current time of a scroll timeline remains at 0% while rubber-banding.
+

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+</style>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script>
+
+const scrollToRubberBand = async () => {
+    const events = [
+        {
+            type : "wheel",
+            viewX : 100,
+            viewY : 100,
+            deltaY : -10,
+            phase : "began"
+        },
+        {
+            type : "wheel",
+            deltaY : -100,
+            phase : "changed"
+        },
+        {
+            type : "wheel",
+            deltaY : -50,
+            phase : "changed"
+        },
+        {
+            type : "wheel",
+            deltaY : 50,
+            phase : "changed"
+        },
+        {
+            type : "wheel",
+            deltaY : 100,
+            phase : "changed"
+        },
+        {
+            type : "wheel",
+            deltaY : 100,
+            phase : "changed"
+        },
+        {
+            type : "wheel",
+            phase : "ended"
+        },
+        {
+            type : "wheel",
+            deltaY : 100,
+            momentumPhase : "began"
+        },
+        {
+            type : "wheel",
+            deltaY : 100,
+            momentumPhase : "changed"
+        },
+        {
+            type : "wheel",
+            momentumPhase : "ended"
+        }
+    ];
+
+    await UIHelper.mouseWheelSequence({ events }, { waitForCompletion: false });
+    await UIHelper.waitForCondition(() => window.scrollY != 0);
+};
+
+promise_test(async () => {
+    window.scrollTo(0, 0);
+    await UIHelper.renderingUpdate();
+
+    const scrollTimeline = new ScrollTimeline({ source: document.documentElement });
+    assert_equals(scrollTimeline.currentTime.toString(), "0%");
+
+    await scrollToRubberBand();
+    await UIHelper.renderingUpdate();
+
+    assert_equals(scrollTimeline.currentTime.toString(), "0%");
+}, "The current time of a scroll timeline remains at 0% while rubber-banding.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -204,6 +204,11 @@ ScrollTimeline::Data ScrollTimeline::computeTimelineData(const TimelineRange& ra
     float maxScrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->maximumScrollOffset().y() : sourceScrollableArea->maximumScrollOffset().x();
     float scrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
 
+    // Chrome appears to clip the current time of a scroll timeline in the [0-100] range.
+    // We match this behavior for compatibility reasons, see https://github.com/w3c/csswg-drafts/issues/11033.
+    if (maxScrollOffset > 0)
+        scrollOffset = std::clamp(scrollOffset, 0.f, maxScrollOffset);
+
     return { scrollOffset, floatValueForOffset(range.start.offset, maxScrollOffset), maxScrollOffset - floatValueForOffset(range.end.offset, maxScrollOffset) };
 }
 


### PR DESCRIPTION
#### 2c4197c1bccc5b6bba8ceb5d5a491f6f7e923b61
<pre>
[scroll-animations] scroll timelines should clamp their current time between `0%` and `100%`.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281690">https://bugs.webkit.org/show_bug.cgi?id=281690</a>
<a href="https://rdar.apple.com/138141442">rdar://138141442</a>

Reviewed by Simon Fraser.

Ensure we clip the scroll offset to be within the minimum and maximum scroll offsets for scroll timelines.
The spec doesn&apos;t call this out but this is Chrome&apos;s behavior. The issue <a href="https://github.com/w3c/csswg-drafts/issues/11033">https://github.com/w3c/csswg-drafts/issues/11033</a>
was filed to discuss this, but we should match that behavior for compatibility.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios-expected.txt: Added.
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html: Added.
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac-expected.txt: Added.
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html: Added.
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::computeTimelineData const):

Canonical link: <a href="https://commits.webkit.org/285416@main">https://commits.webkit.org/285416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84d04d6161fc506060232dfe98321a877e34bb89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72577 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/52002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74692 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/59807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23611 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/59807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/59807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/59807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11143 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47800 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->