### PR TITLE
[scroll-animations] https://scroll-driven-animations.style/demos/image-reveal/css/ fails to create all expected view timelines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL scroll-timeline-name is referenceable in animation-timeline on the declaring element itself assert_equals: expected "100px" but got "50px"
+PASS scroll-timeline-name is referenceable in animation-timeline on the declaring element itself
 PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
 FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "100px"
 PASS scroll-timeline-name on an element which is not a scroll-container

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Keyframes with same easing and timeline offset are merged. assert_equals: number of frames:  expected 4 but got 0
+FAIL Keyframes with same easing and timeline offset are merged. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 FAIL Keyframes with same timeline offset but different easing function are not merged. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Default view-timeline assert_equals: expected "-1" but got "0"
 FAIL Horizontal view-timeline assert_equals: expected "-1" but got "0"
-FAIL Multiple view-timelines on the same element assert_equals: expected "0" but got "-1"
+FAIL Multiple view-timelines on the same element assert_equals: expected "-1" but got "0"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "1"
-FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "-1"
-FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "-1"
-FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "-1"
+FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "2"
+FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "0"
+FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "0"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL view-timeline-inset with one value assert_equals: expected "-1" but got "0"
+FAIL view-timeline-inset with one value assert_equals: expected "0" but got "-1"
 FAIL view-timeline-inset with two values assert_equals: expected "0" but got "-1"
 FAIL view-timeline-inset with em values assert_equals: expected "0" but got "-1"
 FAIL view-timeline-inset with percentage values assert_equals: expected "0" but got "-1"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL view-timeline on self assert_equals: expected "100" but got "0"
-PASS timeline-scope on preceding sibling
-PASS view-timeline on ancestor
-PASS timeline-scope on ancestor sibling
-FAIL timeline-scope on ancestor sibling, conflict remains unresolved assert_equals: expected "auto" but got "50"
-FAIL timeline-scope on ancestor sibling, closer timeline wins assert_equals: expected "auto" but got "75"
+PASS view-timeline on self
+FAIL timeline-scope on preceding sibling assert_equals: expected "75" but got "0"
+FAIL view-timeline on ancestor assert_equals: expected "25" but got "0"
+FAIL timeline-scope on ancestor sibling assert_equals: expected "75" but got "0"
+FAIL timeline-scope on ancestor sibling, conflict remains unresolved assert_equals: expected "auto" but got "0"
+FAIL timeline-scope on ancestor sibling, closer timeline wins assert_equals: expected "auto" but got "0"
 PASS view-timeline on ancestor sibling, scroll-timeline wins on same element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Outer animation can see view timeline defined by :host assert_equals: expected 1 but got 0
 FAIL Outer animation can see view timeline defined by ::slotted assert_equals: expected 1 but got 0
-FAIL Inner animation can see view timeline defined by ::part assert_equals: expected 1 but got 0
-FAIL Slotted element can see view timeline within the shadow assert_equals: expected 1 but got 0
+FAIL Inner animation can see view timeline defined by ::part assert_equals: expected (string) "x" but got (undefined) undefined
+FAIL Slotted element can see view timeline within the shadow assert_equals: expected (string) "y" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Use the last value from view-timeline-axis if omitted assert_equals: expected "-1" but got "0"
+FAIL Use the last value from view-timeline-axis if omitted assert_equals: expected "25" but got "-1"
 FAIL Use the last value from view-timeline-inset if omitted assert_equals: expected "0" but got "-1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline with animation delays and range promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL ViewTimeline with animation delays and range promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state assert_equals: expected "running" but got "finished"
+FAIL Changing the animation range updates the play state promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -72,8 +72,8 @@ public:
     ScrollTimeline* scrollTimelineForName(const AtomString&) const;
 
     void registerNamedViewTimeline(const AtomString&, Element&, ScrollAxis, ViewTimelineInsets&&);
-    void unregisterNamedViewTimeline(const AtomString&);
-    ViewTimeline* viewTimelineForName(const AtomString&) const;
+    void unregisterNamedViewTimelineForSubject(const AtomString&, const Element&);
+    ViewTimeline* viewTimelineForNameAndSubject(const AtomString&, const Element&) const;
 
 private:
     ReducedResolutionSeconds liveCurrentTime() const;
@@ -82,7 +82,7 @@ private:
 
     UncheckedKeyHashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     UncheckedKeyHashMap<AtomString, Ref<ScrollTimeline>> m_nameToScrollTimelineMap;
-    UncheckedKeyHashMap<AtomString, Ref<ViewTimeline>> m_nameToViewTimelineMap;
+    UncheckedKeyHashMap<AtomString, Vector<Ref<ViewTimeline>>> m_nameToViewTimelinesMap;
     WeakHashSet<AnimationTimeline> m_timelines;
     TaskCancellationGroup m_currentTimeClearingTaskCancellationGroup;
     Document& m_document;

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -118,6 +118,7 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
 
     // FIXME: deal with overridden "timeline" property as well.
     ASSERT(owningElement());
+    Ref target = owningElement()->element;
     Ref document = owningElement()->element.document();
     WTF::switchOn(animation.timeline(),
         [&] (Animation::TimelineKeyword keyword) {
@@ -127,7 +128,7 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
             CheckedRef timelinesController = document->ensureTimelinesController();
             if (RefPtr scrollTimeline = timelinesController->scrollTimelineForName(name))
                 setTimeline(WTFMove(scrollTimeline));
-            else if (RefPtr viewTimeline = timelinesController->viewTimelineForName(name))
+            else if (RefPtr viewTimeline = timelinesController->viewTimelineForNameAndSubject(name, target))
                 setTimeline(WTFMove(viewTimeline));
         }, [&] (Ref<ScrollTimeline> anonymousTimeline) {
             setTimeline(RefPtr { anonymousTimeline.ptr() });

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -666,12 +666,6 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         if (oldStyle && (oldStyle->hasTransitions() || resolvedStyle.style->hasTransitions()))
             styleable.updateCSSTransitions(*oldStyle, *resolvedStyle.style, newStyleOriginatedAnimations);
 
-        // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style
-        // to use CSS Animations as defined in the previous style change event. As such, we update CSS Animations after CSS Transitions
-        // such that when CSS Transitions are updated the CSS Animations data is the same as during the previous style change event.
-        if ((oldStyle && oldStyle->hasAnimations()) || resolvedStyle.style->hasAnimations())
-            styleable.updateCSSAnimations(oldStyle, *resolvedStyle.style, resolutionContext, newStyleOriginatedAnimations, isInDisplayNoneTree);
-
         if ((oldStyle && oldStyle->scrollTimelines().size()) || resolvedStyle.style->scrollTimelines().size()
             || (oldStyle && oldStyle->scrollTimelineNames().size()) || resolvedStyle.style->scrollTimelineNames().size()) {
             styleable.updateCSSScrollTimelines(oldStyle, *resolvedStyle.style);
@@ -681,6 +675,12 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             || (oldStyle && oldStyle->viewTimelineNames().size()) || resolvedStyle.style->viewTimelineNames().size()) {
             styleable.updateCSSViewTimelines(oldStyle, *resolvedStyle.style);
         }
+
+        // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style
+        // to use CSS Animations as defined in the previous style change event. As such, we update CSS Animations after CSS Transitions
+        // such that when CSS Transitions are updated the CSS Animations data is the same as during the previous style change event.
+        if ((oldStyle && oldStyle->hasAnimations()) || resolvedStyle.style->hasAnimations())
+            styleable.updateCSSAnimations(oldStyle, *resolvedStyle.style, resolutionContext, newStyleOriginatedAnimations, isInDisplayNoneTree);
     };
 
     auto applyAnimations = [&]() -> std::pair<std::unique_ptr<RenderStyle>, OptionSet<AnimationImpact>> {

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -943,7 +943,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
 
         for (auto& previousTimelineName : currentStyle->viewTimelineNames()) {
             if (!currentTimelineNames.contains(previousTimelineName))
-                timelinesController->unregisterNamedViewTimeline(previousTimelineName);
+                timelinesController->unregisterNamedViewTimelineForSubject(previousTimelineName, element);
         }
     };
 


### PR DESCRIPTION
#### c2b6c884790d5fc4c346051fc38e9ead78713732
<pre>
[scroll-animations] <a href="https://scroll-driven-animations.style/demos/image-reveal/css/">https://scroll-driven-animations.style/demos/image-reveal/css/</a> fails to create all expected view timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=281752">https://bugs.webkit.org/show_bug.cgi?id=281752</a>
<a href="https://rdar.apple.com/138185228">rdar://138185228</a>

Reviewed by Tim Nguyen.

In <a href="https://scroll-driven-animations.style/demos/image-reveal/css/">https://scroll-driven-animations.style/demos/image-reveal/css/</a>, the elements associated with a
view timeline are declared as follows:

```
.revealing-image {
        /* Create View Timeline */
        view-timeline-name: --revealing-image;

        /* Attach animation, linked to the  View Timeline */
        animation: linear reveal both;
        animation-timeline: --revealing-image;
}
```

In the initial patch to associate CSS Animations with style-originated view timelines (285354@main)
we made the incorrect assumption that there could only ever be one `ViewTimeline` created for a given
`view-timeline-name` value. But in fact it&apos;s expected that there may be multiple `ViewTimeline` created
for a given `view-timeline-name` value, one per subject, ie. the element with the `view-timeline-name`
in its computed style.

So we modify the registration system and lookup system for view timelines on `AnimationTimelinesController`
to work with a `Vector&lt;Ref&lt;ViewTimeline&gt;&gt;` per name.

Another issue that surfaced as well was that we would register view timelines for a given element _after_
creating CSS Animations. This is the wrong order of operations since the generated CSS Animations may well
depend upon view timelines with that element as its subject. So we ensure to call `updateCSSScrollTimelines()`
and `updateCSSViewTimelines()` prior to calling `updateCSSAnimations()` in `Style::TreeResolver::createAnimatedElementUpdate()`.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedViewTimelineForSubject):
(WebCore::AnimationTimelinesController::viewTimelineForNameAndSubject const):
(WebCore::AnimationTimelinesController::unregisterNamedViewTimeline): Deleted.
(WebCore::AnimationTimelinesController::viewTimelineForName const): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSViewTimelines const):

Canonical link: <a href="https://commits.webkit.org/285433@main">https://commits.webkit.org/285433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a489bc317ad946284d8b29d7faeefa11ce256bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72649 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/52074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59879 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/23683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75716 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/23683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11152 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/47872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->