### PR TITLE
[scroll-animations] WPT test `scroll-animations/scroll-timelines/setting-timeline.tentative.html` is a crash

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7468,7 +7468,6 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animation
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]
 
 # webkit.org/b/281481 [scroll-animations] some WPT tests are crashing
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Skip ]
 
 # webkit.org/b/281482 [scroll-animations] some WPT reftests can't find their reference

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -1,20 +1,18 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Setting a scroll timeline on a play-pending animation synchronizes currentTime of the animation with the scroll position. Test timed out
-NOTRUN Setting a scroll timeline on a pause-pending animation fixes the currentTime of the animation based on the scroll position once resumed
-NOTRUN Setting a scroll timeline on a reversed play-pending animation synchronizes the currentTime of the animation with the scroll position.
-NOTRUN Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position.
-NOTRUN Setting a scroll timeline on a paused animation fixes the currentTime of the animation based on the scroll position when resumed
-NOTRUN Setting a scroll timeline on a reversed paused animation fixes the currentTime of the animation based on the scroll position when resumed
-NOTRUN Transitioning from a scroll timeline to a document timeline on a running animation preserves currentTime
-NOTRUN Transitioning from a scroll timeline to a document timeline on a pause-pending animation preserves currentTime
-NOTRUN Transition from a scroll timeline to a document timeline on a reversed paused animation maintains correct currentTime
-NOTRUN Transitioning from a scroll timeline to a null timeline on a running animation preserves current progress.
-NOTRUN Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state
-NOTRUN Switching from one scroll timeline to another updates currentTime
-NOTRUN Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS.
-NOTRUN Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
-NOTRUN Switching from a document timeline to a scroll timeline on an infinite duration animation.
-NOTRUN Changing from a scroll-timeline to a view-timeline updates start time.
+PASS Setting a scroll timeline on a play-pending animation synchronizes currentTime of the animation with the scroll position.
+PASS Setting a scroll timeline on a pause-pending animation fixes the currentTime of the animation based on the scroll position once resumed
+PASS Setting a scroll timeline on a reversed play-pending animation synchronizes the currentTime of the animation with the scroll position.
+FAIL Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position. assert_true: expected true got false
+FAIL Setting a scroll timeline on a paused animation fixes the currentTime of the animation based on the scroll position when resumed assert_equals: expected "paused" but got "idle"
+FAIL Setting a scroll timeline on a reversed paused animation fixes the currentTime of the animation based on the scroll position when resumed assert_equals: expected "paused" but got "idle"
+PASS Transitioning from a scroll timeline to a document timeline on a running animation preserves currentTime
+PASS Transitioning from a scroll timeline to a document timeline on a pause-pending animation preserves currentTime
+FAIL Transition from a scroll timeline to a document timeline on a reversed paused animation maintains correct currentTime assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 90 +/- 0.125 but got -100
+PASS Transitioning from a scroll timeline to a null timeline on a running animation preserves current progress.
+FAIL Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state assert_equals: expected "running" but got "idle"
+FAIL Switching from one scroll timeline to another updates currentTime promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+FAIL Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+FAIL Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 0 +/- 0.125 but got 10
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1213,6 +1213,15 @@ void KeyframeEffect::animationTimelineDidChange(const AnimationTimeline* timelin
 {
     AnimationEffect::animationTimelineDidChange(timeline);
 
+    m_isAssociatedWithProgressBasedTimeline = [&] {
+        if (RefPtr animation = this->animation()) {
+            if (RefPtr timeline = animation->timeline())
+                return timeline->isProgressBased();
+        }
+        return false;
+    }();
+    updateAcceleratedAnimationIfNecessary();
+
     auto target = targetStyleable();
     if (!target)
         return;
@@ -1664,6 +1673,9 @@ const TimingFunction* KeyframeEffect::timingFunctionForKeyframeAtIndex(size_t in
 bool KeyframeEffect::canBeAccelerated() const
 {
     if (m_acceleratedPropertiesState == AcceleratedProperties::None)
+        return false;
+
+    if (m_isAssociatedWithProgressBasedTimeline)
         return false;
 
     if (m_hasAcceleratedPropertyOverriddenByCascadeProperty)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -323,6 +323,7 @@ private:
     bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
     bool m_hasReferenceFilter { false };
     bool m_animatesSizeAndSizeDependentTransform { false };
+    bool m_isAssociatedWithProgressBasedTimeline { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -256,12 +256,12 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
     auto previousCurrentTime = currentTime();
 
     // 5. Set previous progress based in the first condition that applies:
-    auto endTime = effectEndTime();
     auto previousProgress = [&]() -> std::optional<double> {
         // If previous current time is unresolved: Set previous progress to unresolved.
         if (!previousCurrentTime)
             return std::nullopt;
         // If end time is zero: Set previous progress to zero.
+        auto endTime = effectEndTime();
         if (endTime.isZero())
             return 0.0;
         // Otherwise: Set previous progress = previous current time / end time
@@ -315,11 +315,11 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
         if (previousPlayState == PlayState::Finished || previousPlayState == PlayState::Running)
             m_timeToRunPendingPlayTask = TimeToRunPendingTask::WhenReady;
         else if (previousPlayState == PlayState::Paused && previousProgress)
-            m_holdTime = endTime * *previousProgress;
+            m_holdTime = effectEndTime() * *previousProgress;
     } else if (fromFiniteTimeline && previousProgress) {
         // If from finite timeline and previous progress is resolved,
         // Run the procedure to set the current time to previous progress * end time.
-        setCurrentTime(endTime * *previousProgress);
+        setCurrentTime(effectEndTime() * *previousProgress);
     }
 
     // 10. If the start time of animation is resolved, make animation’s hold time unresolved.


### PR DESCRIPTION
#### fd1445729caf95b02bc8f55b1e1ff049bde6c40f
<pre>
[scroll-animations] WPT test `scroll-animations/scroll-timelines/setting-timeline.tentative.html` is a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=281741">https://bugs.webkit.org/show_bug.cgi?id=281741</a>
<a href="https://rdar.apple.com/138178537">rdar://138178537</a>

Reviewed by Anne van Kesteren.

There were two issues in this test:

1. we would attempt to run an accelerated effect for an animation associated with a
progress-based timeline, which we simply do not support,
2. we would cache the end time of an animation under `setTimeline()` which lead to
incompatible time values as the timeline would switch between progress-based and
monotonic timelines.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::canBeAccelerated const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):

Canonical link: <a href="https://commits.webkit.org/285396@main">https://commits.webkit.org/285396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16cc2bebe522187bf0087e021430f158cc3c36b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25329 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23750 "Failed to checkout and rebase branch from PR 35424") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23572 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/23750 "Failed to checkout and rebase branch from PR 35424") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75608 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22100 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16830 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/13109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11132 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47760 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->