### PR TITLE
AX: Default to walking the DOM rather than the render tree when building the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
+++ b/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
@@ -18,7 +18,7 @@
 
     if (window.accessibilityController) {
         var listItem1 = accessibilityController.accessibleElementById("item1");
-        var p1 = listItem1.childAtIndex(0);
+        var p1 = listItem1.childAtIndex(1);
         var firstLineRange = p1.textMarkerRangeForElement(p1);
         debug(p1.stringForTextMarkerRange(firstLineRange));
         

--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
@@ -8,9 +8,6 @@ PASS: axRubyText.role === expectedRubyRole
 PASS: axRubyText.subrole === expectedRubyTextSubrole
 Testing #ruby
 PASS: axRuby.role === expectedRubyRole
-Testing AX element with no ID
-PASS: axRuby.role === expectedRubyRole
-PASS: axRuby.subrole === expectedRubyInlineSubrole
 Testing #rt
 PASS: axRubyText.role === expectedRubyRole
 PASS: axRubyText.subrole === expectedRubyTextSubrole

--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
@@ -41,12 +41,6 @@ if (window.accessibilityController) {
         output += expect("axRuby.role", "expectedRubyRole");
         if (expectInline)
             output += expect("axRuby.subrole", "expectedRubyInlineSubrole");
-        else {
-            axRuby = axRuby.childAtIndex(0);
-            logId(axRuby);
-            output += expect("axRuby.role", "expectedRubyRole");
-            output += expect("axRuby.subrole", "expectedRubyInlineSubrole");
-        }
 
         // Test AXRubyText.
         axRubyText = axRuby.childAtIndex(1);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -36,6 +36,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "AXTreeStore.h"
 #include "AccessibilityObject.h"
 #include "SimpleRange.h"
+#include "StyleChange.h"
 #include "Timer.h"
 #include "VisibleUnits.h"
 #include <limits.h>
@@ -344,6 +345,7 @@ public:
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Node&);
+    void onStyleChange(Element&, Style::Change, const RenderStyle* newStyle, const RenderStyle* oldStyle);
     void onTextSecurityChanged(HTMLInputElement&);
     void onTitleChange(Document&);
     void onValidityChange(Element&);
@@ -916,6 +918,8 @@ private:
 bool nodeHasRole(Node*, StringView role);
 bool nodeHasCellRole(Node*);
 bool nodeHasTableRole(Node*);
+ContainerNode* composedParentIgnoringDocumentFragments(Node&);
+ContainerNode* composedParentIgnoringDocumentFragments(Node*);
 
 // Returns true if the element has an attribute that will result in an accname being computed.
 // https://www.w3.org/TR/accname-1.2/

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -66,6 +66,25 @@ AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()
     return AccessibilityRole::MathElement;
 }
 
+void AccessibilityMathMLElement::addChildren()
+{
+    if (!hasTagName(MathMLNames::mfencedTag)) {
+        AccessibilityRenderObject::addChildren();
+        return;
+    }
+
+    // mfenced elements generate lots of anonymous renderers due to their `open`, `close`, and `separators` attributes.
+    // Because of this, default to walking the render tree when adding their children (unlike most other object types for
+    // which we walk the DOM). This may cause unexpected behavior for `display:contents` descendants of mfenced elements.
+    // However, this element is very deprecated, and even the most simple usages of it do not render consistently across
+    // browsers, so it's already unlikely to be used by web developers, even more so with `display:contents` mixed in.
+    m_childrenInitialized = true;
+    for (auto& object : AXChildIterator(*this))
+        addChild(&object);
+
+    m_subtreeDirty = false;
+}
+
 String AccessibilityMathMLElement::textUnderElement(TextUnderElementMode mode) const
 {
     if (m_isAnonymousOperator && !mode.isHidden()) {

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     AccessibilityRole determineAccessibilityRole() final;
+    void addChildren() final;
     String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const final;
     String stringValue() const override;
     bool isIgnoredElementWithinMathTree() const final;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -135,7 +135,6 @@ public:
     AccessibilityObject* previousSibling() const override;
     AccessibilityObject* nextSibling() const override;
     AccessibilityObject* parentObject() const override;
-    AccessibilityObject* parentObjectIfExists() const override;
 
     bool matchesTextAreaRole() const;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -641,6 +641,8 @@ void AccessibilityObject::insertChild(AXCoreObject* newChild, unsigned index, De
         }
     }
 
+#if USE(ATSPI)
+    // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
     RefPtr displayContentsParent = child->displayContentsParent();
     // To avoid double-inserting a child of a `display: contents` element, only insert if `this` is the rightful parent.
     if (displayContentsParent && displayContentsParent != this) {
@@ -657,6 +659,7 @@ void AccessibilityObject::insertChild(AXCoreObject* newChild, unsigned index, De
         if (!allowInsert)
             return;
     }
+#endif // USE(ATSPI)
 
     auto thisAncestorFlags = computeAncestorFlags();
     child->initializeAncestorFlags(thisAncestorFlags);
@@ -1748,7 +1751,7 @@ Vector<RetainPtr<id>> AccessibilityObject::modelElementChildren()
 }
 #endif
 
-// Finds a RenderListItem parent give a node.
+// Finds a RenderListItem parent given a node.
 static RenderListItem* renderListItemContainer(Node* node)
 {
     for (; node; node = node->parentNode()) {

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -351,7 +351,6 @@ public:
         return parentObjectUnignored();
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     }
-    virtual AccessibilityObject* parentObjectIfExists() const { return nullptr; }
     static AccessibilityObject* firstAccessibleObjectFromNode(const Node*);
     AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;
     virtual bool isDescendantOfBarrenParent() const { return false; }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -495,32 +495,16 @@ RenderObject* AccessibilityRenderObject::renderParentObject() const
     return parent;
 }
 
-AccessibilityObject* AccessibilityRenderObject::parentObjectIfExists() const
-{
-    AXObjectCache* cache = axObjectCache();
-    if (!cache)
-        return nullptr;
-
-    // WebArea's parent should be the scroll view containing it.
-    if (m_renderer && isWebArea())
-        return cache->get(&m_renderer->view().frameView());
-
-    if (auto* ownerParent = ownerParentObject())
-        return ownerParent;
-
-    if (auto* displayContentsParent = this->displayContentsParent())
-        return displayContentsParent;
-
-    return cache->get(renderParentObject());
-}
-    
 AccessibilityObject* AccessibilityRenderObject::parentObject() const
 {
     if (auto* ownerParent = ownerParentObject())
         return ownerParent;
 
+#if USE(ATSPI)
+    // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
     if (auto* displayContentsParent = this->displayContentsParent())
         return displayContentsParent;
+#endif // USE(ATSPI)
 
     if (!m_renderer)
         return AccessibilityNodeObject::parentObject();
@@ -529,26 +513,30 @@ AccessibilityObject* AccessibilityRenderObject::parentObject() const
     if (!cache)
         return nullptr;
 
-    if (ariaRoleAttribute() == AccessibilityRole::MenuBar)
-        return cache->getOrCreate(m_renderer->parent());
-
-    // menuButton and its corresponding menu are DOM siblings, but Accessibility needs them to be parent/child
     if (ariaRoleAttribute() == AccessibilityRole::Menu) {
-        AccessibilityObject* parent = menuButtonForMenu();
-        if (parent)
+        // menuButton and its corresponding menu are DOM siblings, but accessibility expects them to be parent/child.
+        if (auto* parent = menuButtonForMenu())
             return parent;
     }
 
-#if USE(ATSPI)
+
+#if !USE(ATSPI)
+    // FIXME: This compiler directive can be removed after https://bugs.webkit.org/show_bug.cgi?id=282117 is fixed.
+    RefPtr node = this->node();
+    if (RefPtr parentNode = composedParentIgnoringDocumentFragments(node.get())) {
+        if (auto* parent = cache->getOrCreate(*parentNode))
+            return parent;
+    }
+#endif // !USE(ATSPI)
+
     // Expose markers that are not direct children of a list item too.
     if (m_renderer->isRenderListMarker()) {
-        if (auto* listItem = ancestorsOfType<RenderListItem>(*m_renderer).first()) {
-            auto* parent = axObjectCache()->getOrCreate(*listItem);
-            if (parent && uncheckedDowncast<AccessibilityRenderObject>(*parent).markerRenderer() == m_renderer)
-                return parent;
+        for (auto& listItemAncestor : ancestorsOfType<RenderListItem>(*m_renderer)) {
+            RefPtr parent = dynamicDowncast<AccessibilityRenderObject>(axObjectCache()->getOrCreate(&listItemAncestor));
+            if (parent && parent->markerRenderer() == m_renderer)
+                return parent.get();
         }
     }
-#endif
 
     if (auto* parentObject = renderParentObject())
         return cache->getOrCreate(*parentObject);
@@ -679,7 +667,13 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
 
     // We use a text iterator for text objects AND for those cases where we are
     // explicitly asking for the full text under a given element.
-    if (is<RenderText>(*m_renderer) || mode.childrenInclusion == TextUnderElementMode::Children::IncludeAllChildren) {
+    WeakPtr renderText = dynamicDowncast<RenderText>(*m_renderer);
+    bool includeAllChildren = false;
+#if USE(ATSPI)
+    // Only ATSPI ever sets IncludeAllChildren.
+    includeAllChildren = mode.childrenInclusion == TextUnderElementMode::Children::IncludeAllChildren;
+#endif
+    if (renderText || includeAllChildren) {
         // If possible, use a text iterator to get the text, so that whitespace
         // is handled consistently.
         Document* nodeDocument = nullptr;
@@ -687,7 +681,10 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
         if (Node* node = m_renderer->node()) {
             nodeDocument = &node->document();
             textRange = makeRangeSelectingNodeContents(*node);
-        } else {
+        }
+#if USE(ATSPI)
+        // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
+        else {
             // For anonymous blocks, we work around not having a direct node to create a range from
             // defining one based in the two external positions defining the boundaries of the subtree.
             RenderObject* firstChildRenderer = m_renderer->firstChildSlow();
@@ -700,6 +697,7 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
                 textRange = makeSimpleRange(positionInParentBeforeNode(&firstNodeInBlock), positionInParentAfterNode(lastChildRenderer->node()));
             }
         }
+#endif // USE(ATSPI)
 
         if (nodeDocument && textRange) {
             if (auto* frame = nodeDocument->frame()) {
@@ -713,30 +711,33 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
 
         // Sometimes text fragments don't have Nodes associated with them (like when
         // CSS content is used to insert text or when a RenderCounter is used.)
-        if (WeakPtr renderText = dynamicDowncast<RenderText>(*m_renderer)) {
-            if (WeakPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(*renderText)) {
-                // The alt attribute may be set on a text fragment through CSS, which should be honored.
-                if (auto& altText = renderTextFragment->altText(); !altText.isNull())
-                    return altText;
-                return renderTextFragment->contentString();
-            }
-            return renderText->text();
+        if (WeakPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(renderText.get())) {
+            // The alt attribute may be set on a text fragment through CSS, which should be honored.
+            if (auto& altText = renderTextFragment->altText(); !altText.isNull())
+                return altText;
+            return renderTextFragment->contentString();
         }
+        if (renderText)
+            return renderText->text();
     }
 
     return AccessibilityNodeObject::textUnderElement(WTFMove(mode));
 }
 
-bool AccessibilityRenderObject::shouldGetTextFromNode(TextUnderElementMode mode) const
+bool AccessibilityRenderObject::shouldGetTextFromNode(const TextUnderElementMode& mode) const
 {
     if (!m_renderer)
         return true;
 
+#if USE(ATSPI)
     // AccessibilityRenderObject::textUnderElement() gets the text of anonymous blocks by using
     // the child nodes to define positions. CSS tables and their anonymous descendants lack
     // children with nodes.
     if (m_renderer->isAnonymous() && m_renderer->isTablePart())
         return mode.childrenInclusion == TextUnderElementMode::Children::IncludeAllChildren;
+#else
+    UNUSED_PARAM(mode);
+#endif // USE(ATSPI)
 
     // AccessibilityRenderObject::textUnderElement() calls rangeOfContents() to create the text
     // range. rangeOfContents() does not include CSS-generated content.
@@ -852,8 +853,8 @@ LayoutRect AccessibilityRenderObject::boundingBoxRect() const
     if (!renderer)
         return AccessibilityNodeObject::boundingBoxRect();
 
-    if (renderer->node()) // If we are a continuation, we want to make sure to use the primary renderer.
-        renderer = renderer->node()->renderer();
+    if (auto* node = renderer->node()) // If we are a continuation, we want to make sure to use the primary renderer.
+        renderer = node->renderer();
 
     // absoluteFocusRingQuads will query the hierarchy below this element, which for large webpages can be very slow.
     // For a web area, which will have the most elements of any element, absoluteQuads should be used.
@@ -2175,8 +2176,13 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
         break;
     }
 
+#if USE(ATSPI)
+    // Non-USE(ATSPI) platforms walk the DOM to build the accessibility tree, and thus never encounter these ignorable
+    // anonymous renderers.
+    // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
     if (m_renderer->isAnonymous() && (is<RenderTableCell>(m_renderer.get()) || is<RenderTableRow>(m_renderer.get()) || is<RenderTable>(m_renderer.get())))
         return AccessibilityRole::Ignored;
+#endif // USE(ATSPI)
 
     // This return value is what will be used if AccessibilityTableCell determines
     // the cell should not be treated as a cell (e.g. because it is a layout table.
@@ -2362,20 +2368,6 @@ void AccessibilityRenderObject::addRemoteSVGChildren()
     addChild(root.get());
 }
 
-void AccessibilityRenderObject::addCanvasChildren()
-{
-    // Add the unrendered canvas children as AX nodes, unless we're not using a canvas renderer
-    // because JS is disabled for example.
-    if (!node() || !node()->hasTagName(canvasTag) || (renderer() && !renderer()->isRenderHTMLCanvas()))
-        return;
-
-    // If it's a canvas, it won't have rendered children, but it might have accessible fallback content.
-    // Clear m_childrenInitialized because AccessibilityNodeObject::addChildren will expect it to be false.
-    ASSERT(!m_children.size());
-    m_childrenInitialized = false;
-    AccessibilityNodeObject::addChildren();
-}
-
 void AccessibilityRenderObject::addAttachmentChildren()
 {
     if (!isAttachment())
@@ -2390,22 +2382,21 @@ void AccessibilityRenderObject::addAttachmentChildren()
         addChild(cache->getOrCreate(*widget));
 }
 
-#if PLATFORM(COCOA)
-void AccessibilityRenderObject::updateAttachmentViewParents()
+#if USE(ATSPI)
+// FIXME: Consider removing these ATSPI-only functions with https://bugs.webkit.org/show_bug.cgi?id=282117.
+void AccessibilityRenderObject::addCanvasChildren()
 {
-    // Only the unignored parent should set the attachment parent, because that's what is reflected in the AX 
-    // hierarchy to the client.
-    if (isIgnored())
+    // Add the unrendered canvas children as AX nodes, unless we're not using a canvas renderer
+    // because JS is disabled for example.
+    if (!node() || !node()->hasTagName(canvasTag) || (renderer() && !renderer()->isRenderHTMLCanvas()))
         return;
-    
-    for (const auto& child : unignoredChildren(/* updateChildrenIfNeeded */ false)) {
-        if (child->isAttachment()) {
-            if (auto* liveChild = dynamicDowncast<AccessibilityObject>(child.get()))
-                liveChild->overrideAttachmentParent(this);
-        }
-    }
+
+    // If it's a canvas, it won't have rendered children, but it might have accessible fallback content.
+    // Clear m_childrenInitialized because AccessibilityNodeObject::addChildren will expect it to be false.
+    ASSERT(!m_children.size());
+    m_childrenInitialized = false;
+    AccessibilityNodeObject::addChildren();
 }
-#endif
 
 // Some elements don't have an associated render object, meaning they won't be picked up by a walk of the render tree.
 // For example, elements with `display: contents`, or aria-hidden=true elements that are focused.
@@ -2432,7 +2423,7 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
             break;
         }
     }
-    
+
     if (!hasNodeOnlyChildren)
         return;
 
@@ -2471,14 +2462,32 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
         insertionIndex += (m_children.size() - previousSize);
     }
 }
+#endif // USE(ATSPI)
 
-#if USE(ATSPI)
+#if PLATFORM(COCOA)
+void AccessibilityRenderObject::updateAttachmentViewParents()
+{
+    // Only the unignored parent should set the attachment parent, because that's
+    // what is reflected in the AX hierarchy to the client.
+    if (isIgnored())
+        return;
+
+    for (const auto& child : unignoredChildren(/* updateChildrenIfNeeded */ false)) {
+        if (child->isAttachment()) {
+            if (auto* liveChild = dynamicDowncast<AccessibilityObject>(child.get()))
+                liveChild->overrideAttachmentParent(this);
+        }
+    }
+}
+#endif // PLATFORM(COCOA)
+
 RenderObject* AccessibilityRenderObject::markerRenderer() const
 {
-    if (isIgnored() || !isListItem() || !m_renderer || !m_renderer->isRenderListItem())
+    CheckedPtr renderListItem = dynamicDowncast<RenderListItem>(m_renderer.get());
+    if (!renderListItem || !isListItem() || isIgnored())
         return nullptr;
 
-    return uncheckedDowncast<RenderListItem>(*m_renderer).markerRenderer();
+    return renderListItem->markerRenderer();
 }
 
 void AccessibilityRenderObject::addListItemMarker()
@@ -2486,7 +2495,6 @@ void AccessibilityRenderObject::addListItemMarker()
     if (auto* marker = markerRenderer())
         insertChild(axObjectCache()->getOrCreate(*marker), 0);
 }
-#endif
 
 void AccessibilityRenderObject::updateRoleAfterChildrenCreation()
 {
@@ -2545,6 +2553,7 @@ void AccessibilityRenderObject::addChildren()
 
     auto addChildIfNeeded = [this](AccessibilityObject& object) {
 #if USE(ATSPI)
+        // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
         if (object.renderer()->isRenderListMarker())
             return;
 #endif
@@ -2555,18 +2564,57 @@ void AccessibilityRenderObject::addChildren()
         addChild(&object);
     };
 
+#if !USE(ATSPI)
+    // Non-ATSPI platforms walk the DOM to build the accessibility tree.
+    // Ideally this would be the case for all platforms, but there are GLib tests that rely on anonymous renderers
+    // being part of the accessibility tree.
+    RefPtr node = dynamicDowncast<ContainerNode>(this->node());
+    auto* element = dynamicDowncast<Element>(node.get());
+    CheckedPtr cache = axObjectCache();
+
+    // ::before and ::after pseudos should be the first and last children of the element
+    // that generates them (rather than being siblings to the generating element).
+    if (RefPtr beforePseudo = element ? element->beforePseudoElement() : nullptr) {
+        if (RefPtr pseudoObject = cache->getOrCreate(*beforePseudo))
+            addChildIfNeeded(*pseudoObject);
+    }
+
+    if (node && !(element && element->isPseudoElement()) && cache) {
+        // If we have a DOM node, use the DOM to find accessible children.
+        for (Ref child : composedTreeChildren(*node)) {
+            if (RefPtr childObject = cache->getOrCreate(child.get()))
+                addChildIfNeeded(*childObject);
+        }
+    } else {
+        if (m_renderer->isAnonymousBlock())
+            return;
+        // If we are a valid anonymous renderer (pseudo-element, list marker), use
+        // AXChildIterator to walk the render tree / DOM (we may walk between the
+        // two — reference AccessibilityObject::iterator documentation for more information).
+        for (auto& object : AXChildIterator(*this))
+            addChildIfNeeded(object);
+    }
+
+    if (RefPtr afterPseudo = element ? element->afterPseudoElement() : nullptr) {
+        if (RefPtr pseudoObject = cache->getOrCreate(*afterPseudo))
+            addChildIfNeeded(*pseudoObject);
+    }
+#else
+    // USE(ATPSI) within this block. Walk the render tree (primarily -- see comments for AccessibilityObject::iterator)
+    // to build the accessibility tree.
+    // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
     for (auto& object : AXChildIterator(*this))
         addChildIfNeeded(object);
 
     addNodeOnlyChildren();
+    addCanvasChildren();
+#endif // !USE(ATSPI)
+
     addAttachmentChildren();
     addImageMapChildren();
     addTextFieldChildren();
-    addCanvasChildren();
     addRemoteSVGChildren();
-#if USE(ATSPI)
     addListItemMarker();
-#endif
 #if PLATFORM(COCOA)
     updateAttachmentViewParents();
 #endif

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -79,7 +79,6 @@ public:
     AccessibilityObject* previousSibling() const final;
     AccessibilityObject* nextSibling() const final;
     AccessibilityObject* parentObject() const override;
-    AccessibilityObject* parentObjectIfExists() const override;
     AccessibilityObject* observableObject() const override;
     AXCoreObject* titleUIElement() const override;
 
@@ -170,9 +169,7 @@ private:
 
     bool renderObjectIsObservable(RenderObject&) const;
     RenderObject* renderParentObject() const;
-#if USE(ATSPI)
     RenderObject* markerRenderer() const;
-#endif
 
     bool isSVGImage() const;
     void detachRemoteSVGRoot();
@@ -182,15 +179,15 @@ private:
     void offsetBoundingBoxForRemoteSVGElement(LayoutRect&) const;
     bool supportsPath() const override;
 
+#if USE(ATSPI)
     void addNodeOnlyChildren();
+    void addCanvasChildren();
+#endif // USE(ATSPI)
     void addTextFieldChildren();
     void addImageMapChildren();
-    void addCanvasChildren();
     void addAttachmentChildren();
     void addRemoteSVGChildren();
-#if USE(ATSPI)
     void addListItemMarker();
-#endif
 #if PLATFORM(COCOA)
     void updateAttachmentViewParents();
 #endif
@@ -200,7 +197,7 @@ private:
 
     bool inheritsPresentationalRole() const override;
 
-    bool shouldGetTextFromNode(TextUnderElementMode) const;
+    bool shouldGetTextFromNode(const TextUnderElementMode&) const;
 
 #if ENABLE(APPLE_PAY)
     bool isApplePayButton() const;

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -77,7 +77,6 @@ private:
     LocalFrameView* documentFrameView() const override;
     LayoutRect elementRect() const override;
     AccessibilityObject* parentObject() const override;
-    AccessibilityObject* parentObjectIfExists() const override { return parentObject(); }
 
     AccessibilityObject* firstChild() const override { return webAreaObject(); }
     AccessibilityScrollbar* addChildScrollbar(Scrollbar*);

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -604,8 +604,7 @@ void AccessibilityTable::addChildren()
         yCurrent += 1;
     };
     auto needsToDescend = [&processedRows] (AXCoreObject& axObject) {
-        return (!axObject.isTableRow() || !axObject.node())
-            && !processedRows.contains(dynamicDowncast<AccessibilityObject>(axObject));
+        return !axObject.isTableRow() && !processedRows.contains(&downcast<AccessibilityObject>(axObject));
     };
     std::function<void(AXCoreObject*)> processRowDescendingIfNeeded = [&] (AXCoreObject* axObject) {
         if (!axObject)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -892,8 +892,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
             // Propagate any subtree updates downwards for this already-existing child.
             if (auto* liveChild = dynamicDowncast<AccessibilityObject>(newChildren[i].get()); liveChild && liveChild->hasDirtySubtree())
                 updateChildren(*liveChild, ResolveNodeChanges::No);
-        }
-        else {
+        } else {
             // This is a new child, add it to the tree.
             childrenChanged = true;
             AXLOG(makeString("AXID "_s, axAncestor->objectID() ? axAncestor->objectID()->loggingString() : ""_str, " gaining new subtree, starting at ID "_s, newChildren[i]->objectID() ? newChildren[i]->objectID()->loggingString() : ""_s, ':'));

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleTreeResolver.h"
 
+#include "AXObjectCache.h"
 #include "AnchorPositionEvaluator.h"
 #include "CSSFontSelector.h"
 #include "ComposedTreeAncestorIterator.h"
@@ -1110,6 +1111,8 @@ void TreeResolver::resolveComposedTree()
 
             if (element.hasCustomStyleResolveCallbacks())
                 element.didRecalcStyle(elementUpdate.change);
+            if (CheckedPtr cache = m_document->existingAXObjectCache())
+                cache->onStyleChange(element, elementUpdate.change, elementUpdate.style.get(), style);
 
             style = elementUpdate.style.get();
             change = elementUpdate.change;


### PR DESCRIPTION
#### 6a44b38c10d068df677abf94c3f1d96e75fefb7a
<pre>
AX: Default to walking the DOM rather than the render tree when building the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=281749">https://bugs.webkit.org/show_bug.cgi?id=281749</a>
<a href="https://rdar.apple.com/138184652">rdar://138184652</a>

Reviewed by Chris Fleizach.

Walking the DOM rather than the render tree allows many simplifications to our code. Before this
patch, we had several display:contents special cases scattered throughout the code that are no longer
needed:

  1. AccessibilityRenderObject::addNodeOnlyChildren() added display:contents children to the right
     place in an object&apos;s render-tree children retroactively. This function is now unnecessary —
     we get this property for free by walking the DOM to build the AX tree.

  2. AccessibilityObject::insertChild had a special case to prevent double-insertion of display:contents children.

  3. AccessibilityRenderObject::addCanvasChildren() only existed because canvas descendants are not rendered,
     and thus not picked up by a render tree walk. This function is now removed.

  4. Numerous other more minor checks throughout the code that only existed because we had to deal with
     anonymous renderers are removed.

The flip side of this is that we don&apos;t get &quot;interesting&quot; anonymous renderers for free anymore, e.g.
list markers, CSS ::before and CSS ::after, mfenced element `open`, `close`, `separators` anonymous
renderers. This is still a great tradeoff, as there are far more uninteresting anonymous renderers
than there are interesting ones.

I tried to apply this change to USE(ATSPI) ports, but there are GTK tests that expect the presence of certain
anonymous renderers that I&apos;m not sure we can outright remove (e.g. those in accessibility/gtk/replaced-objects-in-anonymous-blocks.html).
I filed a follow-up bug (<a href="https://bugs.webkit.org/show_bug.cgi?id=282117)">https://bugs.webkit.org/show_bug.cgi?id=282117)</a> to track this, more details are there.

Another important aspect of this change is the addition of AXObjectCache::onStyleChange. We have accessibility
properties cached based on element styles that never get updated, and the addition of this function gives us the
framework for starting to fix those.

* LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt:
* LayoutTests/accessibility/mac/ruby-hierarchy-roles.html:
Remove an else block from this test that only existed due to a useless
anonymous renderer child.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::onStyleChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::addChildren):
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::parentObject const):
(WebCore::AccessibilityNodeObject::addChildren):
(WebCore::shouldUseAccessibilityObjectInnerText):
(WebCore::AccessibilityNodeObject::parentObjectIfExists const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::parentInCoreTree const):
(WebCore::AccessibilityObject::parentObjectIfExists const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
(WebCore::AccessibilityRenderObject::textUnderElement const):
(WebCore::AccessibilityRenderObject::shouldGetTextFromNode const):
(WebCore::AccessibilityRenderObject::boundingBoxRect const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
(WebCore::AccessibilityRenderObject::markerRenderer const):
(WebCore::AccessibilityRenderObject::addListItemMarker):
(WebCore::AccessibilityRenderObject::addChildren):
(WebCore::AccessibilityRenderObject::parentObjectIfExists const): Deleted.
(WebCore::AccessibilityRenderObject::addCanvasChildren): Deleted.
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::addChildren):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper detailParentForSummaryObject:]):
(-[WebAccessibilityObjectWrapper accessibilitySupportsARIAExpanded]):
(-[WebAccessibilityObjectWrapper accessibilityIsExpanded]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateChildren):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):

Canonical link: <a href="https://commits.webkit.org/285807@main">https://commits.webkit.org/285807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59aa64c5c827b58782d79c578805bdd6830854ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24851 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57885 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20827 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/406 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66241 "Found 2 new test failures: imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7564 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3644 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->