### PR TITLE
Add a way for internal WebKit clients to extract a list of all text and text rects on a webpage

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -33,6 +33,7 @@
 #include "FrameSelection.h"
 #include "HTMLBodyElement.h"
 #include "HTMLButtonElement.h"
+#include "HTMLFrameOwnerElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
@@ -622,6 +623,62 @@ RenderedText extractRenderedText(Element& element)
     }
 
     return { textWithReplacedContent.toString(), textWithoutReplacedContent.toString(), hasLargeReplacedDescendant };
+}
+
+static Vector<std::pair<String, FloatRect>> extractAllTextAndRectsRecursive(Document& document)
+{
+    RefPtr bodyElement = document.body();
+    if (!bodyElement)
+        return { };
+
+    RefPtr view = document.view();
+    if (!view)
+        return { };
+
+    ListHashSet<Ref<HTMLFrameOwnerElement>> frameOwners;
+    Vector<std::pair<String, FloatRect>> result;
+    auto fullRange = makeRangeSelectingNodeContents(*bodyElement);
+    for (TextIterator iterator { fullRange, TextIteratorBehavior::EntersTextControls }; !iterator.atEnd(); iterator.advance()) {
+        RefPtr node = iterator.node();
+        if (!node)
+            continue;
+
+        if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node))
+            frameOwners.add(frameOwner.releaseNonNull());
+
+        auto trimmedText = iterator.text().trim(isASCIIWhitespace<UChar>);
+        if (trimmedText.isEmpty())
+            continue;
+
+        CheckedPtr renderer = node->renderer();
+        if (!renderer)
+            continue;
+
+        result.append({ trimmedText.toString(), view->contentsToRootView(renderer->absoluteBoundingBoxRect()) });
+    }
+
+    for (auto& frameOwner : frameOwners) {
+        RefPtr contentDocument = frameOwner->contentDocument();
+        if (!contentDocument)
+            continue;
+
+        result.appendVector(extractAllTextAndRectsRecursive(*contentDocument));
+    }
+
+    return result;
+}
+
+Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page& page)
+{
+    RefPtr mainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!mainFrame)
+        return { };
+
+    RefPtr document = mainFrame->document();
+    if (!document)
+        return { };
+
+    return extractAllTextAndRectsRecursive(*document);
 }
 
 } // namespace TextExtractor

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -170,6 +170,7 @@ public:
         RunJavaScriptPromptResultListener,
         SpeechRecognitionPermissionCallback,
         TextChecker,
+        TextRun,
         URLSchemeTask,
         UserContentController,
         UserInitiatedAction,

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -51,6 +51,7 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKTargetedElementInfo.h>
 #import <WebKit/_WKTargetedElementRequest.h>
+#import <WebKit/_WKTextRun.h>
 #import <WebKit/_WKThumbnailView.h>
 #import <WebKit/_WKVisitedLinkStore.h>
 #import <WebKit/_WKWebPushAction.h>

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -90,6 +90,7 @@
 #import "_WKResourceLoadStatisticsThirdPartyInternal.h"
 #import "_WKTargetedElementInfoInternal.h"
 #import "_WKTargetedElementRequestInternal.h"
+#import "_WKTextRunInternal.h"
 #import "_WKUserContentWorldInternal.h"
 #import "_WKUserInitiatedActionInternal.h"
 #import "_WKUserStyleSheetInternal.h"
@@ -385,6 +386,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::TargetedElementRequest:
         wrapper = [_WKTargetedElementRequest alloc];
+        break;
+
+    case Type::TextRun:
+        wrapper = [_WKTextRun alloc];
         break;
 
     case Type::UserInitiatedAction:

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -483,6 +483,7 @@ UIProcess/API/APIOpenPanelParameters.cpp
 UIProcess/API/APISessionState.cpp
 UIProcess/API/APITargetedElementInfo.cpp
 UIProcess/API/APITargetedElementRequest.cpp
+UIProcess/API/APITextRun.cpp
 UIProcess/API/APIUIClient.cpp
 UIProcess/API/APIUserScript.cpp
 UIProcess/API/APIUserStyleSheet.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -302,6 +302,7 @@ UIProcess/API/Cocoa/_WKTextManipulationExclusionRule.mm
 UIProcess/API/Cocoa/_WKTextManipulationItem.mm
 UIProcess/API/Cocoa/_WKTextManipulationToken.mm
 UIProcess/API/Cocoa/_WKTextPreview.mm
+UIProcess/API/Cocoa/_WKTextRun.mm
 UIProcess/API/Cocoa/_WKThumbnailView.mm
 UIProcess/API/Cocoa/_WKUserContentExtensionStore.mm
 UIProcess/API/Cocoa/_WKUserContentFilter.mm

--- a/Source/WebKit/UIProcess/API/APITextRun.cpp
+++ b/Source/WebKit/UIProcess/API/APITextRun.cpp
@@ -25,29 +25,24 @@
 
 #pragma once
 
-#include "TextExtractionTypes.h"
-#include <wtf/Expected.h>
+#include "config.h"
+#include "APITextRun.h"
 
-namespace WebCore {
+#include "PageClient.h"
 
-class Element;
-class FloatRect;
-class LocalFrame;
-class Page;
-enum class ExceptionCode : uint8_t;
+namespace API {
 
-namespace TextExtraction {
+WebCore::FloatRect TextRun::rectInWebView() const
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
 
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
-WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
+    RefPtr client = page->protectedPageClient();
+    if (!client)
+        return { };
 
-struct RenderedText {
-    String textWithReplacedContent;
-    String textWithoutReplacedContent;
-    bool hasLargeReplacedDescendant { false };
-};
+    return client->rootViewToWebView(m_rectInRootView);
+}
 
-RenderedText extractRenderedText(Element&);
-
-} // namespace TextExtraction
-} // namespace WebCore
+} // namespace API

--- a/Source/WebKit/UIProcess/API/APITextRun.h
+++ b/Source/WebKit/UIProcess/API/APITextRun.h
@@ -25,29 +25,36 @@
 
 #pragma once
 
-#include "TextExtractionTypes.h"
-#include <wtf/Expected.h>
+#include "APIObject.h"
 
-namespace WebCore {
+#include "WebPageProxy.h"
+#include <WebCore/FloatRect.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
-class Element;
-class FloatRect;
-class LocalFrame;
-class Page;
-enum class ExceptionCode : uint8_t;
+namespace API {
 
-namespace TextExtraction {
+class TextRun final : public ObjectImpl<Object::Type::TextRun> {
+public:
+    static Ref<TextRun> create(WebKit::WebPageProxy& page, WTF::String&& string, WebCore::FloatRect&& rect)
+    {
+        return adoptRef(*new TextRun(page, WTFMove(string), WTFMove(rect)));
+    }
 
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
-WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
+    const WTF::String& string() const { return m_string; }
+    WebCore::FloatRect rectInWebView() const;
 
-struct RenderedText {
-    String textWithReplacedContent;
-    String textWithoutReplacedContent;
-    bool hasLargeReplacedDescendant { false };
+private:
+    explicit TextRun(WebKit::WebPageProxy& page, WTF::String&& string, WebCore::FloatRect&& rect)
+        : m_page { page }
+        , m_string { WTFMove(string) }
+        , m_rectInRootView { WTFMove(rect) }
+    {
+    }
+
+    WeakPtr<WebKit::WebPageProxy> m_page;
+    WTF::String m_string;
+    WebCore::FloatRect m_rectInRootView;
 };
 
-RenderedText extractRenderedText(Element&);
-
-} // namespace TextExtraction
-} // namespace WebCore
+} // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -141,6 +141,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @class _WKTextInputContext;
 @class _WKTextManipulationConfiguration;
 @class _WKTextManipulationItem;
+@class _WKTextRun;
 @class _WKThumbnailView;
 @class _WKWebViewPrintFormatter;
 
@@ -581,6 +582,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 - (BOOL)_allowAnimationControls WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 - (void)_setStatisticsCrossSiteLoadWithLinkDecorationForTesting:(NSString *)fromHost withToHost:(NSString *)toHost withWasFiltered:(BOOL)wasFiltered withCompletionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
+
+- (void)_requestAllTextWithCompletionHandler:(void(^)(NSArray<_WKTextRun *> *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 - (void)_requestTargetedElementInfo:(_WKTargetedElementRequest *)request completionHandler:(void(^)(NSArray<_WKTargetedElementInfo *> *))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.h
@@ -23,31 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
 
-#include "TextExtractionTypes.h"
-#include <wtf/Expected.h>
+NS_ASSUME_NONNULL_BEGIN
 
-namespace WebCore {
+NS_SWIFT_SENDABLE
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface _WKTextRun : NSObject
 
-class Element;
-class FloatRect;
-class LocalFrame;
-class Page;
-enum class ExceptionCode : uint8_t;
+@property (nonatomic, readonly, copy) NSString *text;
+@property (nonatomic, readonly) CGRect rectInWebView;
 
-namespace TextExtraction {
+@end
 
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
-WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
-
-struct RenderedText {
-    String textWithReplacedContent;
-    String textWithoutReplacedContent;
-    bool hasLargeReplacedDescendant { false };
-};
-
-RenderedText extractRenderedText(Element&);
-
-} // namespace TextExtraction
-} // namespace WebCore
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
@@ -23,31 +23,41 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "config.h"
+#import "_WKTextRunInternal.h"
 
-#include "TextExtractionTypes.h"
-#include <wtf/Expected.h>
+#import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/RetainPtr.h>
 
-namespace WebCore {
+@implementation _WKTextRun
 
-class Element;
-class FloatRect;
-class LocalFrame;
-class Page;
-enum class ExceptionCode : uint8_t;
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKTextRun.class, self))
+        return;
+    _textRun->API::TextRun::~TextRun();
+    [super dealloc];
+}
 
-namespace TextExtraction {
+- (API::Object&)_apiObject
+{
+    return *_textRun;
+}
 
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
-WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
+- (NSString *)text
+{
+    return _textRun->string();
+}
 
-struct RenderedText {
-    String textWithReplacedContent;
-    String textWithoutReplacedContent;
-    bool hasLargeReplacedDescendant { false };
-};
+- (CGRect)rectInWebView
+{
+    return Ref { *_textRun }->rectInWebView();
+}
 
-RenderedText extractRenderedText(Element&);
+- (NSString *)debugDescription
+{
+    auto rect = self.rectInWebView;
+    return [NSString stringWithFormat:@"'%@' at {{%.0f, %.0f}, {%.0f, %.0f}}", self.text, rect.origin.x, rect.origin.y, rect.size.width, rect.size.height];
+}
 
-} // namespace TextExtraction
-} // namespace WebCore
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h
@@ -25,29 +25,20 @@
 
 #pragma once
 
-#include "TextExtractionTypes.h"
-#include <wtf/Expected.h>
+#import "APITextRun.h"
+#import "WKObject.h"
+#import "_WKTextRun.h"
 
-namespace WebCore {
+namespace WebKit {
 
-class Element;
-class FloatRect;
-class LocalFrame;
-class Page;
-enum class ExceptionCode : uint8_t;
-
-namespace TextExtraction {
-
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
-WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
-
-struct RenderedText {
-    String textWithReplacedContent;
-    String textWithoutReplacedContent;
-    bool hasLargeReplacedDescendant { false };
+template<> struct WrapperTraits<API::TextRun> {
+    using WrapperClass = _WKTextRun;
 };
 
-RenderedText extractRenderedText(Element&);
+} // namespace WebKit
 
-} // namespace TextExtraction
-} // namespace WebCore
+@interface _WKTextRun () <WKObject> {
+@package
+    API::ObjectStorage<API::TextRun> _textRun;
+}
+@end

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -75,6 +75,7 @@ class ResourceLoadClient;
 class SerializedScriptValue;
 class TargetedElementInfo;
 class TargetedElementRequest;
+class TextRun;
 class UIClient;
 class URL;
 class URLRequest;
@@ -2451,6 +2452,8 @@ public:
     void resetMediaCapability();
     void updateMediaCapability();
 #endif
+
+    void requestAllTextAndRects(CompletionHandler<void(Vector<Ref<API::TextRun>>&&)>&&);
 
     void requestTargetedElement(const API::TargetedElementRequest&, CompletionHandler<void(const Vector<Ref<API::TargetedElementInfo>>&)>&&);
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<Ref<API::TargetedElementInfo>>>&&)>&&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2533,6 +2533,8 @@
 		F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */; };
 		F41795A62AC61B78007F5F12 /* CompactContextMenuPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */; };
 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
+		F42A04712CA1B328000D3118 /* _WKTextRunInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */; };
+		F42A04722CA1B3FC000D3118 /* _WKTextRun.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
 		F430E9422247335F005FE053 /* WebsiteMetaViewportPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */; };
 		F430E94422473DFF005FE053 /* WebContentMode.h in Headers */ = {isa = PBXBuildFile; fileRef = F430E94322473DB8005FE053 /* WebContentMode.h */; };
@@ -2574,6 +2576,7 @@
 		F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */ = {isa = PBXBuildFile; fileRef = F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */; };
 		F49DC6FE2B76A89600816E73 /* WKTextExtractionItem.h in Headers */ = {isa = PBXBuildFile; fileRef = F49DC6FD2B76A88F00816E73 /* WKTextExtractionItem.h */; };
 		F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */ = {isa = PBXBuildFile; fileRef = F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */; };
+		F4A0D3BF2CC2D276008A45B0 /* APITextRun.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A0D3BD2CC2D088008A45B0 /* APITextRun.h */; };
 		F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A30A6C2B08254C004E1F24 /* CoreIPCLocale.mm */; };
 		F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB602B018C1A00C5471A /* CoreIPCError.h */; };
 		F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4ABDB622B018C1B00C5471A /* CoreIPCError.mm */; };
@@ -8190,6 +8193,9 @@
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CompactContextMenuPresenter.mm; path = ios/CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
 		F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationRequest.serialization.in; path = ios/InteractionInformationRequest.serialization.in; sourceTree = "<group>"; };
 		F4299506270E234C0032298B /* StreamMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamMessageReceiver.h; sourceTree = "<group>"; };
+		F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextRun.h; sourceTree = "<group>"; };
+		F42A046D2CA1B2A4000D3118 /* _WKTextRun.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextRun.mm; sourceTree = "<group>"; };
+		F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextRunInternal.h; sourceTree = "<group>"; };
 		F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionData.h; path = ios/WebAutocorrectionData.h; sourceTree = "<group>"; };
 		F42FC8702B7ADA5800BAF8D6 /* CoreIPCNSURLProtectionSpace.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSURLProtectionSpace.serialization.in; sourceTree = "<group>"; };
 		F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsiteMetaViewportPolicy.h; sourceTree = "<group>"; };
@@ -8259,6 +8265,8 @@
 		F49DC6FD2B76A88F00816E73 /* WKTextExtractionItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextExtractionItem.h; sourceTree = "<group>"; };
 		F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDate.serialization.in; sourceTree = "<group>"; };
 		F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDate.h; sourceTree = "<group>"; };
+		F4A0D3BD2CC2D088008A45B0 /* APITextRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APITextRun.h; sourceTree = "<group>"; };
+		F4A0D3C02CC2D587008A45B0 /* APITextRun.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APITextRun.cpp; sourceTree = "<group>"; };
 		F4A30A6C2B08254C004E1F24 /* CoreIPCLocale.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCLocale.mm; sourceTree = "<group>"; };
 		F4A318A7291EFCF600F7A903 /* RemoteMediaPlayerState.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteMediaPlayerState.serialization.in; sourceTree = "<group>"; };
 		F4A7CE842667EB4E00228685 /* TextRecognitionUpdateResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextRecognitionUpdateResult.h; sourceTree = "<group>"; };
@@ -11607,6 +11615,9 @@
 				9B02E0CE235EBB14004044B2 /* _WKTextManipulationToken.mm */,
 				07F327F02CB085A4006D9918 /* _WKTextPreview.h */,
 				07F327F12CB085A4006D9918 /* _WKTextPreview.mm */,
+				F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */,
+				F42A046D2CA1B2A4000D3118 /* _WKTextRun.mm */,
+				F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */,
 				2D6B371918A967AD0042AE80 /* _WKThumbnailView.h */,
 				2D6B371A18A967AD0042AE80 /* _WKThumbnailView.mm */,
 				2DACE64D18ADBFF000E4CA76 /* _WKThumbnailViewInternal.h */,
@@ -14398,6 +14409,8 @@
 				F454C12D2BA3AFFD00871551 /* APITargetedElementInfo.h */,
 				F4500D882BE02D6A0081A5F1 /* APITargetedElementRequest.cpp */,
 				F4500D872BE02D6A0081A5F1 /* APITargetedElementRequest.h */,
+				F4A0D3C02CC2D587008A45B0 /* APITextRun.cpp */,
+				F4A0D3BD2CC2D088008A45B0 /* APITextRun.h */,
 				939EF87129D1181600F23AEE /* APIUIClient.cpp */,
 				1A4D664718A2D91A00D82E21 /* APIUIClient.h */,
 				7CB365AF1D31DD1E007158CA /* APIUserInitiatedAction.h */,
@@ -16190,6 +16203,8 @@
 				9B02E0CC235EB957004044B2 /* _WKTextManipulationItem.h in Headers */,
 				9B02E0D7235FC94F004044B2 /* _WKTextManipulationToken.h in Headers */,
 				07F327F22CB09B74006D9918 /* _WKTextPreview.h in Headers */,
+				F42A04722CA1B3FC000D3118 /* _WKTextRun.h in Headers */,
+				F42A04712CA1B328000D3118 /* _WKTextRunInternal.h in Headers */,
 				2D6B371B18A967AD0042AE80 /* _WKThumbnailView.h in Headers */,
 				2DACE64E18ADBFF000E4CA76 /* _WKThumbnailViewInternal.h in Headers */,
 				99E7189C21F79D9E0055E975 /* _WKTouchEventGenerator.h in Headers */,
@@ -16327,6 +16342,7 @@
 				1AFDE6621954E9B100C48FFA /* APISessionState.h in Headers */,
 				F454C1302BA3AFFD00871551 /* APITargetedElementInfo.h in Headers */,
 				F4500D8A2BE02D6A0081A5F1 /* APITargetedElementRequest.h in Headers */,
+				F4A0D3BF2CC2D276008A45B0 /* APITextRun.h in Headers */,
 				1A4D664818A2D91A00D82E21 /* APIUIClient.h in Headers */,
 				BCDB86C11200FB97007254BE /* APIURL.h in Headers */,
 				BCE2315D122C30CA00D5C35A /* APIURLRequest.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9762,6 +9762,15 @@ void WebPage::frameTextForTesting(WebCore::FrameIdentifier frameID, CompletionHa
     completionHandler(webFrame->frameTextForTesting(includeSubframes));
 }
 
+void WebPage::requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&& completion)
+{
+    RefPtr page = corePage();
+    if (!page)
+        return completion({ });
+
+    completion(TextExtraction::extractAllTextAndRects(*page));
+}
+
 void WebPage::requestTargetedElement(TargetedElementRequest&& request, CompletionHandler<void(Vector<WebCore::TargetedElementInfo>&&)>&& completion)
 {
     RefPtr page = corePage();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2367,6 +2367,8 @@ private:
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
 
+    void requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&&);
+
     void requestTargetedElement(WebCore::TargetedElementRequest&&, CompletionHandler<void(Vector<WebCore::TargetedElementInfo>&&)>&&);
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<WebCore::TargetedElementInfo>>&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -769,6 +769,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     LayerTreeAsTextForTesting(WebCore::FrameIdentifier frameID, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions> options) -> (String layerTreeDump) Synchronous
     FrameTextForTesting(WebCore::FrameIdentifier frameID) -> (String text) Synchronous
 
+    RequestAllTextAndRects() -> (Vector<std::pair<String, WebCore::FloatRect>> textAndRects)
+
     RequestTargetedElement(struct WebCore::TargetedElementRequest request) -> (Vector<WebCore::TargetedElementInfo> elements)
 
     RequestAllTargetableElements(float hitTestInterval) -> (Vector<Vector<WebCore::TargetedElementInfo>> elements)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1272,6 +1272,7 @@
 		F4094CC725545BD5003D73E3 /* DisplayListTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4094CC625545BD5003D73E3 /* DisplayListTests.cpp */; };
 		F418BE151F71B7DC001970E6 /* RoundedRectTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */; };
 		F425831624F07CA5006B985D /* WKWebViewCoders.mm in Sources */ = {isa = PBXBuildFile; fileRef = F425831524F07CA5006B985D /* WKWebViewCoders.mm */; };
+		F42A9E702CC2FE84002280C0 /* subframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42A9E6F2CC2FE84002280C0 /* subframes.html */; };
 		F42D634422A1729F00D2FB3A /* AutocorrectionTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F42D634322A1729F00D2FB3A /* AutocorrectionTestsIOS.mm */; };
 		F434CA1A22E65BCA005DDB26 /* ScrollToRevealSelection.mm in Sources */ = {isa = PBXBuildFile; fileRef = F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */; };
 		F43B320E2C9C801100838ABA /* audio-fingerprinting.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43B320C2C9C801100838ABA /* audio-fingerprinting.js */; };
@@ -1968,6 +1969,7 @@
 				A17C47FF2C98E5C20023F3C7 /* start-offset.ts in Copy Resources */,
 				A17C46872C98E4D20023F3C7 /* StopLoadingFromDidReceiveResponse.html in Copy Resources */,
 				A17C48002C98E5C20023F3C7 /* StoreBlobToBeDeleted.html in Copy Resources */,
+				F42A9E702CC2FE84002280C0 /* subframes.html in Copy Resources */,
 				A17C48012C98E5C20023F3C7 /* sunset-in-cupertino-100px.tiff in Copy Resources */,
 				A17C48022C98E5C20023F3C7 /* sunset-in-cupertino-200px.png in Copy Resources */,
 				A17C48032C98E5C20023F3C7 /* sunset-in-cupertino-400px.gif in Copy Resources */,
@@ -3655,6 +3657,7 @@
 		F422A3E8235ACA9B00CF00CA /* ClipboardTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ClipboardTests.mm; sourceTree = "<group>"; };
 		F422A3EA235BB14500CF00CA /* clipboard.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = clipboard.html; sourceTree = "<group>"; };
 		F425831524F07CA5006B985D /* WKWebViewCoders.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewCoders.mm; sourceTree = "<group>"; };
+		F42A9E6F2CC2FE84002280C0 /* subframes.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = subframes.html; sourceTree = "<group>"; };
 		F42BD7D8245CC4E6001E207A /* attributedStringNewlineAtEndOfDocument.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = attributedStringNewlineAtEndOfDocument.html; sourceTree = "<group>"; };
 		F42D634322A1729F00D2FB3A /* AutocorrectionTestsIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AutocorrectionTestsIOS.mm; sourceTree = "<group>"; };
 		F42DA5151D8CEFDB00336F40 /* large-input-field-focus-onload.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = "large-input-field-focus-onload.html"; path = "Tests/WebKitCocoa/large-input-field-focus-onload.html"; sourceTree = SOURCE_ROOT; };
@@ -5223,6 +5226,7 @@
 				9342589D255B66A00059EEDD /* speechrecognition-user-permission-persistence.html */,
 				0721D4582838295400A95853 /* start-offset.ts */,
 				515BE16E1D4288FF00DD7C68 /* StoreBlobToBeDeleted.html */,
+				F42A9E6F2CC2FE84002280C0 /* subframes.html */,
 				9BD6D3A11F7B202100BD4962 /* sunset-in-cupertino-100px.tiff */,
 				9BD6D3A01F7B202000BD4962 /* sunset-in-cupertino-200px.png */,
 				9BD6D39F1F7B202000BD4962 /* sunset-in-cupertino-400px.gif */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html
@@ -3,6 +3,15 @@
 <head>
 <title>Outer Subframe</title>
 <style>
+@font-face {
+    font-family: Ahem; src: url(Ahem.ttf);
+}
+
+html, body {
+    font-family: Ahem;
+    -webkit-text-size-adjust: none;
+}
+
 iframe {
     width: 100px;
     height: 100px;
@@ -23,6 +32,15 @@ iframe {
             subframe.srcdoc = `
                 <head>
                     <title>Inner Subframe</title>
+                    <style>
+                    @font-face {
+                        font-family: Ahem; src: url(Ahem.ttf);
+                    }
+                    html, body {
+                        font-family: Ahem;
+                        -webkit-text-size-adjust: none;
+                    }
+                    </style>
                 </head>
                 <body>
                     <a href='https://webkit.org'>The ones who see things differently.</a>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/subframes.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/subframes.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+@font-face {
+    font-family: Ahem; src: url(Ahem.ttf);
+}
+
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    font-size: 16px;
+    font-family: Ahem;
+    -webkit-text-size-adjust: none;
+}
+
+iframe {
+    width: 200px;
+    height: 200px;
+    border: 1px solid black;
+}
+</style>
+<script>
+subframeLoaded = false;
+
+addEventListener("message", event => {
+    if (event.data === "subframeLoaded")
+        subframeLoaded = true;
+});
+
+addEventListener("load", () => {
+    const subframe = document.querySelector("iframe");
+    subframe.src = "nested-frames.html";
+});
+</script>
+</head>
+<body>
+    <p>Here's to the crazy ones.</p>
+    <iframe></iframe>
+</body>
+</html>


### PR DESCRIPTION
#### 3d7827fa1ae86043d77a65d3fe8479ba5b2ee20c
<pre>
Add a way for internal WebKit clients to extract a list of all text and text rects on a webpage
<a href="https://bugs.webkit.org/show_bug.cgi?id=281795">https://bugs.webkit.org/show_bug.cgi?id=281795</a>
<a href="https://rdar.apple.com/138221056">rdar://138221056</a>

Reviewed by Abrar Rahman Protyasha.

Add experimental WebKit SPI to collect all of the text on a webpage, along with bounding rects in
`WKWebView` coordinates. See below for more details.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractAllTextAndRectsRecursive):
(WebCore::TextExtraction::extractAllTextAndRects):

Implement the main logic here, which uses `TextIterator` to recursively extract visible text content
from each frame on the page.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APITextRun.cpp: Copied from Source/WebCore/page/text-extraction/TextExtraction.h.
(API::TextRun::rectInWebView const):
* Source/WebKit/UIProcess/API/APITextRun.h: Copied from Source/WebCore/page/text-extraction/TextExtraction.h.

Add a new `API::Object` that represents a single piece of visible text, along with a rect in root
view coordinates.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestAllTextWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.h: Copied from Source/WebCore/page/text-extraction/TextExtraction.h.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm: Copied from Source/WebCore/page/text-extraction/TextExtraction.h.
(-[_WKTextRun dealloc]):
(-[_WKTextRun _apiObject]):
(-[_WKTextRun text]):
(-[_WKTextRun rectInWebView]):
(-[_WKTextRun debugDescription]):

Add a new Objective-C object, that wraps the C++ `API::Object` above.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h: Copied from Source/WebCore/page/text-extraction/TextExtraction.h.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAllTextAndRects):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestAllTextAndRects):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:

Drive-by fix: wrap all of these tests in `namespace TestWebKitAPI`.

(-[WKWebView _allTextRuns]):
(TestWebKitAPI::TEST(WKWebView, GetContentsShouldReturnString)):
(TestWebKitAPI::TEST(WKWebView, GetContentsShouldFailWhenClosingPage)):
(TestWebKitAPI::TEST(WKWebView, GetContentsOfAllFramesShouldReturnString)):
(TestWebKitAPI::TEST(WKWebView, GetContentsShouldReturnAttributedString)):
(TestWebKitAPI::TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringAccessibilityLabel)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringAttributeTypes)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringWithoutNetworkLoads)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringWithSourceApplicationBundleID)):
(TestWebKitAPI::TEST(WKWebView, TextWithWebFontAsAttributedString)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringAndCDATASection)):
(TestWebKitAPI::TEST(WKWebView, RequestAllTextRunsWithSubframes)):
(TEST(WKWebView, GetContentsShouldReturnString)): Deleted.
(TEST(WKWebView, GetContentsShouldFailWhenClosingPage)): Deleted.
(TEST(WKWebView, GetContentsOfAllFramesShouldReturnString)): Deleted.
(TEST(WKWebView, GetContentsShouldReturnAttributedString)): Deleted.
(TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)): Deleted.
(TEST(WKWebView, AttributedStringAccessibilityLabel)): Deleted.
(TEST(WKWebView, AttributedStringAttributeTypes)): Deleted.
(TEST(WKWebView, AttributedStringFromTable)): Deleted.
(TEST(WKWebView, AttributedStringWithLinksInTableCell)): Deleted.
(TEST(WKWebView, AttributedStringFromList)): Deleted.
(TEST(WKWebView, AttributedStringWithoutNetworkLoads)): Deleted.
(TEST(WKWebView, AttributedStringWithSourceApplicationBundleID)): Deleted.
(TEST(WKWebView, TextWithWebFontAsAttributedString)): Deleted.
(TEST(WKWebView, AttributedStringAndCDATASection)): Deleted.
(TEST(WKWebView, AttributedStringIncludesUserSelectNoneContent)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/subframes.html: Added.

Add a basic API test, verifying that the new SPI method finds text inside of nested subframes and
passes back rects in the web view&apos;s coordinate space.

Canonical link: <a href="https://commits.webkit.org/285706@main">https://commits.webkit.org/285706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/275e99429e54657d62d2466652bcbdf583d559ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24743 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79391 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3527 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->