### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from VirtualLocalConnection

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
@@ -54,7 +54,7 @@ public:
         PolicyDecided,
     };
 
-    static Ref<LocalAuthenticator> create(UniqueRef<LocalConnection>&& connection)
+    static Ref<LocalAuthenticator> create(Ref<LocalConnection>&& connection)
     {
         return adoptRef(*new LocalAuthenticator(WTFMove(connection)));
     }
@@ -62,7 +62,7 @@ public:
     static void clearAllCredentials();
 
 private:
-    explicit LocalAuthenticator(UniqueRef<LocalConnection>&&);
+    explicit LocalAuthenticator(Ref<LocalConnection>&&);
 
     std::optional<WebCore::ExceptionData> processClientExtensions(std::variant<Ref<WebCore::AuthenticatorAttestationResponse>, Ref<WebCore::AuthenticatorAssertionResponse>>);
 
@@ -85,8 +85,10 @@ private:
 
     std::optional<Vector<Ref<WebCore::AuthenticatorAssertionResponse>>> getExistingCredentials(const String& rpId);
 
+    Ref<LocalConnection> protectedConnection() const { return m_connection; }
+
     State m_state { State::Init };
-    UniqueRef<LocalConnection> m_connection;
+    Ref<LocalConnection> m_connection;
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_existingCredentials;
     RetainPtr<NSData> m_provisionalCredentialId;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
@@ -29,6 +29,7 @@
 
 #include <wtf/CompletionHandler.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -48,10 +49,12 @@ namespace WebKit {
 // However, such abstraction is still provided to isolate operations
 // that are not allowed in auto test environment such that some mocking
 // mechnism can override them.
-class LocalConnection {
+class LocalConnection : public RefCounted<LocalConnection> {
     WTF_MAKE_TZONE_ALLOCATED(LocalConnection);
     WTF_MAKE_NONCOPYABLE(LocalConnection);
 public:
+    static Ref<LocalConnection> create();
+
     enum class UserVerification : uint8_t {
         No,
         Yes,
@@ -62,7 +65,6 @@ public:
     using AttestationCallback = CompletionHandler<void(NSArray *, NSError *)>;
     using UserVerificationCallback = CompletionHandler<void(UserVerification, LAContext *)>;
 
-    LocalConnection() = default;
     virtual ~LocalConnection();
 
     // Overrided by MockLocalConnection.
@@ -71,6 +73,9 @@ public:
     virtual void verifyUser(SecAccessControlRef, LAContext *, CompletionHandler<void(UserVerification)>&&);
     virtual RetainPtr<SecKeyRef> createCredentialPrivateKey(LAContext *, SecAccessControlRef, const String& secAttrLabel, NSData *secAttrApplicationTag) const;
     virtual void filterResponses(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&) const { };
+
+protected:
+    LocalConnection() = default;
 
 private:
     RetainPtr<LAContext> m_context;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -59,6 +59,11 @@ static inline String bundleName()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalConnection);
 
+Ref<LocalConnection> LocalConnection::create()
+{
+    return adoptRef(*new LocalConnection);
+}
+
 LocalConnection::~LocalConnection()
 {
     // Dismiss any showing LocalAuthentication dialogs.

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
@@ -50,7 +50,7 @@ private:
     void startDiscoveryInternal() final;
     // Overrided by MockLocalService.
     virtual bool platformStartDiscovery() const;
-    virtual UniqueRef<LocalConnection> createLocalConnection() const;
+    virtual Ref<LocalConnection> createLocalConnection() const;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
@@ -91,9 +91,9 @@ bool LocalService::platformStartDiscovery() const
     return LocalService::isAvailable();
 }
 
-UniqueRef<LocalConnection> LocalService::createLocalConnection() const
+Ref<LocalConnection> LocalService::createLocalConnection() const
 {
-    return makeUniqueRef<LocalConnection>();
+    return LocalConnection::create();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
@@ -34,10 +34,13 @@
 namespace WebKit {
 
 class MockLocalConnection final : public LocalConnection {
+    WTF_MAKE_TZONE_ALLOCATED(MockLocalConnection);
 public:
-    explicit MockLocalConnection(const WebCore::MockWebAuthenticationConfiguration&);
+    static Ref<MockLocalConnection> create(const WebCore::MockWebAuthenticationConfiguration&);
 
 private:
+    explicit MockLocalConnection(const WebCore::MockWebAuthenticationConfiguration&);
+
     RetainPtr<NSArray> getExistingCredentials(const String& rpId) final;
     void verifyUser(const String&, WebCore::ClientDataType, SecAccessControlRef, WebCore::UserVerificationRequirement,  UserVerificationCallback&&) final;
     void verifyUser(SecAccessControlRef, LAContext *, CompletionHandler<void(UserVerification)>&&) final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -33,6 +33,7 @@
 #import <WebCore/AuthenticatorAssertionResponse.h>
 #import <WebCore/ExceptionData.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/WTFString.h>
@@ -43,6 +44,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockLocalConnection);
+
+Ref<MockLocalConnection> MockLocalConnection::create(const WebCore::MockWebAuthenticationConfiguration& configuration)
+{
+    return adoptRef(*new MockLocalConnection(configuration));
+}
 
 MockLocalConnection::MockLocalConnection(const MockWebAuthenticationConfiguration& configuration)
     : m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
@@ -40,7 +40,7 @@ private:
     MockLocalService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
     bool platformStartDiscovery() const final;
-    UniqueRef<LocalConnection> createLocalConnection() const final;
+    Ref<LocalConnection> createLocalConnection() const final;
 
     WebCore::MockWebAuthenticationConfiguration m_configuration;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
@@ -57,9 +57,9 @@ bool MockLocalService::platformStartDiscovery() const
     return !!m_configuration.local;
 }
 
-UniqueRef<LocalConnection> MockLocalService::createLocalConnection() const
+Ref<LocalConnection> MockLocalService::createLocalConnection() const
 {
-    return makeUniqueRef<MockLocalConnection>(m_configuration);
+    return MockLocalConnection::create(m_configuration);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.h
@@ -32,22 +32,16 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class VirtualLocalConnection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::VirtualLocalConnection> : std::true_type { };
-}
-
-namespace WebKit {
 struct VirtualAuthenticatorConfiguration;
 
-class VirtualLocalConnection final : public CanMakeWeakPtr<VirtualLocalConnection>, public LocalConnection {
+class VirtualLocalConnection final : public LocalConnection, public CanMakeWeakPtr<VirtualLocalConnection> {
+    WTF_MAKE_TZONE_ALLOCATED(VirtualLocalConnection);
 public:
-    explicit VirtualLocalConnection(const VirtualAuthenticatorConfiguration&);
+    static Ref<VirtualLocalConnection> create(const VirtualAuthenticatorConfiguration&);
 
 private:
+    explicit VirtualLocalConnection(const VirtualAuthenticatorConfiguration&);
+
     void verifyUser(const String&, WebCore::ClientDataType, SecAccessControlRef, WebCore::UserVerificationRequirement, UserVerificationCallback&&) final;
     void verifyUser(SecAccessControlRef, LAContext *, CompletionHandler<void(UserVerification)>&&) final;
     void filterResponses(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&) const final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -84,7 +84,7 @@ void VirtualService::startDiscoveryInternal()
             observer()->authenticatorAdded(CtapAuthenticator::create(CtapHidDriver::create(VirtualHidConnection::create(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
             break;
         case WebCore::AuthenticatorTransport::Internal:
-            observer()->authenticatorAdded(LocalAuthenticator::create(makeUniqueRef<VirtualLocalConnection>(config)));
+            observer()->authenticatorAdded(LocalAuthenticator::create(VirtualLocalConnection::create(config)));
             break;
         default:
             UNIMPLEMENTED();


### PR DESCRIPTION
#### 3fed38e56bca1d28c0d19d799418069d5df94574
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from VirtualLocalConnection
<a href="https://bugs.webkit.org/show_bug.cgi?id=281760">https://bugs.webkit.org/show_bug.cgi?id=281760</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::LocalAuthenticator):
(WebKit::LocalAuthenticator::getExistingCredentials):
(WebKit::LocalAuthenticator::makeCredential):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterReceivingLAContext):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::getAssertion):
(WebKit::LocalAuthenticator::continueGetAssertionAfterResponseSelected):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm:
(WebKit::LocalService::createLocalConnection const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::create):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm:
(WebKit::MockLocalService::createLocalConnection const):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm:
(WebKit::VirtualLocalConnection::create):
(WebKit::VirtualLocalConnection::verifyUser):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::VirtualService::startDiscoveryInternal):

Canonical link: <a href="https://commits.webkit.org/285444@main">https://commits.webkit.org/285444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a8b45c1af608fdf79de3172f9ae362ddddc9392

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15649 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43722 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22148 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6788 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11159 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->