### PR TITLE
Bring up tvOS 18, watchOS 11, and visionOS 2

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -123,7 +123,7 @@
     { "name": "ews166", "platform": "*" },
     { "name": "ews167", "platform": "*" },
     { "name": "ews168", "platform": "*" },
-    { "name": "ews170", "platform": "tvos-simulator-17" },
+    { "name": "ews170", "platform": "tvos-simulator-18" },
     { "name": "ews171", "platform": "mac-sonoma" },
     { "name": "ews172", "platform": "mac-sonoma" },
     { "name": "ews173", "platform": "mac-sonoma" },
@@ -157,21 +157,21 @@
     { "name": "ews202", "platform": "mac-ventura" },
     { "name": "ews203", "platform": "mac-ventura" },
     { "name": "ews204", "platform": "mac-ventura" },    
-    { "name": "ews216", "platform": "visionos-1" },
-    { "name": "ews217", "platform": "visionos-1" },
-    { "name": "ews218", "platform": "visionos-1" },
-    { "name": "ews219", "platform": "visionos-1" },
-    { "name": "ews220", "platform": "visionos-1" },
-    { "name": "ews221", "platform": "visionos-simulator-1" },
-    { "name": "ews222", "platform": "visionos-simulator-1" },
-    { "name": "ews223", "platform": "visionos-simulator-1" },
-    { "name": "ews224", "platform": "visionos-simulator-1" },
-    { "name": "ews225", "platform": "visionos-simulator-1" },
-    { "name": "ews226", "platform": "visionos-simulator-1" },
-    { "name": "ews227", "platform": "visionos-simulator-1" },
-    { "name": "ews228", "platform": "visionos-simulator-1" },
-    { "name": "ews229", "platform": "visionos-simulator-1" },
-    { "name": "ews230", "platform": "visionos-simulator-1" },
+    { "name": "ews216", "platform": "visionos-2" },
+    { "name": "ews217", "platform": "visionos-2" },
+    { "name": "ews218", "platform": "visionos-2" },
+    { "name": "ews219", "platform": "visionos-2" },
+    { "name": "ews220", "platform": "visionos-2" },
+    { "name": "ews221", "platform": "visionos-simulator-2" },
+    { "name": "ews222", "platform": "visionos-simulator-2" },
+    { "name": "ews223", "platform": "visionos-simulator-2" },
+    { "name": "ews224", "platform": "visionos-simulator-2" },
+    { "name": "ews225", "platform": "visionos-simulator-2" },
+    { "name": "ews226", "platform": "visionos-simulator-2" },
+    { "name": "ews227", "platform": "visionos-simulator-2" },
+    { "name": "ews228", "platform": "visionos-simulator-2" },
+    { "name": "ews229", "platform": "visionos-simulator-2" },
+    { "name": "ews230", "platform": "visionos-simulator-2" },
     { "name": "ews237", "platform": "mac-sonoma" },
     { "name": "ews238", "platform": "*" },
     { "name": "ews239", "platform": "*" },
@@ -302,47 +302,47 @@
       "workernames": ["ews237", "ews246", "ews247", "ews248", "ews249", "ews250"]
     },
     {
-      "name": "watchOS-10-Build-EWS", "shortname": "watch", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-10",
+      "name": "watchOS-11-Build-EWS", "shortname": "watch", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-11",
       "configuration": "release", "architectures": ["arm64_32", "arm64"],
       "workernames": ["ews163", "ews164", "ews165", "ews238", "ews239"]
     },
     {
-      "name": "watchOS-10-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-10",
+      "name": "watchOS-11-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-11",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews164", "ews165", "ews166", "ews240"]
     },
     {
-      "name": "tvOS-17-Build-EWS", "shortname": "tv", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-17",
+      "name": "tvOS-18-Build-EWS", "shortname": "tv", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-18",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews167", "ews168", "ews243", "ews244"]
     },
     {
-      "name": "tvOS-17-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-17",
+      "name": "tvOS-18-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-18",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews168", "ews170", "ews245"]
     },
     {
-      "name": "visionOS-1-Build-EWS", "shortname": "vision", "icon": "buildOnly",
-      "factory": "visionOSEmbeddedBuildFactory", "platform": "visionos-1",
+      "name": "visionOS-2-Build-EWS", "shortname": "vision", "icon": "buildOnly",
+      "factory": "visionOSEmbeddedBuildFactory", "platform": "visionos-2",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews216", "ews217", "ews218", "ews219", "ews220"]
     },
     {
-      "name": "visionOS-1-Simulator-Build-EWS", "shortname": "vision-sim", "icon": "buildOnly",
-      "factory": "visionOSBuildFactory", "platform": "visionos-simulator-1",
+      "name": "visionOS-2-Simulator-Build-EWS", "shortname": "vision-sim", "icon": "buildOnly",
+      "factory": "visionOSBuildFactory", "platform": "visionos-simulator-2",
       "configuration": "release", "architectures": ["arm64"],
-      "triggers": ["visionos-1-sim-wk2-tests-ews"],
+      "triggers": ["visionos-2-sim-wk2-tests-ews"],
       "workernames": ["ews221", "ews222", "ews223", "ews224", "ews225"]
     },
     {
-      "name": "visionOS-1-Simulator-WK2-Tests-EWS", "shortname": "vision-wk2", "icon": "testOnly",
-      "factory": "visionOSTestsFactory", "platform": "visionos-simulator-1",
+      "name": "visionOS-2-Simulator-WK2-Tests-EWS", "shortname": "vision-wk2", "icon": "testOnly",
+      "factory": "visionOSTestsFactory", "platform": "visionos-simulator-2",
       "configuration": "release",
-      "triggered_by": ["visionos-1-sim-build-ews"],
+      "triggered_by": ["visionos-2-sim-build-ews"],
       "additionalArguments": ["--child-processes=2"],
       "workernames": ["ews226", "ews227", "ews228", "ews229", "ews230"]
     },
@@ -483,8 +483,8 @@
             "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
             "macOS-Sonoma-Debug-Build-EWS", "macOS-Ventura-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
-            "Services-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "visionOS-1-Build-EWS", "visionOS-1-Simulator-Build-EWS",
-            "watchOS-10-Build-EWS", "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
+            "Services-EWS", "Style-EWS", "tvOS-18-Build-EWS", "tvOS-18-Simulator-Build-EWS", "visionOS-2-Build-EWS", "visionOS-2-Simulator-Build-EWS",
+            "watchOS-11-Build-EWS", "watchOS-11-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
             "WPE-Cairo-Build-EWS"
       ]
     },
@@ -498,8 +498,8 @@
             "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
             "macOS-Sonoma-Debug-Build-EWS", "macOS-Ventura-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
-            "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "visionOS-1-Build-EWS", "visionOS-1-Simulator-Build-EWS",
-            "watchOS-10-Build-EWS", "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
+            "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-18-Build-EWS", "tvOS-18-Simulator-Build-EWS", "visionOS-2-Build-EWS", "visionOS-2-Simulator-Build-EWS",
+            "watchOS-11-Build-EWS", "watchOS-11-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
             "WPE-Cairo-Build-EWS"
       ]
     },
@@ -576,12 +576,12 @@
       "builderNames": ["GTK-WK2-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "visionos-1-sim-build-ews",
-      "builderNames": ["visionOS-1-Simulator-Build-EWS"]
+      "type": "Triggerable", "name": "visionos-2-sim-build-ews",
+      "builderNames": ["visionOS-2-Simulator-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "visionos-1-sim-wk2-tests-ews",
-      "builderNames": ["visionOS-1-Simulator-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "visionos-2-sim-wk2-tests-ews",
+      "builderNames": ["visionOS-2-Simulator-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "win-build-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -336,7 +336,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'visionOS-1-Build-EWS': [
+        'visionOS-2-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -351,7 +351,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'visionOS-1-Simulator-Build-EWS': [
+        'visionOS-2-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -366,7 +366,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'visionOS-1-Simulator-WK2-Tests-EWS': [
+        'visionOS-2-Simulator-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -389,7 +389,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'watchOS-10-Build-EWS': [
+        'watchOS-11-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -404,7 +404,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'watchOS-10-Simulator-Build-EWS': [
+        'watchOS-11-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -419,7 +419,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'tvOS-17-Build-EWS': [
+        'tvOS-18-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -434,7 +434,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'tvOS-17-Simulator-Build-EWS': [
+        'tvOS-18-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',


### PR DESCRIPTION
#### 8cc309779cb67784824a66d80a87820848b3a490
<pre>
Bring up tvOS 18, watchOS 11, and visionOS 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=281205">https://bugs.webkit.org/show_bug.cgi?id=281205</a>
<a href="https://rdar.apple.com/137659514">rdar://137659514</a>

Reviewed by Jonathan Bedard.

Tracking a bring up of tvOS 18, watchOS 11, and visionOS 2 to EWS

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/285515@main">https://commits.webkit.org/285515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db80399138fc4a92244a076c82333dfcc2673f9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72610 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/52035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76799 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23823 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/74725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/59840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/23644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76799 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23823 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/75677 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/59840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76799 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/59840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/59840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78469 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/23644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78469 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/72285 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78469 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16066 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Checked out pull request; Reviewed by Jonathan Bedard; Compiled WebKit (warnings); 15 flakes 1 failures") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11208 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/47833 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48900 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50195 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48645 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->