### PR TITLE
[scroll-animations] WPT tests `scroll-timelines/setting-start-time.html` and `scroll-timelines/setting-current-time.html` under `scroll-animations` are crashes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7425,7 +7425,9 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animat
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/update-playback-rate.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 
@@ -7466,8 +7468,6 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animation
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]
 
 # webkit.org/b/281481 [scroll-animations] some WPT tests are crashing
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time-expected.txt
@@ -1,12 +1,12 @@
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT Setting animation current time to null throws TypeError. Test timed out
-NOTRUN Setting the current time to an absolute time value throws exception
-NOTRUN Set animation current time to a valid value without playing.
-NOTRUN Set animation current time to a valid value while playing.
-NOTRUN Set animation current time to a value beyond effect end.
-NOTRUN Set animation current time to a negative value.
+PASS Setting animation current time to null throws TypeError.
+PASS Setting the current time to an absolute time value throws exception
+PASS Set animation current time to a valid value without playing.
+PASS Set animation current time to a valid value while playing.
+PASS Set animation current time to a value beyond effect end.
+TIMEOUT Set animation current time to a negative value. Test timed out
 NOTRUN Setting current time while play pending overrides the current time
 NOTRUN Setting animation.currentTime then restarting the animation should reset the current time.
 NOTRUN Set Animation current time then scroll.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html
@@ -42,13 +42,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const animation = createScrollLinkedAnimation(t);
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("300");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("300ms");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("0.3s");
   });
 }, 'Setting the current time to an absolute time value throws exception');

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time-expected.txt
@@ -1,20 +1,16 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Setting the start time to an absolute time value throws exception assert_throws_dom: function "() => {
-    animation.startTime = CSSNumericValue.parse("300");
-  }" did not throw
-FAIL Setting the start time clears the hold time promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting the start time clears the hold time when the timeline is inactive promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting an unresolved start time sets the hold time promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting an unresolved start time sets the hold time to unresolved when the timeline is inactive promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting the start time resolves a pending ready promise promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting the start time resolves a pending ready promise when the timelineis inactive promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Setting an unresolved start time on a play-pending animation makes it idle assert_equals: Animation is idle expected "idle" but got "paused"
-FAIL Setting the start time updates the finished state promise_test: Unhandled rejection with value: object "TypeError: Type error"
-TIMEOUT Setting the start time on a running animation updates the play state Test timed out
-NOTRUN Setting the start time on a reverse running animation updates the play state
-NOTRUN Setting the start time resolves a pending pause task
-NOTRUN Setting the start time of a play-pending animation applies a pending playback rate
-NOTRUN Setting the start time of a playing animation applies a pending playback rate
+PASS Setting the start time to an absolute time value throws exception
+PASS Setting the start time clears the hold time
+PASS Setting the start time clears the hold time when the timeline is inactive
+PASS Setting an unresolved start time sets the hold time
+PASS Setting an unresolved start time sets the hold time to unresolved when the timeline is inactive
+PASS Setting the start time resolves a pending ready promise
+PASS Setting the start time resolves a pending ready promise when the timelineis inactive
+PASS Setting an unresolved start time on a play-pending animation makes it idle
+PASS Setting the start time updates the finished state
+PASS Setting the start time on a running animation updates the play state
+PASS Setting the start time on a reverse running animation updates the play state
+PASS Setting the start time resolves a pending pause task
+PASS Setting the start time of a play-pending animation applies a pending playback rate
+PASS Setting the start time of a playing animation applies a pending playback rate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html
@@ -26,13 +26,13 @@
 
 promise_test(async t => {
   const animation = createScrollLinkedAnimation(t);
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("300");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("300ms");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("0.3s");
   });
 }, 'Setting the start time to an absolute time value throws exception');

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -110,10 +110,7 @@ std::optional<double> CSSNumberishTime::percentage() const
 
 bool CSSNumberishTime::isValid() const
 {
-    // FIXME: We should consider a number valid as long as it's not "Unknown"
-    // but currently only mark time values as valid until we can do per-timeline
-    // validation when processing a value through the JS APIs that consume them.
-    return m_type == Type::Time;
+    return m_type != Type::Unknown;
 }
 
 bool CSSNumberishTime::isInfinity() const

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -363,9 +363,21 @@ void WebAnimation::effectTargetDidChange(const std::optional<const Styleable>& p
     InspectorInstrumentation::didChangeWebAnimationEffectTarget(*this);
 }
 
+bool WebAnimation::isTimeValid(const std::optional<CSSNumberishTime>& time) const
+{
+    // https://drafts.csswg.org/web-animations-2/#validating-a-css-numberish-time
+    if (time && !time->isValid())
+        return false;
+    if (m_timeline && m_timeline->isProgressBased() && time && time->time())
+        return false;
+    if ((!m_timeline || m_timeline->isMonotonic()) && time && time->percentage())
+        return false;
+    return true;
+}
+
 ExceptionOr<void> WebAnimation::setBindingsStartTime(const std::optional<CSSNumberishTime>& startTime)
 {
-    if (startTime && !startTime->isValid())
+    if (!isTimeValid(startTime))
         return Exception { ExceptionCode::TypeError };
     setStartTime(startTime);
     return { };
@@ -428,7 +440,7 @@ void WebAnimation::setStartTime(std::optional<CSSNumberishTime> newStartTime)
 
 ExceptionOr<void> WebAnimation::setBindingsCurrentTime(const std::optional<CSSNumberishTime>& currentTime)
 {
-    if (currentTime && !currentTime->isValid())
+    if (!isTimeValid(currentTime))
         return Exception { ExceptionCode::TypeError };
     return setCurrentTime(currentTime);
 }

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -210,6 +210,7 @@ private:
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
     void autoAlignStartTime();
+    bool isTimeValid(const std::optional<CSSNumberishTime>&) const;
 
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;


### PR DESCRIPTION
#### be9c3ff059a105eba308b1127545802fea2f8280
<pre>
[scroll-animations] WPT tests `scroll-timelines/setting-start-time.html` and `scroll-timelines/setting-current-time.html` under `scroll-animations` are crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281731">https://bugs.webkit.org/show_bug.cgi?id=281731</a>
<a href="https://rdar.apple.com/138170672">rdar://138170672</a>

Reviewed by Tim Nguyen.

We would incorrectly mark absolute time values provided through the bindings
for `Animation.currentTime` and `Animation.startTime` as valid because we failed
to validate them per spec accounting for the associated timeline type (progress-based
vs. monotonic). This meant we&apos;d let some absolute time values slip by and later
compare them to percentage time values which would trigger some debug assertions
and a crash.

We now correctly report any `CSSNumberishTime` that was successfully created from
a `CSSNumberish` as valid through `CSSNumberishTime::isValid()` and check whether
the provided type matches the current timeline in `WebAnimation::isTimeValid()`.

We also update the tests in question to expect a JS `TypeError` rather than a DOM
`NotSupported` since that&apos;s what the Web Animations spec discusses in
<a href="https://drafts.csswg.org/web-animations-2/#validating-a-css-numberish-time.">https://drafts.csswg.org/web-animations-2/#validating-a-css-numberish-time.</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-current-time.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-start-time.html:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::isValid const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::isTimeValid const):
(WebCore::WebAnimation::setBindingsStartTime):
(WebCore::WebAnimation::setBindingsCurrentTime):
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/285390@main">https://commits.webkit.org/285390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc20ccb385150d6a27c010ef40fad5cfad532356

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76714 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23739 "Failed to checkout and rebase branch from PR 35417") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23561 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/23739 "Failed to checkout and rebase branch from PR 35417") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75597 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22089 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16819 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/13100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11129 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47749 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->