### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RemoteCDMFactory

### DIFF
--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -130,13 +130,13 @@ GPUProcessConnection::~GPUProcessConnection()
 
 void GPUProcessConnection::didBecomeUnresponsive()
 {
-    auto& webProcess = WebProcess::singleton();
+    Ref webProcess = WebProcess::singleton();
     // The function call might have been posted asynchronously from other thread.
     // Guard against notifying a problem for a GPUProcessConnection that has already been
     // switched away.
-    if (webProcess.existingGPUProcessConnection() != this)
+    if (webProcess->existingGPUProcessConnection() != this)
         return;
-    webProcess.gpuProcessConnectionDidBecomeUnresponsive();
+    webProcess->gpuProcessConnectionDidBecomeUnresponsive();
 }
 
 #if HAVE(AUDIT_TOKEN)
@@ -165,12 +165,12 @@ void GPUProcessConnection::didClose(IPC::Connection&)
 {
     RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::didClose", this);
     auto protector = Ref { *this };
-    auto& webProcess = WebProcess::singleton();
-    ASSERT(webProcess.existingGPUProcessConnection() == this);
-    webProcess.gpuProcessConnectionClosed();
+    Ref webProcess = WebProcess::singleton();
+    ASSERT(webProcess->existingGPUProcessConnection() == this);
+    webProcess->gpuProcessConnectionClosed();
 
 #if ENABLE(ROUTING_ARBITRATION)
-    if (auto* arbitrator = WebProcess::singleton().audioSessionRoutingArbitrator())
+    if (auto* arbitrator = webProcess->audioSessionRoutingArbitrator())
         arbitrator->leaveRoutingAbritration();
 #endif
 
@@ -255,7 +255,7 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
 
 #if ENABLE(ENCRYPTED_MEDIA)
     if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSession::messageReceiverName()) {
-        WebProcess::singleton().cdmFactory().didReceiveSessionMessage(connection, decoder);
+        WebProcess::singleton().protectedCDMFactory()->didReceiveSessionMessage(connection, decoder);
         return true;
     }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -42,11 +42,22 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCDMFactory);
 
-RemoteCDMFactory::RemoteCDMFactory(WebProcess&)
+RemoteCDMFactory::RemoteCDMFactory(WebProcess& webProcess)
+    : m_webProcess(webProcess)
 {
 }
 
 RemoteCDMFactory::~RemoteCDMFactory() = default;
+
+void RemoteCDMFactory::ref() const
+{
+    return m_webProcess->ref();
+}
+
+void RemoteCDMFactory::deref() const
+{
+    return m_webProcess->deref();
+}
 
 void RemoteCDMFactory::registerFactory(Vector<CDMFactory*>& factories)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -36,15 +36,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class RemoteCDMFactory;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteCDMFactory> : std::true_type { };
-}
-
 namespace WebCore {
 class Settings;
 }
@@ -70,6 +61,9 @@ public:
     explicit RemoteCDMFactory(WebProcess&);
     virtual ~RemoteCDMFactory();
 
+    void ref() const;
+    void deref() const;
+
     static ASCIILiteral supplementName();
 
     GPUProcessConnection& gpuProcessConnection();
@@ -87,6 +81,7 @@ private:
     std::unique_ptr<WebCore::CDMPrivate> createCDM(const String&, const WebCore::CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 
+    WeakRef<WebProcess> m_webProcess;
     UncheckedKeyHashMap<RemoteCDMInstanceSessionIdentifier, WeakPtr<RemoteCDMInstanceSession>> m_sessions;
     UncheckedKeyHashMap<RemoteCDMIdentifier, std::unique_ptr<RemoteCDM>> m_cdms;
 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
@@ -51,17 +51,18 @@ RemoteCDMInstance::RemoteCDMInstance(WeakPtr<RemoteCDMFactory>&& factory, Remote
     , m_identifier(WTFMove(identifier))
     , m_configuration(WTFMove(configuration))
 {
-    if (m_factory)
-        m_factory->gpuProcessConnection().messageReceiverMap().addMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64(), *this);
+    if (RefPtr factory = m_factory.get())
+        factory->gpuProcessConnection().messageReceiverMap().addMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64(), *this);
 }
 
 RemoteCDMInstance::~RemoteCDMInstance()
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return;
 
-    m_factory->removeInstance(m_identifier);
-    m_factory->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
+    factory->removeInstance(m_identifier);
+    factory->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCDMInstance::unrequestedInitializationDataReceived(const String& type, Ref<SharedBuffer>&& initData)
@@ -72,35 +73,36 @@ void RemoteCDMInstance::unrequestedInitializationDataReceived(const String& type
 
 void RemoteCDMInstance::initializeWithConfiguration(const WebCore::CDMKeySystemConfiguration& configuration, AllowDistinctiveIdentifiers distinctiveIdentifiers, AllowPersistentState persistentState, SuccessCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback(Failed);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::InitializeWithConfiguration(configuration, distinctiveIdentifiers, persistentState), WTFMove(callback), m_identifier);
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::InitializeWithConfiguration(configuration, distinctiveIdentifiers, persistentState), WTFMove(callback), m_identifier);
 }
 
 void RemoteCDMInstance::setServerCertificate(Ref<WebCore::SharedBuffer>&& certificate, SuccessCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback(Failed);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::SetServerCertificate(WTFMove(certificate)), WTFMove(callback), m_identifier);
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceProxy::SetServerCertificate(WTFMove(certificate)), WTFMove(callback), m_identifier);
 }
 
 void RemoteCDMInstance::setStorageDirectory(const String& directory)
 {
-    if (!m_factory)
-        return;
-
-    m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceProxy::SetStorageDirectory(directory), m_identifier);
+    if (RefPtr factory = m_factory.get())
+        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceProxy::SetStorageDirectory(directory), m_identifier);
 }
 
 RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return nullptr;
 
     uint64_t logIdentifier { 0 };
@@ -109,12 +111,12 @@ RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
         logIdentifier = reinterpret_cast<uint64_t>(m_client->logIdentifier());
 #endif
 
-    auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
+    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    auto session = RemoteCDMInstanceSession::create(m_factory.get(), WTFMove(*identifier));
-    m_factory->addSession(session.copyRef());
+    auto session = RemoteCDMInstanceSession::create(factory.get(), WTFMove(*identifier));
+    factory->addSession(session.copyRef());
     return session;
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -50,24 +50,30 @@ RemoteCDMInstanceSession::RemoteCDMInstanceSession(WeakPtr<RemoteCDMFactory>&& f
 
 RemoteCDMInstanceSession::~RemoteCDMInstanceSession()
 {
-    m_factory->removeSession(m_identifier);
+    protectedFactory()->removeSession(m_identifier);
+}
+
+RefPtr<RemoteCDMFactory> RemoteCDMInstanceSession::protectedFactory() const
+{
+    return m_factory.get();
 }
 
 #if !RELEASE_LOG_DISABLED
 void RemoteCDMInstanceSession::setLogIdentifier(uint64_t logIdentifier)
 {
-    m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
+    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
 }
 #endif
 
 void RemoteCDMInstanceSession::requestLicense(LicenseType type, KeyGroupingStrategy keyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback(SharedBuffer::create(), emptyString(), false, Failed);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RequestLicense(type, keyGroupingStrategy, initDataType, WTFMove(initData)), [callback = WTFMove(callback)] (RefPtr<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, bool succeeded) mutable {
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RequestLicense(type, keyGroupingStrategy, initDataType, WTFMove(initData)), [callback = WTFMove(callback)] (RefPtr<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, bool succeeded) mutable {
         if (!message) {
             callback(SharedBuffer::create(), emptyString(), false, Failed);
             return;
@@ -78,58 +84,60 @@ void RemoteCDMInstanceSession::requestLicense(LicenseType type, KeyGroupingStrat
 
 void RemoteCDMInstanceSession::updateLicense(const String& sessionId, LicenseType type, Ref<SharedBuffer>&& response, LicenseUpdateCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback(false, std::nullopt, std::nullopt, std::nullopt, Failed);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::UpdateLicense(sessionId, type, WTFMove(response)), [callback = WTFMove(callback)] (bool sessionWasClosed, std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded) mutable {
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::UpdateLicense(sessionId, type, WTFMove(response)), [callback = WTFMove(callback)] (bool sessionWasClosed, std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded) mutable {
         callback(sessionWasClosed, WTFMove(changedKeys), WTFMove(changedExpiration), WTFMove(message), succeeded ? Succeeded : Failed);
     }, m_identifier);
 }
 
 void RemoteCDMInstanceSession::loadSession(LicenseType type, const String& sessionId, const String& origin, LoadSessionCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback(std::nullopt, std::nullopt, std::nullopt, Failed, SessionLoadFailure::Other);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::LoadSession(type, sessionId, origin), [callback = WTFMove(callback)] (std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded, SessionLoadFailure loadFailure) mutable {
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::LoadSession(type, sessionId, origin), [callback = WTFMove(callback)] (std::optional<KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<Message>&& message, bool succeeded, SessionLoadFailure loadFailure) mutable {
         callback(WTFMove(changedKeys), WTFMove(changedExpiration), WTFMove(message), succeeded ? Succeeded : Failed, loadFailure);
     }, m_identifier);
 }
 
 void RemoteCDMInstanceSession::closeSession(const String& sessionId, CloseSessionCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback();
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::CloseSession(sessionId), [callback = WTFMove(callback)] () mutable {
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::CloseSession(sessionId), [callback = WTFMove(callback)] () mutable {
         callback();
     }, m_identifier);
 }
 
 void RemoteCDMInstanceSession::removeSessionData(const String& sessionId, LicenseType type, RemoveSessionDataCallback&& callback)
 {
-    if (!m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!factory) {
         callback({ }, nullptr, Failed);
         return;
     }
 
-    m_factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RemoveSessionData(sessionId, type), [callback = WTFMove(callback)] (KeyStatusVector&& changedKeys, RefPtr<SharedBuffer>&& message, bool succeeded) mutable {
+    factory->gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteCDMInstanceSessionProxy::RemoveSessionData(sessionId, type), [callback = WTFMove(callback)] (KeyStatusVector&& changedKeys, RefPtr<SharedBuffer>&& message, bool succeeded) mutable {
         callback(WTFMove(changedKeys), WTFMove(message), succeeded ? Succeeded : Failed);
     }, m_identifier);
 }
 
 void RemoteCDMInstanceSession::storeRecordOfKeyUsage(const String& sessionId)
 {
-    if (!m_factory)
-        return;
-
-    m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::StoreRecordOfKeyUsage(sessionId), m_identifier);
+    if (RefPtr factory = m_factory.get())
+        factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::StoreRecordOfKeyUsage(sessionId), m_identifier);
 }
 
 void RemoteCDMInstanceSession::updateKeyStatuses(KeyStatusVector&& keyStatuses)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -71,6 +71,8 @@ private:
     void removeSessionData(const String& sessionId, LicenseType, RemoveSessionDataCallback&&) final;
     void storeRecordOfKeyUsage(const String& sessionId) final;
 
+    RefPtr<RemoteCDMFactory> protectedFactory() const;
+
     WeakPtr<RemoteCDMFactory> m_factory;
     RemoteCDMInstanceSessionIdentifier m_identifier;
     WeakPtr<WebCore::CDMInstanceSessionClient> m_client;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -207,19 +207,19 @@ bool WebInspectorUI::supportsDockSide(DockSide dockSide)
 
 void WebInspectorUI::requestSetDockSide(DockSide dockSide)
 {
-    auto& webProcess = WebProcess::singleton();
+    Ref webProcess = WebProcess::singleton();
     switch (dockSide) {
     case DockSide::Undocked:
-        webProcess.parentProcessConnection()->send(Messages::WebInspectorUIProxy::Detach(), *m_inspectedPageIdentifier);
+        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::Detach(), *m_inspectedPageIdentifier);
         break;
     case DockSide::Right:
-        webProcess.parentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachRight(), *m_inspectedPageIdentifier);
+        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachRight(), *m_inspectedPageIdentifier);
         break;
     case DockSide::Left:
-        webProcess.parentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachLeft(), *m_inspectedPageIdentifier);
+        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachLeft(), *m_inspectedPageIdentifier);
         break;
     case DockSide::Bottom:
-        webProcess.parentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachBottom(), *m_inspectedPageIdentifier);
+        webProcess->protectedParentProcessConnection()->send(Messages::WebInspectorUIProxy::AttachBottom(), *m_inspectedPageIdentifier);
         break;
     }
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -328,7 +328,7 @@ WebProcess::WebProcess()
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
-    addSupplement<RemoteCDMFactory>();
+    addSupplementWithoutRefCountedCheck<RemoteCDMFactory>();
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -2245,7 +2245,7 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
     auto& cdmFactories = CDMFactory::registeredFactories();
     cdmFactories.clear();
     if (useGPUProcessForMedia)
-        cdmFactory().registerFactory(cdmFactories);
+        protectedCDMFactory()->registerFactory(cdmFactories);
     else
         CDMFactory::platformRegisterFactories(cdmFactories);
 #endif
@@ -2364,6 +2364,11 @@ RemoteLegacyCDMFactory& WebProcess::legacyCDMFactory()
 RemoteCDMFactory& WebProcess::cdmFactory()
 {
     return *supplement<RemoteCDMFactory>();
+}
+
+Ref<RemoteCDMFactory> WebProcess::protectedCDMFactory()
+{
+    return cdmFactory();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -198,6 +198,17 @@ public:
         m_supplements.add(T::supplementName(), makeUniqueWithoutRefCountedCheck<T>(*this));
     }
 
+    template <typename T>
+    void addSupplementWithoutRefCountedCheck()
+    {
+        m_supplements.add(T::supplementName(), makeUniqueWithoutRefCountedCheck<T>(*this));
+    }
+
+    // ref() & deref() do nothing since WebProcess is a singleton object.
+    // This is for objects owned by the WebProcess to forward their refcounting to their owner.
+    void ref() const { }
+    void deref() const { }
+
     WebPage* webPage(WebCore::PageIdentifier) const;
     void createWebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
     void removeWebPage(WebCore::PageIdentifier);
@@ -274,6 +285,7 @@ public:
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
     RemoteCDMFactory& cdmFactory();
+    Ref<RemoteCDMFactory> protectedCDMFactory();
 #endif
     RemoteMediaEngineConfigurationFactory& mediaEngineConfigurationFactory();
 #endif // ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### 0d199d482580e036ce9ac68429c0e119c3f8b65c
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RemoteCDMFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=281703">https://bugs.webkit.org/show_bug.cgi?id=281703</a>

Reviewed by Darin Adler.

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::setLogIdentifier):
(WebKit::RemoteCDM::getSupportedConfiguration):
(WebKit::RemoteCDM::createInstance):
(WebKit::RemoteCDM::loadAndInitialize):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::RemoteCDMFactory):
(WebKit::RemoteCDMFactory::ref const):
(WebKit::RemoteCDMFactory::deref const):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp:
(WebKit::RemoteCDMInstance::RemoteCDMInstance):
(WebKit::RemoteCDMInstance::~RemoteCDMInstance):
(WebKit::RemoteCDMInstance::initializeWithConfiguration):
(WebKit::RemoteCDMInstance::setServerCertificate):
(WebKit::RemoteCDMInstance::setStorageDirectory):
(WebKit::RemoteCDMInstance::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp:
(WebKit::RemoteCDMInstanceSession::~RemoteCDMInstanceSession):
(WebKit::RemoteCDMInstanceSession::protectedFactory const):
(WebKit::RemoteCDMInstanceSession::setLogIdentifier):
(WebKit::RemoteCDMInstanceSession::requestLicense):
(WebKit::RemoteCDMInstanceSession::updateLicense):
(WebKit::RemoteCDMInstanceSession::loadSession):
(WebKit::RemoteCDMInstanceSession::closeSession):
(WebKit::RemoteCDMInstanceSession::removeSessionData):
(WebKit::RemoteCDMInstanceSession::storeRecordOfKeyUsage):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::m_nonVisibleProcessMemoryCleanupTimer):
(WebKit::WebProcess::setUseGPUProcessForMedia):
(WebKit::WebProcess::protectedCDMFactory):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/285431@main">https://commits.webkit.org/285431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca13236b3a39004e46fdd1b542cf64de053c95e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23768 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57118 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15634 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43690 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19444 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6770 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->