### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from PlatformXRSystem and PlatformXRCoordinator

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1544,7 +1544,7 @@ void WebPageProxy::didAttachToRunningProcess()
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     ASSERT(!internals().xrSystem);
-    internals().xrSystem = makeUnique<PlatformXRSystem>(*this);
+    internals().xrSystem = PlatformXRSystem::create(*this);
 #endif
 }
 
@@ -8906,8 +8906,8 @@ PlatformXRSystem* WebPageProxy::xrSystem() const
 
 void WebPageProxy::restartXRSessionActivityOnProcessResumeIfNeeded()
 {
-    if (xrSystem() && xrSystem()->hasActiveSession())
-        xrSystem()->ensureImmersiveSessionActivity();
+    if (RefPtr xrSystem = internals().xrSystem; xrSystem && xrSystem->hasActiveSession())
+        xrSystem->ensureImmersiveSessionActivity();
 }
 #endif
 
@@ -10856,8 +10856,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     m_speechRecognitionPermissionManager = nullptr;
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
-    if (internals().xrSystem) {
-        internals().xrSystem->invalidate();
+    if (RefPtr xrSystem = internals().xrSystem) {
+        xrSystem->invalidate();
         internals().xrSystem = nullptr;
     }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -420,7 +420,7 @@ public:
 #endif
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
-    std::unique_ptr<PlatformXRSystem> xrSystem;
+    RefPtr<PlatformXRSystem> xrSystem;
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -30,16 +30,8 @@
 #include "XRDeviceIdentifier.h"
 #include "XRDeviceInfo.h"
 #include <WebCore/PlatformXR.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Function.h>
-
-namespace WebKit {
-class PlatformXRCoordinatorSessionEventClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PlatformXRCoordinatorSessionEventClient> : std::true_type { };
-}
 
 namespace WebCore {
 class SecurityOriginData;
@@ -49,7 +41,7 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class PlatformXRCoordinatorSessionEventClient : public CanMakeWeakPtr<PlatformXRCoordinatorSessionEventClient> {
+class PlatformXRCoordinatorSessionEventClient : public AbstractRefCountedAndCanMakeWeakPtr<PlatformXRCoordinatorSessionEventClient> {
 public:
     virtual ~PlatformXRCoordinatorSessionEventClient() = default;
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -145,8 +145,8 @@ void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClie
         },
         [&](Active&) {
             RELEASE_LOG_ERROR(XR, "ARKitCoordinator: an existing immersive session is active");
-            if (sessionEventClient)
-                sessionEventClient->sessionDidEnd(m_deviceIdentifier);
+            if (RefPtr protectedSessionEventClient = sessionEventClient.get())
+                protectedSessionEventClient->sessionDidEnd(m_deviceIdentifier);
         });
 }
 


### PR DESCRIPTION
#### 759668c3b7e07ee703f5a0ea76ecbcb0965e2787
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from PlatformXRSystem and PlatformXRCoordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=281740">https://bugs.webkit.org/show_bug.cgi?id=281740</a>
<a href="https://rdar.apple.com/138175388">rdar://138175388</a>

Reviewed by Chris Dumez.

Drop the exception by making both classes ref-counted.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::restartXRSessionActivityOnProcessResumeIfNeeded):
(WebKit::WebPageProxy::resetState):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::PlatformXRSystem):
(WebKit::PlatformXRSystem::~PlatformXRSystem):
(WebKit::PlatformXRSystem::sharedPreferencesForWebProcess const):
(WebKit::PlatformXRSystem::invalidate):
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
(WebKit::PlatformXRSystem::enumerateImmersiveXRDevices):
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures):
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
(WebKit::PlatformXRSystem::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystem::requestFrame):
(WebKit::PlatformXRSystem::submitFrame):
(WebKit::PlatformXRSystem::didCompleteShutdownTriggeredBySystem):
(WebKit::PlatformXRSystem::sessionDidEnd):
(WebKit::PlatformXRSystem::sessionDidUpdateVisibilityState):
(WebKit::PlatformXRSystem::setImmersiveSessionState):
(WebKit::PlatformXRSystem::webXREnabled const):
(WebKit::PlatformXRSystem::protectedPage const): Deleted.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
(WebKit::PlatformXRSystem::create):
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):

Canonical link: <a href="https://commits.webkit.org/285559@main">https://commits.webkit.org/285559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c3e7faa48a51fad19545e9bc2d29c3f1d876aba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24157 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75026 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57326 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15820 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62753 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37747 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72418 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43967 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78782 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17157 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19721 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests running") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65046 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7025 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2934 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->