### PR TITLE
Implement Wasm tail calls in IPInt

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-call-indirect-arg.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-call-indirect-arg.js
@@ -1,0 +1,34 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $i2i (func (param i32) (result i32)))
+    (table $table (export "table") 1 funcref)
+    (elem (i32.const 0) $inc)
+    (func $inc (export "inc") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 1)
+        (i32.add)
+        (return)
+    )
+    (func (export "test") (param i32) (result i32)
+        (i32.const 1094795585)
+        (local.get 0)
+        (i32.const 0)
+        (call_indirect $table (type $i2i))
+        (i32.const 0)
+        (call_indirect $table (type $i2i))
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test } = instance.exports
+    assert.eq(test(2), 4)
+    assert.eq(test(3), 5)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-indirect-simple.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-indirect-simple.js
@@ -1,0 +1,42 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $sig (func (param i64) (param i64) (result i64)))
+    (table $table (export "table") 1 funcref)
+    (elem (i32.const 0) $fac_aux)
+    (func $fac (export "fac") (param $x i64) (result i64)
+      (return_call $fac_aux (local.get $x) (i64.const 1))
+    )
+
+    (func $fac_aux (param $x i64) (param $r i64) (result i64)
+      (if (result i64) (i64.eqz (local.get $x))
+        (then
+          (return (local.get $r))
+        )
+        (else
+          (i64.sub (local.get $x) (i64.const 1))
+          (i64.mul (local.get $x) (local.get $r))
+          (i32.const 0)
+          (return_call_indirect $table (type $sig))
+        )
+      )
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { fac } = instance.exports
+    assert.eq(fac(0n), 1n);
+    assert.eq(fac(1n), 1n);
+    assert.eq(fac(2n), 2n);
+    assert.eq(fac(3n), 6n);
+    assert.eq(fac(4n), 24n);
+    assert.eq(fac(5n), 120n);
+    assert.eq(fac(6n), 720n);
+    assert.eq(fac(7n), 5040n);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-simple.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-simple.js
@@ -1,0 +1,38 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $fac (export "fac") (param $x i64) (result i64)
+      (return_call $fac_aux (local.get $x) (i64.const 1))
+    )
+
+    (func $fac_aux (param $x i64) (param $r i64) (result i64)
+      (if (result i64) (i64.eqz (local.get $x))
+        (then
+          (return (local.get $r))
+        )
+        (else
+          (i64.sub (local.get $x) (i64.const 1))
+          (i64.mul (local.get $x) (local.get $r))
+          (return_call $fac_aux)
+        )
+      )
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { fac } = instance.exports
+    assert.eq(fac(0n), 1n);
+    assert.eq(fac(1n), 1n);
+    assert.eq(fac(2n), 2n);
+    assert.eq(fac(3n), 6n);
+    assert.eq(fac(4n), 24n);
+    assert.eq(fac(5n), 120n);
+    assert.eq(fac(6n), 720n);
+    assert.eq(fac(7n), 5040n);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-bigchange.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-bigchange.js
@@ -1,0 +1,93 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $test (export "test")
+        (param i32)
+        (result i32)
+    
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+    
+        (call $caller)
+
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+    )
+
+    (func $caller
+        (result i32)
+
+        (return_call $callee
+            (i32.const 21)
+            (i32.const 22)
+            (i32.const 23)
+            (i32.const 24)
+            (i32.const 25)
+            (i32.const 26)
+            (i32.const 27)
+            (i32.const 28)
+            (i32.const 29)
+            (i32.const 30)
+            (i32.const 31)
+            (i32.const 32)
+            (i32.const 33)
+            (i32.const 34)
+            (i32.const 35)
+            (i32.const 36)
+        )
+    )
+
+    (func $callee
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (i32.sub (local.get 15) (local.get 0))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { test } = instance.exports
+    assert.eq(test(), 93);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-less.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-less.js
@@ -1,0 +1,103 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $test (export "test")
+        (param i32)
+        (result i32)
+    
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+    
+        (call $caller
+            (i32.const 20)
+            (i32.const 21)
+            (i32.const 22)
+            (i32.const 23)
+            (i32.const 24)
+            (i32.const 25)
+            (i32.const 26)
+            (i32.const 27)
+            (i32.const 28)
+            (i32.const 29)
+            (i32.const 30)
+        )
+
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+    )
+
+    (func $caller
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (return_call $callee
+            (local.get 0)
+            (local.get 1)
+            (local.get 2)
+            (local.get 3)
+            (local.get 4)
+            (local.get 5)
+            (local.get 6)
+            (local.get 7)
+            (local.get 8)
+        )
+    )
+
+    (func $callee
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (i32.const 40)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { test } = instance.exports
+    assert.eq(test(), 118);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-more.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-more.js
@@ -1,0 +1,107 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $test (export "test")
+        (param i32)
+        (result i32)
+    
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+    
+        (call $caller
+            (i32.const 20)
+            (i32.const 21)
+            (i32.const 22)
+            (i32.const 23)
+            (i32.const 24)
+            (i32.const 25)
+            (i32.const 26)
+            (i32.const 27)
+            (i32.const 28)
+            (i32.const 29)
+        )
+
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+    )
+
+    (func $caller
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (return_call $callee
+            (i32.const 30)
+            (i32.const 31)
+            (i32.const 32)
+            (i32.const 33)
+            (i32.const 34)
+            (i32.const 35)
+            (i32.const 36)
+            (i32.const 37)
+            (i32.const 38)
+            (i32.const 39)
+            (i32.const 40)
+            (i32.const 41)
+        )
+    )
+
+    (func $callee
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (i32.const 50)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { test } = instance.exports
+    assert.eq(test(), 128);
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-same.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-same.js
@@ -1,0 +1,103 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $test (export "test")
+        (param i32)
+        (result i32)
+    
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+    
+        (call $caller
+            (i32.const 20)
+            (i32.const 21)
+            (i32.const 22)
+            (i32.const 23)
+            (i32.const 24)
+            (i32.const 25)
+            (i32.const 26)
+            (i32.const 27)
+            (i32.const 28)
+            (i32.const 29)
+        )
+
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+    )
+
+    (func $caller
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (return_call $callee
+            (local.get 0)
+            (local.get 1)
+            (local.get 2)
+            (local.get 3)
+            (local.get 4)
+            (local.get 5)
+            (local.get 6)
+            (local.get 7)
+            (local.get 8)
+            (local.get 9)
+        )
+    )
+
+    (func $callee
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+        (param i32)
+
+        (result i32)
+
+        (i32.const 30)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { tail_call: true });
+    const { test } = instance.exports
+    assert.eq(test(), 108);
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1518,6 +1518,7 @@ op :wasm_trampoline_wasm_tail_call
 op :wasm_trampoline_wasm_tail_call_indirect
 op :wasm_trampoline_wasm_tail_call_ref
 op :wasm_trampoline_wasm_ipint_call
+op :wasm_trampoline_wasm_ipint_tail_call
 
 end_section :NativeHelpers
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -56,8 +56,8 @@ extern "C" void ipint_catch_all_entry();
     m(0x0f, return) \
     m(0x10, call) \
     m(0x11, call_indirect) \
-    m(0x12, reserved_0x12) \
-    m(0x13, reserved_0x13) \
+    m(0x12, return_call) \
+    m(0x13, return_call_indirect) \
     m(0x14, reserved_0x14) \
     m(0x15, reserved_0x15) \
     m(0x16, reserved_0x16) \
@@ -698,8 +698,12 @@ extern "C" void ipint_catch_all_entry();
     m(0x0f, mint_fa7) \
     m(0x10, mint_stackzero) \
     m(0x11, mint_stackeight) \
-    m(0x12, mint_gap) \
-    m(0x13, mint_call) \
+    m(0x12, mint_tail_stackzero) \
+    m(0x13, mint_tail_stackeight) \
+    m(0x14, mint_gap) \
+    m(0x15, mint_tail_gap) \
+    m(0x16, mint_tail_call) \
+    m(0x17, mint_call) \
 
 #define FOR_EACH_IPINT_MINT_RETURN_OPCODE(m) \
     m(0x00, mint_r0) \

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -208,8 +208,8 @@ unimplementedInstruction(_br_table)
 unimplementedInstruction(_return)
 unimplementedInstruction(_call)
 unimplementedInstruction(_call_indirect)
-reservedOpcode(0x12)
-reservedOpcode(0x13)
+unimplementedInstruction(_return_call)
+unimplementedInstruction(_return_call_indirect)
 reservedOpcode(0x14)
 reservedOpcode(0x15)
 reservedOpcode(0x16)
@@ -1011,7 +1011,19 @@ mintAlign(_stackzero)
 mintAlign(_stackeight)
     break
 
+mintAlign(_tail_stackzero)
+    break
+
+mintAlign(_tail_stackeight)
+    break
+
 mintAlign(_gap)
+    break
+
+mintAlign(_tail_gap)
+    break
+
+mintAlign(_tail_call)
     break
 
 mintAlign(_call)
@@ -1201,4 +1213,9 @@ _wasm_trampoline_wasm_ipint_call_wide32:
 _wasm_ipint_call_return_location:
 _wasm_ipint_call_return_location_wide16:
 _wasm_ipint_call_return_location_wide32:
+    break
+
+_wasm_trampoline_wasm_ipint_tail_call:
+_wasm_trampoline_wasm_ipint_tail_call_wide16:
+_wasm_trampoline_wasm_ipint_tail_call_wide32:
     break

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -214,6 +214,14 @@ void initialize()
     {
         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
         if (Options::useJIT())
+            codeRef.construct(createWasmTailCallGate(WasmEntryPtrTag));
+        else
+            codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&wasmTailCallTrampoline))));
+        g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmIPIntTailCallWasmEntryPtrTag)]= codeRef.get().code().taggedPtr();
+    }
+    {
+        static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
+        if (Options::useJIT())
             codeRef.construct(exceptionHandlerGateThunk());
         else
             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&exceptionHandlerTrampoline))));

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2932,6 +2932,9 @@ _wasm_trampoline_wasm_tail_call_ref_wide32:
 _wasm_trampoline_wasm_ipint_call:
 _wasm_trampoline_wasm_ipint_call_wide16:
 _wasm_trampoline_wasm_ipint_call_wide32:
+_wasm_trampoline_wasm_ipint_tail_call:
+_wasm_trampoline_wasm_ipint_tail_call_wide16:
+_wasm_trampoline_wasm_ipint_tail_call_wide32:
 
 _wasm_ipint_call_return_location:
 _wasm_ipint_call_return_location_wide16:

--- a/Source/JavaScriptCore/runtime/Gate.h
+++ b/Source/JavaScriptCore/runtime/Gate.h
@@ -38,6 +38,7 @@ namespace JSC {
     v(entryOSREntry, NoPtrTag) \
     v(wasmOSREntry, NoPtrTag) \
     v(wasmTailCallWasmEntryPtrTag, NoPtrTag) \
+    v(wasmIPIntTailCallWasmEntryPtrTag, NoPtrTag) \
     v(exceptionHandler, NoPtrTag) \
     v(returnFromLLInt, NoPtrTag) \
     v(llint_function_for_call_arity_checkUntag, NoPtrTag) \

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -146,17 +146,17 @@ void FunctionIPIntMetadataGenerator::addReturnData(const FunctionSignature& sig)
 
         if (loc.isGPR()) {
             ASSERT_UNUSED(NUM_UINT_GPRS, loc.jsr().payloadGPR() < NUM_UINT_GPRS);
-            m_uINTBytecode.append(loc.jsr().payloadGPR());
+            m_uINTBytecode.append(static_cast<uint8_t>(IPInt::UIntBytecode::RetGPR) + loc.jsr().payloadGPR());
         } else if (loc.isFPR()) {
             ASSERT_UNUSED(NUM_UINT_FPRS, fprToIndex(loc.fpr()) < NUM_UINT_FPRS);
-            m_uINTBytecode.append(0x08 + fprToIndex(loc.fpr()));
+            m_uINTBytecode.append(static_cast<uint8_t>(IPInt::UIntBytecode::RetFPR) + fprToIndex(loc.fpr()));
         } else if (loc.isStack()) {
             m_highestReturnStackOffset = loc.offsetFromFP();
-            m_uINTBytecode.append(0x10);
+            m_uINTBytecode.append(static_cast<uint8_t>(IPInt::UIntBytecode::Stack));
         }
     }
     m_uINTBytecode.reverse();
-    m_uINTBytecode.append(0x11);
+    m_uINTBytecode.append(static_cast<uint8_t>(IPInt::UIntBytecode::End));
 }
 
 } }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -172,13 +172,26 @@ enum class CallArgumentBytecode : uint8_t { // (mINT)
     ArgumentFPR = 0x8, // 0x08 - 0x0f: push into fa0, fa1, ...
     ArgumentStackAligned = 0x10, // 0x10: pop stack value, push onto stack[0]
     ArgumentStackUnaligned = 0x11, // 0x11: pop stack value, add another 16B for params, push onto stack[8]
-    StackAlign = 0x12, // 0x12: add another 16B for params
-    End = 0x13 // 0x13: stop
+    TailArgumentStackAligned = 0x12, // 0x12: pop stack value, push onto stack[0]
+    TailArgumentStackUnaligned = 0x13, // 0x13: pop stack value, add another 16B for params, push onto stack[8]
+    StackAlign = 0x14, // 0x14: add another 16B for params
+    TailStackAlign = 0x15, // 0x15: add another 16B for params
+    TailCall = 0x16, // 0x16: tail call
+    Call = 0x17, // 0x17: regular call
+
+    NumOpcodes // this must be the last element of the enum!
 };
 
 struct CallMetadata {
     uint8_t length; // 1B for instruction length
     Wasm::FunctionSpaceIndex functionIndex; // 4B for decoded index
+    CallArgumentBytecode argumentBytecode[0];
+};
+
+struct TailCallMetadata {
+    uint8_t length; // 1B for instruction length
+    Wasm::FunctionSpaceIndex functionIndex; // 4B for decoded index
+    int32_t callerStackArgSize; // 4B for caller stack size
     CallArgumentBytecode argumentBytecode[0];
 };
 
@@ -189,19 +202,49 @@ struct CallIndirectMetadata {
     CallArgumentBytecode argumentBytecode[0];
 };
 
+struct TailCallIndirectMetadata {
+    uint8_t length; // 1B for instruction length
+    uint32_t tableIndex; // 4B for table index
+    uint32_t typeIndex; // 4B for type index
+    int32_t callerStackArgSize; // 4B for caller stack size
+    CallArgumentBytecode argumentBytecode[0];
+};
+
 // Metadata structure for returns:
 
 enum class CallResultBytecode : uint8_t { // (mINT)
     ResultGPR = 0x0, // 0x00 - 0x07: r0 - r7
     ResultFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
     ResultStack = 0x10, // 0x0c: stack
-    End = 0x11 // 0x0d: end
+    End = 0x11, // 0x0d: end
+
+    NumOpcodes // this must be the last element of the enum!
 };
 
-struct callReturnMetadata {
+struct CallReturnMetadata {
     uint16_t stackSlots; // 2B for number of arguments on stack (to clean up current call frame)
     uint16_t argumentCount; // 2B for number of arguments (to take off arguments)
     CallResultBytecode resultBytecode[0];
+};
+
+// argumINT / uINT
+
+enum class ArgumINTBytecode: uint8_t {
+    ArgGPR = 0x0, // 0x00 - 0x07: r0 - r7
+    RegFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
+    Stack = 0x10, // 0x0c: stack
+    End = 0x11, // 0x0d: end
+
+    NumOpcodes // this must be the last element of the enum!
+};
+
+enum class UIntBytecode: uint8_t {
+    RetGPR = 0x0, // 0x00 - 0x07: r0 - r7
+    RetFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
+    Stack = 0x10, // 0x0c: stack
+    End = 0x11, // 0x0d: end
+
+    NumOpcodes // this must be the last element of the enum!
 };
 
 #pragma pack()

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -525,12 +525,12 @@ static inline UGPRPair doWasmCall(JSWebAssemblyInstance* instance, Wasm::Functio
     WASM_CALL_RETURN(instance, codePtr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(call, unsigned functionIndex, EncodedJSValue* callee)
+WASM_IPINT_EXTERN_CPP_DECL(prepare_call, unsigned functionIndex, EncodedJSValue* callee)
 {
     return doWasmCall(instance, Wasm::FunctionSpaceIndex(functionIndex), callee);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call)
+WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call)
 {
     unsigned tableIndex = call->tableIndex;
     unsigned typeIndex = call->typeIndex;

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -77,9 +77,9 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, IPIntStackEntry* sp, TableCopyMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call);
 // We can't use FunctionSpaceIndex here since ARMv7 ABI always passes structs on th stack...
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned functionSpaceIndex, EncodedJSValue* callee);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call, unsigned functionSpaceIndex, EncodedJSValue* callee);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -20,7 +20,7 @@ if ARCH == 'arm64':
 
 IPINT_INSTRUCTIONS = [
     'unreachable', 'nop', 'block', 'loop', 'if', 'else', 'try', 'catch', 'throw', 'rethrow', 'end', 'br', 'br_if',
-    'br_table', 'return', 'call', 'call_indirect', 'delegate', 'catch_all', 'drop', 'select', 'select_t', 'local_get',
+    'br_table', 'return', 'call', 'call_indirect', 'return_call', 'delegate', 'catch_all', 'drop', 'select', 'select_t', 'local_get',
     'local_set', 'local_tee', 'global_get', 'global_set', 'table_get', 'table_set', 'i32_load_mem', 'i64_load_mem',
     'f32_load_mem', 'f64_load_mem', 'i32_load8s_mem', 'i32_load8u_mem', 'i32_load16s_mem', 'i32_load16u_mem',
     'i64_load8s_mem', 'i64_load8u_mem', 'i64_load16s_mem', 'i64_load16u_mem', 'i64_load32s_mem', 'i64_load32u_mem',


### PR DESCRIPTION
#### 34f187fe40afbd66733d33ebb514da0ae2a40177
<pre>
Implement Wasm tail calls in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=281785">https://bugs.webkit.org/show_bug.cgi?id=281785</a>
<a href="https://rdar.apple.com/138213801">rdar://138213801</a>

Reviewed by Keith Miller.

This patch implements `return_call` and `return_call_indirect` in IPInt, bringing
us closer to feature parity with LLInt.

* JSTests/wasm/ipint-tests/ipint-test-call-indirect-arg.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.i2i.func.param.i32.result.i32.table.table.export.string_appeared_here.1.funcref.elem.i32.const.0.inc.func.inc.export.string_appeared_here.param.i32.result.i32.local.0.i32.const.1.i32.add.return.func.export.string_appeared_here.param.i32.result.i32.i32.const.1094795585.local.0.i32.const.0.call_indirect.table.type.i2i.i32.const.0.call_indirect.table.type.i2i.return.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-indirect-simple.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.sig.func.param.i64.param.i64.result.i64.table.table.export.string_appeared_here.1.funcref.elem.i32.const.0.fac_aux.func.fac.export.string_appeared_here.param.x.i64.result.i64.return_call.fac_aux.local.x.i64.const.1.func.fac_aux.param.x.i64.param.r.i64.result.i64.result.i64.i64.eqz.local.x.then.return.local.r.else.i64.sub.local.x.i64.const.1.i64.mul.local.x.local.r.i32.const.0.return_call_indirect.table.type.sig.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-simple.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.fac.export.string_appeared_here.param.x.i64.result.i64.return_call.fac_aux.local.x.i64.const.1.func.fac_aux.param.x.i64.param.r.i64.result.i64.result.i64.i64.eqz.local.x.then.return.local.r.else.i64.sub.local.x.i64.const.1.i64.mul.local.x.local.r.return_call.fac_aux.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-bigchange.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.test.export.string_appeared_here.param.i32.result.i32.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.call.caller.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.func.caller.result.i32.return_call.callee.i32.const.21.i32.const.22.i32.const.23.i32.const.24.i32.const.25.i32.const.26.i32.const.27.i32.const.28.i32.const.29.i32.const.30.i32.const.31.i32.const.32.i32.const.33.i32.const.34.i32.const.35.i32.const.36.func.callee.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.i32.sub.local.15.local.0.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-less.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.test.export.string_appeared_here.param.i32.result.i32.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.call.caller.i32.const.20.i32.const.21.i32.const.22.i32.const.23.i32.const.24.i32.const.25.i32.const.26.i32.const.27.i32.const.28.i32.const.29.i32.const.30.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.func.caller.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.return_call.callee.local.0.local.1.local.2.local.3.local.4.local.5.local.6.local.7.local.8.func.callee.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.i32.const.40.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-more.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.test.export.string_appeared_here.param.i32.result.i32.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.call.caller.i32.const.20.i32.const.21.i32.const.22.i32.const.23.i32.const.24.i32.const.25.i32.const.26.i32.const.27.i32.const.28.i32.const.29.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.func.caller.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.return_call.callee.i32.const.30.i32.const.31.i32.const.32.i32.const.33.i32.const.34.i32.const.35.i32.const.36.i32.const.37.i32.const.38.i32.const.39.i32.const.40.i32.const.41.func.callee.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.i32.const.50.async test):
* JSTests/wasm/ipint-tests/ipint-test-tail-call-stack-params-same.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.test.export.string_appeared_here.param.i32.result.i32.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.call.caller.i32.const.20.i32.const.21.i32.const.22.i32.const.23.i32.const.24.i32.const.25.i32.const.26.i32.const.27.i32.const.28.i32.const.29.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.i32.add.func.caller.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.return_call.callee.local.0.local.1.local.2.local.3.local.4.local.5.local.6.local.7.local.8.local.9.func.callee.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.result.i32.i32.const.30.async test):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::initialize):
* Source/JavaScriptCore/runtime/Gate.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::IPIntGenerator):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Tools/lldb/debug_ipint.py:

Canonical link: <a href="https://commits.webkit.org/286874@main">https://commits.webkit.org/286874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bbafb5dd4194d86ec1e5c3cc48d55b9ea05e505

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18521 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26778 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70358 "Found 3 new JSC stress test failures: stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-inline-validate, stress/get-by-val-hoist-above-structure.js.mini-mode, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83160 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76451 "Found 2 new JSC stress test failures: stress/attribute-custom-accessor.js.dfg-eager, wasm.yaml/wasm/stress/referenced-function.js.wasm-collect-continuously (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4553 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3065 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66212 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68001 "Found 2 new API test failures: /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10075 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98704 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4500 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21593 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->