### PR TITLE
Adopt more smart pointers in WebPageProxy (part 3)

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -283,7 +283,6 @@ UIProcess/WebEditCommandProxy.cpp
 UIProcess/WebFrameProxy.cpp
 UIProcess/WebOpenPanelResultListenerProxy.cpp
 UIProcess/WebPageProxy.cpp
-UIProcess/WebPageProxy.h
 UIProcess/WebPreferences.cpp
 UIProcess/WebPreferences.h
 UIProcess/WebProcessActivityState.cpp

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -49,6 +49,8 @@ public:
     WebCore::BackForwardItemIdentifier identifier() const;
 
     WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
+    RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent.get(); }
+
     WebBackForwardListFrameItem& rootFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -111,6 +111,7 @@ public:
     bool currentRequestIsCrossSiteRedirect() const;
 
     WebKit::WebBackForwardListItem* targetItem() const { return m_targetItem.get(); }
+    RefPtr<WebKit::WebBackForwardListItem> protectedTargetItem() const { return m_targetItem; }
     WebKit::WebBackForwardListItem* fromItem() const { return m_fromItem.get(); }
     std::optional<WebCore::FrameLoadType> backForwardFrameLoadType() const { return m_backForwardFrameLoadType; }
     WebKit::WebBackForwardListItem* reloadItem() const { return m_reloadItem.get(); }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -156,11 +156,6 @@ void PageConfiguration::setOpenerInfo(std::optional<OpenerInfo>&& info)
 
 bool PageConfiguration::OpenerInfo::operator==(const OpenerInfo&) const = default;
 
-WebCore::SandboxFlags PageConfiguration::initialSandboxFlags() const
-{
-    return m_data.initialSandboxFlags;
-}
-
 void PageConfiguration::setInitialSandboxFlags(WebCore::SandboxFlags sandboxFlags)
 {
     m_data.initialSandboxFlags = sandboxFlags;
@@ -169,6 +164,11 @@ void PageConfiguration::setInitialSandboxFlags(WebCore::SandboxFlags sandboxFlag
 WebProcessPool& PageConfiguration::processPool() const
 {
     return m_data.processPool.get();
+}
+
+Ref<WebKit::WebProcessPool> PageConfiguration::protectedProcessPool() const
+{
+    return processPool();
 }
 
 void PageConfiguration::setProcessPool(RefPtr<WebProcessPool>&& processPool)

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -123,13 +123,14 @@ public:
     const WTF::String& openedMainFrameName() const;
     void setOpenedMainFrameName(const WTF::String&);
 
-    WebCore::SandboxFlags initialSandboxFlags() const;
+    WebCore::SandboxFlags initialSandboxFlags() const { return m_data.initialSandboxFlags; }
     void setInitialSandboxFlags(WebCore::SandboxFlags);
 
     const std::optional<WebCore::WindowFeatures>& windowFeatures() const;
     void setWindowFeatures(WebCore::WindowFeatures&&);
 
     WebKit::WebProcessPool& processPool() const;
+    Ref<WebKit::WebProcessPool> protectedProcessPool() const;
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
     WebKit::WebUserContentControllerProxy& userContentController() const;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -33,11 +33,13 @@ class WebPageProxy;
 
 class WebNotificationManagerMessageHandler : public NotificationManagerMessageHandler {
     friend class WebPageProxy;
-private:
-    explicit WebNotificationManagerMessageHandler(WebPageProxy&);
 
+public:
     void ref() const final;
     void deref() const final;
+
+private:
+    explicit WebNotificationManagerMessageHandler(WebPageProxy&);
 
     void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
     void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) final;

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -255,21 +255,6 @@ double PageLoadState::estimatedProgress() const
     return estimatedProgress(m_committedState);
 }
 
-const String& PageLoadState::pendingAPIRequestURL() const
-{
-    return m_committedState.pendingAPIRequest.url;
-}
-
-auto PageLoadState::pendingAPIRequest() const -> const PendingAPIRequest&
-{
-    return m_committedState.pendingAPIRequest;
-}
-
-const URL& PageLoadState::resourceDirectoryURL() const
-{
-    return m_committedState.resourceDirectoryURL;
-}
-
 void PageLoadState::setPendingAPIRequest(const Transaction::Token& token, PendingAPIRequest&& pendingAPIRequest, const URL& resourceDirectoryURL)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -158,10 +158,10 @@ public:
 
     const WebCore::CertificateInfo& certificateInfo() const { return m_committedState.certificateInfo; }
 
-    const URL& resourceDirectoryURL() const;
+    const URL& resourceDirectoryURL() const { return m_committedState.resourceDirectoryURL; }
 
-    const String& pendingAPIRequestURL() const;
-    const PendingAPIRequest& pendingAPIRequest() const;
+    const String& pendingAPIRequestURL() const { return m_committedState.pendingAPIRequest.url; }
+    const PendingAPIRequest& pendingAPIRequest() const { return m_committedState.pendingAPIRequest; }
     void setPendingAPIRequest(const Transaction::Token&, PendingAPIRequest&& pendingAPIRequest, const URL& resourceDirectoryPath = { });
     void clearPendingAPIRequest(const Transaction::Token&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -618,7 +618,7 @@ public:
 
     static void forMostVisibleWebPageIfAny(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&&);
 
-    const API::PageConfiguration& configuration() const;
+    const API::PageConfiguration& configuration() const { return m_configuration.get(); }
     Ref<API::PageConfiguration> protectedConfiguration() const;
 
     using Identifier = WebPageProxyIdentifier;
@@ -652,7 +652,7 @@ public:
     bool shouldEnableLockdownMode() const;
 
     bool hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration&) const;
-    bool hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy& page) const { return hasSameGPUAndNetworkProcessPreferencesAs(Ref { page }->configuration()); }
+    bool hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy&) const;
 
     void processIsNoLongerAssociatedWithPage(WebProcessProxy&);
 
@@ -1630,8 +1630,8 @@ public:
 
     WebProcessProxy& ensureRunningProcess();
     Ref<WebProcessProxy> ensureProtectedRunningProcess();
-    WebProcessProxy& legacyMainFrameProcess() const { return m_legacyMainFrameProcess; }
     WebProcessProxy& siteIsolatedProcess() const { return m_legacyMainFrameProcess; }
+    WebProcessProxy& legacyMainFrameProcess() const { return m_legacyMainFrameProcess; }
     Ref<WebProcessProxy> protectedLegacyMainFrameProcess() const;
     ProcessID legacyMainFrameProcessID() const;
 
@@ -1639,6 +1639,7 @@ public:
     ProcessID modelProcessID() const;
 
     WebBackForwardCache& backForwardCache() const;
+    Ref<WebBackForwardCache> protectedBackForwardCache() const;
 
     const WebPreferences& preferences() const { return m_preferences; }
     WebPreferences& preferences() { return m_preferences; }

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -522,6 +522,13 @@ public:
     bool alwaysOnLoggingAllowed() const final { return protectedPage()->isAlwaysOnLoggingAllowed(); }
     RetainPtr<PlatformView> platformView() const final;
 #endif
+
+    Ref<PageLoadState> protectedPageLoadState() { return pageLoadState; }
+    Ref<WebNotificationManagerMessageHandler> protectedNotificationManagerMessageHandler() { return notificationManagerMessageHandler; }
+    Ref<PageLoadTimingFrameLoadStateObserver> protectedPageLoadTimingFrameLoadStateObserver() { return pageLoadTimingFrameLoadStateObserver; }
+#if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
+    RefPtr<WebPageProxyFrameLoadStateObserver> protectedFrameLoadStateObserver() { return frameLoadStateObserver.get(); }
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5ebdb0cd30e4ec687ce7246148b47b05bf6ffbbc
<pre>
Adopt more smart pointers in WebPageProxy (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=281700">https://bugs.webkit.org/show_bug.cgi?id=281700</a>
<a href="https://rdar.apple.com/138149402">rdar://138149402</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::protectedParent const):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::protectedTargetItem const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::protectedProcessPool const):
(API::PageConfiguration::initialSandboxFlags const): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::initialSandboxFlags const):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::pendingAPIRequestURL const): Deleted.
(WebKit::PageLoadState::pendingAPIRequest const const): Deleted.
(WebKit::PageLoadState::resourceDirectoryURL const): Deleted.
* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadState::resourceDirectoryURL const):
(WebKit::PageLoadState::pendingAPIRequestURL const):
(WebKit::PageLoadState::pendingAPIRequest const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::gpuProcessID const):
(WebKit::WebPageProxy::sendWithAsyncReply):
(WebKit::WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::backForwardCache const):
(WebKit::WebPageProxy::protectedBackForwardCache const):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::setDrawingArea):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadDataWithNavigationShared):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::recordAutomaticNavigationSnapshot):
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::didChangeBackForwardList):
(WebKit::WebPageProxy::willGoToBackForwardListItem):
(WebKit::WebPageProxy::inspectable const):
(WebKit::WebPageProxy::setInspectable):
(WebKit::WebPageProxy::setRemoteInspectionNameOverride):
(WebKit::WebPageProxy::remoteInspectorInformationDidChange):
(WebKit::WebPageProxy::setUnderPageBackgroundColorOverride):
(WebKit::WebPageProxy::updateActivityState):
(WebKit::WebPageProxy::viewDidLeaveWindow):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::updateThrottleState):
(WebKit::WebPageProxy::updateHiddenPageThrottlingAutoIncreases):
(WebKit::WebPageProxy::setInitialFocus):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::configuration const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/288118@main">https://commits.webkit.org/288118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b504bebf8c93be7647a56e42b61de4157e4cad6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81899 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/980 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31350 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14480 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14628 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->