### PR TITLE
Reset main frame opener between tests in a way that works with site isolation

### DIFF
--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -183,9 +183,7 @@ void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
     frame.resetWindowProxy();
     m_windowProxy->replaceFrame(*this);
 
-    // FIXME: We ought to be able to assert that there is no existing opener here,
-    // but WKBundleFrameClearOpener is used to clear state between tests and it
-    // only clears in one process.
+    ASSERT(!m_opener);
     m_opener = frame.m_opener;
     for (auto& opened : frame.m_openedFrames) {
         ASSERT(opened.m_opener.get() == &frame);

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -542,11 +542,11 @@ void WKPageTerminate(WKPageRef pageRef)
     protectedProcessProxy->requestTermination(ProcessTerminationReason::RequestedByClient);
 }
 
-void WKPageResetProcessState(WKPageRef pageRef)
+void WKPageResetStateBetweenTests(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->legacyMainFrameProcess());
-    protectedProcessProxy->resetState();
+    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
+        pageForTesting->resetStateBetweenTests();
 }
 
 WKStringRef WKPageGetSessionHistoryURLValueType()
@@ -3032,7 +3032,7 @@ WKMediaState WKPageGetMediaState(WKPageRef page)
 void WKPageClearWheelEventTestMonitor(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
         pageForTesting->clearWheelEventTestMonitor();
 }
 
@@ -3090,7 +3090,7 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
 void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(nullptr, callbackContext);
 
@@ -3102,7 +3102,7 @@ void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClick
 void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3114,7 +3114,7 @@ void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateCli
 void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementOverrideTimerForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3126,7 +3126,7 @@ void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, 
 void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3138,7 +3138,7 @@ void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef p
 void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementEphemeralMeasurementForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3150,7 +3150,7 @@ void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pa
 void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPageSimulatePrivateClickMeasurementSessionRestartFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3162,7 +3162,7 @@ void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPa
 void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3174,7 +3174,7 @@ void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenSignatureURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3186,7 +3186,7 @@ void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef pageRef, WKURLRef sourceURL, WKURLRef destinationURL, WKPageSetPrivateClickMeasurementAttributionReportURLsForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3198,7 +3198,7 @@ void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef p
 void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3210,7 +3210,7 @@ void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WK
 void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef unlinkableToken, WKStringRef secretToken, WKStringRef signature, WKStringRef keyID, WKPageSetPCMFraudPreventionValuesForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3222,7 +3222,7 @@ void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef 
 void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef pageRef, WKStringRef appBundleIDForTesting, WKPageSetPrivateClickMeasurementAppBundleIDForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3298,7 +3298,7 @@ void WKPageSetMediaCaptureReportingDelayForTesting(WKPageRef pageRef, double del
 void WKPageDispatchActivityStateUpdateForTesting(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
         pageForTesting->dispatchActivityStateUpdate();
 }
 
@@ -3316,7 +3316,7 @@ void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKSt
 
 bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef command)
 {
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return false;
 
@@ -3325,13 +3325,13 @@ bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef comm
 
 void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, bool allowed)
 {
-    if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
         pageForTesting->setPermissionLevel(toImpl(origin)->string(), allowed);
 }
 
 void WKPageSetTopContentInsetForTesting(WKPageRef pageRef, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback)
 {
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(context);
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -136,8 +136,6 @@ WK_EXPORT void WKPageSetCustomTextEncodingName(WKPageRef page, WKStringRef encod
 
 WK_EXPORT void WKPageTerminate(WKPageRef page);
 
-WK_EXPORT void WKPageResetProcessState(WKPageRef pageRef);
-
 WK_EXPORT WKStringRef WKPageGetSessionHistoryURLValueType(void);
 WK_EXPORT WKStringRef WKPageGetSessionBackForwardListItemValueType(void);
 

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -223,6 +223,7 @@ WK_EXPORT void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef o
 WK_EXPORT void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value);
 WK_EXPORT bool WKPageIsEditingCommandEnabledForTesting(WKPageRef page, WKStringRef command);
 WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef origin, bool allowed);
+WK_EXPORT void WKPageResetStateBetweenTests(WKPageRef pageRef);
 
 typedef void (*WKPageSetTopContentInsetForTestingFunction)(void* functionContext);
 WK_EXPORT void WKPageSetTopContentInsetForTesting(WKPageRef page, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3199,7 +3199,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 
 - (void)_setStatisticsCrossSiteLoadWithLinkDecorationForTesting:(NSString *)fromHost withToHost:(NSString *)toHost withWasFiltered:(BOOL)wasFiltered withCompletionHandler:(void(^)(void))completionHandler
 {
-    if (auto* pageForTesting = _page->pageForTesting())
+    if (RefPtr pageForTesting = _page->pageForTesting())
         pageForTesting->setCrossSiteLoadWithLinkDecorationForTesting(URL { fromHost }, URL { toHost }, wasFiltered, makeBlockPtr(completionHandler));
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -339,7 +339,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setDefersLoadingForTesting:(BOOL)defersLoading
 {
-    if (auto* pageForTesting = _page->pageForTesting())
+    if (RefPtr pageForTesting = _page->pageForTesting())
         pageForTesting->setDefersLoading(defersLoading);
 }
 
@@ -406,7 +406,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (nsIndex)
         index = nsIndex.unsignedIntValue;
 
-    if (auto* pageForTesting = _page->pageForTesting())
+    if (RefPtr pageForTesting = _page->pageForTesting())
         pageForTesting->setIndexOfGetDisplayMediaDeviceSelectedForTesting(index);
 #endif
 }
@@ -417,7 +417,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (!_page)
         return;
 
-    if (auto* pageForTesting = _page->pageForTesting())
+    if (RefPtr pageForTesting = _page->pageForTesting())
         pageForTesting->setSystemCanPromptForGetDisplayMediaForTesting(!!canPrompt);
 #endif
 }
@@ -513,7 +513,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPrivateClickMeasurementOverrideTimerForTesting:(BOOL)overrideTimer completionHandler:(void(^)(void))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler();
 
@@ -524,7 +524,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPrivateClickMeasurementAttributionReportURLsForTesting:(NSURL *)sourceURL destinationURL:(NSURL *)destinationURL completionHandler:(void(^)(void))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler();
 
@@ -535,7 +535,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPrivateClickMeasurementAttributionTokenPublicKeyURLForTesting:(NSURL *)url completionHandler:(void(^)(void))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler();
 
@@ -546,7 +546,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPrivateClickMeasurementAttributionTokenSignatureURLForTesting:(NSURL *)url completionHandler:(void(^)(void))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler();
 
@@ -557,7 +557,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPrivateClickMeasurementAppBundleIDForTesting:(NSString *)appBundleID completionHandler:(void(^)(void))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler();
 
@@ -568,7 +568,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_dumpPrivateClickMeasurement:(void(^)(NSString *))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler({ });
 
@@ -641,7 +641,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_isLayerTreeFrozenForTesting:(void (^)(BOOL frozen))completionHandler
 {
-    auto* pageForTesting = _page->pageForTesting();
+    RefPtr pageForTesting = _page->pageForTesting();
     if (!pageForTesting)
         return completionHandler(false);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -789,7 +789,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #if ENABLE(GAMEPAD)
     , m_recentGamepadAccessHysteresis([this](PAL::HysteresisState state) { recentGamepadAccessStateChanged(state); }, gamepadsRecentlyAccessedThreshold)
 #endif
-    , m_pageForTesting(makeUnique<WebPageProxyTesting>(*this))
+    , m_pageForTesting(WebPageProxyTesting::create(*this))
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "constructor:");
 
@@ -10980,6 +10980,16 @@ void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason termina
 
     // FIXME: <rdar://problem/38676604> In case of process swaps, the old process should gracefully suspend instead of terminating.
     protectedLegacyMainFrameProcess()->processTerminated();
+}
+
+WebPageProxyTesting* WebPageProxy::pageForTesting() const
+{
+    return m_pageForTesting.get();
+}
+
+RefPtr<WebPageProxyTesting> WebPageProxy::protectedPageForTesting() const
+{
+    return m_pageForTesting;
 }
 
 #if PLATFORM(COCOA) && !ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2551,7 +2551,8 @@ public:
     void didAdjustVisibilityWithSelectors(Vector<String>&&);
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup; }
 
-    WebPageProxyTesting* pageForTesting() const { return m_pageForTesting.get(); }
+    WebPageProxyTesting* pageForTesting() const;
+    RefPtr<WebPageProxyTesting> protectedPageForTesting() const;
 
     void hasActiveNowPlayingSessionChanged(bool);
 
@@ -3734,7 +3735,7 @@ private:
 #endif
 #endif
 
-    std::unique_ptr<WebPageProxyTesting> m_pageForTesting;
+    RefPtr<WebPageProxyTesting> m_pageForTesting;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -210,4 +210,16 @@ Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
     return m_page.get();
 }
 
+void WebPageProxyTesting::resetStateBetweenTests()
+{
+    protectedPage()->protectedLegacyMainFrameProcess()->resetState();
+
+    if (RefPtr mainFrame = m_page->mainFrame())
+        mainFrame->disownOpener();
+
+    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPageTesting::ResetStateBetweenTests(), pageID);
+    });
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -39,11 +39,11 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class WebPageProxyTesting : public IPC::MessageSender {
+class WebPageProxyTesting : public IPC::MessageSender, public RefCounted<WebPageProxyTesting> {
     WTF_MAKE_TZONE_ALLOCATED(WebPageProxyTesting);
     WTF_MAKE_NONCOPYABLE(WebPageProxyTesting);
 public:
-    explicit WebPageProxyTesting(WebPageProxy&);
+    static Ref<WebPageProxyTesting> create(WebPageProxy& page) { return adoptRef(*new WebPageProxyTesting(page)); }
 
     void setDefersLoading(bool);
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
@@ -51,6 +51,7 @@ public:
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
     void setPermissionLevel(const String& origin, bool allowed);
     bool isEditingCommandEnabled(const String& commandName);
+    void resetStateBetweenTests();
 
     void dumpPrivateClickMeasurement(CompletionHandler<void(const String&)>&&);
     void clearPrivateClickMeasurement(CompletionHandler<void()>&&);
@@ -78,6 +79,8 @@ public:
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
 private:
+    explicit WebPageProxyTesting(WebPageProxy&);
+
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -146,12 +146,6 @@ WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
     return toAPI(WebKit::toImpl(frameRef)->page());
 }
 
-void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
-{
-    if (auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame())
-        coreFrame->disownOpener();
-}
-
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
 {
     WebKit::toImpl(frameRef)->stopLoading();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -41,7 +41,6 @@ extern "C" {
 WK_EXPORT WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frame, JSObjectRef element);
 WK_EXPORT unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frame);
 WK_EXPORT WKStringRef WKBundleFrameCopyLayerTreeAsText(WKBundleFrameRef frame);
-WK_EXPORT void WKBundleFrameClearOpener(WKBundleFrameRef frame);
 WK_EXPORT void WKBundleFrameStopLoading(WKBundleFrameRef frame);
 
 WK_EXPORT bool WKBundleFrameContainsAnyFormElements(WKBundleFrameRef frame);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -373,7 +373,7 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
     };
     auto newFrame = ownerElement
         ? WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess(*corePage, WTFMove(clientCreator), m_frameID, *ownerElement, layerHostingContextIdentifier)
-        : parent ? WebCore::RemoteFrame::createSubframe(*corePage, WTFMove(clientCreator), m_frameID, *parent, localFrame->opener()) : WebCore::RemoteFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, localFrame->opener());
+        : parent ? WebCore::RemoteFrame::createSubframe(*corePage, WTFMove(clientCreator), m_frameID, *parent, nullptr) : WebCore::RemoteFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, nullptr);
     if (!parent)
         corePage->setMainFrame(newFrame.copyRef());
     newFrame->takeWindowProxyAndOpenerFrom(*localFrame);

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -122,4 +122,10 @@ Ref<WebPage> WebPageTesting::protectedPage() const
     return m_page.get();
 }
 
+void WebPageTesting::resetStateBetweenTests()
+{
+    if (RefPtr mainFrame = protectedPage()->mainFrame())
+        mainFrame->disownOpener();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -34,10 +34,6 @@ class Connection;
 class Decoder;
 }
 
-namespace WebCore {
-class IntPoint;
-}
-
 namespace WebKit {
 
 class WebPage;
@@ -57,6 +53,7 @@ private:
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
     void setPermissionLevel(const String& origin, bool allowed);
     void isEditingCommandEnabled(const String& commandName, CompletionHandler<void(bool)>&&);
+    void resetStateBetweenTests();
 
 #if ENABLE(NOTIFICATIONS)
     void clearNotificationPermissionState();

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -31,6 +31,6 @@ messages -> WebPageTesting NotRefCounted {
 #endif
 
     ClearWheelEventTestMonitor()
-
+    ResetStateBetweenTests()
     SetTopContentInset(float contentInset) -> ()
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -354,10 +354,6 @@ void InjectedBundlePage::prepare()
 
     WKBundleClearHistoryForTesting(m_page);
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WKBundleFrameClearOpener(WKBundlePageGetMainFrame(m_page));
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
     WKBundlePageSetTracksRepaints(m_page, false);
     
     // Force consistent "responsive" behavior for WebPage::eventThrottlingDelay() for testing. Tests can override via internals.

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1274,7 +1274,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
 
     WKPageDispatchActivityStateUpdateForTesting(m_mainWebView->page());
 
-    WKPageResetProcessState(m_mainWebView->page());
+    WKPageResetStateBetweenTests(m_mainWebView->page());
 
     m_didReceiveServerRedirectForProvisionalNavigation = false;
     m_serverTrustEvaluationCallbackCallsCount = 0;


### PR DESCRIPTION
#### 51105b97099cb96676981910dc9fd04e3f76cdb8
<pre>
Reset main frame opener between tests in a way that works with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=281694">https://bugs.webkit.org/show_bug.cgi?id=281694</a>
<a href="https://rdar.apple.com/138143721">rdar://138143721</a>

Reviewed by Charlie Wolfe.

Some tests, such as fast/dom/Window/window-focus-self.html, leave behind a
main frame that has an opener (itself).  Between tests, we need to reset this
state so that future tests that may check for an opener find no opener.
WKBundleFrameClearOpener only cleared the opener in one process and left state
inconsistent between web processes and with the UI process.  This fixes that
and makes a path for replacing the rest of InjectedBundlePage::prepare.

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::takeWindowProxyAndOpenerFrom):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageResetStateBetweenTests):
(WKPageClearWheelEventTestMonitor):
(WKPageDumpPrivateClickMeasurement):
(WKPageClearPrivateClickMeasurement):
(WKPageSetPrivateClickMeasurementOverrideTimerForTesting):
(WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting):
(WKPageSimulatePrivateClickMeasurementSessionRestart):
(WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting):
(WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting):
(WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting):
(WKPageMarkPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPCMFraudPreventionValuesForTesting):
(WKPageSetPrivateClickMeasurementAppBundleIDForTesting):
(WKPageDispatchActivityStateUpdateForTesting):
(WKPageIsEditingCommandEnabledForTesting):
(WKPageSetPermissionLevelForTesting):
(WKPageSetTopContentInsetForTesting):
(WKPageResetProcessState): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setStatisticsCrossSiteLoadWithLinkDecorationForTesting:withToHost:withWasFiltered:withCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setDefersLoadingForTesting:]):
(-[WKWebView _setIndexOfGetDisplayMediaDeviceSelectedForTesting:]):
(-[WKWebView _setSystemCanPromptForGetDisplayMediaForTesting:]):
(-[WKWebView _setPrivateClickMeasurementOverrideTimerForTesting:completionHandler:]):
(-[WKWebView _setPrivateClickMeasurementAttributionReportURLsForTesting:destinationURL:completionHandler:]):
(-[WKWebView _setPrivateClickMeasurementAttributionTokenPublicKeyURLForTesting:completionHandler:]):
(-[WKWebView _setPrivateClickMeasurementAttributionTokenSignatureURLForTesting:completionHandler:]):
(-[WKWebView _setPrivateClickMeasurementAppBundleIDForTesting:completionHandler:]):
(-[WKWebView _dumpPrivateClickMeasurement:]):
(-[WKWebView _isLayerTreeFrozenForTesting:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::pageForTesting const):
(WebKit::WebPageProxy::protectedPageForTesting const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::resetStateBetweenTests):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
(WebKit::WebPageProxyTesting::create):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameClearOpener): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::resetStateBetweenTests):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::prepare):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/285688@main">https://commits.webkit.org/285688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b67eb02396a462619edef5b9f3b7cdee65de48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57735 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44420 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20701 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65409 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7443 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/753 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->