### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from WebMDNSRegister

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -29,6 +29,7 @@
 #include "LibWebRTCNetworkMessages.h"
 #include "Logging.h"
 #include "NetworkConnectionToWebProcessMessages.h"
+#include "WebProcess.h"
 #include <WebCore/SharedBuffer.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -37,9 +38,27 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetwork);
 
+LibWebRTCNetwork::LibWebRTCNetwork(WebProcess& webProcess)
+    : m_webProcess(webProcess)
+#if ENABLE(WEB_RTC)
+    , m_mdnsRegister(*this)
+#endif
+{
+}
+
 LibWebRTCNetwork::~LibWebRTCNetwork()
 {
     ASSERT_NOT_REACHED();
+}
+
+void LibWebRTCNetwork::ref() const
+{
+    m_webProcess->ref();
+}
+
+void LibWebRTCNetwork::deref() const
+{
+    m_webProcess->deref();
 }
 
 void LibWebRTCNetwork::setAsActive()

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -90,7 +90,7 @@ void LibWebRTCNetworkManager::close()
 
 void LibWebRTCNetworkManager::unregisterMDNSNames()
 {
-    WebProcess::singleton().libWebRTCNetwork().mdnsRegister().unregisterMDNSNames(m_documentIdentifier);
+    WebProcess::singleton().protectedLibWebRTCNetwork()->protectedMDNSRegister()->unregisterMDNSNames(m_documentIdentifier);
 }
 
 void LibWebRTCNetworkManager::setEnumeratingAllNetworkInterfacesEnabled(bool enabled)
@@ -229,7 +229,7 @@ void LibWebRTCNetworkManager::CreateNameForAddress(const rtc::IPAddress& address
         if (!weakThis)
             return;
 
-        WebProcess::singleton().libWebRTCNetwork().mdnsRegister().registerMDNSName(weakThis->m_documentIdentifier, fromStdString(address.ToString()), [address, callback = std::move(callback)](auto name, auto error) mutable {
+        WebProcess::singleton().protectedLibWebRTCNetwork()->protectedMDNSRegister()->registerMDNSName(weakThis->m_documentIdentifier, fromStdString(address.ToString()), [address, callback = std::move(callback)](auto name, auto error) mutable {
             WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([address, callback = std::move(callback), name = WTFMove(name).isolatedCopy(), error] {
                 RELEASE_LOG_ERROR_IF(error, WebRTC, "MDNS registration of a host candidate failed with error %hhu", enumToUnderlyingType(*error));
                 // In case of error, we provide the name to let gathering complete.

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
@@ -30,20 +30,12 @@
 #include <WebCore/MDNSRegisterError.h>
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class WebMDNSRegister;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebMDNSRegister> : std::true_type { };
-}
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -51,10 +43,14 @@ class Decoder;
 }
 
 namespace WebKit {
+class LibWebRTCNetwork;
 
 class WebMDNSRegister : public CanMakeWeakPtr<WebMDNSRegister> {
 public:
-    WebMDNSRegister() = default;
+    explicit WebMDNSRegister(LibWebRTCNetwork&);
+
+    void ref() const;
+    void deref() const;
 
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);
     void registerMDNSName(WebCore::ScriptExecutionContextIdentifier, const String& ipAddress, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&&);
@@ -65,6 +61,8 @@ private:
     void finishedRegisteringMDNSName(WebCore::ScriptExecutionContextIdentifier, const String& ipAddress, String&& mdnsName, std::optional<WebCore::MDNSRegisterError>, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&&);
 
     UncheckedKeyHashMap<WebCore::ScriptExecutionContextIdentifier, UncheckedKeyHashMap<String, String>> m_registeringDocuments;
+
+    WeakRef<LibWebRTCNetwork> m_libWebRTCNetwork;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2001,8 +2001,13 @@ void WebProcess::clearCachedPage(BackForwardItemIdentifier backForwardItemID, Co
 LibWebRTCNetwork& WebProcess::libWebRTCNetwork()
 {
     if (!m_libWebRTCNetwork)
-        m_libWebRTCNetwork = LibWebRTCNetwork::create().moveToUniquePtr();
+        m_libWebRTCNetwork = makeUniqueWithoutRefCountedCheck<LibWebRTCNetwork>(*this);
     return *m_libWebRTCNetwork;
+}
+
+Ref<LibWebRTCNetwork> WebProcess::protectedLibWebRTCNetwork()
+{
+    return libWebRTCNetwork();
 }
 
 void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType workerType, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, PageIdentifier pageID, const WebPreferencesStore& store, RegistrableDomain&& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, RemoteWorkerInitializationData&& initializationData, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -298,6 +298,7 @@ public:
 #endif // ENABLE(MODEL_PROCESS)
 
     LibWebRTCNetwork& libWebRTCNetwork();
+    Ref<LibWebRTCNetwork> protectedLibWebRTCNetwork();
 
     void setCacheModel(CacheModel);
 


### PR DESCRIPTION
#### f76b826b5fc047c430744a474795de677f948f22
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from WebMDNSRegister
<a href="https://bugs.webkit.org/show_bug.cgi?id=281729">https://bugs.webkit.org/show_bug.cgi?id=281729</a>
<a href="https://rdar.apple.com/138170193">rdar://138170193</a>

Reviewed by Chris Dumez.

WebMDNSRegister forwards its ref-counting to its owner LibWebRTCNetwork,
which forwards its own ref-counting to its owner WebProcess.

* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::LibWebRTCNetwork):
(WebKit::LibWebRTCNetwork::ref const):
(WebKit::LibWebRTCNetwork::deref const):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
(WebKit::LibWebRTCNetwork::create): Deleted.
(WebKit::LibWebRTCNetwork::connection): Deleted.
(WebKit::LibWebRTCNetwork::isActive const): Deleted.
(WebKit::LibWebRTCNetwork::monitor): Deleted.
(WebKit::LibWebRTCNetwork::socketFactory): Deleted.
(WebKit::LibWebRTCNetwork::disableNonLocalhostConnections): Deleted.
(WebKit::LibWebRTCNetwork::resolver): Deleted.
(WebKit::LibWebRTCNetwork::mdnsRegister): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::unregisterMDNSNames):
(WebKit::LibWebRTCNetworkManager::CreateNameForAddress):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp:
(WebKit::WebMDNSRegister::WebMDNSRegister):
(WebKit::WebMDNSRegister::ref const):
(WebKit::WebMDNSRegister::deref const):
(WebKit::WebMDNSRegister::registerMDNSName):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::libWebRTCNetwork):
(WebKit::WebProcess::protectedLibWebRTCNetwork):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/285554@main">https://commits.webkit.org/285554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd9253e23c89918a00739b89fcc673c063c5251

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72907 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15817 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43952 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17153 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19723 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests running") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65060 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7022 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11239 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2917 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->