### PR TITLE
[WebDriver] Add BiDi message handling support

### DIFF
--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -133,6 +133,11 @@ private:
     void takeScreenshot(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void takeElementScreenshot(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
 
+#if ENABLE(WEBDRIVER_BIDI)
+    // BiDi message handlers
+    void bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
+#endif
+
     static Capabilities platformCapabilities();
     Vector<Capabilities> processCapabilities(const JSON::Object&, Function<void (CommandResult&&)>&) const;
     RefPtr<JSON::Object> validatedCapabilities(const JSON::Object&) const;
@@ -157,6 +162,14 @@ private:
     void clientDisconnected(const WebSocketMessageHandler::Connection&) override;
 
     void onBrowserTerminated(const String& sessionId);
+
+    typedef void (WebDriverService::*BidiCommandHandler)(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
+    struct BidiCommand {
+        String method;
+        BidiCommandHandler handler;
+    };
+    static const BidiCommand s_bidiCommands[];
+    static bool findBidiCommand(RefPtr<JSON::Value>&, BidiCommandHandler*, unsigned& id, RefPtr<JSON::Object>& parsedParams);
 #endif // ENABLE(WEBDRIVER_BIDI)
 
     HTTPServer m_server;

--- a/Source/WebDriver/WebSocketServer.h
+++ b/Source/WebDriver/WebSocketServer.h
@@ -91,10 +91,10 @@ public:
         // Optional connection, as the message might be generated without a connection object available (e.g. inside a method handler).
         // In this case, it gets associated to the connection when sending the message back to the client.
         Connection connection;
-        const char* data { nullptr };
-        size_t dataLength { 0 };
+        const CString payload;
 
-        static Message fail(CommandResult::ErrorCode, std::optional<Connection>, std::optional<String> errorMessage = std::nullopt, std::optional<String> commandId = std::nullopt);
+        static Message fail(CommandResult::ErrorCode, std::optional<Connection>, std::optional<String> errorMessage = std::nullopt, std::optional<int> commandId = std::nullopt);
+        static Message reply(const String& type, unsigned id, Ref<JSON::Value>&& result);
     };
 
     virtual bool acceptHandshake(HTTPRequestHandler::Request&&) = 0;
@@ -128,6 +128,7 @@ public:
     String getResourceName(const String& sessionId);
     String getWebSocketURL(const RefPtr<WebSocketListener>, const String& sessionId);
     String getSessionID(const String& resource);
+    void sendMessage(const String& session, const String& message);
 
     // Non-spec method
     void removeResourceForSession(const String& sessionId);

--- a/Source/WebDriver/soup/WebSocketServerSoup.cpp
+++ b/Source/WebDriver/soup/WebSocketServerSoup.cpp
@@ -32,6 +32,7 @@
 #include <libsoup/soup-websocket-connection.h>
 #include <libsoup/soup.h>
 #include <optional>
+#include <span>
 #include <tuple>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/WTFString.h>
@@ -92,7 +93,7 @@ static void handleWebSocketMessage(SoupWebsocketConnection* connection, SoupWebs
     if (messageType != SOUP_WEBSOCKET_DATA_TEXT) {
         WTFLogAlways("websocket message handler received non-text message. error return");
         auto errorReply = WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, { "Non-text message received"_s });
-        GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(errorReply.data, errorReply.dataLength));
+        GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(errorReply.payload.data(), errorReply.payload.length()));
         soup_websocket_connection_send_message(connection, SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
         return;
     }
@@ -100,13 +101,13 @@ static void handleWebSocketMessage(SoupWebsocketConnection* connection, SoupWebs
 
     gsize messageSize;
     gconstpointer messageData = g_bytes_get_data(message, &messageSize);
-    WebSocketMessageHandler::Message messageObj = { connection, static_cast<const char*>(messageData), messageSize };
+    WebSocketMessageHandler::Message messageObj = { connection, { std::span<const char>(static_cast<const char*>(messageData), messageSize) } };
     webSocketServer->messageHandler().handleMessage(WTFMove(messageObj), [](WebSocketMessageHandler::Message&& message) {
         if (!message.connection) {
-            WTFLogAlways("No connection found when trying to send message: %s", message.data);
+            WTFLogAlways("No connection found when trying to send message: %s", message.payload.data());
             return;
         }
-        GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.data, message.dataLength));
+        GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.payload.data(), message.payload.length()));
         // Using send_message to avoid dealing with null chars in the middle of the message
         soup_websocket_connection_send_message(message.connection.get(), SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
     });
@@ -160,6 +161,17 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
         { "/session"_s }
     );
     return getWebSocketURL(m_listener, nullString());
+}
+
+void WebSocketServer::sendMessage(const String& session, const String& message)
+{
+    for (const auto& pair : m_connectionToSession) {
+        if (pair.value == session) {
+            GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.utf8().data(), message.utf8().length()));
+            soup_websocket_connection_send_message(pair.key.get(), SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
+            return;
+        }
+    }
 }
 
 void WebSocketServer::disconnect()


### PR DESCRIPTION
#### fb7cd496792a8bdb747212b73b53dc8acf8c3faf
<pre>
[WebDriver] Add BiDi message handling support
<a href="https://bugs.webkit.org/show_bug.cgi?id=280501">https://bugs.webkit.org/show_bug.cgi?id=280501</a>

Reviewed by Carlos Garcia Campos.

This commit adds the basic incoming message handling and replying. It
uses the simple `session.status` method.

As we support a single session, calling `session.status()` will always
return false for now, given we do not support calling static methods
without a session yet.

This version matches the incoming message with the message handler
only by the &quot;method&quot; name parameter, leaving the matching of the
method parameters to the handler function.

This commit also changes the Message data type to hold a CString instead
of pair of plain C string + length.

* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::handleMessage): Added.
(WebDriver::WebDriverService::findBidiCommand): Added.
(WebDriver::WebDriverService::bidiSessionStatus): Added.
* Source/WebDriver/WebDriverService.h:
* Source/WebDriver/WebSocketServer.cpp:
(WebDriver::WebSocketMessageHandler::Message::fail): Use int for command
ids.
(WebDriver::WebSocketMessageHandler::Message::reply): Added.
* Source/WebDriver/WebSocketServer.h:
* Source/WebDriver/soup/WebSocketServerSoup.cpp:
(WebDriver::WebSocketServer::sendMessage):

amend: ensure we call the completion handler
Canonical link: <a href="https://commits.webkit.org/286076@main">https://commits.webkit.org/286076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495baddc3b5abf044ad659d07256579479ebf98d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25696 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80360 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66077 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8168 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1739 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->