### PR TITLE
[Tools][WPE] generate-bundle: fix shipping of inspector.gresource after 284551@main

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -259,39 +259,43 @@ class BundleCreator(object):
         variables = dict()
         mydir = self._bundler.VAR_MYDIR
         lib_dir = os.path.join(self._bundler.destination_dir(), 'lib')
-        syslib_dir = os.path.join(self._bundler.destination_dir(), 'sys/lib')
+        sys_lib_dir = os.path.join(self._bundler.destination_dir(), 'sys/lib')
         bin_dir = os.path.join(self._bundler.destination_dir(), 'bin')
-        share_dir = os.path.join(self._bundler.destination_dir(), 'sys/share')
+        share_dir = os.path.join(self._bundler.destination_dir(), 'share')
+        sys_share_dir = os.path.join(self._bundler.destination_dir(), 'sys/share')
 
-        if os.path.isdir(os.path.join(syslib_dir, 'gio')):
+        if os.path.isdir(os.path.join(sys_lib_dir, 'gio')):
             gio_var = 'GIO_MODULE_DIR' if self._syslibs == 'bundle-all' else 'GIO_EXTRA_MODULES'
             variables[gio_var] = '${%s}/sys/lib/gio' % mydir
-        if os.path.isdir(os.path.join(syslib_dir, 'gst')):
+        if os.path.isdir(os.path.join(sys_lib_dir, 'gst')):
             gst_var = 'GST_PLUGIN_SYSTEM_PATH_1_0' if self._syslibs == 'bundle-all' else 'GST_PLUGIN_PATH_1_0'
             variables[gst_var] = '${%s}/sys/lib/gst' % mydir
             variables['GST_REGISTRY_1_0'] = '${%s}/sys/lib/gst/gstreamer-1.0.registry' % mydir
             if os.path.isfile(os.path.join(bin_dir, 'gst-plugin-scanner')):
                 variables['GST_PLUGIN_SCANNER'] = '${%s}/bin/gst-plugin-scanner' % mydir
             # pipewire plugins may be needed by gstreamer-pipewire
-            if os.path.isdir(os.path.join(syslib_dir, 'pipewire', 'spa')):
+            if os.path.isdir(os.path.join(sys_lib_dir, 'pipewire', 'spa')):
                 variables['SPA_PLUGIN_DIR'] = '${%s}/sys/lib/pipewire/spa' % mydir
-            if os.path.isdir(os.path.join(syslib_dir, 'pipewire', 'modules')):
+            if os.path.isdir(os.path.join(sys_lib_dir, 'pipewire', 'modules')):
                 variables['PIPEWIRE_MODULE_DIR'] = '${%s}/sys/lib/pipewire/modules' % mydir
-        if os.path.isdir(os.path.join(syslib_dir, 'dri')):
+        if os.path.isdir(os.path.join(sys_lib_dir, 'dri')):
             variables['LIBGL_DRIVERS_PATH'] = '${%s}/sys/lib/dri' % mydir
-        if os.path.isdir(os.path.join(syslib_dir, 'glvnd/egl_vendor.d')):
+        if os.path.isdir(os.path.join(sys_lib_dir, 'glvnd/egl_vendor.d')):
             variables['__EGL_VENDOR_LIBRARY_DIRS'] = '${%s}/sys/lib/glvnd/egl_vendor.d' % mydir
-        if os.path.isdir(os.path.join(share_dir)):
+        if os.path.isdir(os.path.join(sys_share_dir)):
             assert(self._syslibs == 'bundle-all')
             variables['XDG_DATA_HOME'] = '${%s}/sys/share' % mydir
             variables['XDG_DATA_DIRS'] = '${%s}/sys/share' % mydir
-        if os.path.isdir(os.path.join(share_dir, 'fonts')):
+        if os.path.isdir(os.path.join(sys_share_dir, 'fonts')):
             variables['FONTCONFIG_PATH'] = '${%s}/sys/share/fonts/config' % mydir
-        if os.path.isdir(os.path.join(syslib_dir, 'gtk')):
+        if os.path.isdir(os.path.join(sys_lib_dir, 'gtk')):
             variables['GTK_PATH'] = '${%s}/sys/lib/gtk' % mydir
         if binary_to_wrap != 'jsc':
             variables['WEBKIT_EXEC_PATH'] = '${%s}/bin' % mydir
             variables['WEBKIT_INJECTED_BUNDLE_PATH'] = '${%s}/lib' % mydir
+            if os.path.isfile(os.path.join(share_dir, 'inspector.gresource')):
+                variables['WEBKIT_INSPECTOR_RESOURCES_PATH'] = '${%s}/share' % mydir
+
         if self._syslibs == 'bundle-all':
             # with bundle-all we can't execute system bwrap, we can only execute our own binaries.
             variables['WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS'] = '1'
@@ -696,7 +700,8 @@ class BundleCreator(object):
             objects_to_copy.extend(self._get_webkit_binaries())
             objects_to_copy.append(self._get_webkit_lib('InjectedBundle'))
             if self._platform == 'wpe':
-                objects_to_copy.append(self._get_webkit_lib('InspectorResources'))
+                webinspector_gresource = os.path.join(self._buildpath, 'WebInspectorUI', 'DerivedSources', 'inspector.gresource')
+                self._bundler.copy(webinspector_gresource, subdir='share')
             # Bundle extra system related libraries
             gio_modules = self._get_gio_modules()
             objects_to_copy.extend(gio_modules)
@@ -791,14 +796,11 @@ class BundleCreator(object):
         if needs_to_create_wpe_backend_symlink:
             self._ensure_wpe_backend_symlink()
 
-        if self._platform == 'wpe':
-            self._bundler.copy(os.path.join(self._buildpath, 'WebInspectorUI', 'DerivedSources', 'inspector.gresource'))
-
         # Now copy data files to share dir (only needed when bunding all for MiniBrowser).
         # We assume that the system uses standard paths at /usr/share and /etc for this resources
         # Every path should be checked and if some one is not found, then it will raise an error.
         if bundle_binary == 'MiniBrowser' and self._syslibs == 'bundle-all':
-            target_share_dir = os.path.join(self._tmpdir, 'sys/share')
+            target_sys_share_dir = os.path.join(self._tmpdir, 'sys/share')
             # Copy glvnd EGL json files
             _log.info('Copy EGL config files')
             egl_icd_configdir_dest = os.path.join(self._tmpdir, 'sys/lib/glvnd/egl_vendor.d')
@@ -807,7 +809,7 @@ class BundleCreator(object):
                 shutil.copy(egl_icd_mesa_config_file, egl_icd_configdir_dest)
             # Copy glib-2 compiled schemas
             _log.info('Copy Glib compiled schemas')
-            schemas_target_dir = os.path.join(target_share_dir, 'glib-2.0/schemas')
+            schemas_target_dir = os.path.join(target_sys_share_dir, 'glib-2.0/schemas')
             os.makedirs(schemas_target_dir)
             compiled_schemas_file = '/usr/share/glib-2.0/schemas/gschemas.compiled'
             if not os.path.isfile(compiled_schemas_file):
@@ -815,7 +817,7 @@ class BundleCreator(object):
             shutil.copy(compiled_schemas_file, schemas_target_dir)
             _log.info('Copy shared mime info cache')
             # Same for shared-mime-info cache
-            mime_target_dir = os.path.join(target_share_dir, 'mime')
+            mime_target_dir = os.path.join(target_sys_share_dir, 'mime')
             os.makedirs(mime_target_dir)
             mime_cache = '/usr/share/mime/mime.cache'
             if not os.path.isfile(mime_cache):
@@ -823,8 +825,8 @@ class BundleCreator(object):
             shutil.copy(mime_cache, mime_target_dir)
             _log.info('Generate fontconfig config')
             # Fontconfig fonts and config
-            target_font_config_dir = os.path.join(target_share_dir, 'fonts/config')
-            target_font_data_dir = os.path.join(target_share_dir, 'fonts/fonts')
+            target_font_config_dir = os.path.join(target_sys_share_dir, 'fonts/config')
+            target_font_data_dir = os.path.join(target_sys_share_dir, 'fonts/fonts')
             os.makedirs(target_font_config_dir)
             # We keep assuming standard locations for this files on the target system
             system_font_config_dir = '/etc/fonts/conf.d'
@@ -848,7 +850,7 @@ class BundleCreator(object):
             system_xkb_data = '/usr/share/X11/xkb'
             if not (os.path.isdir(system_xkb_data)):
                 raise NotImplementedError("Can't find the XKB data files at the standard location in this system")
-            target_xkb_data = os.path.join(target_share_dir, 'xkb')
+            target_xkb_data = os.path.join(target_sys_share_dir, 'xkb')
             shutil.copytree(system_xkb_data, target_xkb_data)
             # Flatpak configures gnutls to use the p11-kit trust store and then uses p11-kit to access the host SSL certificates.
             # - It starts a p11 kit server on the hosts and bind-mounting a socket that later is used from inside the sandbox via p11-kit-client.so
@@ -863,12 +865,12 @@ class BundleCreator(object):
             # To debug this is useful to export P11_KIT_DEBUG=all
             # This approach also allows this bundle script go generate a working bundle when gnutls is not configured to use p11-kit.
             _log.info('Generate TLS CA certificates file')
-            certs_target_dir = os.path.join(target_share_dir, 'certs')
+            certs_target_dir = os.path.join(target_sys_share_dir, 'certs')
             os.makedirs(certs_target_dir)
             self._generate_tls_cafile(certs_target_dir)
             if self._platform == 'gtk':
                 _log.info('Copy basic GTK icons.')
-                icons_target_dir = os.path.join(target_share_dir, 'icons')
+                icons_target_dir = os.path.join(target_sys_share_dir, 'icons')
                 os.makedirs(icons_target_dir)
                 gtk_icon_basedir = '/run/host/share/icons' if flatpakutils.is_sandboxed() else '/usr/share/icons'
                 gtk_target_icon_dir = os.path.join(icons_target_dir, 'hicolor')


### PR DESCRIPTION
#### 316bb98852764d9d5d31b8bb8617ffdfff6ca797
<pre>
[Tools][WPE] generate-bundle: fix shipping of inspector.gresource after 284551@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=281717">https://bugs.webkit.org/show_bug.cgi?id=281717</a>

Reviewed by Carlos Garcia Campos.

Ship the inspector.gresource file on a share subdir inside the bundle
and specify the path to it on the wrapper via the designed environment variable
for that (WEBKIT_INSPECTOR_RESOURCES_PATH)

Also stop trying to copy the old library that is not available anymore and
breaks the script.

Meanwhile at it do a bit of cleaning with the variable naming to avoid confusion
between the subdirectories on the bundle that ship system resources and the ones
that ship webkit ones.

* Tools/Scripts/generate-bundle:
(BundleCreator._generate_wrapper):
(BundleCreator._create_bundle):
* Tools/Scripts/webkitpy/binary_bundling/bundle.py:
(BinaryBundler.copy):
(BinaryBundler.copy_and_maybe_strip_patchelf):
(BinaryBundler.is_xkb_bundled):
(BinaryBundler.generate_wrapper_script):
(BinaryBundler.generate_and_build_static_cwrapper):

Canonical link: <a href="https://commits.webkit.org/285389@main">https://commits.webkit.org/285389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/927b6125e822902637f1e7eee80706ac16c8d4d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62406 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/71982 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19872 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78325 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64776 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6696 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47694 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->