### PR TITLE
REGRESSION(281282@main): Web process crashes when opening PDF in Safari on macOS Recovery

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -88,9 +88,6 @@ void PDFPresentationController::clearAsyncRenderer()
 RefPtr<GraphicsLayer> PDFPresentationController::createGraphicsLayer(const String& name, GraphicsLayer::Type layerType)
 {
     auto* graphicsLayerFactory = m_plugin->graphicsLayerFactory();
-    if (!graphicsLayerFactory)
-        return nullptr;
-
     Ref graphicsLayer = GraphicsLayer::create(graphicsLayerFactory, graphicsLayerClient(), layerType);
     graphicsLayer->setName(name);
     return graphicsLayer;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -29,7 +29,6 @@ WKWebViewConfigurationExtras.mm
 cocoa/CGImagePixelReader.cpp
 cocoa/DaemonTestUtilities.mm
 cocoa/DragAndDropSimulator.mm
-cocoa/EnableUISideCompositingScope.mm
 cocoa/ImageAnalysisTestingUtilities.mm
 cocoa/NSItemProviderAdditions.mm
 cocoa/PlatformUtilitiesCocoa.mm
@@ -44,6 +43,7 @@ cocoa/TestUIDelegate.mm
 cocoa/TestWebExtensionsDelegate.mm
 cocoa/TestWKWebView.mm
 cocoa/TestWKWebViewConfiguration.mm
+cocoa/UISideCompositingScope.mm
 cocoa/UserMediaCaptureUIDelegate.mm
 ios/IOSMouseEventTestHarness.mm
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3739,8 +3739,8 @@
 		F4A715A72950C8D900B4D0D6 /* AdvancedPrivacyProtections.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AdvancedPrivacyProtections.mm; sourceTree = "<group>"; };
 		F4A74B9129DDD9F100CB5288 /* CGImagePixelReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CGImagePixelReader.h; path = cocoa/CGImagePixelReader.h; sourceTree = "<group>"; };
 		F4A74B9229DDD9F100CB5288 /* CGImagePixelReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CGImagePixelReader.cpp; path = cocoa/CGImagePixelReader.cpp; sourceTree = "<group>"; };
-		F4A74B9D29DDE1AC00CB5288 /* EnableUISideCompositingScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EnableUISideCompositingScope.h; path = cocoa/EnableUISideCompositingScope.h; sourceTree = "<group>"; };
-		F4A74BA829DDE8C000CB5288 /* EnableUISideCompositingScope.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = EnableUISideCompositingScope.mm; path = cocoa/EnableUISideCompositingScope.mm; sourceTree = "<group>"; };
+		F4A74B9D29DDE1AC00CB5288 /* UISideCompositingScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UISideCompositingScope.h; path = cocoa/UISideCompositingScope.h; sourceTree = "<group>"; };
+		F4A74BA829DDE8C000CB5288 /* UISideCompositingScope.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = UISideCompositingScope.mm; path = cocoa/UISideCompositingScope.mm; sourceTree = "<group>"; };
 		F4A7CE772662D6E800228685 /* TouchEventTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TouchEventTests.mm; sourceTree = "<group>"; };
 		F4A7CE792662D83E00228685 /* active-touch-events.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "active-touch-events.html"; sourceTree = "<group>"; };
 		F4A9202E1FEE34C800F59590 /* apple-data-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "apple-data-url.html"; sourceTree = "<group>"; };
@@ -4035,8 +4035,6 @@
 				3302A64D2A11B4410093FA2A /* DragAndDropSimulator.mm */,
 				F44D06481F3962E3001A0E29 /* EditingTestHarness.h */,
 				F44D06491F3962E3001A0E29 /* EditingTestHarness.mm */,
-				F4A74B9D29DDE1AC00CB5288 /* EnableUISideCompositingScope.h */,
-				F4A74BA829DDE8C000CB5288 /* EnableUISideCompositingScope.mm */,
 				5C7C24FB237C972300599C91 /* HTTPServer.h */,
 				5C7C24FA237C972300599C91 /* HTTPServer.mm */,
 				F42F081727449FFD007E0D90 /* ImageAnalysisTestingUtilities.h */,
@@ -4076,6 +4074,8 @@
 				2EFF06D21D8AEDBB0004BB30 /* TestWKWebView.h */,
 				2EFF06D31D8AEDBB0004BB30 /* TestWKWebView.mm */,
 				2EFF06D31D8AEDBB0004BB31 /* TestWKWebViewConfiguration.mm */,
+				F4A74B9D29DDE1AC00CB5288 /* UISideCompositingScope.h */,
+				F4A74BA829DDE8C000CB5288 /* UISideCompositingScope.mm */,
 				41733D7A25DE96DA00A136E5 /* UserMediaCaptureUIDelegate.h */,
 				41733D7B25DE96DA00A136E5 /* UserMediaCaptureUIDelegate.mm */,
 				7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
@@ -28,12 +28,12 @@
 #if PLATFORM(MAC)
 
 #import "CGImagePixelReader.h"
-#import "EnableUISideCompositingScope.h"
 #import "JavaScriptTest.h"
 #import "OffscreenWindow.h"
 #import "PlatformUtilities.h"
 #import "PlatformWebView.h"
 #import "TestWKWebView.h"
+#import "UISideCompositingScope.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKThumbnailView.h>
@@ -350,7 +350,7 @@ void checkThumbnailViewSnapshotConsistency(TestWKWebView *webView)
 
 TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositing)
 {
-    EnableUISideCompositingScope enableUISideCompositing;
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"fixed-nav-bar"];
@@ -361,7 +361,7 @@ TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositing)
 
 TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositingAndTopContentInset)
 {
-    EnableUISideCompositingScope enableUISideCompositing;
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setAutomaticallyAdjustsContentInsets:NO];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -25,10 +25,10 @@
 
 #import "config.h"
 
-#import "EnableUISideCompositingScope.h"
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
+#import "UISideCompositingScope.h"
 #import "UserMediaCaptureUIDelegate.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRefPrivate.h>
@@ -227,7 +227,7 @@ TEST(GPUProcess, GPUProcessForDOMRenderingCarriesOverFromRelatedPage)
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    EnableUISideCompositingScope enableUISideCompositing;
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
 
     RetainPtr<WKWebViewConfiguration> configuration;
     RetainPtr<TestWKWebView> originalWebView;

--- a/Tools/TestWebKitAPI/cocoa/UISideCompositingScope.h
+++ b/Tools/TestWebKitAPI/cocoa/UISideCompositingScope.h
@@ -35,11 +35,13 @@
 
 namespace TestWebKitAPI {
 
-class EnableUISideCompositingScope {
+enum class UISideCompositingState : bool { Disabled, Enabled };
+
+class UISideCompositingScope {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    EnableUISideCompositingScope();
-    ~EnableUISideCompositingScope();
+    UISideCompositingScope(UISideCompositingState);
+    ~UISideCompositingScope();
 
 private:
     Method m_originalMethod;


### PR DESCRIPTION
#### 6bbee059a4bff61ccb29cfd7a97aab753d91e5c1
<pre>
REGRESSION(281282@main): Web process crashes when opening PDF in Safari on macOS Recovery
<a href="https://bugs.webkit.org/show_bug.cgi?id=281691">https://bugs.webkit.org/show_bug.cgi?id=281691</a>
<a href="https://rdar.apple.com/138067010">rdar://138067010</a>

Reviewed by Simon Fraser and Wenson Hsieh.

Whenever we open a PDF in the macOS Recovery system, we crash when
ensuring layers are created because we fail to create any layers in the
presentation controller to begin with.

To answer this, we need to understand the relation between UI side
compositing and graphics layer creation. The general pattern for
graphics layer creation is to pass in a (maybe null) graphics layer
factory pointer to GraphicsLayer::create(), and this callee is smart
enough to have a fallback layer creation path if the factory pointer is
null. How this relates to UI side compositing is that, when disabled, we
use TiledCoreAnimationDrawingArea instead of RemoteLayerTreeDrawingArea.
Note that the former drawing area does not have an associated graphics
layer factory, which means with UI side compositing disabled we go down
the fallback path I talked about in GraphicsLayer::create().

The bug materializes in PDFPresentationController because we make the
mistake of early returning a null graphics layer if we get a null
graphics layer factory from the page chrome client, instead of allowing
GraphicsLayer::create() to deal with that case. We fix the crash by
removing the early return path.

This patch also generalizes the EnableUISideCompositingScope test utility
such that we can choose between enablement and disablement of UI side
compositing in a certain scope.

Test coverage: TestWebKitAPI.UnifiedPDF.WebProcessShouldNotCrashWithUISideCompositingDisabled

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::createGraphicsLayer):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
(TestWebKitAPI::TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositing)):
(TestWebKitAPI::TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositingAndTopContentInset)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TestWebKitAPI::TEST(GPUProcess, GPUProcessForDOMRenderingCarriesOverFromRelatedPage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(-[ObserveWebContentCrashNavigationDelegate _webView:webContentProcessDidTerminateWithReason:]):
(-[ObserveWebContentCrashNavigationDelegate webView:didFinishNavigation:]):
(-[ObserveWebContentCrashNavigationDelegate webProcessCrashed]):
(-[ObserveWebContentCrashNavigationDelegate navigationFinished]):
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/cocoa/UISideCompositingScope.h: Renamed from Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.h.
* Tools/TestWebKitAPI/cocoa/UISideCompositingScope.mm: Renamed from Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.mm.
(-[NSUserDefaults swizzled_objectForKey:]):
(TestWebKitAPI::UISideCompositingScope::UISideCompositingScope):
(TestWebKitAPI::UISideCompositingScope::~UISideCompositingScope):

Canonical link: <a href="https://commits.webkit.org/285385@main">https://commits.webkit.org/285385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5ed5b32afa08a5f9cd121f9b979f1190d9533d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23670 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62400 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22020 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16702 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19356 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 13 flakes") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6690 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->