### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from WebViewDidMoveToWindowObserver

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -44,6 +44,9 @@ class NavigationSOAuthorizationSession : public SOAuthorizationSession, private 
 public:
     ~NavigationSOAuthorizationSession();
 
+    void ref() const { SOAuthorizationSession::ref(); }
+    void deref() const { SOAuthorizationSession::deref(); }
+
 protected:
     using Callback = CompletionHandler<void(bool)>;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14231,8 +14231,8 @@ WindowKind WebPageProxy::windowKind() const
 
 void WebPageProxy::webViewDidMoveToWindow()
 {
-    m_webViewDidMoveToWindowObservers.forEach([](auto& observer) {
-        observer.webViewDidMoveToWindow();
+    m_webViewDidMoveToWindowObservers.forEach([](Ref<WebViewDidMoveToWindowObserver> observer) {
+        observer->webViewDidMoveToWindow();
     });
 
     RefPtr pageClient = this->pageClient();

--- a/Source/WebKit/UIProcess/WebViewDidMoveToWindowObserver.h
+++ b/Source/WebKit/UIProcess/WebViewDidMoveToWindowObserver.h
@@ -25,20 +25,11 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class WebViewDidMoveToWindowObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebViewDidMoveToWindowObserver> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebKit {
 
-class WebViewDidMoveToWindowObserver : public CanMakeWeakPtr<WebViewDidMoveToWindowObserver> {
+class WebViewDidMoveToWindowObserver : public AbstractRefCountedAndCanMakeWeakPtr<WebViewDidMoveToWindowObserver> {
 public:
     virtual ~WebViewDidMoveToWindowObserver() = default;
 


### PR DESCRIPTION
#### 3795f9bc47b07d4b3ba5fee7430ca86e63fa0c9f
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from WebViewDidMoveToWindowObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=281733">https://bugs.webkit.org/show_bug.cgi?id=281733</a>
<a href="https://rdar.apple.com/138170848">rdar://138170848</a>

Reviewed by Geoffrey Garen and Chris Dumez.

Make WebViewDidMoveToWindowObserver ref-counted.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h:
(WebKit::NavigationSOAuthorizationSession::ref const):
(WebKit::NavigationSOAuthorizationSession::deref const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::webViewDidMoveToWindow):
* Source/WebKit/UIProcess/WebViewDidMoveToWindowObserver.h:

Canonical link: <a href="https://commits.webkit.org/285523@main">https://commits.webkit.org/285523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e116cc879ea61f47019b843b1b431b60a3150409

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23929 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57193 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15666 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43787 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65639 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19530 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65625 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-color-animation-fallback-missing-100-percent.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64900 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6846 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11216 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->