### PR TITLE
Implement URLPatternInit support for URLPatternAPI.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -599,6 +599,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/system-preview/ARKitBadgeSystemImage.h
 
     Modules/url-pattern/URLPattern.h
+    Modules/url-pattern/URLPatternCanonical.h
     Modules/url-pattern/URLPatternInit.h
     Modules/url-pattern/URLPatternOptions.h
     Modules/url-pattern/URLPatternResult.h

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -26,28 +26,237 @@
 #include "config.h"
 #include "URLPattern.h"
 
+#include "URLPatternCanonical.h"
 #include "URLPatternInit.h"
 #include "URLPatternOptions.h"
 #include "URLPatternResult.h"
 #include <wtf/RefCounted.h>
+#include <wtf/URL.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(URLPattern);
 
-Ref<URLPattern> URLPattern::create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&)
+template<typename CharacterType>
+static String escapePatternStringForCharacters(std::span<const CharacterType> characters)
+{
+    static constexpr std::array escapeCharacters { '+', '*', '?', ':', '(', ')', '\\', '{', '}' }; // NOLINT
+
+    StringBuilder result;
+    result.reserveCapacity(characters.size());
+
+    for (auto character : characters) {
+        if (std::find(escapeCharacters.begin(), escapeCharacters.end(), character) != escapeCharacters.end())
+            result.append('\\');
+
+        result.append(character);
+    }
+
+    return result.toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#escape-a-pattern-string
+static String escapePatternString(StringView input)
+{
+    ASSERT(input.containsOnlyASCII());
+
+    if (input.is8Bit())
+        return escapePatternStringForCharacters(input.span8());
+
+    return escapePatternStringForCharacters(input.span16());
+}
+
+// https://urlpattern.spec.whatwg.org/#process-a-base-url-string
+static String processBaseURLString(StringView input, BaseURLStringType type)
+{
+    if (type != BaseURLStringType::Pattern)
+        return input.toString();
+
+    return escapePatternString(input);
+}
+
+// https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit
+static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStringType type, String&& protocol = { }, String&& username = { }, String&& password = { }, String&& hostname = { }, String&& port = { }, String&& pathname = { }, String&& search = { }, String&& hash = { })
+{
+    URLPatternInit result { WTFMove(protocol), WTFMove(username), WTFMove(password), WTFMove(hostname), WTFMove(port), WTFMove(pathname), WTFMove(search), WTFMove(hash), { } };
+
+    URL baseURL;
+
+    if  (!init.baseURL.isNull()) {
+        baseURL = URL(init.baseURL);
+
+        if (!baseURL.isValid()) {
+            // FIXME: Check if empty string should be allowed.
+            return Exception { ExceptionCode::TypeError, "Invalid baseURL."_s };
+        }
+
+        if (init.protocol.isNull())
+            result.protocol = processBaseURLString(baseURL.protocol(), type);
+
+        if (type != BaseURLStringType::Pattern
+            && init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()
+            && init.username.isNull())
+            result.username = processBaseURLString(baseURL.user(), type);
+
+        if (type != BaseURLStringType::Pattern
+            && init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()
+            && init.username.isNull()
+            && init.password.isNull())
+            result.password = processBaseURLString(baseURL.password(), type);
+
+        if (init.protocol.isNull()
+            && init.hostname.isNull()) {
+            result.hostname = processBaseURLString(!baseURL.host().isNull() ? baseURL.host() : StringView { emptyString() }, type);
+        }
+
+        if (init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()) {
+            auto port = baseURL.port();
+            result.port = port ? String::number(*port) : emptyString();
+        }
+
+        if (init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()
+            && init.pathname.isNull()) {
+            result.pathname = processBaseURLString(baseURL.path(), type);
+        }
+
+        if (init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()
+            && init.pathname.isNull()
+            && init.search.isNull()) {
+            result.search = processBaseURLString(baseURL.hasQuery() ? baseURL.query() : StringView { emptyString() }, type);
+        }
+
+        if (init.protocol.isNull()
+            && init.hostname.isNull()
+            && init.port.isNull()
+            && init.pathname.isNull()
+            && init.search.isNull()
+            && init.hash.isNull()) {
+            result.hash = processBaseURLString(baseURL.hasFragmentIdentifier() ? baseURL.fragmentIdentifier() : StringView { emptyString() }, type);
+        }
+    }
+
+    if (!init.protocol.isNull()) {
+        auto protocolResult = canonicalizeProtocol(init.protocol, type);
+
+        if (protocolResult.hasException())
+            return protocolResult.releaseException();
+
+        result.protocol = protocolResult.releaseReturnValue();
+    }
+
+    if (!init.username.isNull())
+        result.username = canonicalizeUsername(init.username, type);
+
+    if (!init.password.isNull())
+        result.password = canonicalizePassword(init.password, type);
+
+    if (!init.hostname.isNull()) {
+        auto hostResult = canonicalizeHost(init.hostname, type);
+
+        if (hostResult.hasException())
+            return hostResult.releaseException();
+
+        result.hostname = hostResult.releaseReturnValue();
+    }
+
+    if (!init.port.isNull()) {
+        auto portResult = canonicalizePort(init.port, init.protocol, type);
+
+        if (portResult.hasException())
+            return portResult.releaseException();
+
+        result.port = portResult.releaseReturnValue();
+    }
+
+    if (!init.pathname.isNull()) {
+        result.pathname = init.pathname;
+
+        if (!baseURL.isNull() && baseURL.hasOpaquePath() && !isAbsolutePathname(result.pathname, type)) {
+            auto baseURLPath = processBaseURLString(baseURL.path(), type);
+            size_t slashIndex = baseURLPath.reverseFind('/');
+
+            if (slashIndex != notFound)
+                result.pathname = makeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
+
+            auto pathResult = canonicalizePath(result.pathname, baseURL.protocol(), type);
+
+            if (pathResult.hasException())
+                return pathResult.releaseException();
+
+            result.pathname = pathResult.releaseReturnValue();
+        }
+    }
+
+    if (!init.search.isNull()) {
+        auto queryResult = canonicalizeSearch(init.search, type);
+
+        if (queryResult.hasException())
+            return queryResult.releaseException();
+
+        result.search = queryResult.releaseReturnValue();
+    }
+
+    if (!init.hash.isNull()) {
+        auto fragmentResult = canonicalizeHash(init.hash, type);
+
+        if (fragmentResult.hasException())
+            return fragmentResult.releaseException();
+
+        result.hash = fragmentResult.releaseReturnValue();
+    }
+
+    return result;
+}
+
+ExceptionOr<Ref<URLPattern>> URLPattern::create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&)
 {
     UNUSED_PARAM(baseURL);
 
-    return adoptRef(*new URLPattern());
+    return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
 }
 
-Ref<URLPattern> URLPattern::create(std::optional<URLPatternInput>&&, URLPatternOptions&&)
+ExceptionOr<Ref<URLPattern>> URLPattern::create(std::optional<URLPatternInput>&& input, URLPatternOptions&&)
 {
-    return adoptRef(*new URLPattern());
+    URLPatternInit init;
+    if (!input)
+        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
+    if (std::holds_alternative<String>(*input) && !std::get<String>(*input).isNull())
+        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
+    if (std::holds_alternative<URLPatternInit>(*input))
+        init = std::get<URLPatternInit>(*input);
+
+    auto maybeProcessedInit = processInit(WTFMove(init), BaseURLStringType::Pattern);
+
+    if (maybeProcessedInit.hasException())
+        return maybeProcessedInit.releaseException();
+
+    auto processedInit = maybeProcessedInit.releaseReturnValue();
+
+    // FIXME: Implement compiling the component for each URLPattern member field to replace this current placeholder code which reroutes processed URLPatternInit object to URLPattern result.
+    return adoptRef(*new URLPattern(WTFMove(processedInit)));
 }
 
-URLPattern::URLPattern() = default;
+URLPattern::URLPattern(URLPatternInit&& initInput)
+    : m_protocol(WTFMove(initInput.protocol))
+    , m_username(WTFMove(initInput.username))
+    , m_password(WTFMove(initInput.password))
+    , m_hostname(WTFMove(initInput.hostname))
+    , m_port(WTFMove(initInput.port))
+    , m_pathname(WTFMove(initInput.pathname))
+    , m_search(WTFMove(initInput.search))
+    , m_hash(WTFMove(initInput.hash))
+{
+}
 
 URLPattern::~URLPattern() = default;
 

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -36,14 +36,15 @@ namespace WebCore {
 struct URLPatternInit;
 struct URLPatternOptions;
 struct URLPatternResult;
+enum class BaseURLStringType : bool { Pattern, URL };
 
 class URLPattern final : public RefCounted<URLPattern> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(URLPattern);
 public:
     using URLPatternInput = std::variant<String, URLPatternInit>;
 
-    static Ref<URLPattern> create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
-    static Ref<URLPattern> create(std::optional<URLPatternInput>&&, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(std::optional<URLPatternInput>&&, URLPatternOptions&&);
     ~URLPattern();
 
     ExceptionOr<bool> test(std::optional<URLPatternInput>&&, String&& baseURL) const;
@@ -62,7 +63,7 @@ public:
     bool hasRegExpGroups() const { return m_hasRegExpGroups; }
 
 private:
-    URLPattern();
+    explicit URLPattern(URLPatternInit&& initInput);
 
     String m_protocol;
     String m_username;

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "URLPatternCanonical.h"
+
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringToIntegerConversion.h>
+
+namespace WebCore {
+
+static constexpr auto dummyURLCharacters { "https://www.webkit.org"_s };
+
+static bool isInvalidIPv6HostCodePoint(auto codepoint)
+{
+    static constexpr std::array validSpecialCodepoints { '[', ']', ':' };
+    return !isASCIIHexDigit(codepoint) && std::find(validSpecialCodepoints.begin(), validSpecialCodepoints.end(), codepoint) != validSpecialCodepoints.end();
+}
+
+// https://urlpattern.spec.whatwg.org/#is-an-absolute-pathname
+bool isAbsolutePathname(StringView input, BaseURLStringType inputType)
+{
+    if (input.isEmpty())
+        return false;
+
+    if (input[0] == '/')
+        return true;
+
+    if (inputType == BaseURLStringType::URL)
+        return false;
+
+    if (input.length() < 2)
+        return false;
+
+    if (input.startsWith("\\/"_s))
+        return true;
+
+    if (input.startsWith("{/"_s))
+        return true;
+
+    return false;
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-protocol, combined with https://urlpattern.spec.whatwg.org/#process-protocol-for-init
+ExceptionOr<String> canonicalizeProtocol(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    auto strippedValue = value.endsWith(':') ? value.left(value.length() - 1) : value;
+
+    if (valueType == BaseURLStringType::Pattern)
+        return strippedValue;
+
+    URL dummyURL(makeString(strippedValue, "://webkit.test"_s));
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL protocol string."_s };
+
+    return dummyURL.protocol().toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-username, combined with https://urlpattern.spec.whatwg.org/#process-username-for-init
+String canonicalizeUsername(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    if (valueType == BaseURLStringType::Pattern)
+        return String { value };
+
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setUser(value);
+
+    return dummyURL.user();
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-password, combined with https://urlpattern.spec.whatwg.org/#process-password-for-init
+String canonicalizePassword(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    if (valueType == BaseURLStringType::Pattern)
+        return String { value };
+
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setPassword(value);
+
+    return dummyURL.password();
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-hostname, combined with https://urlpattern.spec.whatwg.org/#process-hostname-for-init
+ExceptionOr<String> canonicalizeHost(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    if (valueType == BaseURLStringType::Pattern)
+        return String { value };
+
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setHost(value);
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL host string."_s };
+
+    return String { value };
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-an-ipv6-hostname
+ExceptionOr<String> canonicalizeIPv6Host(const String& value, BaseURLStringType valueType)
+{
+    if (valueType == BaseURLStringType::Pattern)
+        return String { value };
+
+    StringBuilder result;
+    result.reserveCapacity(result.length());
+
+    for (auto codepoint : StringView(value).codePoints()) {
+        if (isInvalidIPv6HostCodePoint(codepoint))
+            return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL IPv6 host string."_s };
+
+        result.append(toASCIILower(codepoint));
+    }
+
+    return result.toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-port, combined with https://urlpattern.spec.whatwg.org/#process-port-for-init
+ExceptionOr<String> canonicalizePort(const String& portValue, std::optional<StringView> protocolValue, BaseURLStringType portValueType)
+{
+    if (portValue.isEmpty())
+        return String { portValue };
+
+    if (portValueType == BaseURLStringType::Pattern)
+        return String { portValue };
+
+    URL dummyURL(dummyURLCharacters);
+
+    if (protocolValue)
+        dummyURL.setProtocol(*protocolValue);
+
+    dummyURL.setPort(parseInteger<uint16_t>(portValue));
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL port string."_s };
+
+    return String::number(*dummyURL.port());
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-an-opaque-pathname
+static ExceptionOr<String> canonicalizeOpaquePath(const String& value)
+{
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setPath(value);
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL opaque path string."_s };
+
+    return String { value };
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname, combined with https://urlpattern.spec.whatwg.org/#process-pathname-for-init
+ExceptionOr<String> canonicalizePath(const String& pathnameValue, StringView protocolValue, BaseURLStringType pathnameValueType)
+{
+    if (pathnameValue.isEmpty())
+        return String { pathnameValue };
+
+    if (pathnameValueType == BaseURLStringType::Pattern)
+        return String { pathnameValue };
+
+    if (protocolValue == "ftp"_s || protocolValue == "file"_s
+        || protocolValue == "http"_s || protocolValue == "https"_s
+        || protocolValue == "ws"_s || protocolValue == "wss"_s) {
+
+        bool hasLeadingSlash = pathnameValue[0] == '/';
+        auto maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue : makeString("/-"_s, pathnameValue);
+
+        URL dummyURL(dummyURLCharacters);
+        dummyURL.setPath(maybeAddSlashPrefix);
+
+        if (!dummyURL.isValid())
+            return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL path string."_s };
+
+        auto result = dummyURL.path();
+        if (hasLeadingSlash)
+            result = result.substring(2);
+
+        return result.toString();
+    }
+    return canonicalizeOpaquePath(pathnameValue);
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-search, combined with https://urlpattern.spec.whatwg.org/#process-search-for-init
+ExceptionOr<String> canonicalizeSearch(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    auto strippedValue = value[0] == '?' ? value.substring(1) : value;
+
+    if (valueType == BaseURLStringType::Pattern)
+        return strippedValue;
+
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setQuery(strippedValue);
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL search string."_s };
+
+    return dummyURL.query().toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-hash, combined with https://urlpattern.spec.whatwg.org/#process-hash-for-init
+ExceptionOr<String> canonicalizeHash(const String& value, BaseURLStringType valueType)
+{
+    if (value.isEmpty())
+        return String { value };
+
+    auto strippedValue = value[0] == '#' ? value.substring(1) : value;
+
+    if (valueType == BaseURLStringType::Pattern)
+        return strippedValue;
+
+    URL dummyURL(dummyURLCharacters);
+    dummyURL.setFragmentIdentifier(strippedValue);
+
+    if (!dummyURL.isValid())
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL hash string."_s };
+
+    return dummyURL.fragmentIdentifier().toString();
+}
+
+}

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class BaseURLStringType : bool;
+
+bool isAbsolutePathname(StringView input, BaseURLStringType inputType);
+ExceptionOr<String> canonicalizeProtocol(const String& value, BaseURLStringType valueType);
+String canonicalizeUsername(const String& value, BaseURLStringType valueType);
+String canonicalizePassword(const String& value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeHost(const String& value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeIPv6Host(const String& value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizePort(const String& portValue, std::optional<StringView> protocolValue, BaseURLStringType portValueType);
+ExceptionOr<String> canonicalizePath(const String& pathnameValue, StringView protocolValue, BaseURLStringType pathnameValueType);
+ExceptionOr<String> canonicalizeSearch(const String& value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeHash(const String& value, BaseURLStringType valueType);
+
+}

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -371,6 +371,7 @@ Modules/streams/ReadableStreamSource.cpp
 Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp
+Modules/url-pattern/URLPatternCanonical.cpp
 Modules/web-locks/WebLock.cpp
 Modules/web-locks/WebLockManager.cpp
 Modules/web-locks/WebLockRegistry.cpp


### PR DESCRIPTION
#### 1e937703de6af995ef2cd93867292c9da1d3b86c
<pre>
Implement URLPatternInit support for URLPatternAPI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281711">https://bugs.webkit.org/show_bug.cgi?id=281711</a>
<a href="https://rdar.apple.com/138169179">rdar://138169179</a>

Reviewed by Chris Dumez and Sihui Liu.

URLPattern API spec for processing a URLPatternInit: <a href="https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit.">https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit.</a>

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::escapePatternStringForCharacters):
(WebCore::escapePatternString):
(WebCore::processBaseURLString):
(WebCore::processInit):
(WebCore::URLPattern::create):
(WebCore::URLPattern::URLPattern):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp: Added.
(WebCore::isInvalidIPv6HostCodePoint):
(WebCore::isAbsolutePathname):
(WebCore::canonicalizeProtocol):
(WebCore::canonicalizeUsername):
(WebCore::canonicalizePassword):
(WebCore::canonicalizeHost):
(WebCore::canonicalizeIPv6Host):
(WebCore::canonicalizePort):
(WebCore::canonicalizeOpaquePath):
(WebCore::canonicalizePath):
(WebCore::canonicalizeSearch):
(WebCore::canonicalizeHash):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.h: Copied from Source/WebCore/Modules/url-pattern/URLPattern.cpp.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285640@main">https://commits.webkit.org/285640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c4d107563bc174fb9d7b881ac9b374925717796

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57589 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79183 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63082 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65301 "Found 1 new API test failure: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7308 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11297 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3317 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->