### PR TITLE
AX: accessibility/mac/scrolling-in-pdf-crash.html times out in Sequoia

### DIFF
--- a/LayoutTests/accessibility/mac/scrolling-in-pdf-crash-expected.txt
+++ b/LayoutTests/accessibility/mac/scrolling-in-pdf-crash-expected.txt
@@ -1,9 +1,7 @@
 This test ensures that scrolling a PDF with accessibility enabled does not cause a crash.
 
-PASS: pdfLayerController.stringAttributeValue('AXRole') === 'AXGroup'
-PASS: pdfLayerController.stringAttributeValue('AXDescription') === 'document'
-PASS: pdfLayerController.childAtIndex(0).role === 'AXRole: AXPage'
-PASS: pdfLayerController.childAtIndex(1).role === 'AXRole: AXPage'
+PASS: pageOne.role === 'AXRole: AXPage'
+PASS: pageTwo.role === 'AXRole: AXPage'
 PASS: Scrolling to the second page of the PDF didn't cause a crash.
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html
+++ b/LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html
@@ -14,6 +14,7 @@ var output = "This test ensures that scrolling a PDF with accessibility enabled 
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
+    var pageOne, pageTwo;
     var pdfAxObject, pdfLayerController;
     requestAnimationFrame(async function() {
         await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for the embed plugin to load after style update.
@@ -26,18 +27,31 @@ if (window.accessibilityController) {
             pdfAxObject = embedElement.childAtIndex(0);
             return pdfAxObject && pdfAxObject.children.length >= 1;
         });
-        await waitFor(() => {
-            pdfLayerController = pdfAxObject.childAtIndex(0);
-            return pdfLayerController && pdfLayerController.children.length >= 2;
-        });
 
-        output += expect("pdfLayerController.stringAttributeValue('AXRole')", "'AXGroup'");
-        output += expect("pdfLayerController.stringAttributeValue('AXDescription')", "'document'");
+        if (pdfAxObject.childAtIndex(0).role.includes("AXPage")) {
+            // Post-Sequoia, the pages in the PDF document are direct children of the PDF AX object in the PDFKit accessibility hierarchy.
+            pageOne = pdfAxObject.childAtIndex(0);
+            pageTwo = pdfAxObject.childAtIndex(1);
+        } else {
+            // Pre-Sequoia, the pages are children of the PDF layer controller.
+            await waitFor(() => {
+                pdfLayerController = pdfAxObject.childAtIndex(0);
+                return pdfLayerController && pdfLayerController.children.length >= 2;
+            });
 
-        output += expect("pdfLayerController.childAtIndex(0).role", "'AXRole: AXPage'");
-        output += expect("pdfLayerController.childAtIndex(1).role", "'AXRole: AXPage'");
+            let role = pdfLayerController.stringAttributeValue("AXRole");
+            let description = pdfLayerController.stringAttributeValue("AXDescription");
+            if (role !== "AXGroup" && description !== "document")
+                output += `FAIL: PDF layer controller had unexpected role (${role}) or description (${descripton})\n`;
 
-        pdfLayerController.childAtIndex(1).scrollToMakeVisible();
+            pageOne = pdfLayerController.childAtIndex(0);
+            pageTwo = pdfLayerController.childAtIndex(1);
+        }
+
+        output += expect("pageOne.role", "'AXRole: AXPage'");
+        output += expect("pageTwo.role", "'AXRole: AXPage'");
+
+        pageTwo.scrollToMakeVisible();
         output += "PASS: Scrolling to the second page of the PDF didn't cause a crash.\n";
 
         debug(output);


### PR DESCRIPTION
#### 2dbee2ab0f5ff311ff36ed3d3c7b4ec3ab1268f1
<pre>
AX: accessibility/mac/scrolling-in-pdf-crash.html times out in Sequoia
<a href="https://bugs.webkit.org/show_bug.cgi?id=281759">https://bugs.webkit.org/show_bug.cgi?id=281759</a>
<a href="https://rdar.apple.com/138191479">rdar://138191479</a>

Reviewed by Chris Fleizach.

These tests walk into PDFKit accessibility hierarchy, which changed in macOS Sequoia. Work around this by making the
test more resilient when trying to find the PDF page accessibility objects.

* LayoutTests/accessibility/mac/scrolling-in-pdf-crash-expected.txt:
* LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html:

Canonical link: <a href="https://commits.webkit.org/286281@main">https://commits.webkit.org/286281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad8dca472f3583a26ea302c926b43f79fd66864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26618 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22234 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24945 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2693 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1691 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8780 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->