### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLegacyCDMFactory

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1420,7 +1420,7 @@ void MediaPlayerPrivateRemote::setCDM(LegacyCDM* cdm)
     if (!cdm)
         return;
 
-    auto remoteCDM = WebProcess::singleton().legacyCDMFactory().findCDM(cdm->cdmPrivate());
+    auto remoteCDM = WebProcess::singleton().protectedLegacyCDMFactory()->findCDM(cdm->cdmPrivate());
     if (!remoteCDM)
         return;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -44,7 +44,8 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLegacyCDMFactory);
 
-RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess&)
+RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess& webProcess)
+    : m_webProcess(webProcess)
 {
 }
 
@@ -143,6 +144,16 @@ RemoteLegacyCDM* RemoteLegacyCDMFactory::findCDM(CDMPrivateInterface* privateInt
             return cdm.get();
     }
     return nullptr;
+}
+
+void RemoteLegacyCDMFactory::ref() const
+{
+    m_webProcess->ref();
+}
+
+void RemoteLegacyCDMFactory::deref() const
+{
+    m_webProcess->ref();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -35,15 +35,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class RemoteLegacyCDMFactory;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLegacyCDMFactory> : std::true_type { };
-}
-
 namespace IPC {
 class Connection;
 class Decoder;
@@ -85,11 +76,15 @@ public:
 
     RemoteLegacyCDM* findCDM(WebCore::CDMPrivateInterface*) const;
 
+    void ref() const;
+    void deref() const;
+
 private:
     bool supportsKeySystem(const String&);
     bool supportsKeySystemAndMimeType(const String&, const String&);
     std::unique_ptr<WebCore::CDMPrivateInterface> createCDM(WebCore::LegacyCDM*);
 
+    WeakRef<WebProcess> m_webProcess;
     UncheckedKeyHashMap<RemoteLegacyCDMSessionIdentifier, WeakPtr<RemoteLegacyCDMSession>> m_sessions;
     UncheckedKeyHashMap<RemoteLegacyCDMIdentifier, WeakPtr<RemoteLegacyCDM>> m_cdms;
     UncheckedKeyHashMap<String, bool> m_supportsKeySystemCache;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -332,7 +332,7 @@ WebProcess::WebProcess()
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    addSupplement<RemoteLegacyCDMFactory>();
+    addSupplementWithoutRefCountedCheck<RemoteLegacyCDMFactory>();
 #endif
 
 #if ENABLE(GPU_PROCESS)
@@ -2266,7 +2266,7 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     if (useGPUProcessForMedia)
-        legacyCDMFactory().registerFactory();
+        protectedLegacyCDMFactory()->registerFactory();
     else
         LegacyCDM::resetFactories();
 #endif
@@ -2357,6 +2357,11 @@ SpeechRecognitionRealtimeMediaSourceManager& WebProcess::ensureSpeechRecognition
 RemoteLegacyCDMFactory& WebProcess::legacyCDMFactory()
 {
     return *supplement<RemoteLegacyCDMFactory>();
+}
+
+Ref<RemoteLegacyCDMFactory> WebProcess::protectedLegacyCDMFactory()
+{
+    return legacyCDMFactory();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -282,6 +282,7 @@ public:
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactory& legacyCDMFactory();
+    Ref<RemoteLegacyCDMFactory> protectedLegacyCDMFactory();
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
     RemoteCDMFactory& cdmFactory();


### PR DESCRIPTION
#### 03de2c96e9bddc2f6663494f52dfe4a3c52ea01b
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLegacyCDMFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=281794">https://bugs.webkit.org/show_bug.cgi?id=281794</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::RemoteLegacyCDMFactory):
(WebKit::RemoteLegacyCDMFactory::ref const):
(WebKit::RemoteLegacyCDMFactory::deref const):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::m_nonVisibleProcessMemoryCleanupTimer):

Canonical link: <a href="https://commits.webkit.org/285471@main">https://commits.webkit.org/285471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ff185a7b795673af1db4cd9089641f19bc7b99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57182 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43810 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78590 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19577 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65643 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64920 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6864 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11178 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2736 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->