### PR TITLE
Add tokenizer support for URLPattern API

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -598,12 +598,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/system-preview/ARKitBadgeSystemImage.h
 
-    Modules/url-pattern/URLPattern.h
-    Modules/url-pattern/URLPatternCanonical.h
-    Modules/url-pattern/URLPatternInit.h
-    Modules/url-pattern/URLPatternOptions.h
-    Modules/url-pattern/URLPatternResult.h
-
     Modules/web-locks/WebLock.h
     Modules/web-locks/WebLockIdentifier.h
     Modules/web-locks/WebLockManagerSnapshot.h

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "URLPatternTokenizer.h"
+
+#include <unicode/utf16.h>
+#include <unicode/utf8.h>
+
+namespace WebCore {
+namespace URLPatternUtilities {
+
+// https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point
+static bool isValidNameCodepoint(UChar codepoint, bool first)
+{
+    if (first)
+        return u_isIDStart(codepoint);
+
+    return u_isIDPart(codepoint);
+}
+
+bool Token::isNull() const
+{
+    return type == TokenType::Open && !index && !value;
+}
+
+// https://urlpattern.spec.whatwg.org/#get-the-next-code-point
+void Tokenizer::getNextCodePoint()
+{
+    if (m_input.is8Bit()) {
+        auto characters = m_input.span8();
+        U8_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
+    } else {
+        auto characters = m_input.span16();
+        U16_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
+    }
+}
+
+// https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point
+void Tokenizer::seekNextCodePoint(size_t index)
+{
+    m_nextIndex = index;
+    getNextCodePoint();
+}
+
+// https://urlpattern.spec.whatwg.org/#add-a-token
+void Tokenizer::addToken(TokenType currentType, size_t nextPosition, size_t valuePosition, size_t valueLength)
+{
+    m_tokenList.append(Token { currentType, m_index, m_input.substring(valuePosition, valueLength) });
+    m_index = nextPosition;
+}
+
+// https://urlpattern.spec.whatwg.org/#add-a-token-with-default-length
+void Tokenizer::addToken(TokenType currentType, size_t nextPosition, size_t valuePosition)
+{
+    addToken(currentType, nextPosition, valuePosition, nextPosition - valuePosition);
+}
+
+// https://urlpattern.spec.whatwg.org/#add-a-token-with-default-position-and-length
+void Tokenizer::addToken(TokenType currentType)
+{
+    addToken(currentType, m_nextIndex, m_index);
+}
+
+// https://urlpattern.spec.whatwg.org/#process-a-tokenizing-error
+ExceptionOr<void> Tokenizer::processTokenizingError(size_t nextPosition, size_t valuePosition)
+{
+    if (m_policy == TokenizePolicy::Strict)
+        return Exception { ExceptionCode::TypeError, "Invalid token provided to URLPattern tokenizer with strict tokenize policy."_s };
+
+    ASSERT(m_policy == TokenizePolicy::Lenient);
+
+    addToken(TokenType::InvalidChar, nextPosition, valuePosition);
+
+    return { };
+}
+
+Tokenizer::Tokenizer(StringView input, TokenizePolicy tokenizerPolicy)
+    : m_input(input)
+    , m_policy(tokenizerPolicy)
+{
+}
+
+// https://urlpattern.spec.whatwg.org/#tokenize
+ExceptionOr<Vector<Token>> Tokenizer::tokenize()
+{
+    ExceptionOr<void> maybeException;
+
+    while (m_index < m_input.length()) {
+        if (m_policy == TokenizePolicy::Strict && maybeException.hasException())
+            return maybeException.releaseException();
+
+        seekNextCodePoint(m_index);
+
+        if (m_codepoint == '*') {
+            addToken(TokenType::Asterisk);
+            continue;
+        }
+
+        if (m_codepoint == '+' || m_codepoint == '?') {
+            addToken(TokenType::OtherModifier);
+            continue;
+        }
+
+        if (m_codepoint == '\\') {
+            if (m_index == m_input.length() - 1) {
+                maybeException = processTokenizingError(m_nextIndex, m_index);
+                continue;
+            }
+
+            auto escapedIndex = m_nextIndex;
+            getNextCodePoint();
+
+            addToken(TokenType::EscapedChar, m_nextIndex, escapedIndex);
+            continue;
+        }
+
+        if (m_codepoint == '{') {
+            addToken(TokenType::Open);
+            continue;
+        }
+
+        if (m_codepoint == '}') {
+            addToken(TokenType::Close);
+            continue;
+        }
+
+        if (m_codepoint ==  ':') {
+            auto namePosition = m_nextIndex;
+            auto nameStart = namePosition;
+
+            while (namePosition < m_input.length()) {
+                seekNextCodePoint(namePosition);
+
+                bool isValidCodepoint = isValidNameCodepoint(m_codepoint, namePosition == nameStart);
+
+                if (!isValidCodepoint)
+                    break;
+
+                namePosition = m_nextIndex;
+            }
+
+            if (namePosition <= nameStart) {
+                maybeException = processTokenizingError(nameStart, m_index);
+                continue;
+            }
+
+            addToken(TokenType::Name, namePosition, nameStart);
+            continue;
+        }
+
+        if (m_codepoint == '(') {
+            int depth = 1;
+            auto regexPosition = m_nextIndex;
+            auto regexStart = regexPosition;
+            bool hasError = false;
+
+            while (regexPosition < m_input.length()) {
+                seekNextCodePoint(regexPosition);
+
+                if (!isASCII(m_codepoint)) {
+                    maybeException = processTokenizingError(regexStart, m_index);
+                    hasError = true;
+                    break;
+                }
+
+                if (regexPosition == regexStart && m_codepoint == '?') {
+                    maybeException = processTokenizingError(regexStart, m_index);
+                    hasError = true;
+                    break;
+                }
+
+                if (m_codepoint == '\\') {
+                    if (m_index == m_input.length() - 1) {
+                        maybeException = processTokenizingError(regexStart, m_index);
+                        hasError = true;
+                        break;
+                    }
+
+                    getNextCodePoint();
+
+                    if (!isASCII(m_codepoint)) {
+                        maybeException = processTokenizingError(regexStart, m_index);
+                        hasError = true;
+                        break;
+                    }
+
+                    regexPosition = m_nextIndex;
+                    continue;
+                }
+
+                if (m_codepoint == ')') {
+                    depth = depth - 1;
+
+                    if (!depth) {
+                        regexPosition = m_nextIndex;
+                        break;
+                    }
+                }
+
+                if (m_codepoint == '(') {
+                    depth = depth + 1;
+
+                    if (m_index == m_input.length() - 1) {
+                        maybeException = processTokenizingError(regexStart, m_index);
+                        hasError = true;
+                        break;
+                    }
+
+                    int temporaryPosition = m_nextIndex;
+                    getNextCodePoint();
+
+                    if (m_codepoint != '?') {
+                        maybeException = processTokenizingError(regexStart, m_index);
+                        hasError = true;
+                        break;
+                    }
+
+                    m_nextIndex = temporaryPosition;
+                }
+
+                regexPosition = m_nextIndex;
+            }
+
+            if (hasError)
+                continue;
+
+            if (depth) {
+                maybeException = processTokenizingError(regexStart, m_index);
+                continue;
+            }
+
+            auto regexLength = regexPosition - regexStart - 1;
+
+            if (!regexLength)
+                maybeException = processTokenizingError(regexStart, m_index);
+
+            addToken(TokenType::Regexp, regexPosition, regexStart, regexLength);
+            continue;
+        }
+
+        addToken(TokenType::Char);
+    }
+
+    addToken(TokenType::End, m_index, m_index);
+    return WTFMove(m_tokenList);
+}
+
+} // namespace URLPatternUtilities
+} // namespace WebCore

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+namespace URLPatternUtilities {
+
+enum class TokenType : uint8_t { Open, Close, Regexp, Name, Char, EscapedChar, OtherModifier, Asterisk, End, InvalidChar };
+enum class TokenizePolicy : bool { Strict, Lenient };
+
+struct Token {
+    TokenType type;
+    size_t index;
+    StringView value;
+
+    bool isNull() const;
+};
+
+class Tokenizer {
+public:
+    Tokenizer(StringView input, TokenizePolicy tokenizerPolicy);
+
+    ExceptionOr<Vector<Token>> tokenize();
+
+private:
+    StringView m_input;
+    TokenizePolicy m_policy { TokenizePolicy::Strict };
+    Vector<Token> m_tokenList;
+    size_t m_index { 0 };
+    size_t m_nextIndex { 0 };
+    UChar m_codepoint;
+
+    void getNextCodePoint();
+    void seekNextCodePoint(size_t index);
+
+    void addToken(TokenType currentType, size_t nextPosition, size_t valuePosition, size_t valueLength);
+    void addToken(TokenType currentType, size_t nextPosition, size_t valuePosition);
+    void addToken(TokenType currentType);
+
+    ExceptionOr<void> processTokenizingError(size_t nextPosition, size_t valuePosition);
+};
+
+} // namespace URLPatternUtilities
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -372,6 +372,7 @@ Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp
 Modules/url-pattern/URLPatternCanonical.cpp
+Modules/url-pattern/URLPatternTokenizer.cpp
 Modules/web-locks/WebLock.cpp
 Modules/web-locks/WebLockManager.cpp
 Modules/web-locks/WebLockRegistry.cpp


### PR DESCRIPTION
#### bd6d30811d4248b258082ae01ef4626866f15b40
<pre>
Add tokenizer support for URLPattern API
<a href="https://bugs.webkit.org/show_bug.cgi?id=281730">https://bugs.webkit.org/show_bug.cgi?id=281730</a>
<a href="https://rdar.apple.com/138171576">rdar://138171576</a>

Reviewed by Chris Dumez.

URLPattern API spec for tokenizer: <a href="https://urlpattern.spec.whatwg.org/#tokenizer">https://urlpattern.spec.whatwg.org/#tokenizer</a>

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp: Added.
(WebCore::URLPatternUtilities::isValidNameCodepoint):
(WebCore::URLPatternUtilities::Token::isNull const):
(WebCore::URLPatternUtilities::Tokenizer::getNextCodePoint):
(WebCore::URLPatternUtilities::Tokenizer::seekNextCodePoint):
(WebCore::URLPatternUtilities::Tokenizer::addToken):
(WebCore::URLPatternUtilities::Tokenizer::processTokenizingError):
(WebCore::URLPatternUtilities::Tokenizer::Tokenizer):
(WebCore::URLPatternUtilities::Tokenizer::tokenize):
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285699@main">https://commits.webkit.org/285699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22db86a29ff89c5fdc5b4c566699a4b7dd86775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57803 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66186 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7498 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/820 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->