### PR TITLE
[WPE][GTK] Fix default return value for webkit_settings_get_webrtc_udp_ports_range()

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -4413,7 +4413,7 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
 const gchar*
 webkit_settings_get_webrtc_udp_ports_range(WebKitSettings* settings)
 {
-    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), nullptr);
 #if ENABLE(WEB_RTC)
     return settings->priv->webrtcUDPPortsRange.data();
 #else


### PR DESCRIPTION
#### 346fb4f0cdc4c49d4ba7c9ae746ec4bcb82fc9b6
<pre>
[WPE][GTK] Fix default return value for webkit_settings_get_webrtc_udp_ports_range()
<a href="https://bugs.webkit.org/show_bug.cgi?id=281742">https://bugs.webkit.org/show_bug.cgi?id=281742</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_get_webrtc_udp_ports_range):

Canonical link: <a href="https://commits.webkit.org/285399@main">https://commits.webkit.org/285399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/871e52c1f383c6c0cb95b3880d8a0f81b386083f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23746 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15619 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62465 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43678 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22096 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20290 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78390 "Hash 871e52c1 for PR 35425 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19420 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/78390 "Hash 871e52c1 for PR 35425 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62478 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/78390 "Hash 871e52c1 for PR 35425 does not build (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6752 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47756 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->