### PR TITLE
Implement JITless Wasm test mode

### DIFF
--- a/JSTests/wasm/gc/bug254412.js
+++ b/JSTests/wasm/gc/bug254412.js
@@ -1,4 +1,5 @@
 //@ skip unless $isSIMDPlatform
+//@ requireOptions("--useWasmSIMD=1")
 //@ runWebAssemblySuite("--useWasmGC=true")
 
 import * as assert from "../assert.js";

--- a/JSTests/wasm/gc/simd.js
+++ b/JSTests/wasm/gc/simd.js
@@ -1,4 +1,5 @@
 //@ skip unless $isSIMDPlatform
+//@ requireOptions("--useWasmSIMD=1")
 //@ runWebAssemblySuite("--useWasmGC=true")
 
 import * as assert from "../assert.js";

--- a/JSTests/wasm/stress/call-returns-v128.js
+++ b/JSTests/wasm/stress/call-returns-v128.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip unless $isSIMDPlatform
 (async function () {
   let bytes0 = readFile('./resources/call-returns-v128.wasm', 'binary');

--- a/JSTests/wasm/stress/exception-containing-v128.js
+++ b/JSTests/wasm/stress/exception-containing-v128.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip unless $isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";

--- a/JSTests/wasm/stress/import-exception-tag-with-v128.js
+++ b/JSTests/wasm/stress/import-exception-tag-with-v128.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip unless $isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";

--- a/JSTests/wasm/stress/omg-simd-simple.js
+++ b/JSTests/wasm/stress/omg-simd-simple.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/omg-simd-stress.js
+++ b/JSTests/wasm/stress/omg-simd-stress.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tail-call-simple.js
+++ b/JSTests/wasm/stress/simd-tail-call-simple.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/try-table-simd.js
+++ b/JSTests/wasm/stress/try-table-simd.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 
 import { instantiate } from "../wabt-wrapper.js";

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -84,6 +84,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useLLInt,  true, Normal, "allows the LLINT to be used if true"_s) \
     v(Bool, useJIT, jitEnabledByDefault(), Normal, "allows the executable pages to be allocated for JIT and thunks if true"_s) \
+    v(Bool, useWasmJIT, jitEnabledByDefault(), Normal, "allows wasm to use JIT and thunks if true"_s) \
     v(Bool, useBaselineJIT, true, Normal, "allows the baseline JIT to be used if true"_s) \
     v(Bool, useDFGJIT, true, Normal, "allows the DFG JIT to be used if true"_s) \
     v(Bool, useRegExpJIT, jitEnabledByDefault(), Normal, "allows the RegExp JIT to be used if true"_s) \

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -454,7 +454,7 @@ JSEntrypointCallee::JSEntrypointCallee(TypeIndex typeIndex, bool usesSIMD)
     m_frameSize = totalFrameSize;
 
 #if ENABLE(JIT)
-    if (Options::useJIT()) {
+    if (Options::useWasmJIT()) {
 #else
     if (false) {
 #endif
@@ -481,7 +481,7 @@ JSEntrypointCallee::JSEntrypointCallee(TypeIndex typeIndex, bool usesSIMD)
 CodePtr<WasmEntryPtrTag> JSEntrypointCallee::entrypointImpl() const
 {
 #if ENABLE(JIT)
-    if (Options::useJIT())
+    if (Options::useWasmJIT())
         return createJSToWasmJITShared().retaggedCode<WasmEntryPtrTag>();
 #endif
     return LLInt::getCodeFunctionPtr<CFunctionPtrTag>(js_to_wasm_wrapper_entry);

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -293,7 +293,7 @@ bool EntryPlan::generateWasmToWasmStubs()
             continue;
         dataLogLnIf(WasmEntryPlanInternal::verbose, "Processing import function number "_s, importFunctionIndex, ": "_s, makeString(import->module), ": "_s, makeString(import->field));
 #if ENABLE(JIT)
-        if (Options::useJIT()) {
+        if (Options::useWasmJIT()) {
             auto binding = wasmToWasm(importFunctionIndex);
             if (UNLIKELY(!binding))
                 return false;
@@ -316,7 +316,7 @@ bool EntryPlan::generateWasmToJSStubs()
     for (unsigned importIndex = 0; importIndex < m_moduleInformation->importFunctionCount(); ++importIndex) {
 #if ENABLE(JIT)
         Wasm::TypeIndex typeIndex = m_moduleInformation->importFunctionTypeIndices.at(importIndex);
-        if (Options::useJIT()) {
+        if (Options::useWasmJIT()) {
             auto binding = wasmToJS(typeIndex, importIndex);
             if (UNLIKELY(!binding))
                 return false;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -129,7 +129,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
         ASSERT(!callee->entrypoint());
 
 #if ENABLE(JIT)
-        if (Options::useJIT())
+        if (Options::useWasmJIT())
             callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>());
 #else
         if (false);

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -134,7 +134,7 @@ void LLIntPlan::compileFunction(FunctionCodeIndex functionIndex)
         auto callee = LLIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
         ASSERT(!callee->entrypoint());
 
-        if (Options::useJIT()) {
+        if (Options::useWasmJIT()) {
 #if ENABLE(JIT)
             if (m_moduleInformation->usesSIMD(functionIndex))
                 callee->setEntrypoint(LLInt::wasmFunctionEntryThunkSIMD().retaggedCode<WasmEntryPtrTag>());

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -474,7 +474,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
         return m_jsToWasmICCallee->jsEntrypoint();
     }
 
-    if (Options::forceICFailure() || !Options::useJIT())
+    if (Options::forceICFailure() || !Options::useWasmJIT())
         return nullptr;
 
     Locker locker(m_jitCodeLock);

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -104,6 +104,7 @@ my $runMozillaTests = RUN_IF_NO_TESTS_SPECIFIED;
 # Instead it is only meaningful for when we want to disable using JIT test configurations
 # on the JSC stress test or mozilla tests.
 my $runJITStressTests = 1;
+my $runJITlessWasm = 0;
 
 my $runCLoopMode = 0;
 my $runQuickMode = 0;
@@ -239,6 +240,7 @@ my $testapiDefault = defaultStringForTestState($runTestAPI);
 my $jscStressDefault = defaultStringForTestState($runJSCStress);
 my $mozillaTestsDefault = defaultStringForTestState($runMozillaTests);
 my $jitStressTestsDefault = $runJITStressTests ? "will run" : " will not run";
+my $jitlessWasmDefault = $runJITlessWasm ? "will run" : " will not run";
 my $quickModeDefault = $runQuickMode ? "some" : "all";
 my $failFastDefault = $failFast ? "fail fast" : "don't fail fast";
 my $coverageDefault = $coverage ? "coverage enabled" : "coverage disabled";
@@ -262,6 +264,7 @@ Usage: $programName [options] [options to pass to build system]
   --[no-]jsc-stress             Only run (or don't run) the JSC stress tests (default: $jscStressDefault)
   --[no-]mozilla-tests          Only run (or don't run) the Mozilla tests (default: $mozillaTestsDefault)
   --[no-]jit-stress-tests       Run (or don't run) the JIT stress tests (default: $jitStressTestsDefault)
+  --[no-]jitless-wasm           Run (or don't run) the JITless Wasm tests (default: $jitlessWasmDefault)
   --[no-]quick                  Run some (or all) of the regular testing modes (default: $quickModeDefault)
                                 If the runner only runs some it will run the default and no-cjit-validate modes.
                                 Note, this will not change the behavior of tests that specify their own modes.
@@ -344,6 +347,7 @@ GetOptions(
     'testdfg!' => \$runTestDFG,
     'testapi!' => \$runTestAPI,
     'jsc-stress!' => \$runJSCStress,
+    'jitless-wasm!' => \$runJITlessWasm,
     'mozilla-tests!' => \$runMozillaTests,
     'jit-stress-tests!' => \$runJITStressTests,
     'cloop' => \$runCLoopMode,
@@ -879,6 +883,9 @@ sub runJSCStressTests
 
     if (!$runJITStressTests) {
         push(@jscStressDriverCmd, "--no-jit");
+    }
+    if ($runJITlessWasm) {
+        push(@jscStressDriverCmd, "--jitless-wasm");
     }
     if ($createTarball) {
         push(@jscStressDriverCmd, "--tarball");

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -162,6 +162,7 @@ $architecture = nil
 $forceArchitecture = nil
 $hostOS = nil
 $model = nil
+$runJITlessWasm = false
 $filter = nil
 $envVars = []
 $mode = "full"
@@ -226,6 +227,7 @@ def usage
     puts "                            no-cjit-validate-phases, no-cjit-collect-continuously, dfg-eager"
     puts "                            and for FTL platforms: no-ftl, ftl-eager-no-cjit and"
     puts "                            ftl-no-cjit-small-pool."
+    puts "--jitless-wasm              Run the no-wasm-jit mode"
     puts "--no-retry                  Disable auto retry"
     exit 1
 end
@@ -269,6 +271,7 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--release', GetoptLong::NO_ARGUMENT],
                ['--quick', '-q', GetoptLong::NO_ARGUMENT],
                ['--basic', GetoptLong::NO_ARGUMENT],
+               ['--jitless-wasm', GetoptLong::NO_ARGUMENT],
                ['--no-retry', GetoptLong::NO_ARGUMENT]).each {
     | opt, arg |
     case opt
@@ -373,6 +376,8 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
         $mode = "quick"
     when '--basic'
         $mode = "basic"
+    when '--jitless-wasm'
+        $runJITlessWasm = true
     when '--debug'
         $buildType = "debug"
     when '--release'
@@ -1876,6 +1881,10 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
+        if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
+          run("wasm-no-wasm-jit", "--useWasmJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        end
         if $isOMGPlatform
             run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=true", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end


### PR DESCRIPTION
#### 43d87cd9cf468761d5f4cde71c81b6e0808324f7
<pre>
Implement JITless Wasm test mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=281698">https://bugs.webkit.org/show_bug.cgi?id=281698</a>
<a href="https://rdar.apple.com/137215038">rdar://137215038</a>

Reviewed by Keith Miller.

This patch provides a `--useWasmJIT` test mode, which specifically disables JIT for Wasm
functions. This allows us to test JITless Wasm more effectively, since the JS wrappers
will not be slowed down. This can be optionally enabled in `run-javascriptcore-tests`
using the `--jitless-wasm` flag.

* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllWasmJITOptions):
(JSC::disableAllJITOptions):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::generateWasmToWasmStubs):
(JSC::Wasm::EntryPlan::generateWasmToJSStubs):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):

Canonical link: <a href="https://commits.webkit.org/285672@main">https://commits.webkit.org/285672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56b051abcd1e9a2c5fc1b054c6f29ef63797a794

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/61985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16146 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47782 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63176 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20658 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22996 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66562 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79310 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72684 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66106 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63188 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65384 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7407 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94464 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/706 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20764 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->