### PR TITLE
import-w3c-tests: invert --clean-dest-dir

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -128,7 +128,7 @@ To import a web-platform-tests test suite named xyz, use:
 To import a web-platform-tests suite from a local copy of web platform tests:
    1. Your local WPT copy must be in a directory called "web-platform-tests".
    2. If the local copy is at, for example, "~/dev/web-platform-tests/", use:
-      import-w3c-tests web-platform-tests/xyz --src-dir ~/dev/ --clean-dest-dir"""
+      import-w3c-tests web-platform-tests/xyz --src-dir ~/dev/"""
     parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument('-n', '--no-overwrite', dest='overwrite', action='store_false', default=True,
@@ -154,8 +154,8 @@ To import a web-platform-tests suite from a local copy of web platform tests:
     parser.add_argument('--import-all', action='store_true', default=False,
                         help='Ignore the import-expectations.json file. All tests will be imported. This option only applies when tests are downloaded from W3C repository')
 
-    parser.add_argument('--clean-dest-dir', action='store_true', dest='clean_destination_directory', default=False,
-                        help='Clean destination directory. All files in the destination directory will be deleted except for WebKit specific files (test expectations, .gitignore...) before new tests import. Dangling test expectations (expectation file that is no longer related to a test) are removed after tests import.')
+    parser.add_argument('--no-clean-dest-dir', action='store_false', dest='clean_destination_directory', default=True,
+                        help='Do not clean the destination directory. By default all files in the destination directory will be deleted except for WebKit specific files (test expectations, .gitignore...) before new tests import. Dangling test expectations (expectation file that is no longer related to a test) are removed after tests import.')
 
     parser.add_argument('test_paths', metavar='web-platform-tests/test_path', nargs='*',
                         help='directories to import')

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -156,7 +156,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/t/test.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
@@ -180,7 +180,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/dir-to-skip/file-to-import.html': 'to be imported',
         })
 
-        fs = self.import_downloaded_tests(['--no-fetch', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/dir-to-skip/file-to-import.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/dir-to-skip/dir-to-import/test-to-import.html'))
@@ -204,7 +204,7 @@ class TestImporterTest(unittest.TestCase):
             '/home/user/wpt/web-platform-tests/dir-to-skip/file-to-import.html': 'to be imported',
         })
 
-        fs = self.import_downloaded_tests(['-s', '/home/user/wpt', '--no-fetch', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['-s', '/home/user/wpt', '--no-fetch', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/dir-to-skip/file-to-import.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/dir-to-skip/dir-to-import/test-to-import.html'))
@@ -251,7 +251,7 @@ class TestImporterTest(unittest.TestCase):
             }
         )
 
-        fs = self.import_downloaded_tests(["--no-fetch", "-d", "w3c"], FAKE_FILES)
+        fs = self.import_downloaded_tests(["--no-fetch", "--no-clean-dest-dir", "-d", "w3c"], FAKE_FILES)
 
         import_expectations = json.loads(
             fs.read_text_file(
@@ -283,7 +283,7 @@ class TestImporterTest(unittest.TestCase):
 
         os.environ['WEBKIT_OUTPUTDIR'] = '/mock-checkout/WebKitBuild2'
         try:
-            fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+            fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
         finally:
             del os.environ['WEBKIT_OUTPUTDIR']
 
@@ -304,7 +304,7 @@ class TestImporterTest(unittest.TestCase):
 
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c', '--clean-dest-dir'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/old-test.html'))
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/old-test-expected.txt'))
@@ -335,7 +335,7 @@ class TestImporterTest(unittest.TestCase):
 
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir'], FAKE_FILES)
 
         # 'slow' should remain in tests-options.json.
         tests_options = json.loads(fs.read_text_file('/mock-checkout/LayoutTests/tests-options.json'))
@@ -373,7 +373,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '-1',
         })
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--clean-dest-dir', 'web-platform-tests/b'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', 'web-platform-tests/b'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/a/old-test.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/a/old-test-expected.txt'))
@@ -422,7 +422,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '-1',
         })
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--clean-dest-dir', 'web-platform-tests/cssom'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', 'web-platform-tests/cssom'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/cssom-view/old-test.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/cssom-view/old-test-expected.txt'))
@@ -451,7 +451,7 @@ class TestImporterTest(unittest.TestCase):
         host.executive = MockExecutive2()
         host.filesystem = MockFileSystem(files=FAKE_FILES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/csswg-tests/__init__.py'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/__init__.py'))
@@ -472,7 +472,7 @@ class TestImporterTest(unittest.TestCase):
         host.executive = MockExecutive2()
         host.filesystem = MockFileSystem(files=FAKE_FILES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/obsolete.html'))
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/obsolete-expected.txt'))
@@ -490,7 +490,7 @@ class TestImporterTest(unittest.TestCase):
         host.executive = MockExecutive2()
         host.filesystem = MockFileSystem(files=FAKE_FILES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/new-manual.html'))
         self.assertEqual(tests_options, fs.read_text_file('/mock-checkout/LayoutTests/tests-options.json'))
 
@@ -529,7 +529,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/test.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
@@ -553,7 +553,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
         # test3
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/css-images/test3.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/css-images/test3-expected.html'))
@@ -623,7 +623,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.any.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.any.worker.html'))
@@ -656,7 +656,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any.html'))
         self.assertTrue('<!-- META: variant=?1-10 -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any.html'))
@@ -672,7 +672,7 @@ class TestImporterTest(unittest.TestCase):
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
 
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any.html'))
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any_1-10-expected.txt'))
@@ -690,7 +690,7 @@ class TestImporterTest(unittest.TestCase):
             '/test.checkout/LayoutTests/platform/unknown-platform/w3c/web-platform-tests/t/test-expected.txt': '4',
         }
 
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--clean-dest-dir', '-d', 'w3c'], FAKE_FILES, test_port=True)
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES, test_port=True)
 
         self.assertTrue(fs.exists('/test.checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
         self.assertTrue(fs.exists('/test.checkout/LayoutTests/w3c/web-platform-tests/t/test-expected.txt'))


### PR DESCRIPTION
#### 79cfffaf5857be694874f4309a1ae6a41fb336bd
<pre>
import-w3c-tests: invert --clean-dest-dir
<a href="https://bugs.webkit.org/show_bug.cgi?id=281818">https://bugs.webkit.org/show_bug.cgi?id=281818</a>
<a href="https://rdar.apple.com/138242239">rdar://138242239</a>

Reviewed by Sihui Liu.

--clean-dest-dir has been working reliably for quite a while now. But
many people forget to set it, which can result in significant cleanup
work needed down the line.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:

Canonical link: <a href="https://commits.webkit.org/285476@main">https://commits.webkit.org/285476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8932df420bb7260a62290ea6fcbfd71556188add

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57214 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37643 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72277 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64945 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6903 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11182 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47993 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->