### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLegacyCDM

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
@@ -52,11 +52,11 @@ struct LegacyCDMFactory {
 
 static void platformRegisterFactories(Vector<LegacyCDMFactory>& factories)
 {
-    factories.append({ [](LegacyCDM* cdm) { return makeUnique<LegacyCDMPrivateClearKey>(cdm); }, LegacyCDMPrivateClearKey::supportsKeySystem, LegacyCDMPrivateClearKey::supportsKeySystemAndMimeType });
+    factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<LegacyCDMPrivateClearKey>(cdm); }, LegacyCDMPrivateClearKey::supportsKeySystem, LegacyCDMPrivateClearKey::supportsKeySystemAndMimeType });
     // FIXME: initialize specific UA CDMs. http://webkit.org/b/109318, http://webkit.org/b/109320
-    factories.append({ [](LegacyCDM* cdm) { return makeUnique<CDMPrivateMediaPlayer>(cdm); }, CDMPrivateMediaPlayer::supportsKeySystem, CDMPrivateMediaPlayer::supportsKeySystemAndMimeType });
+    factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<CDMPrivateMediaPlayer>(cdm); }, CDMPrivateMediaPlayer::supportsKeySystem, CDMPrivateMediaPlayer::supportsKeySystemAndMimeType });
 #if HAVE(AVCONTENTKEYSESSION) && ENABLE(MEDIA_SOURCE)
-    factories.append({ [](LegacyCDM* cdm) { return makeUnique<CDMPrivateMediaSourceAVFObjC>(cdm); }, CDMPrivateMediaSourceAVFObjC::supportsKeySystem, CDMPrivateMediaSourceAVFObjC::supportsKeySystemAndMimeType });
+    factories.append({ [](LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<CDMPrivateMediaSourceAVFObjC>(cdm); }, CDMPrivateMediaSourceAVFObjC::supportsKeySystem, CDMPrivateMediaSourceAVFObjC::supportsKeySystemAndMimeType });
 #endif
 }
 
@@ -109,31 +109,35 @@ bool LegacyCDM::keySystemSupportsMimeType(const String& keySystem, const String&
     return false;
 }
 
-std::unique_ptr<LegacyCDM> LegacyCDM::create(const String& keySystem)
+RefPtr<LegacyCDM> LegacyCDM::create(const String& keySystem)
 {
     if (!supportsKeySystem(keySystem))
         return nullptr;
 
-    return makeUnique<LegacyCDM>(keySystem);
+    return adoptRef(*new LegacyCDM(keySystem));
 }
 
 LegacyCDM::LegacyCDM(const String& keySystem)
     : m_keySystem(keySystem)
-    , m_client(nullptr)
+    , m_private(CDMFactoryForKeySystem(keySystem)->constructor(*this))
 {
-    m_private = CDMFactoryForKeySystem(keySystem)->constructor(this);
 }
 
 LegacyCDM::~LegacyCDM() = default;
 
 bool LegacyCDM::supportsMIMEType(const String& mimeType) const
 {
-    return m_private->supportsMIMEType(mimeType);
+    return protectedCDMPrivate()->supportsMIMEType(mimeType);
+}
+
+RefPtr<CDMPrivateInterface> LegacyCDM::protectedCDMPrivate() const
+{
+    return cdmPrivate();
 }
 
 std::unique_ptr<LegacyCDMSession> LegacyCDM::createSession(LegacyCDMSessionClient& client)
 {
-    auto session = m_private->createSession(client);
+    auto session = protectedCDMPrivate()->createSession(client);
     if (mediaPlayer())
         mediaPlayer()->setCDMSession(session.get());
     return session;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
@@ -28,8 +28,10 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include "LegacyCDMSession.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,26 +41,26 @@ class LegacyCDM;
 class CDMPrivateInterface;
 class MediaPlayer;
 
-using CreateCDM = Function<std::unique_ptr<CDMPrivateInterface>(LegacyCDM*)>;
+using CreateCDM = Function<std::unique_ptr<CDMPrivateInterface>(LegacyCDM&)>;
 using CDMSupportsKeySystem = Function<bool(const String&)>;
 using CDMSupportsKeySystemAndMimeType = Function<bool(const String&, const String&)>;
 
-class LegacyCDMClient {
+class LegacyCDMClient : public CanMakeCheckedPtr<LegacyCDMClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyCDMClient);
 public:
     virtual ~LegacyCDMClient() = default;
 
     virtual RefPtr<MediaPlayer> cdmMediaPlayer(const LegacyCDM*) const = 0;
 };
 
-class WEBCORE_EXPORT LegacyCDM final {
+class WEBCORE_EXPORT LegacyCDM final : public RefCountedAndCanMakeWeakPtr<LegacyCDM> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(LegacyCDM, WEBCORE_EXPORT);
 public:
-    explicit LegacyCDM(const String& keySystem);
-
     enum CDMErrorCode { NoError, UnknownError, ClientError, ServiceError, OutputError, HardwareChangeError, DomainError };
     static bool supportsKeySystem(const String&);
     static bool keySystemSupportsMimeType(const String& keySystem, const String& mimeType);
-    static std::unique_ptr<LegacyCDM> create(const String& keySystem);
+    static RefPtr<LegacyCDM> create(const String& keySystem);
     static void registerCDMFactory(CreateCDM&&, CDMSupportsKeySystem&&, CDMSupportsKeySystemAndMimeType&&);
     ~LegacyCDM();
 
@@ -70,16 +72,19 @@ public:
 
     const String& keySystem() const { return m_keySystem; }
 
-    LegacyCDMClient* client() const { return m_client; }
+    LegacyCDMClient* client() const { return m_client.get(); }
     void setClient(LegacyCDMClient* client) { m_client = client; }
 
     RefPtr<MediaPlayer> mediaPlayer() const;
     CDMPrivateInterface* cdmPrivate() const { return m_private.get(); }
+    RefPtr<CDMPrivateInterface> protectedCDMPrivate() const;
 
 private:
+    explicit LegacyCDM(const String& keySystem);
+
     String m_keySystem;
+    CheckedPtr<LegacyCDMClient> m_client;
     std::unique_ptr<CDMPrivateInterface> m_private;
-    LegacyCDMClient* m_client;
 };
 
 }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
@@ -35,13 +36,13 @@ namespace WebCore {
 class LegacyCDMSession;
 class LegacyCDMSessionClient;
 
-class CDMPrivateInterface {
+class CDMPrivateInterface : public AbstractRefCounted {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(CDMPrivateInterface);
 public:
     CDMPrivateInterface() = default;
     virtual ~CDMPrivateInterface() = default;
 
-    virtual bool supportsMIMEType(const String&) = 0;
+    virtual bool supportsMIMEType(const String&) const = 0;
 
     virtual std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) = 0;
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp
@@ -57,7 +57,7 @@ bool LegacyCDMPrivateClearKey::supportsKeySystemAndMimeType(const String& keySys
     return MediaPlayer::supportsKeySystem(keySystem, mimeType);
 }
 
-bool LegacyCDMPrivateClearKey::supportsMIMEType(const String& mimeType)
+bool LegacyCDMPrivateClearKey::supportsMIMEType(const String& mimeType) const
 {
     return MediaPlayer::supportsKeySystem(m_cdm->keySystem(), mimeType);
 }
@@ -65,6 +65,16 @@ bool LegacyCDMPrivateClearKey::supportsMIMEType(const String& mimeType)
 std::unique_ptr<LegacyCDMSession> LegacyCDMPrivateClearKey::createSession(LegacyCDMSessionClient& client)
 {
     return makeUnique<CDMSessionClearKey>(client);
+}
+
+void LegacyCDMPrivateClearKey::ref() const
+{
+    m_cdm->ref();
+}
+
+void LegacyCDMPrivateClearKey::deref() const
+{
+    m_cdm->deref();
 }
 
 }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h
@@ -29,29 +29,32 @@
 
 #include "LegacyCDMPrivate.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
 class LegacyCDM;
 
-class LegacyCDMPrivateClearKey : public CDMPrivateInterface {
+class LegacyCDMPrivateClearKey final : public CDMPrivateInterface {
     WTF_MAKE_TZONE_ALLOCATED(LegacyCDMPrivateClearKey);
 public:
-    explicit LegacyCDMPrivateClearKey(LegacyCDM* cdm)
+    explicit LegacyCDMPrivateClearKey(LegacyCDM& cdm)
         : m_cdm(cdm)
     {
     }
-
     virtual ~LegacyCDMPrivateClearKey() = default;
 
     static bool supportsKeySystem(const String&);
     static bool supportsKeySystemAndMimeType(const String& keySystem, const String& mimeType);
 
-    bool supportsMIMEType(const String& mimeType) override;
+    bool supportsMIMEType(const String& mimeType) const override;
     std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
-protected:
-    LegacyCDM* m_cdm;
+    void ref() const final;
+    void deref() const final;
+
+private:
+    WeakRef<LegacyCDM> m_cdm;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp
@@ -52,18 +52,29 @@ bool CDMPrivateMediaPlayer::supportsKeySystemAndMimeType(const String& keySystem
     return MediaPlayer::supportsKeySystem(keySystem, mimeType);
 }
 
-bool CDMPrivateMediaPlayer::supportsMIMEType(const String& mimeType)
+bool CDMPrivateMediaPlayer::supportsMIMEType(const String& mimeType) const
 {
     return MediaPlayer::supportsKeySystem(m_cdm->keySystem(), mimeType);
 }
 
 std::unique_ptr<LegacyCDMSession> CDMPrivateMediaPlayer::createSession(LegacyCDMSessionClient& client)
 {
-    auto mediaPlayer = m_cdm->mediaPlayer();
+    Ref cdm = m_cdm.get();
+    auto mediaPlayer = cdm->mediaPlayer();
     if (!mediaPlayer)
         return nullptr;
 
-    return mediaPlayer->createSession(m_cdm->keySystem(), client);
+    return mediaPlayer->createSession(cdm->keySystem(), client);
+}
+
+void CDMPrivateMediaPlayer::ref() const
+{
+    m_cdm->ref();
+}
+
+void CDMPrivateMediaPlayer::deref() const
+{
+    m_cdm->deref();
 }
 
 }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h
@@ -30,15 +30,16 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
 class LegacyCDM;
 
-class CDMPrivateMediaPlayer : public CDMPrivateInterface {
+class CDMPrivateMediaPlayer final : public CDMPrivateInterface {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateMediaPlayer);
 public:
-    explicit CDMPrivateMediaPlayer(LegacyCDM* cdm)
+    explicit CDMPrivateMediaPlayer(LegacyCDM& cdm)
         : m_cdm(cdm)
     { }
 
@@ -47,13 +48,16 @@ public:
 
     virtual ~CDMPrivateMediaPlayer() = default;
 
-    bool supportsMIMEType(const String& mimeType) override;
+    bool supportsMIMEType(const String& mimeType) const override;
     std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
-    LegacyCDM* cdm() const { return m_cdm; }
+    LegacyCDM& cdm() const { return m_cdm; }
 
-protected:
-    LegacyCDM* m_cdm;
+    void ref() const final;
+    void deref() const final;
+
+private:
+    WeakRef<LegacyCDM> m_cdm;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
@@ -41,6 +41,8 @@ class HTMLMediaElement;
 class WebKitMediaKeySession;
 
 class WebKitMediaKeys final : public RefCounted<WebKitMediaKeys>, private LegacyCDMClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebKitMediaKeys);
 public:
     static ExceptionOr<Ref<WebKitMediaKeys>> create(const String& keySystem);
     virtual ~WebKitMediaKeys();
@@ -49,7 +51,7 @@ public:
     static bool isTypeSupported(const String& keySystem, const String& mimeType);
     const String& keySystem() const { return m_keySystem; }
 
-    LegacyCDM& cdm() { ASSERT(m_cdm); return *m_cdm; }
+    LegacyCDM& cdm() { return m_cdm; }
 
     void setMediaElement(HTMLMediaElement*);
 
@@ -59,12 +61,12 @@ public:
 private:
     RefPtr<MediaPlayer> cdmMediaPlayer(const LegacyCDM*) const final;
 
-    WebKitMediaKeys(const String& keySystem, std::unique_ptr<LegacyCDM>&&);
+    WebKitMediaKeys(const String& keySystem, Ref<LegacyCDM>&&);
 
     Vector<Ref<WebKitMediaKeySession>> m_sessions;
     WeakPtr<HTMLMediaElement> m_mediaElement;
     String m_keySystem;
-    std::unique_ptr<LegacyCDM> m_cdm;
+    Ref<LegacyCDM> m_cdm;
 };
 
 }

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,7 +1,6 @@
 CommandLineAPIModuleSourceBuiltins.h
 Modules/WebGPU/GPUPresentationContextDescriptor.h
 Modules/encryptedmedia/MediaKeyStatusMap.h
-Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
 Modules/fetch/FetchBodyOwner.h
 Modules/mediasource/SourceBuffer.h
 Modules/mediastream/RTCPeerConnection.h

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
@@ -31,16 +31,17 @@
 #include "LegacyCDMPrivate.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class LegacyCDM;
 class CDMSessionMediaSourceAVFObjC;
 
-class CDMPrivateMediaSourceAVFObjC : public CDMPrivateInterface {
+class CDMPrivateMediaSourceAVFObjC final : public CDMPrivateInterface, public CanMakeWeakPtr<CDMPrivateMediaSourceAVFObjC> {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateMediaSourceAVFObjC);
 public:
-    explicit CDMPrivateMediaSourceAVFObjC(LegacyCDM* cdm)
+    explicit CDMPrivateMediaSourceAVFObjC(LegacyCDM& cdm)
         : m_cdm(cdm)
     { }
     virtual ~CDMPrivateMediaSourceAVFObjC();
@@ -48,20 +49,24 @@ public:
     static bool supportsKeySystem(const String&);
     static bool supportsKeySystemAndMimeType(const String& keySystem, const String& mimeType);
 
-    bool supportsMIMEType(const String& mimeType) override;
+    bool supportsMIMEType(const String& mimeType) const override;
     std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
-    LegacyCDM* cdm() const { return m_cdm; }
+    LegacyCDM& cdm() const { return m_cdm.get(); }
 
     void invalidateSession(CDMSessionMediaSourceAVFObjC*);
-protected:
+
+    void ref() const final;
+    void deref() const final;
+
+private:
     struct KeySystemParameters {
         int version;
         Vector<int> protocols;
     };
     static std::optional<KeySystemParameters> parseKeySystem(const String& keySystem);
     
-    LegacyCDM* m_cdm;
+    WeakRef<LegacyCDM> m_cdm;
     Vector<CDMSessionMediaSourceAVFObjC*> m_sessions;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
@@ -112,7 +112,7 @@ bool CDMPrivateMediaSourceAVFObjC::supportsKeySystemAndMimeType(const String& ke
     return MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs(parameters) != MediaPlayer::SupportsType::IsNotSupported;
 }
 
-bool CDMPrivateMediaSourceAVFObjC::supportsMIMEType(const String& mimeType)
+bool CDMPrivateMediaSourceAVFObjC::supportsMIMEType(const String& mimeType) const
 {
     // FIXME: Why is this checking case since the check in supportsKeySystemAndMimeType is ignoring case?
     if (mimeType == "keyrelease"_s)
@@ -143,6 +143,16 @@ void CDMPrivateMediaSourceAVFObjC::invalidateSession(CDMSessionMediaSourceAVFObj
 {
     ASSERT(m_sessions.contains(session));
     m_sessions.removeAll(session);
+}
+
+void CDMPrivateMediaSourceAVFObjC::ref() const
+{
+    m_cdm->ref();
+}
+
+void CDMPrivateMediaSourceAVFObjC::deref() const
+{
+    m_cdm->deref();
 }
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
@@ -87,7 +87,7 @@ protected:
     WTFLogChannel& logChannel() const;
 #endif
 
-    CDMPrivateMediaSourceAVFObjC* m_cdm;
+    WeakPtr<CDMPrivateMediaSourceAVFObjC> m_cdm;
     WeakPtr<LegacyCDMSessionClient> m_client;
     Vector<RefPtr<SourceBufferPrivateAVFObjC>> m_sourceBuffers;
     RefPtr<Uint8Array> m_certificate;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMSessionMediaSourceAVFObjC);
 
 CDMSessionMediaSourceAVFObjC::CDMSessionMediaSourceAVFObjC(CDMPrivateMediaSourceAVFObjC& cdm, LegacyCDMSessionClient& client)
-    : m_cdm(&cdm)
+    : m_cdm(cdm)
     , m_client(client)
 #if !RELEASE_LOG_DISABLED
     , m_logger(client.logger())
@@ -51,8 +51,8 @@ CDMSessionMediaSourceAVFObjC::CDMSessionMediaSourceAVFObjC(CDMPrivateMediaSource
 
 CDMSessionMediaSourceAVFObjC::~CDMSessionMediaSourceAVFObjC()
 {
-    if (m_cdm)
-        m_cdm->invalidateSession(this);
+    if (RefPtr cdm = m_cdm.get())
+        cdm->invalidateSession(this);
 
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->unregisterForErrorNotifications(this);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4353,7 +4353,7 @@ void Internals::enableSizeToContentAutoSizeMode(bool enabled, int width, int hei
 
 void Internals::initializeMockCDM()
 {
-    LegacyCDM::registerCDMFactory([] (LegacyCDM* cdm) { return makeUnique<LegacyMockCDM>(cdm); },
+    LegacyCDM::registerCDMFactory([] (LegacyCDM& cdm) { return makeUniqueWithoutRefCountedCheck<LegacyMockCDM>(cdm); },
         LegacyMockCDM::supportsKeySystem, LegacyMockCDM::supportsKeySystemAndMimeType);
 }
 

--- a/Source/WebCore/testing/LegacyMockCDM.cpp
+++ b/Source/WebCore/testing/LegacyMockCDM.cpp
@@ -70,7 +70,7 @@ bool LegacyMockCDM::supportsKeySystemAndMimeType(const String& keySystem, const 
     return equalLettersIgnoringASCIICase(mimeType, "video/mock"_s);
 }
 
-bool LegacyMockCDM::supportsMIMEType(const String& mimeType)
+bool LegacyMockCDM::supportsMIMEType(const String& mimeType) const
 {
     return equalLettersIgnoringASCIICase(mimeType, "video/mock"_s);
 }
@@ -78,6 +78,16 @@ bool LegacyMockCDM::supportsMIMEType(const String& mimeType)
 std::unique_ptr<LegacyCDMSession> LegacyMockCDM::createSession(LegacyCDMSessionClient& client)
 {
     return makeUnique<MockCDMSession>(client);
+}
+
+void LegacyMockCDM::ref() const
+{
+    m_cdm->ref();
+}
+
+void LegacyMockCDM::deref() const
+{
+    m_cdm->deref();
 }
 
 static Uint8Array* initDataPrefix()

--- a/Source/WebCore/testing/LegacyMockCDM.h
+++ b/Source/WebCore/testing/LegacyMockCDM.h
@@ -29,15 +29,16 @@
 
 #include "LegacyCDMPrivate.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
 class LegacyCDM;
 
-class LegacyMockCDM : public CDMPrivateInterface {
+class LegacyMockCDM final : public CDMPrivateInterface {
     WTF_MAKE_TZONE_ALLOCATED(LegacyMockCDM);
 public:
-    explicit LegacyMockCDM(LegacyCDM* cdm)
+    explicit LegacyMockCDM(LegacyCDM& cdm)
         : m_cdm(cdm)
     { }
 
@@ -47,11 +48,14 @@ public:
 
     virtual ~LegacyMockCDM() = default;
 
-    bool supportsMIMEType(const String& mimeType) override;
+    bool supportsMIMEType(const String& mimeType) const override;
     std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
-protected:
-    LegacyCDM* m_cdm;
+    void ref() const final;
+    void deref() const final;
+
+private:
+    WeakRef<LegacyCDM> m_cdm;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -72,13 +72,13 @@ void RemoteLegacyCDMFactoryProxy::clear()
 
 void RemoteLegacyCDMFactoryProxy::createCDM(const String& keySystem, std::optional<MediaPlayerIdentifier>&& playerId, CompletionHandler<void(std::optional<RemoteLegacyCDMIdentifier>&&)>&& completion)
 {
-    auto privateCDM = LegacyCDM::create(keySystem);
+    RefPtr privateCDM = LegacyCDM::create(keySystem);
     if (!privateCDM) {
         completion(std::nullopt);
         return;
     }
 
-    auto proxy = RemoteLegacyCDMProxy::create(*this, playerId, WTFMove(privateCDM));
+    auto proxy = RemoteLegacyCDMProxy::create(*this, playerId, privateCDM.releaseNonNull());
     auto identifier = RemoteLegacyCDMIdentifier::generate();
     addProxy(identifier, WTFMove(proxy));
     completion(WTFMove(identifier));

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -41,8 +41,10 @@ namespace WebKit {
 class RemoteLegacyCDMProxy
     : public IPC::MessageReceiver
     , public WebCore::LegacyCDMClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLegacyCDMProxy);
 public:
-    static std::unique_ptr<RemoteLegacyCDMProxy> create(WeakPtr<RemoteLegacyCDMFactoryProxy>, std::optional<WebCore::MediaPlayerIdentifier>, std::unique_ptr<WebCore::LegacyCDM>&&);
+    static std::unique_ptr<RemoteLegacyCDMProxy> create(WeakPtr<RemoteLegacyCDMFactoryProxy>, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
     ~RemoteLegacyCDMProxy();
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
@@ -50,7 +52,7 @@ public:
 
 private:
     friend class RemoteLegacyCDMFactoryProxy;
-    RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&&, std::optional<WebCore::MediaPlayerIdentifier>, std::unique_ptr<WebCore::LegacyCDM>&&);
+    RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&&, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
 
     RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
 
@@ -68,9 +70,11 @@ private:
     // LegacyCDMClient
     RefPtr<WebCore::MediaPlayer> cdmMediaPlayer(const WebCore::LegacyCDM*) const final;
 
+    Ref<WebCore::LegacyCDM> protectedCDM() const { return m_cdm; }
+
     WeakPtr<RemoteLegacyCDMFactoryProxy> m_factory;
     Markable<WebCore::MediaPlayerIdentifier> m_playerId;
-    std::unique_ptr<WebCore::LegacyCDM> m_cdm;
+    Ref<WebCore::LegacyCDM> m_cdm;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1420,11 +1420,8 @@ void MediaPlayerPrivateRemote::setCDM(LegacyCDM* cdm)
     if (!cdm)
         return;
 
-    auto remoteCDM = WebProcess::singleton().protectedLegacyCDMFactory()->findCDM(cdm->cdmPrivate());
-    if (!remoteCDM)
-        return;
-
-    remoteCDM->setPlayerId(m_id);
+    if (RefPtr remoteCDM = WebProcess::singleton().protectedLegacyCDMFactory()->findCDM(cdm->cdmPrivate()))
+        remoteCDM->setPlayerId(m_id);
 }
 
 void MediaPlayerPrivateRemote::setCDMSession(LegacyCDMSession* session)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
@@ -32,15 +32,6 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class RemoteLegacyCDM;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLegacyCDM> : std::true_type { };
-}
-
 namespace WebCore {
 class Settings;
 }
@@ -54,18 +45,22 @@ class RemoteLegacyCDMSession;
 class RemoteLegacyCDM final
     : public WebCore::CDMPrivateInterface
     , public CanMakeWeakPtr<RemoteLegacyCDM> {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLegacyCDM);
 public:
-    static std::unique_ptr<RemoteLegacyCDM> create(WeakPtr<RemoteLegacyCDMFactory>&&, RemoteLegacyCDMIdentifier);
+    RemoteLegacyCDM(RemoteLegacyCDMFactory&, RemoteLegacyCDMIdentifier);
     virtual ~RemoteLegacyCDM();
 
-    bool supportsMIMEType(const String&) final;
+    bool supportsMIMEType(const String&) const final;
     std::unique_ptr<WebCore::LegacyCDMSession> createSession(WebCore::LegacyCDMSessionClient&) final;
     void setPlayerId(std::optional<WebCore::MediaPlayerIdentifier>);
 
-private:
-    RemoteLegacyCDM(WeakPtr<RemoteLegacyCDMFactory>&&, RemoteLegacyCDMIdentifier&&);
+    void ref() const final;
+    void deref() const final;
 
-    WeakPtr<RemoteLegacyCDMFactory> m_factory;
+private:
+    Ref<RemoteLegacyCDMFactory> protectedFactory() const;
+
+    WeakRef<RemoteLegacyCDMFactory> m_factory;
     RemoteLegacyCDMIdentifier m_identifier;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -51,20 +51,28 @@ RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess& webProcess)
 
 RemoteLegacyCDMFactory::~RemoteLegacyCDMFactory() = default;
 
+void RemoteLegacyCDMFactory::ref() const
+{
+    m_webProcess->ref();
+}
+
+void RemoteLegacyCDMFactory::deref() const
+{
+    m_webProcess->deref();
+}
+
 void RemoteLegacyCDMFactory::registerFactory()
 {
     LegacyCDM::clearFactories();
     LegacyCDM::registerCDMFactory(
-        [weakThis = WeakPtr { *this }] (LegacyCDM* privateCDM) -> std::unique_ptr<WebCore::CDMPrivateInterface> {
-            if (weakThis)
-                return weakThis->createCDM(privateCDM);
-            return nullptr;
+        [protectedThis = Ref { *this }] (LegacyCDM& privateCDM) -> std::unique_ptr<WebCore::CDMPrivateInterface> {
+            return protectedThis->createCDM(privateCDM);
         },
-        [weakThis = WeakPtr { *this }] (const String& keySystem) {
-            return weakThis ? weakThis->supportsKeySystem(keySystem) : false;
+        [protectedThis = Ref { *this }] (const String& keySystem) {
+            return protectedThis->supportsKeySystem(keySystem);
         },
-        [weakThis = WeakPtr { *this }] (const String& keySystem, const String& mimeType) {
-            return weakThis ? weakThis->supportsKeySystemAndMimeType(keySystem, mimeType) : false;
+        [protectedThis = Ref { *this }] (const String& keySystem, const String& mimeType) {
+            return protectedThis->supportsKeySystemAndMimeType(keySystem, mimeType);
         }
     );
 }
@@ -104,24 +112,19 @@ bool RemoteLegacyCDMFactory::supportsKeySystemAndMimeType(const String& keySyste
     return supported;
 }
 
-std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::LegacyCDM* cdm)
+std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::LegacyCDM& cdm)
 {
-    if (!cdm) {
-        ASSERT_NOT_REACHED();
-        return nullptr;
-    }
-
     std::optional<MediaPlayerIdentifier> playerId;
-    if (auto player = cdm->mediaPlayer())
+    if (auto player = cdm.mediaPlayer())
         playerId = gpuProcessConnection().mediaPlayerManager().findRemotePlayerId(player->playerPrivate());
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm->keySystem(), WTFMove(playerId)), { });
+    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm.keySystem(), WTFMove(playerId)), { });
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    auto remoteCDM = RemoteLegacyCDM::create(*this, *identifier);
+    auto remoteCDM = makeUniqueRef<RemoteLegacyCDM>(*this, *identifier);
     m_cdms.set(*identifier, remoteCDM.get());
-    return remoteCDM;
+    return remoteCDM.moveToUniquePtr();
 }
 
 void RemoteLegacyCDMFactory::addSession(RemoteLegacyCDMSessionIdentifier identifier, RemoteLegacyCDMSession& session)
@@ -144,16 +147,6 @@ RemoteLegacyCDM* RemoteLegacyCDMFactory::findCDM(CDMPrivateInterface* privateInt
             return cdm.get();
     }
     return nullptr;
-}
-
-void RemoteLegacyCDMFactory::ref() const
-{
-    m_webProcess->ref();
-}
-
-void RemoteLegacyCDMFactory::deref() const
-{
-    m_webProcess->ref();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -82,7 +82,7 @@ public:
 private:
     bool supportsKeySystem(const String&);
     bool supportsKeySystemAndMimeType(const String&, const String&);
-    std::unique_ptr<WebCore::CDMPrivateInterface> createCDM(WebCore::LegacyCDM*);
+    std::unique_ptr<WebCore::CDMPrivateInterface> createCDM(WebCore::LegacyCDM&);
 
     WeakRef<WebProcess> m_webProcess;
     UncheckedKeyHashMap<RemoteLegacyCDMSessionIdentifier, WeakPtr<RemoteLegacyCDMSession>> m_sessions;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -65,15 +65,15 @@ static RefPtr<SharedBuffer> convertToSharedBuffer(T array)
     return SharedBuffer::create(array->span());
 }
 
-std::unique_ptr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(WeakPtr<RemoteLegacyCDMFactory> factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
+std::unique_ptr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(RemoteLegacyCDMFactory& factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
 {
-    auto session = std::unique_ptr<RemoteLegacyCDMSession>(new RemoteLegacyCDMSession(WTFMove(factory), WTFMove(identifier), client));
+    auto session = std::unique_ptr<RemoteLegacyCDMSession>(new RemoteLegacyCDMSession(factory, WTFMove(identifier), client));
     if (session->m_factory)
         session->m_factory->addSession(identifier, *session);
     return session;
 }
 
-RemoteLegacyCDMSession::RemoteLegacyCDMSession(WeakPtr<RemoteLegacyCDMFactory> factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
+RemoteLegacyCDMSession::RemoteLegacyCDMSession(RemoteLegacyCDMFactory& factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
     : m_factory(WTFMove(factory))
     , m_identifier(WTFMove(identifier))
     , m_client(client)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
@@ -53,7 +53,7 @@ class RemoteLegacyCDMSession final
     : public WebCore::LegacyCDMSession
     , public IPC::MessageReceiver {
 public:
-    static std::unique_ptr<RemoteLegacyCDMSession> create(WeakPtr<RemoteLegacyCDMFactory>, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
+    static std::unique_ptr<RemoteLegacyCDMSession> create(RemoteLegacyCDMFactory&, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
     ~RemoteLegacyCDMSession();
 
     // MessageReceiver
@@ -62,7 +62,7 @@ public:
     const RemoteLegacyCDMSessionIdentifier& identifier() const { return m_identifier; }
 
 private:
-    RemoteLegacyCDMSession(WeakPtr<RemoteLegacyCDMFactory>, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
+    RemoteLegacyCDMSession(RemoteLegacyCDMFactory&, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
 
     // LegacyCDMSession
     WebCore::LegacyCDMSessionType type() final { return WebCore::CDMSessionTypeRemote; }


### PR DESCRIPTION
#### ee6907b1f48ccc9474e4006cb9955e625e4169dd
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLegacyCDM
<a href="https://bugs.webkit.org/show_bug.cgi?id=281791">https://bugs.webkit.org/show_bug.cgi?id=281791</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp:
(WebCore::platformRegisterFactories):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp:
(WebCore::LegacyCDMPrivateClearKey::create):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h:
(WebCore::LegacyCDMPrivateClearKey::LegacyCDMPrivateClearKey): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp:
(WebCore::CDMPrivateMediaPlayer::create):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h:
(WebCore::CDMPrivateMediaPlayer::CDMPrivateMediaPlayer): Deleted.
(WebCore::CDMPrivateMediaPlayer::cdm const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h:
(WebCore::CDMPrivateMediaSourceAVFObjC::CDMPrivateMediaSourceAVFObjC): Deleted.
(WebCore::CDMPrivateMediaSourceAVFObjC::cdm const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm:
(WebCore::CDMPrivateMediaSourceAVFObjC::create):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::initializeMockCDM):
* Source/WebCore/testing/LegacyMockCDM.cpp:
(WebCore::LegacyMockCDM::create):
* Source/WebCore/testing/LegacyMockCDM.h:
(WebCore::LegacyMockCDM::LegacyMockCDM): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::create):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::registerFactory):
(WebKit::RemoteLegacyCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:

Canonical link: <a href="https://commits.webkit.org/285488@main">https://commits.webkit.org/285488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4eb35f9e58d0a1eae0c2ac4936930da95d7e40f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72812 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78681 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64974 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6937 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11189 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2822 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->