### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from UserMediaPermissionRequestManager

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -55,6 +55,9 @@ public:
     static ExceptionOr<Ref<AudioContext>> create(Document&, AudioContextOptions&&);
     ~AudioContext();
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::ref(); }
+
     WEBCORE_EXPORT static void setDefaultSampleRateForTesting(std::optional<float>);
 
     void close(DOMPromiseDeferred<void>&&);

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -147,8 +147,8 @@ public:
     ExceptionOr<Ref<AudioBuffer>> createBuffer(unsigned numberOfChannels, unsigned length, float sampleRate);
 
     // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCounted::ref(); }
-    void deref() const final { ThreadSafeRefCounted::deref(); }
+    void ref() const override { ThreadSafeRefCounted::ref(); }
+    void deref() const override { ThreadSafeRefCounted::deref(); }
 
     // Called at the start of each render quantum.
     void handlePreRenderTasks(const AudioIOPosition& outputPosition);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8247,10 +8247,10 @@ MediaCanStartListener* Document::takeAnyMediaCanStartListener()
     if (m_mediaCanStartListeners.isEmptyIgnoringNullReferences())
         return nullptr;
 
-    MediaCanStartListener* listener = m_mediaCanStartListeners.begin().get();
+    RefPtr listener = m_mediaCanStartListeners.begin().get();
     m_mediaCanStartListeners.remove(*listener);
 
-    return listener;
+    return listener.get();
 }
 
 void Document::addDisplayChangedObserver(const DisplayChangedObserver& observer)

--- a/Source/WebCore/page/MediaCanStartListener.h
+++ b/Source/WebCore/page/MediaCanStartListener.h
@@ -25,22 +25,13 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class MediaCanStartListener;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaCanStartListener> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class Document;
 
-class MediaCanStartListener : public CanMakeWeakPtr<MediaCanStartListener> {
+class MediaCanStartListener : public AbstractRefCountedAndCanMakeWeakPtr<MediaCanStartListener> {
 public:
     virtual void mediaCanStart(Document&) = 0;
 protected:

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -202,16 +202,16 @@ void RealtimeMediaSourceCenter::captureDevicesChanged()
 void RealtimeMediaSourceCenter::captureDeviceWillBeRemoved(const String& persistentId)
 {
     Ref protectedThis { *this };
-    m_observers.forEach([&](auto& observer) {
-        observer.deviceWillBeRemoved(persistentId);
+    m_observers.forEach([&](Ref<RealtimeMediaSourceCenterObserver> observer) {
+        observer->deviceWillBeRemoved(persistentId);
     });
 }
 
 void RealtimeMediaSourceCenter::triggerDevicesChangedObservers()
 {
     Ref protectedThis { *this };
-    m_observers.forEach([](auto& observer) {
-        observer.devicesChanged();
+    m_observers.forEach([](Ref<RealtimeMediaSourceCenterObserver> observer) {
+        observer->devicesChanged();
     });
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -37,6 +37,7 @@
 #include "ExceptionOr.h"
 #include "MediaStreamRequest.h"
 #include "RealtimeMediaSource.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -48,15 +49,6 @@
 #endif
 
 namespace WebCore {
-class RealtimeMediaSourceCenterObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RealtimeMediaSourceCenterObserver> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CaptureDevice;
 class CaptureDeviceManager;
@@ -65,7 +57,7 @@ class TrackSourceInfo;
 
 struct MediaConstraints;
 
-class WEBCORE_EXPORT RealtimeMediaSourceCenterObserver : public CanMakeWeakPtr<RealtimeMediaSourceCenterObserver> {
+class WEBCORE_EXPORT RealtimeMediaSourceCenterObserver : public AbstractRefCountedAndCanMakeWeakPtr<RealtimeMediaSourceCenterObserver> {
 public:
     virtual ~RealtimeMediaSourceCenterObserver();
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -77,6 +77,10 @@ class GStreamerAudioCaptureDeviceManager final : public GStreamerCaptureDeviceMa
 public:
     static GStreamerAudioCaptureDeviceManager& singleton();
     CaptureDevice::DeviceType deviceType() final { return CaptureDevice::DeviceType::Microphone; }
+
+    // ref() and deref() do nothing because this object is a singleton.
+    void ref() const final { }
+    void deref() const final { }
 };
 
 class GStreamerVideoCaptureDeviceManager final : public GStreamerCaptureDeviceManager {
@@ -84,6 +88,10 @@ class GStreamerVideoCaptureDeviceManager final : public GStreamerCaptureDeviceMa
 public:
     static GStreamerVideoCaptureDeviceManager& singleton();
     CaptureDevice::DeviceType deviceType() final { return CaptureDevice::DeviceType::Camera; }
+
+    // ref() and deref() do nothing because this object is a singleton.
+    void ref() const final { }
+    void deref() const final { }
 };
 
 class GStreamerDisplayCaptureDeviceManager final : public DisplayCaptureManager {

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -53,6 +53,9 @@ class BaseAudioSharedUnit : public RefCounted<BaseAudioSharedUnit>, public Realt
 public:
     virtual ~BaseAudioSharedUnit();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void startProducingData();
     void stopProducingData();
     void reconfigure();

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -143,6 +143,16 @@ void MediaKeySystemPermissionRequestManager::mediaKeySystemWasDenied(MediaKeySys
     request->deny(WTFMove(message));
 }
 
+void MediaKeySystemPermissionRequestManager::ref() const
+{
+    m_page->ref();
+}
+
+void MediaKeySystemPermissionRequestManager::deref() const
+{
+    m_page->deref();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -47,6 +47,9 @@ public:
     explicit MediaKeySystemPermissionRequestManager(WebPage&);
     ~MediaKeySystemPermissionRequestManager() = default;
 
+    void ref() const final;
+    void deref() const final;
+
     void startMediaKeySystemRequest(WebCore::MediaKeySystemRequest&);
     void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&);
     void mediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier);

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -35,15 +35,6 @@
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
-class UserMediaPermissionRequestManager;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::UserMediaPermissionRequestManager> : std::true_type { };
-}
-
-namespace WebKit {
 
 class WebPage;
 
@@ -59,8 +50,8 @@ public:
     explicit UserMediaPermissionRequestManager(WebPage&);
     ~UserMediaPermissionRequestManager() = default;
 
-    void ref() const;
-    void deref() const;
+    void ref() const final;
+    void deref() const final;
 
     void startUserMediaRequest(WebCore::UserMediaRequest&);
     void cancelUserMediaRequest(WebCore::UserMediaRequest&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
@@ -49,14 +49,19 @@ void WebMediaKeySystemClient::pageDestroyed()
     delete this;
 }
 
+Ref<WebPage> WebMediaKeySystemClient::protectedPage() const
+{
+    return m_page.get();
+}
+
 void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& request)
 {
-    m_page->mediaKeySystemPermissionRequestManager().startMediaKeySystemRequest(request);
+    protectedPage()->protectedMediaKeySystemPermissionRequestManager()->startMediaKeySystemRequest(request);
 }
 
 void WebMediaKeySystemClient::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
 {
-    m_page->mediaKeySystemPermissionRequestManager().cancelMediaKeySystemRequest(request);
+    protectedPage()->protectedMediaKeySystemPermissionRequestManager()->cancelMediaKeySystemRequest(request);
 }
 
 } // namespace WebKit;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
@@ -46,6 +46,8 @@ private:
     void requestMediaKeySystem(WebCore::MediaKeySystemRequest&) final;
     void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&) final;
 
+    Ref<WebPage> protectedPage() const;
+
     WeakRef<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5943,14 +5943,19 @@ void WebPage::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool is
 #endif // ENABLE(MEDIA_STREAM)
 
 #if ENABLE(ENCRYPTED_MEDIA)
+Ref<MediaKeySystemPermissionRequestManager> WebPage::protectedMediaKeySystemPermissionRequestManager()
+{
+    return m_mediaKeySystemPermissionRequestManager.get();
+}
+
 void WebPage::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier mediaKeySystemID)
 {
-    m_mediaKeySystemPermissionRequestManager->mediaKeySystemWasGranted(mediaKeySystemID);
+    protectedMediaKeySystemPermissionRequestManager()->mediaKeySystemWasGranted(mediaKeySystemID);
 }
 
 void WebPage::mediaKeySystemWasDenied(MediaKeySystemRequestIdentifier mediaKeySystemID, String&& message)
 {
-    m_mediaKeySystemPermissionRequestManager->mediaKeySystemWasDenied(mediaKeySystemID, WTFMove(message));
+    protectedMediaKeySystemPermissionRequestManager()->mediaKeySystemWasDenied(mediaKeySystemID, WTFMove(message));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -881,6 +881,7 @@ public:
 
 #if ENABLE(ENCRYPTED_MEDIA)
     MediaKeySystemPermissionRequestManager& mediaKeySystemPermissionRequestManager() { return m_mediaKeySystemPermissionRequestManager; }
+    Ref<MediaKeySystemPermissionRequestManager> protectedMediaKeySystemPermissionRequestManager();
 #endif
 
     void copyLinkWithHighlight();


### PR DESCRIPTION
#### b7f8ba6a5b1056bdd8a909d9fba303671a9365b2
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from UserMediaPermissionRequestManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=281724">https://bugs.webkit.org/show_bug.cgi?id=281724</a>
<a href="https://rdar.apple.com/138168649">rdar://138168649</a>

Reviewed by Chris Dumez.

UserMediaPermissionRequestManager forwards its ref/deref to its owner WebPage.

* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::takeAnyMediaCanStartListener):
* Source/WebCore/page/MediaCanStartListener.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::captureDeviceWillBeRemoved):
(WebCore::RealtimeMediaSourceCenter::triggerDevicesChangedObservers):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::ref const):
(WebKit::MediaKeySystemPermissionRequestManager::deref const):
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp:
(WebKit::WebMediaKeySystemClient::protectedPage const):
(WebKit::WebMediaKeySystemClient::requestMediaKeySystem):
(WebKit::WebMediaKeySystemClient::cancelMediaKeySystemRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::protectedMediaKeySystemPermissionRequestManager):
(WebKit::WebPage::mediaKeySystemWasGranted):
(WebKit::WebPage::mediaKeySystemWasDenied):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/285464@main">https://commits.webkit.org/285464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05cb47298629892ceabdb320e2ab0c6dfaad0d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6832 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2686 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->