### PR TITLE
[macOS] Fullscreen.VideoPausesAfterExitingFullscreen is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
@@ -25,8 +25,6 @@
 
 #import "config.h"
 
-#if PLATFORM(MAC)
-
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKPreferencesPrivate.h>
@@ -55,6 +53,8 @@ static bool fullscreenStateChanged;
 }
 
 @end
+
+#if PLATFORM(MAC)
 
 TEST(Fullscreen, AudioLifecycle)
 {
@@ -146,12 +146,11 @@ TEST(Fullscreen, VideoLifecycleElementFullscreenDisabled)
     runTest(configuration.get());
 }
 
-// rdar://136783989
-#if PLATFORM(MAC) && defined(NDEBUG)
-TEST(Fullscreen, DISABLED_VideoPausesAfterExitingFullscreen)
-#else
+#endif // PLATFORM(MAC)
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
+
 TEST(Fullscreen, VideoPausesAfterExitingFullscreen)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
@@ -183,4 +182,4 @@ TEST(Fullscreen, VideoPausesAfterExitingFullscreen)
     ASSERT_TRUE(fullscreenStateChanged);
 }
 
-#endif // PLATFORM(MAC)
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)


### PR DESCRIPTION
#### 3353ae4348a20e725ea3fada9e8d139f936437d7
<pre>
[macOS] Fullscreen.VideoPausesAfterExitingFullscreen is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=281809">https://bugs.webkit.org/show_bug.cgi?id=281809</a>
<a href="https://rdar.apple.com/136783989">rdar://136783989</a>

Unreviewed test gardening.

Fullscreen.VideoPausesAfterExitingFullscreen tests behavior that is only implemented on iOS-family
platforms, so the test should be skipped on macOS.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm:
(TEST(Fullscreen, VideoPausesAfterExitingFullscreen)):

Canonical link: <a href="https://commits.webkit.org/285516@main">https://commits.webkit.org/285516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/318f8e70c569ae804cc70a675572ef0630924d49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16998 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19568 "Found 60 new test failures: fast/canvas/image-buffer-resource-limits.html fast/canvas/offscreen-nested-worker-serialization.html http/tests/cache/network-error-during-revalidation.html http/tests/dom/noopener-window-not-targetable2.html http/tests/images/gif-progressive-load.html http/tests/misc/repeat-open-cancel.html http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-ident.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65653 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16068 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6883 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->