### PR TITLE
[Intelligence Effects] Document markers are not hidden during intelligence effect animations

### DIFF
--- a/LayoutTests/editing/spelling/transparent-content-marker-expected.html
+++ b/LayoutTests/editing/spelling/transparent-content-marker-expected.html
@@ -1,0 +1,38 @@
+<html>
+    <head>
+        <style>
+        .editing {
+            border: 2px solid red;
+            padding: 12px;
+            font-size: 24px;
+        }
+        </style>
+        <script src=../editing.js language="JavaScript" type="text/JavaScript" ></script>
+        <script>
+            function editingTest() {
+                document.getElementById("root").focus();
+                document.execCommand("InsertText", false, "I have a issue.");
+
+                internals.setMarkerFor("spelling", 2, 2, "AAAA");
+                internals.setMarkerFor("transparentcontent", 4, 8, "");
+
+                finishJSTest();
+            }
+        </script>
+        <title>Editing Test</title>
+    </head>
+    <body>
+        <div contenteditable id="root" class="editing"></div>
+        <script>
+            jsTestIsAsync = true;
+
+            if (window.internals) {
+                internals.settings.setUnifiedTextCheckerEnabled(true);
+                internals.settings.setAsynchronousSpellCheckingEnabled(true);
+            }
+
+            editingTest();
+        </script>
+
+    </body>
+</html>

--- a/LayoutTests/editing/spelling/transparent-content-marker.html
+++ b/LayoutTests/editing/spelling/transparent-content-marker.html
@@ -1,0 +1,38 @@
+<html>
+    <head>
+        <style>
+            .editing {
+                border: 2px solid red;
+                padding: 12px;
+                font-size: 24px;
+            }
+        </style>
+        <script src=../editing.js language="JavaScript" type="text/JavaScript" ></script>
+        <script>
+            function editingTest() {
+                document.getElementById("root").focus();
+                document.execCommand("InsertText", false, "I have a issue.");
+
+                internals.setMarkerFor("spelling", 2, 4, "AAAA");
+                internals.setMarkerFor("transparentcontent", 4, 8, "");
+
+                finishJSTest();
+            }
+        </script>
+        <title>Editing Test</title>
+    </head>
+    <body>
+        <div contenteditable id="root" class="editing"></div>
+        <script>
+            jsTestIsAsync = true;
+
+            if (window.internals) {
+                internals.settings.setUnifiedTextCheckerEnabled(true);
+                internals.settings.setAsynchronousSpellCheckingEnabled(true);
+            }
+
+            editingTest();
+        </script>
+
+    </body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4288,7 +4288,43 @@ bool Editor::selectionStartHasMarkerFor(DocumentMarker::Type markerType, int fro
     }
 
     return false;
-}       
+}
+
+void Editor::selectionStartSetMarkerForTesting(DocumentMarker::Type markerType, int from, int length, const String& data)
+{
+    RefPtr node = findFirstMarkable(document().selection().selection().start().protectedDeprecatedNode().get());
+    if (!node)
+        return;
+
+    RefPtr text = dynamicDowncast<Text>(node);
+    if (!text)
+        return;
+
+    CheckedRef markers = document().checkedMarkers();
+
+    unsigned unsignedFrom = static_cast<unsigned>(from);
+    unsigned unsignedLength = static_cast<unsigned>(length);
+
+    switch (markerType) {
+    case DocumentMarker::Type::TransparentContent:
+        markers->addMarker(*text, unsignedFrom, unsignedLength, markerType, DocumentMarker::TransparentContentData { node, WTF::UUID { 0 } });
+        return;
+
+    case DocumentMarker::Type::DraggedContent:
+        markers->addMarker(*text, unsignedFrom, unsignedLength, markerType, node);
+        return;
+
+    case DocumentMarker::Type::Grammar:
+    case DocumentMarker::Type::Spelling:
+    case DocumentMarker::Type::Replacement:
+        markers->addMarker(*text, unsignedFrom, unsignedLength, markerType, data);
+        return;
+
+    default:
+        // FIXME: Support more marker types in this testing utility function.
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
 
 OptionSet<TextCheckingType> Editor::resolveTextCheckingTypeMask(const Node& rootEditableElement, OptionSet<TextCheckingType> textCheckingOptions)
 {

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -518,6 +518,7 @@ public:
     WEBCORE_EXPORT void replaceSelectionWithFragment(DocumentFragment&, SelectReplacement, SmartReplace, MatchStyle, EditAction = EditAction::Insert, MailBlockquoteHandling = MailBlockquoteHandling::RespectBlockquote);
     WEBCORE_EXPORT void replaceSelectionWithText(const String&, SelectReplacement, SmartReplace, EditAction = EditAction::Insert);
     WEBCORE_EXPORT bool selectionStartHasMarkerFor(DocumentMarker::Type, int from, int length) const;
+    WEBCORE_EXPORT void selectionStartSetMarkerForTesting(DocumentMarker::Type, int from, int length, const String&);
     void updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionAtWordBoundary);
     void deletedAutocorrectionAtPosition(const Position&, const String& originalString);
     

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2798,6 +2798,22 @@ bool Internals::hasMarkerFor(DocumentMarker::Type type, int from, int length)
     return document->editor().selectionStartHasMarkerFor(type, from, length);
 }
 
+ExceptionOr<void> Internals::setMarkerFor(const String& markerTypeString, int from, int length, const String& data)
+{
+    DocumentMarker::Type markerType;
+    if (!markerTypeFrom(markerTypeString, markerType))
+        return Exception { ExceptionCode::SyntaxError };
+
+    Document* document = contextDocument();
+    if (!document || !document->frame())
+        return { };
+
+    updateEditorUINowIfScheduled();
+
+    document->editor().selectionStartSetMarkerForTesting(markerType, from, length, data);
+    return { };
+}
+
 bool Internals::hasSpellingMarker(int from, int length)
 {
     return hasMarkerFor(DocumentMarker::Type::Spelling, from, length);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -471,6 +471,8 @@ public:
 
     bool isSpellcheckDisabledExceptTextReplacement(const HTMLInputElement&) const;
 
+    ExceptionOr<void> setMarkerFor(const String& markerTypeString, int from, int length, const String&);
+
     void handleAcceptedCandidate(const String& candidate, unsigned location, unsigned length);
     void changeSelectionListType();
     void changeBackToReplacedString(const String& replacedString);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -685,7 +685,10 @@ enum RenderingMode {
     undefined setAutomaticTextReplacementEnabled(boolean enabled);
     undefined setAutomaticSpellingCorrectionEnabled(boolean enabled);
 
+    undefined setMarkerFor(DOMString markerTypeString, long from, long length, DOMString data);
+
     undefined handleAcceptedCandidate(DOMString candidate, unsigned long location, unsigned long length);
+
     undefined changeSelectionListType();
     undefined changeBackToReplacedString(DOMString replacedString);
 


### PR DESCRIPTION
#### 7d00282bd5ca61f15a047bc7fe67b6f6e6ab0032
<pre>
[Intelligence Effects] Document markers are not hidden during intelligence effect animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=281780">https://bugs.webkit.org/show_bug.cgi?id=281780</a>
<a href="https://rdar.apple.com/138209992">rdar://138209992</a>

Reviewed by Abrar Rahman Protyasha.

Currently, when intelligence effects are active (such as during a Writing Tools rewrite operation), transparent
content document markers are added to the affected range with the intention of hiding all content within that range.
However, they were only hiding the associated text, and were not hiding other document markers.

To fix, the transparent content markers are combined with the other markers such that the transparent content markers
take precedence during any overlapping ranges with other markers during the subdivision operation.

Also adds testing support infrastructure to facilitate adding markers from JavaScript.

* LayoutTests/editing/spelling/transparent-content-marker-expected.html: Added.
* LayoutTests/editing/spelling/transparent-content-marker.html: Added.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionStartHasMarkerFor const):
(WebCore::Editor::selectionStartSetMarkerFor):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarkers):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMarkerFor):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/285455@main">https://commits.webkit.org/285455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d365e1b0be679d3e255e2a55fc35bed9e0d278de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25529 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23764 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62595 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20061 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20420 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/17024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62603 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16048 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47953 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/49020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->