### PR TITLE
[Skia] Prefer text precise positioning on HiDPI

### DIFF
--- a/Source/WebCore/platform/graphics/FontRenderOptions.h
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.h
@@ -77,6 +77,8 @@ public:
     SkFontHinting hinting() const { return m_hinting; }
     SkFont::Edging antialias() const { return m_antialias; }
     SkPixelGeometry subpixelOrder() const { return m_subpixelOrder; }
+    void setUseSubpixelPositioning(bool enable) { m_useSubpixelPositioning = enable; }
+    bool useSubpixelPositioning() const { return m_useSubpixelPositioning; }
 #endif
 
     WEBCORE_EXPORT void disableHintingForTesting();
@@ -92,6 +94,7 @@ private:
     SkFontHinting m_hinting { SkFontHinting::kNormal };
     SkFont::Edging m_antialias { SkFont::Edging::kAntiAlias };
     SkPixelGeometry m_subpixelOrder { kUnknown_SkPixelGeometry };
+    bool m_useSubpixelPositioning { false };
 #endif
     bool m_isHintingDisabledForTesting { false };
 };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -436,6 +436,10 @@
 #include "ModelProcessConnection.h"
 #endif
 
+#if USE(SKIA)
+#include <WebCore/FontRenderOptions.h>
+#endif
+
 #if USE(CG)
 // FIXME: Move the CG-specific PDF painting code out of WebPage.cpp.
 #include <WebCore/GraphicsContextCG.h>
@@ -863,6 +867,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     // We need to set the device scale factor before creating the drawing area
     // to ensure it's created with the right size.
     m_page->setDeviceScaleFactor(parameters.deviceScaleFactor);
+
+#if USE(SKIA)
+    FontRenderOptions::singleton().setUseSubpixelPositioning(parameters.deviceScaleFactor >= 2.);
+#endif
 
     RefPtr drawingArea = m_drawingArea;
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
@@ -2745,6 +2753,10 @@ void WebPage::setDeviceScaleFactor(float scaleFactor)
         pluginView.setDeviceScaleFactor(scaleFactor);
 
     updateHeaderAndFooterLayersForDeviceScaleChange(scaleFactor);
+#endif
+
+#if USE(SKIA)
+    FontRenderOptions::singleton().setUseSubpixelPositioning(scaleFactor >= 2.);
 #endif
 
     if (findController().isShowingOverlay()) {


### PR DESCRIPTION
#### 7bc4999d07fcc1c5ecdb790e37ecf59689cdbb76
<pre>
[Skia] Prefer text precise positioning on HiDPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=281725">https://bugs.webkit.org/show_bug.cgi?id=281725</a>

Reviewed by Adrian Perez de Castro.

By disabling hinting and enabling subpixel positioning and linear
metrics.

* Source/WebCore/platform/graphics/FontRenderOptions.h:
(WebCore::FontRenderOptions::setUseSubpixelPositioning):
(WebCore::FontRenderOptions::useSubpixelPositioning const):
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::FontPlatformData):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::setDeviceScaleFactor):

Canonical link: <a href="https://commits.webkit.org/285465@main">https://commits.webkit.org/285465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db31cee59e15a8315eddb5c8b5f7a00820b548a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57101 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15613 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62460 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37528 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19929 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22091 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64813 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6747 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11174 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2556 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->