### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLayerTreeNode

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
@@ -35,7 +35,7 @@ class RemoteLayerTreeHost;
 
 class RemoteLayerTreePropertyApplier {
 public:
-    using RelatedLayerMap = UncheckedKeyHashMap<WebCore::PlatformLayerIdentifier, std::unique_ptr<RemoteLayerTreeNode>>;
+    using RelatedLayerMap = UncheckedKeyHashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteLayerTreeNode>>;
     
     static void applyHierarchyUpdates(RemoteLayerTreeNode&, const LayerProperties&, const RelatedLayerMap&);
     static void applyProperties(RemoteLayerTreeNode&, RemoteLayerTreeHost*, const LayerProperties&, const RelatedLayerMap&, LayerContentsType);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -426,7 +426,7 @@ void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const
         return;
     }
 
-    auto* maskNode = properties.maskLayerID ? relatedLayers.get(*properties.maskLayerID) : nullptr;
+    RefPtr maskNode = properties.maskLayerID ? relatedLayers.get(*properties.maskLayerID) : nullptr;
     ASSERT(maskNode);
     if (!maskNode)
         return;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -321,7 +321,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 
         if (m_remoteLayerTreeHost->updateLayerTree(connection, layerTreeTransaction)) {
             if (!m_replyForUnhidingContent)
-                webPageProxy->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->rootNode());
+                webPageProxy->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->protectedRootNode().get());
             else
                 m_remoteLayerTreeHost->detachRootLayer();
         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -54,6 +54,7 @@ public:
 
     RemoteLayerTreeNode* nodeForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     RemoteLayerTreeNode* rootNode() const { return m_rootNode.get(); }
+    RefPtr<RemoteLayerTreeNode> protectedRootNode() const { return m_rootNode.get(); }
 
     CALayer *layerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     CALayer *rootLayer() const;
@@ -104,7 +105,7 @@ public:
 
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
-    std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
+    RefPtr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 
     bool updateBannerLayers(const RemoteLayerTreeTransaction&);
 
@@ -114,7 +115,7 @@ private:
 
     WeakPtr<RemoteLayerTreeDrawingAreaProxy> m_drawingArea;
     WeakPtr<RemoteLayerTreeNode> m_rootNode;
-    UncheckedKeyHashMap<WebCore::PlatformLayerIdentifier, std::unique_ptr<RemoteLayerTreeNode>> m_nodes;
+    UncheckedKeyHashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteLayerTreeNode>> m_nodes;
     UncheckedKeyHashMap<WebCore::LayerHostingContextIdentifier, WebCore::PlatformLayerIdentifier> m_hostingLayers;
     UncheckedKeyHashMap<WebCore::LayerHostingContextIdentifier, WebCore::PlatformLayerIdentifier> m_hostedLayers;
     UncheckedKeyHashMap<WebCore::ProcessIdentifier, HashSet<WebCore::PlatformLayerIdentifier>> m_hostedLayersInProcess;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -32,6 +32,7 @@
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -43,29 +44,20 @@ OBJC_CLASS UIView;
 #endif
 
 namespace WebKit {
-class RemoteLayerTreeNode;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLayerTreeNode> : std::true_type { };
-}
-
-namespace WebKit {
 
 class RemoteLayerTreeHost;
 class RemoteLayerTreeScrollbars;
 
-class RemoteLayerTreeNode : public CanMakeWeakPtr<RemoteLayerTreeNode> {
+class RemoteLayerTreeNode final : public RefCountedAndCanMakeWeakPtr<RemoteLayerTreeNode> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeNode);
 public:
-    RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<CALayer>);
+    static Ref<RemoteLayerTreeNode> create(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<CALayer>);
 #if PLATFORM(IOS_FAMILY)
-    RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<UIView>);
+    static Ref<RemoteLayerTreeNode> create(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<UIView>);
 #endif
     ~RemoteLayerTreeNode();
 
-    static std::unique_ptr<RemoteLayerTreeNode> createWithPlainLayer(WebCore::PlatformLayerIdentifier);
+    static Ref<RemoteLayerTreeNode> createWithPlainLayer(WebCore::PlatformLayerIdentifier);
 
     CALayer *layer() const { return m_layer.get(); }
 #if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS)
@@ -155,6 +147,11 @@ public:
     void setBackdropRootIsOpaque(bool backdropRootIsOpaque) { m_backdropRootIsOpaque = backdropRootIsOpaque; }
 
 private:
+    RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<CALayer>);
+#if PLATFORM(IOS_FAMILY)
+    RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<UIView>);
+#endif
+
     void initializeLayer();
 
     WebCore::PlatformLayerIdentifier m_layerID;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -45,10 +45,10 @@
 namespace WebKit {
 using namespace WebCore;
 
-std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties& properties)
+RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties& properties)
 {
     auto makeWithView = [&] (RetainPtr<UIView>&& view) {
-        return makeUnique<RemoteLayerTreeNode>(*properties.layerID, properties.hostIdentifier(), WTFMove(view));
+        return RemoteLayerTreeNode::create(*properties.layerID, properties.hostIdentifier(), WTFMove(view));
     };
 
     switch (properties.type) {


### PR DESCRIPTION
#### 31843970a5ca313da03cbbf09f8460ec1dda2a72
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for RemoteLayerTreeNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=281804">https://bugs.webkit.org/show_bug.cgi?id=281804</a>

Reviewed by Sihui Liu.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::rootLayer const):
(WebKit::RemoteLayerTreeHost::createLayer):
(WebKit::RemoteLayerTreeHost::makeNode):
(WebKit::RemoteLayerTreeHost::detachRootLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::layer const): Deleted.
(WebKit::RemoteLayerTreeNode::VisibleRectMarkableTraits::isEmptyValue): Deleted.
(WebKit::RemoteLayerTreeNode::VisibleRectMarkableTraits::emptyValue): Deleted.
(WebKit::RemoteLayerTreeNode::visibleRect const): Deleted.
(WebKit::RemoteLayerTreeNode::setVisibleRect): Deleted.
(WebKit::RemoteLayerTreeNode::uiView const): Deleted.
(WebKit::RemoteLayerTreeNode::layerID const): Deleted.
(WebKit::RemoteLayerTreeNode::eventRegion const): Deleted.
(WebKit::RemoteLayerTreeNode::actingScrollContainerID const): Deleted.
(WebKit::RemoteLayerTreeNode::stationaryScrollContainerIDs const): Deleted.
(WebKit::RemoteLayerTreeNode::setActingScrollContainerID): Deleted.
(WebKit::RemoteLayerTreeNode::setStationaryScrollContainerIDs): Deleted.
(WebKit::RemoteLayerTreeNode::scrollingNodeID const): Deleted.
(WebKit::RemoteLayerTreeNode::setScrollingNodeID): Deleted.
(WebKit::RemoteLayerTreeNode::remoteContextHostingIdentifier const): Deleted.
(WebKit::RemoteLayerTreeNode::remoteContextHostedIdentifier const): Deleted.
(WebKit::RemoteLayerTreeNode::setRemoteContextHostedIdentifier): Deleted.
(WebKit::RemoteLayerTreeNode::takeCachedContentsBuffers): Deleted.
(WebKit::RemoteLayerTreeNode::setCachedContentsBuffers): Deleted.
(WebKit::RemoteLayerTreeNode::asyncContentsIdentifier const): Deleted.
(WebKit::RemoteLayerTreeNode::setAsyncContentsIdentifier): Deleted.
(WebKit::RemoteLayerTreeNode::effectStack const): Deleted.
(WebKit::RemoteLayerTreeNode::takeEffectStack): Deleted.
(WebKit::RemoteLayerTreeNode::backdropRootIsOpaque const): Deleted.
(WebKit::RemoteLayerTreeNode::setBackdropRootIsOpaque): Deleted.
(WebKit::RemoteLayerTreeNode::hasInteractionRegionsDescendant const): Deleted.
(WebKit::RemoteLayerTreeNode::setHasInteractionRegionsDescendant): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::create):
(WebKit::RemoteLayerTreeNode::createWithPlainLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):

Canonical link: <a href="https://commits.webkit.org/285484@main">https://commits.webkit.org/285484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65492edd646d9fefa91d58b2d14006da2b665348

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57226 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15722 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43856 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65679 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64956 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6914 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->