### PR TITLE
text-spacing: text-spacing-trim: implement trim-all for complex path

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -318,6 +318,7 @@ void ComplexTextController::collectComplexTextRuns()
     bool dontSynthesizeSmallCaps = !m_font.fontDescription().hasAutoFontSynthesisSmallCaps();
     bool engageAllSmallCapsProcessing = fontVariantCaps == FontVariantCaps::AllSmall || fontVariantCaps == FontVariantCaps::AllPetite;
     bool engageSmallCapsProcessing = engageAllSmallCapsProcessing || fontVariantCaps == FontVariantCaps::Small || fontVariantCaps == FontVariantCaps::Petite;
+    auto shouldProcessTextSpacingTrim = !m_font.textSpacingTrim().isSpaceAll();
 
     if (engageAllSmallCapsProcessing || engageSmallCapsProcessing)
         m_smallCapsBuffer.resize(m_end);
@@ -329,6 +330,7 @@ void ComplexTextController::collectComplexTextRuns()
     RefPtr<const Font> nextFont;
     RefPtr<const Font> synthesizedFont;
     RefPtr<const Font> smallSynthesizedFont;
+    RefPtr<const Font> halfWidthFont;
 
     CachedTextBreakIterator graphemeClusterIterator(m_run.text(), { }, TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
 
@@ -339,6 +341,12 @@ void ComplexTextController::collectComplexTextRuns()
     // We may want to change this code to do so in the future; if we do, then the logic in initiateFontLoadingByAccessingGlyphDataIfApplicable()
     // would need to be updated accordingly too.
     nextFont = m_font.fontForCombiningCharacterSequence(baseOfString.first(currentIndex));
+
+    if (shouldProcessTextSpacingTrim && nextFont && !nextFont->isSystemFontFallbackPlaceholder()) {
+        TextSpacing::CharactersData charactersData = { .currentCharacter = baseCharacter, .currentCharacterClass = TextSpacing::characterClass(baseCharacter) };
+        halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*nextFont, m_font.textSpacingTrim(), charactersData);
+        nextFont = halfWidthFont ? halfWidthFont : nextFont;
+    }
 
     bool isSmallCaps = false;
     bool nextIsSmallCaps = false;
@@ -359,6 +367,7 @@ void ComplexTextController::collectComplexTextRuns()
         font = nextFont.get();
         isSmallCaps = nextIsSmallCaps;
         auto previousIndex = currentIndex;
+        halfWidthFont = nullptr;
 
         advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter);
 
@@ -379,6 +388,12 @@ void ComplexTextController::collectComplexTextRuns()
         }
 
         nextFont = m_font.fontForCombiningCharacterSequence(baseOfString.subspan(previousIndex, currentIndex - previousIndex));
+
+        if (shouldProcessTextSpacingTrim && nextFont && !nextFont->isSystemFontFallbackPlaceholder()) {
+            TextSpacing::CharactersData charactersData = { .currentCharacter = baseCharacter, .currentCharacterClass = TextSpacing::characterClass(baseCharacter) };
+            halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*nextFont, m_font.textSpacingTrim(), charactersData);
+            nextFont = halfWidthFont ? halfWidthFont : nextFont;
+        }
 
         capitalizedBase = capitalized(baseCharacter);
         if (!synthesizedFont && shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -490,6 +490,10 @@ const Font* Font::smallCapsFont(const FontDescription& fontDescription) const
 
 const RefPtr<Font> Font::halfWidthFont() const
 {
+    if (isSystemFontFallbackPlaceholder()) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
     DerivedFonts& derivedFontData = ensureDerivedFontData();
     if (!derivedFontData.halfWidthFont)
         derivedFontData.halfWidthFont = createHalfWidthFont();

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -393,18 +393,12 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
 
     auto glyphData = m_font->glyphDataForCharacter(character, false, FontVariant::NormalVariant);
 
-    auto getHalfWidthFontAndSetGlyphDataIfNeeded = [&](GlyphData& glyphData, const TextSpacing::CharactersData& charactersData) {
-        auto halfWidthFont = fontDescription.textSpacingTrim().shouldTrimSpacing(charactersData) ? glyphData.font->halfWidthFont() : nullptr;
-        if (halfWidthFont)
-            glyphData.font = halfWidthFont.get();
-        return halfWidthFont;
-    };
-
     RefPtr<Font> halfWidthFont;
     auto shouldProcessTextSpacingTrim = !fontDescription.textSpacingTrim().isSpaceAll();
     if (shouldProcessTextSpacingTrim) {
         TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
-        halfWidthFont = getHalfWidthFontAndSetGlyphDataIfNeeded(glyphData, charactersData);
+        halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.font, fontDescription.textSpacingTrim(), charactersData);
+        glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
     }
 
     advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());
@@ -439,7 +433,8 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
 
         if (shouldProcessTextSpacingTrim) {
             TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
-            halfWidthFont = getHalfWidthFontAndSetGlyphDataIfNeeded(glyphData, charactersData);
+            halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.font, fontDescription.textSpacingTrim(), charactersData);
+            glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
         }
 
         advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());

--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -138,5 +138,10 @@ CharacterClass characterClass(char32_t character)
     return CharacterClass::Undefined;
 }
 
+RefPtr<Font> getHalfWidthFontIfNeeded(const Font& font, const TextSpacingTrim& textSpacingTrim, CharactersData& charactersData)
+{
+    return textSpacingTrim.shouldTrimSpacing(charactersData) ? font.halfWidthFont() : nullptr;
+}
+
 } // namespace TextSpacing
 } // namespace WebCore

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class Font;
+class TextSpacingTrim;
 
 namespace TextSpacing {
 
@@ -66,6 +67,7 @@ struct SpacingState {
 
 bool isIdeograph(char32_t character);
 
+RefPtr<Font> getHalfWidthFontIfNeeded(const Font&, const TextSpacingTrim&, CharactersData&);
 } // namespace TextSpacing
 
 class TextSpacingTrim {
@@ -150,5 +152,6 @@ inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextAutospace& val
         ts << "ideograph-numeric";
     return ts;
 }
+
 
 } // namespace WebCore


### PR DESCRIPTION
#### 85ed15ffe2c774c383a60e98b3087b73bd143d08
<pre>
text-spacing: text-spacing-trim: implement trim-all for complex path
<a href="https://bugs.webkit.org/show_bug.cgi?id=281761">https://bugs.webkit.org/show_bug.cgi?id=281761</a>
<a href="https://rdar.apple.com/137795771">rdar://137795771</a>

Reviewed by Sammy Gill.

Simple path (WidthIterator) already covers this behavior.
We should now do the same for the Complex path (ComplexTextController).

trim-all:
Set fullwidth opening punctuation, fullwidth closing punctuation, and fullwidth middle dot punctuation with half-width glyphs,
without regards for the position within the line nor for adjacent characters.

* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::halfWidthFont const):

Canonical link: <a href="https://commits.webkit.org/286983@main">https://commits.webkit.org/286983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/010d8905f09ac7a0d86baaf0bd9e485cf26eed18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60505 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18552 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4615 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3113 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17093 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10125 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7377 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->