### PR TITLE
[web-animations] Rename `CSSNumberishTime` to `WebAnimationTime`

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -708,7 +708,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/AnimationFrameRatePreset.h
     animation/AnimationTimeline.h
     animation/AnimationTimelinesController.h
-    animation/CSSNumberishTime.h
     animation/CSSPropertyBlendingClient.h
     animation/CustomAnimationOptions.h
     animation/CompositeOperation.h
@@ -729,6 +728,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/TimelineScope.h
     animation/ViewTimeline.h
     animation/ViewTimelineOptions.h
+    animation/WebAnimationTime.h
     animation/WebAnimationTypes.h
 
     bindings/IDLTypes.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -543,7 +543,6 @@ animation/AnimationTimeline.cpp
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp
 animation/CSSAnimation.cpp
-animation/CSSNumberishTime.cpp
 animation/CSSPropertyAnimation.cpp
 animation/CSSTransition.cpp
 animation/DocumentTimeline.cpp
@@ -553,6 +552,7 @@ animation/KeyframeInterpolation.cpp
 animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp
 animation/WebAnimation.cpp
+animation/WebAnimationTime.cpp
 animation/WebAnimationUtilities.cpp
 bindings/js/CommonVM.cpp
 bindings/js/DOMWrapperWorld.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -593,7 +593,6 @@ animation/AnimationTimeline.cpp
 animation/BlendingKeyframes.cpp
 animation/CSSAnimation.cpp
 animation/CSSAnimationEvent.cpp
-animation/CSSNumberishTime.cpp
 animation/CSSPropertyAnimation.cpp
 animation/CSSTransition.cpp
 animation/CSSTransitionEvent.cpp
@@ -613,6 +612,7 @@ animation/StyleOriginatedAnimationEvent.cpp
 animation/TimelineRange.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
+animation/WebAnimationTime.cpp
 animation/WebAnimationUtilities.cpp
 bindings/js/CachedModuleScriptLoader.cpp
 bindings/js/CachedScriptFetcher.cpp

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -57,7 +57,7 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
 }
 
 enum class IsComputed : bool { No, Yes };
-static std::variant<double, RefPtr<CSSNumericValue>, String> durationAPIValue(const CSSNumberishTime& duration, IsComputed isComputed)
+static std::variant<double, RefPtr<CSSNumericValue>, String> durationAPIValue(const WebAnimationTime& duration, IsComputed isComputed)
 {
     if (duration.percentage())
         return autoAtom();
@@ -94,7 +94,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     return timing;
 }
 
-AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optional<CSSNumberishTime> startTime) const
+AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optional<WebAnimationTime> startTime) const
 {
     if (!m_animation)
         return { };
@@ -110,7 +110,7 @@ AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optio
     };
 }
 
-BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<CSSNumberishTime> startTime) const
+BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<WebAnimationTime> startTime) const
 {
     return m_timing.getBasicTiming(resolutionData(startTime));
 }
@@ -122,7 +122,7 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<CSSNumberishTime> startTime) const
+ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<WebAnimationTime> startTime) const
 {
     auto data = resolutionData(startTime);
     auto resolvedTiming = m_timing.resolve(data);
@@ -249,12 +249,12 @@ void AnimationEffect::normalizeSpecifiedTiming(std::variant<double, String> dura
         if (m_animation) {
             if (RefPtr timeline = m_animation->timeline()) {
                 if (timeline->duration())
-                    return CSSNumberishTime::fromPercentage(100);
+                    return WebAnimationTime::fromPercentage(100);
             }
         }
         if (auto* doubleValue = std::get_if<double>(&duration))
-            return CSSNumberishTime::fromMilliseconds(*doubleValue);
-        return CSSNumberishTime::fromMilliseconds(0);
+            return WebAnimationTime::fromMilliseconds(*doubleValue);
+        return WebAnimationTime::fromMilliseconds(0);
     }();
 }
 

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -56,9 +56,9 @@ public:
     virtual bool isKeyframeEffect() const { return false; }
 
     EffectTiming getBindingsTiming() const;
-    BasicEffectTiming getBasicTiming(std::optional<CSSNumberishTime> = std::nullopt) const;
+    BasicEffectTiming getBasicTiming(std::optional<WebAnimationTime> = std::nullopt) const;
     ComputedEffectTiming getBindingsComputedTiming() const;
-    ComputedEffectTiming getComputedTiming(std::optional<CSSNumberishTime> = std::nullopt) const;
+    ComputedEffectTiming getComputedTiming(std::optional<WebAnimationTime> = std::nullopt) const;
     ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
@@ -89,7 +89,7 @@ public:
     double iterations() const { return m_timing.iterations; }
     ExceptionOr<void> setIterations(double);
 
-    CSSNumberishTime iterationDuration() const { return m_timing.iterationDuration; }
+    WebAnimationTime iterationDuration() const { return m_timing.iterationDuration; }
     void setIterationDuration(const Seconds&);
 
     PlaybackDirection direction() const { return m_timing.direction; }
@@ -98,8 +98,8 @@ public:
     TimingFunction* timingFunction() const { return m_timing.timingFunction.get(); }
     void setTimingFunction(const RefPtr<TimingFunction>&);
 
-    CSSNumberishTime activeDuration() const { return m_timing.activeDuration; }
-    CSSNumberishTime endTime() const { return m_timing.endTime; }
+    WebAnimationTime activeDuration() const { return m_timing.activeDuration; }
+    WebAnimationTime endTime() const { return m_timing.endTime; }
 
     void updateStaticTimingProperties();
 
@@ -114,7 +114,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    AnimationEffectTiming::ResolutionData resolutionData(std::optional<CSSNumberishTime>) const;
+    AnimationEffectTiming::ResolutionData resolutionData(std::optional<WebAnimationTime>) const;
     void normalizeSpecifiedTiming(std::variant<double, String>);
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -34,7 +34,7 @@ void AnimationEffectTiming::updateComputedProperties(IsProgressBased isProgressB
 {
     // https://drafts.csswg.org/web-animations-2/#intrinsic-iteration-duration
     if (isProgressBased == IsProgressBased::Yes && iterations)
-        intrinsicIterationDuration = CSSNumberishTime::fromPercentage(100) / iterations;
+        intrinsicIterationDuration = WebAnimationTime::fromPercentage(100) / iterations;
     else
         intrinsicIterationDuration = iterationDuration;
 
@@ -91,7 +91,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
             if (!data.playbackRate)
                 return false;
             // Let effective start time be the animation’s start time if resolved, or zero otherwise.
-            auto effectiveStartTime = data.startTime.value_or(CSSNumberishTime::fromPercentage(0));
+            auto effectiveStartTime = data.startTime.value_or(WebAnimationTime::fromPercentage(0));
             // Set unlimited current time based on the first matching condition:
             // - start time is resolved: (timeline time - start time) × playback rate
             // - Otherwise: animation's current time
@@ -107,7 +107,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
 
         auto animationIsBackwards = data.playbackRate < 0;
 
-        auto beforeActiveBoundaryTime = [&]() -> CSSNumberishTime {
+        auto beforeActiveBoundaryTime = [&]() -> WebAnimationTime {
             if (auto endTimeSeconds = endTime.time())
                 return { std::max(std::min(delay, *endTimeSeconds), 0_s) };
             return endTime.matchingZero();
@@ -121,7 +121,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
         if (localTime->approximatelyLessThan(beforeActiveBoundaryTime) || (animationIsBackwards && localTime->approximatelyEqualTo(beforeActiveBoundaryTime) && !atProgressTimelineBoundary()))
             return AnimationEffectPhase::Before;
 
-        auto activeAfterBoundaryTime = [&]() -> CSSNumberishTime {
+        auto activeAfterBoundaryTime = [&]() -> WebAnimationTime {
             if (endTime.percentage())
                 return std::max(std::min(activeDuration, endTime), activeDuration.matchingZero());
             ASSERT(endTime.time());
@@ -143,7 +143,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
         return AnimationEffectPhase::Active;
     }();
 
-    auto activeTime = [this, localTime, phase]() -> std::optional<CSSNumberishTime> {
+    auto activeTime = [this, localTime, phase]() -> std::optional<WebAnimationTime> {
         // 3.8.3.1. Calculating the active time
         // https://drafts.csswg.org/web-animations-1/#calculating-the-active-time
 

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -54,16 +54,16 @@ struct AnimationEffectTiming {
     double iterations { 1 };
     Seconds delay { 0_s };
     Seconds endDelay { 0_s };
-    CSSNumberishTime iterationDuration { 0_s };
-    CSSNumberishTime intrinsicIterationDuration { 0_s };
-    CSSNumberishTime activeDuration { 0_s };
-    CSSNumberishTime endTime { 0_s };
+    WebAnimationTime iterationDuration { 0_s };
+    WebAnimationTime intrinsicIterationDuration { 0_s };
+    WebAnimationTime activeDuration { 0_s };
+    WebAnimationTime endTime { 0_s };
 
     struct ResolutionData {
-        std::optional<CSSNumberishTime> timelineTime;
-        std::optional<CSSNumberishTime> timelineDuration;
-        std::optional<CSSNumberishTime> startTime;
-        std::optional<CSSNumberishTime> localTime;
+        std::optional<WebAnimationTime> timelineTime;
+        std::optional<WebAnimationTime> timelineDuration;
+        std::optional<WebAnimationTime> startTime;
+        std::optional<WebAnimationTime> localTime;
         double playbackRate { 0 };
     };
 

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -40,7 +40,7 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const Ani
 {
 }
 
-AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<CSSNumberishTime> scheduledTime, std::optional<CSSNumberishTime> timelineTime, std::optional<CSSNumberishTime> currentTime)
+AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<WebAnimationTime> scheduledTime, std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> currentTime)
     : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, animation, scheduledTime)
 {
     if (timelineTime)

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class AnimationPlaybackEvent final : public AnimationEventBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AnimationPlaybackEvent);
 public:
-    static Ref<AnimationPlaybackEvent> create(const AtomString& type, WebAnimation* animation, std::optional<CSSNumberishTime> scheduledTime, std::optional<CSSNumberishTime> timelineTime, std::optional<CSSNumberishTime> currentTime)
+    static Ref<AnimationPlaybackEvent> create(const AtomString& type, WebAnimation* animation, std::optional<WebAnimationTime> scheduledTime, std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> currentTime)
     {
         return adoptRef(*new AnimationPlaybackEvent(type, animation, scheduledTime, timelineTime, currentTime));
     }
@@ -49,15 +49,15 @@ public:
 
     bool isAnimationPlaybackEvent() const final { return true; }
 
-    std::optional<CSSNumberishTime> timelineTime() const { return m_timelineTime; }
-    std::optional<CSSNumberishTime> currentTime() const { return m_currentTime; }
+    std::optional<WebAnimationTime> timelineTime() const { return m_timelineTime; }
+    std::optional<WebAnimationTime> currentTime() const { return m_currentTime; }
 
 private:
-    AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<CSSNumberishTime> scheduledTime, std::optional<CSSNumberishTime> timelineTime, std::optional<CSSNumberishTime> currentTime);
+    AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<WebAnimationTime> scheduledTime, std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> currentTime);
     AnimationPlaybackEvent(const AtomString&, const AnimationPlaybackEventInit&, IsTrusted);
 
-    std::optional<CSSNumberishTime> m_timelineTime;
-    std::optional<CSSNumberishTime> m_currentTime;
+    std::optional<WebAnimationTime> m_timelineTime;
+    std::optional<WebAnimationTime> m_currentTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationPlaybackEventInit.h
+++ b/Source/WebCore/animation/AnimationPlaybackEventInit.h
@@ -31,8 +31,8 @@
 namespace WebCore {
 
 struct AnimationPlaybackEventInit : EventInit {
-    std::optional<CSSNumberishTime> currentTime;
-    std::optional<CSSNumberishTime> timelineTime;
+    std::optional<WebAnimationTime> currentTime;
+    std::optional<WebAnimationTime> timelineTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-AnimationTimeline::AnimationTimeline(std::optional<CSSNumberishTime> duration)
+AnimationTimeline::AnimationTimeline(std::optional<WebAnimationTime> duration)
     : m_duration(duration)
 {
 }

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -52,8 +52,8 @@ public:
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
 
-    virtual std::optional<CSSNumberishTime> currentTime() { return m_currentTime; }
-    virtual std::optional<CSSNumberishTime> duration() const { return m_duration; }
+    virtual std::optional<WebAnimationTime> currentTime() { return m_currentTime; }
+    virtual std::optional<WebAnimationTime> duration() const { return m_duration; }
 
     virtual void detachFromDocument();
 
@@ -67,15 +67,15 @@ public:
     virtual AnimationTimelinesController* controller() const { return nullptr; }
 
 protected:
-    AnimationTimeline(std::optional<CSSNumberishTime> = std::nullopt);
+    AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
     AnimationCollection m_animations;
 
 private:
     void updateGlobalPosition(WebAnimation&);
 
-    std::optional<CSSNumberishTime> m_currentTime;
-    std::optional<CSSNumberishTime> m_duration;
+    std::optional<WebAnimationTime> m_currentTime;
+    std::optional<WebAnimationTime> m_duration;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/BasicEffectTiming.h
+++ b/Source/WebCore/animation/BasicEffectTiming.h
@@ -26,17 +26,17 @@
 #pragma once
 
 #include "AnimationEffectPhase.h"
-#include "CSSNumberishTime.h"
+#include "WebAnimationTime.h"
 #include <wtf/Markable.h>
 #include <wtf/Seconds.h>
 
 namespace WebCore {
 
 struct BasicEffectTiming {
-    std::optional<CSSNumberishTime> localTime;
-    std::optional<CSSNumberishTime> activeTime;
-    CSSNumberishTime endTime;
-    CSSNumberishTime activeDuration;
+    std::optional<WebAnimationTime> localTime;
+    std::optional<WebAnimationTime> activeTime;
+    WebAnimationTime endTime;
+    WebAnimationTime activeDuration;
     AnimationEffectPhase phase;
 };
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -198,7 +198,7 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
     }
 }
 
-ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<CSSNumberishTime>& startTime)
+ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<WebAnimationTime>& startTime)
 {
     // https://drafts.csswg.org/css-animations-2/#animations
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -59,7 +59,7 @@ private:
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;
     void setBindingsEffect(RefPtr<AnimationEffect>&&) final;
-    ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberishTime>&) final;
+    ExceptionOr<void> setBindingsStartTime(const std::optional<WebAnimationTime>&) final;
     ExceptionOr<void> bindingsReverse() final;
 
     enum class Property : uint16_t {

--- a/Source/WebCore/animation/ComputedEffectTiming.h
+++ b/Source/WebCore/animation/ComputedEffectTiming.h
@@ -35,12 +35,12 @@ namespace WebCore {
 
 struct ComputedEffectTiming : EffectTiming {
     AnimationEffectPhase phase { AnimationEffectPhase::Idle };
-    std::optional<CSSNumberishTime> localTime;
+    std::optional<WebAnimationTime> localTime;
     MarkableDouble simpleIterationProgress;
     MarkableDouble progress;
     MarkableDouble currentIteration;
-    CSSNumberishTime endTime;
-    CSSNumberishTime activeDuration;
+    WebAnimationTime endTime;
+    WebAnimationTime activeDuration;
     TimingFunction::Before before { TimingFunction::Before::No };
 };
 

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -125,7 +125,7 @@ unsigned DocumentTimeline::numberOfActiveAnimationsForTesting() const
     return count;
 }
 
-std::optional<CSSNumberishTime> DocumentTimeline::currentTime()
+std::optional<WebAnimationTime> DocumentTimeline::currentTime()
 {
     if (auto* controller = this->controller()) {
         if (auto currentTime = controller->currentTime())

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -58,7 +58,7 @@ public:
 
     Document* document() const { return m_document.get(); }
 
-    std::optional<CSSNumberishTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime() override;
     ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, std::optional<std::variant<double, CustomAnimationOptions>>&&);
 
     void animationTimingDidChange(WebAnimation&) override;

--- a/Source/WebCore/animation/KeyframeInterpolation.cpp
+++ b/Source/WebCore/animation/KeyframeInterpolation.cpp
@@ -121,14 +121,14 @@ const KeyframeInterpolation::KeyframeInterval KeyframeInterpolation::interpolati
     return { intervalEndpoints, hasImplicitZeroKeyframe, hasImplicitOneKeyframe };
 }
 
-static double transformProgressDuration(const CSSNumberishTime& duration)
+static double transformProgressDuration(const WebAnimationTime& duration)
 {
     if (auto time = duration.time())
         return time->seconds();
     return 1.0;
 }
 
-void KeyframeInterpolation::interpolateKeyframes(Property property, const KeyframeInterval& interval, double iterationProgress, double currentIteration, const CSSNumberishTime& iterationDuration, TimingFunction::Before before, const CompositionCallback& compositionCallback, const AccumulationCallback& accumulationCallback, const InterpolationCallback& interpolationCallback, const RequiresBlendingForAccumulativeIterationCallback& requiresBlendingForAccumulativeIterationCallback) const
+void KeyframeInterpolation::interpolateKeyframes(Property property, const KeyframeInterval& interval, double iterationProgress, double currentIteration, const WebAnimationTime& iterationDuration, TimingFunction::Before before, const CompositionCallback& compositionCallback, const AccumulationCallback& accumulationCallback, const InterpolationCallback& interpolationCallback, const RequiresBlendingForAccumulativeIterationCallback& requiresBlendingForAccumulativeIterationCallback) const
 {
     auto& intervalEndpoints = interval.endpoints;
     if (intervalEndpoints.isEmpty())

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -69,7 +69,7 @@ public:
     using AccumulationCallback = Function<void(const Keyframe&)>;
     using InterpolationCallback = Function<void(double intervalProgress, double currentIteration, IterationCompositeOperation)>;
     using RequiresBlendingForAccumulativeIterationCallback = Function<bool()>;
-    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, const CSSNumberishTime& iterationDuration, TimingFunction::Before, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
+    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, const WebAnimationTime& iterationDuration, TimingFunction::Before, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
 
     virtual ~KeyframeInterpolation() = default;
 };

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -79,7 +79,7 @@ Ref<ScrollTimeline> ScrollTimeline::createFromCSSValue(const CSSScrollValue& css
 // the duration has a fixed upper bound. In this case, the timeline is a
 // progress-based timeline, and its timeline duration is 100%.
 ScrollTimeline::ScrollTimeline(ScrollTimelineOptions&& options)
-    : AnimationTimeline(CSSNumberishTime::fromPercentage(100))
+    : AnimationTimeline(WebAnimationTime::fromPercentage(100))
     , m_source(WTFMove(options.source))
     , m_axis(options.axis)
 {
@@ -212,7 +212,7 @@ ScrollTimeline::Data ScrollTimeline::computeTimelineData(const TimelineRange& ra
     return { scrollOffset, floatValueForOffset(range.start.offset, maxScrollOffset), maxScrollOffset - floatValueForOffset(range.end.offset, maxScrollOffset) };
 }
 
-std::optional<CSSNumberishTime> ScrollTimeline::currentTime()
+std::optional<WebAnimationTime> ScrollTimeline::currentTime()
 {
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // Progress (the current time) for a scroll progress timeline is calculated as:
@@ -223,7 +223,7 @@ std::optional<CSSNumberishTime> ScrollTimeline::currentTime()
         return std::nullopt;
     auto distance = data.scrollOffset - data.rangeStart;
     auto progress = distance / range;
-    return CSSNumberishTime::fromPercentage(progress * 100);
+    return WebAnimationTime::fromPercentage(progress * 100);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -63,7 +63,7 @@ public:
     AnimationTimelinesController* controller() const override;
     static ScrollableArea* scrollableAreaForSourceRenderer(RenderElement*, Ref<Document>);
 
-    std::optional<CSSNumberishTime> currentTime() override;
+    std::optional<WebAnimationTime> currentTime() override;
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -131,13 +131,13 @@ void StyleOriginatedAnimation::syncPropertiesWithBackingAnimation()
 {
 }
 
-std::optional<CSSNumberishTime> StyleOriginatedAnimation::bindingsStartTime() const
+std::optional<WebAnimationTime> StyleOriginatedAnimation::bindingsStartTime() const
 {
     flushPendingStyleChanges();
     return WebAnimation::bindingsStartTime();
 }
 
-std::optional<CSSNumberishTime> StyleOriginatedAnimation::bindingsCurrentTime() const
+std::optional<WebAnimationTime> StyleOriginatedAnimation::bindingsCurrentTime() const
 {
     flushPendingStyleChanges();
     return WebAnimation::bindingsCurrentTime();
@@ -203,7 +203,7 @@ void StyleOriginatedAnimation::setTimeline(RefPtr<AnimationTimeline>&& newTimeli
 
 void StyleOriginatedAnimation::cancel(WebAnimation::Silently silently)
 {
-    CSSNumberishTime cancelationTime = 0_s;
+    WebAnimationTime cancelationTime = 0_s;
 
     auto shouldFireEvents = shouldFireDOMEvents();
     if (shouldFireEvents != ShouldFireEvents::No) {
@@ -237,14 +237,14 @@ AnimationEffectPhase StyleOriginatedAnimation::phaseWithoutEffect() const
     return *animationCurrentTime < 0_s ? AnimationEffectPhase::Before : AnimationEffectPhase::After;
 }
 
-CSSNumberishTime StyleOriginatedAnimation::effectTimeAtStart() const
+WebAnimationTime StyleOriginatedAnimation::effectTimeAtStart() const
 {
     if (auto* effect = this->effect())
         return effect->delay();
     return 0_s;
 }
 
-CSSNumberishTime StyleOriginatedAnimation::effectTimeAtIteration(double iteration) const
+WebAnimationTime StyleOriginatedAnimation::effectTimeAtIteration(double iteration) const
 {
     if (auto* effect = this->effect()) {
         auto iterationDuration = effect->iterationDuration();
@@ -257,7 +257,7 @@ CSSNumberishTime StyleOriginatedAnimation::effectTimeAtIteration(double iteratio
     return 0_s;
 }
 
-CSSNumberishTime StyleOriginatedAnimation::effectTimeAtEnd() const
+WebAnimationTime StyleOriginatedAnimation::effectTimeAtEnd() const
 {
     if (auto* effect = this->effect())
         return effect->endTime();
@@ -281,7 +281,7 @@ auto StyleOriginatedAnimation::shouldFireDOMEvents() const -> ShouldFireEvents
     return ShouldFireEvents::No;
 }
 
-void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEvents, CSSNumberishTime elapsedTime)
+void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEvents, WebAnimationTime elapsedTime)
 {
     if (!m_owningElement)
         return;
@@ -292,8 +292,8 @@ void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEv
 
     double iteration = 0;
     AnimationEffectPhase currentPhase;
-    CSSNumberishTime intervalStart;
-    CSSNumberishTime intervalEnd;
+    WebAnimationTime intervalStart;
+    WebAnimationTime intervalEnd;
 
     auto* animationEffect = effect();
     if (animationEffect) {
@@ -393,7 +393,7 @@ void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEv
     m_previousIteration = iteration;
 }
 
-void StyleOriginatedAnimation::enqueueDOMEvent(const AtomString& eventType, CSSNumberishTime elapsedTime, CSSNumberishTime scheduledEffectTime)
+void StyleOriginatedAnimation::enqueueDOMEvent(const AtomString& eventType, WebAnimationTime elapsedTime, WebAnimationTime scheduledEffectTime)
 {
     if (!m_owningElement)
         return;

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -52,8 +52,8 @@ public:
     void setBackingAnimation(const Animation&);
     void cancelFromStyle(WebAnimation::Silently = WebAnimation::Silently::No);
 
-    std::optional<CSSNumberishTime> bindingsStartTime() const final;
-    std::optional<CSSNumberishTime> bindingsCurrentTime() const final;
+    std::optional<WebAnimationTime> bindingsStartTime() const final;
+    std::optional<WebAnimationTime> bindingsCurrentTime() const final;
     WebAnimation::PlayState bindingsPlayState() const final;
     WebAnimation::ReplaceState bindingsReplaceState() const final;
     bool bindingsPending() const final;
@@ -83,12 +83,12 @@ private:
     AnimationEffectPhase phaseWithoutEffect() const;
     enum class ShouldFireEvents : uint8_t { No, YesForCSSAnimation, YesForCSSTransition };
     ShouldFireEvents shouldFireDOMEvents() const;
-    void invalidateDOMEvents(ShouldFireEvents, CSSNumberishTime elapsedTime = 0_s);
-    void enqueueDOMEvent(const AtomString&, CSSNumberishTime elapsedTime, CSSNumberishTime scheduledEffectTime);
+    void invalidateDOMEvents(ShouldFireEvents, WebAnimationTime elapsedTime = 0_s);
+    void enqueueDOMEvent(const AtomString&, WebAnimationTime elapsedTime, WebAnimationTime scheduledEffectTime);
 
-    CSSNumberishTime effectTimeAtStart() const;
-    CSSNumberishTime effectTimeAtIteration(double) const;
-    CSSNumberishTime effectTimeAtEnd() const;
+    WebAnimationTime effectTimeAtStart() const;
+    WebAnimationTime effectTimeAtIteration(double) const;
+    WebAnimationTime effectTimeAtEnd() const;
 
     bool m_wasPending { false };
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -85,8 +85,8 @@ public:
     AnimationTimeline* timeline() const { return m_timeline.get(); }
     virtual void setTimeline(RefPtr<AnimationTimeline>&&);
 
-    std::optional<CSSNumberishTime> currentTime(std::optional<CSSNumberishTime> = std::nullopt) const;
-    ExceptionOr<void> setCurrentTime(std::optional<CSSNumberishTime>);
+    std::optional<WebAnimationTime> currentTime(std::optional<WebAnimationTime> = std::nullopt) const;
+    ExceptionOr<void> setCurrentTime(std::optional<WebAnimationTime>);
 
     double playbackRate() const { return m_playbackRate + 0; }
     void setPlaybackRate(double);
@@ -117,12 +117,12 @@ public:
     void persist();
     ExceptionOr<void> commitStyles();
 
-    virtual std::optional<CSSNumberishTime> bindingsStartTime() const { return startTime(); }
-    virtual ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberishTime>&);
-    std::optional<CSSNumberishTime> startTime() const { return m_startTime; }
-    void setStartTime(std::optional<CSSNumberishTime>);
-    virtual std::optional<CSSNumberishTime> bindingsCurrentTime() const { return currentTime(); };
-    virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberishTime>&);
+    virtual std::optional<WebAnimationTime> bindingsStartTime() const { return startTime(); }
+    virtual ExceptionOr<void> setBindingsStartTime(const std::optional<WebAnimationTime>&);
+    std::optional<WebAnimationTime> startTime() const { return m_startTime; }
+    void setStartTime(std::optional<WebAnimationTime>);
+    virtual std::optional<WebAnimationTime> bindingsCurrentTime() const { return currentTime(); };
+    virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<WebAnimationTime>&);
     std::optional<double> progress() const;
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
@@ -131,7 +131,7 @@ public:
     virtual FinishedPromise& bindingsFinished() { return finished(); }
     virtual ExceptionOr<void> bindingsPlay() { return play(); }
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
-    std::optional<CSSNumberishTime> holdTime() const { return m_holdTime; }
+    std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
 
     virtual std::variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);
@@ -160,7 +160,7 @@ public:
     bool isSuspended() const { return m_isSuspended; }
     bool isReplaceable() const;
     void remove();
-    void enqueueAnimationPlaybackEvent(const AtomString&, std::optional<CSSNumberishTime> currentTime, std::optional<CSSNumberishTime> scheduledTime);
+    void enqueueAnimationPlaybackEvent(const AtomString&, std::optional<WebAnimationTime> currentTime, std::optional<WebAnimationTime> scheduledTime);
 
     uint64_t globalPosition() const { return m_globalPosition; }
     void setGlobalPosition(uint64_t globalPosition) { m_globalPosition = globalPosition; }
@@ -179,7 +179,7 @@ protected:
     void initialize();
     void enqueueAnimationEvent(Ref<AnimationEventBase>&&);
     virtual void animationDidFinish();
-    CSSNumberishTime zeroTime() const;
+    WebAnimationTime zeroTime() const;
 
 private:
     enum class DidSeek : bool { No, Yes };
@@ -190,11 +190,11 @@ private:
 
     void timingDidChange(DidSeek, SynchronouslyNotify, Silently = Silently::No);
     void updateFinishedState(DidSeek, SynchronouslyNotify);
-    CSSNumberishTime effectEndTime() const;
+    WebAnimationTime effectEndTime() const;
     WebAnimation& readyPromiseResolve();
     WebAnimation& finishedPromiseResolve();
-    std::optional<CSSNumberishTime> currentTime(RespectHoldTime, std::optional<CSSNumberishTime> = std::nullopt) const;
-    ExceptionOr<void> silentlySetCurrentTime(std::optional<CSSNumberishTime>);
+    std::optional<WebAnimationTime> currentTime(RespectHoldTime, std::optional<WebAnimationTime> = std::nullopt) const;
+    ExceptionOr<void> silentlySetCurrentTime(std::optional<WebAnimationTime>);
     void finishNotificationSteps();
     bool hasPendingPauseTask() const { return m_timeToRunPendingPauseTask != TimeToRunPendingTask::NotScheduled; }
     bool hasPendingPlayTask() const { return m_timeToRunPendingPlayTask != TimeToRunPendingTask::NotScheduled; }
@@ -210,7 +210,7 @@ private:
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
     void autoAlignStartTime();
-    bool isTimeValid(const std::optional<CSSNumberishTime>&) const;
+    bool isTimeValid(const std::optional<WebAnimationTime>&) const;
 
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;
@@ -227,9 +227,9 @@ private:
     RefPtr<AnimationTimeline> m_timeline;
     UniqueRef<ReadyPromise> m_readyPromise;
     UniqueRef<FinishedPromise> m_finishedPromise;
-    std::optional<CSSNumberishTime> m_previousCurrentTime;
-    std::optional<CSSNumberishTime> m_startTime;
-    std::optional<CSSNumberishTime> m_holdTime;
+    std::optional<WebAnimationTime> m_previousCurrentTime;
+    std::optional<WebAnimationTime> m_startTime;
+    std::optional<WebAnimationTime> m_holdTime;
     MarkableDouble m_pendingPlaybackRate;
     double m_playbackRate { 1 };
     std::variant<FramesPerSecond, AnimationFrameRatePreset> m_bindingsFrameRate { AnimationFrameRatePreset::Auto };

--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "CSSNumberishTime.h"
+#include "WebAnimationTime.h"
 
 #include "CSSNumericFactory.h"
 #include "CSSUnitValue.h"
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-CSSNumberishTime::CSSNumberishTime(std::optional<Seconds> time, std::optional<double> percentage)
+WebAnimationTime::WebAnimationTime(std::optional<Seconds> time, std::optional<double> percentage)
 {
     ASSERT(time || percentage);
     ASSERT(!!time != !!percentage);
@@ -45,19 +45,19 @@ CSSNumberishTime::CSSNumberishTime(std::optional<Seconds> time, std::optional<do
     }
 }
 
-CSSNumberishTime::CSSNumberishTime(const Seconds& value)
+WebAnimationTime::WebAnimationTime(const Seconds& value)
     : m_type(Type::Time)
     , m_value(value.seconds())
 {
 }
 
-CSSNumberishTime::CSSNumberishTime(Type type, double value)
+WebAnimationTime::WebAnimationTime(Type type, double value)
     : m_type(type)
     , m_value(value)
 {
 }
 
-CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
+WebAnimationTime::WebAnimationTime(const CSSNumberish& value)
 {
     if (auto* doubleValue = std::get_if<double>(&value)) {
         m_type = Type::Time;
@@ -84,58 +84,58 @@ CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
     }
 }
 
-CSSNumberishTime CSSNumberishTime::fromMilliseconds(double milliseconds)
+WebAnimationTime WebAnimationTime::fromMilliseconds(double milliseconds)
 {
     return { Type::Time, milliseconds / 1000 };
 }
 
-CSSNumberishTime CSSNumberishTime::fromPercentage(double percentage)
+WebAnimationTime WebAnimationTime::fromPercentage(double percentage)
 {
     return { Type::Percentage, percentage };
 }
 
-std::optional<Seconds> CSSNumberishTime::time() const
+std::optional<Seconds> WebAnimationTime::time() const
 {
     if (m_type == Type::Time)
         return Seconds { m_value };
     return std::nullopt;
 }
 
-std::optional<double> CSSNumberishTime::percentage() const
+std::optional<double> WebAnimationTime::percentage() const
 {
     if (m_type == Type::Percentage)
         return m_value;
     return std::nullopt;
 }
 
-bool CSSNumberishTime::isValid() const
+bool WebAnimationTime::isValid() const
 {
     return m_type != Type::Unknown;
 }
 
-bool CSSNumberishTime::isInfinity() const
+bool WebAnimationTime::isInfinity() const
 {
     return std::isinf(m_value);
 }
 
-bool CSSNumberishTime::isZero() const
+bool WebAnimationTime::isZero() const
 {
     return !m_value;
 }
 
-CSSNumberishTime CSSNumberishTime::matchingZero() const
+WebAnimationTime WebAnimationTime::matchingZero() const
 {
     return { m_type, 0 };
 }
 
-CSSNumberishTime CSSNumberishTime::matchingEpsilon() const
+WebAnimationTime WebAnimationTime::matchingEpsilon() const
 {
     if (m_type == Type::Percentage)
-        return CSSNumberishTime::fromPercentage(0.000001);
+        return WebAnimationTime::fromPercentage(0.000001);
     return { WebCore::timeEpsilon };
 }
 
-bool CSSNumberishTime::approximatelyEqualTo(const CSSNumberishTime& other) const
+bool WebAnimationTime::approximatelyEqualTo(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     if (m_type == Type::Time)
@@ -143,7 +143,7 @@ bool CSSNumberishTime::approximatelyEqualTo(const CSSNumberishTime& other) const
     return m_value == other.m_value;
 }
 
-bool CSSNumberishTime::approximatelyLessThan(const CSSNumberishTime& other) const
+bool WebAnimationTime::approximatelyLessThan(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     if (m_type == Type::Time)
@@ -151,7 +151,7 @@ bool CSSNumberishTime::approximatelyLessThan(const CSSNumberishTime& other) cons
     return m_value < other.m_value;
 }
 
-bool CSSNumberishTime::approximatelyGreaterThan(const CSSNumberishTime& other) const
+bool WebAnimationTime::approximatelyGreaterThan(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     if (m_type == Type::Time)
@@ -159,125 +159,125 @@ bool CSSNumberishTime::approximatelyGreaterThan(const CSSNumberishTime& other) c
     return m_value > other.m_value;
 }
 
-CSSNumberishTime CSSNumberishTime::operator+(const CSSNumberishTime& other) const
+WebAnimationTime WebAnimationTime::operator+(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return { m_type, m_value + other.m_value };
 }
 
-CSSNumberishTime CSSNumberishTime::operator-(const CSSNumberishTime& other) const
+WebAnimationTime WebAnimationTime::operator-(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return { m_type, m_value - other.m_value };
 }
 
-double CSSNumberishTime::operator/(const CSSNumberishTime& other) const
+double WebAnimationTime::operator/(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value / other.m_value;
 }
 
-CSSNumberishTime& CSSNumberishTime::operator+=(const CSSNumberishTime& other)
+WebAnimationTime& WebAnimationTime::operator+=(const WebAnimationTime& other)
 {
     ASSERT(m_type == other.m_type);
     m_value += other.m_value;
     return *this;
 }
 
-CSSNumberishTime& CSSNumberishTime::operator-=(const CSSNumberishTime& other)
+WebAnimationTime& WebAnimationTime::operator-=(const WebAnimationTime& other)
 {
     ASSERT(m_type == other.m_type);
     m_value -= other.m_value;
     return *this;
 }
 
-bool CSSNumberishTime::operator<(const CSSNumberishTime& other) const
+bool WebAnimationTime::operator<(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value < other.m_value;
 }
 
-bool CSSNumberishTime::operator<=(const CSSNumberishTime& other) const
+bool WebAnimationTime::operator<=(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value <= other.m_value;
 }
 
-bool CSSNumberishTime::operator>(const CSSNumberishTime& other) const
+bool WebAnimationTime::operator>(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value > other.m_value;
 }
 
-bool CSSNumberishTime::operator>=(const CSSNumberishTime& other) const
+bool WebAnimationTime::operator>=(const WebAnimationTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value >= other.m_value;
 }
 
-bool CSSNumberishTime::operator==(const CSSNumberishTime& other) const
+bool WebAnimationTime::operator==(const WebAnimationTime& other) const
 {
     return m_type == other.m_type && m_value == other.m_value;
 }
 
-CSSNumberishTime CSSNumberishTime::operator+(const Seconds& other) const
+WebAnimationTime WebAnimationTime::operator+(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return { m_type, m_value + other.seconds() };
 }
 
-CSSNumberishTime CSSNumberishTime::operator-(const Seconds& other) const
+WebAnimationTime WebAnimationTime::operator-(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return { m_type, m_value - other.seconds() };
 }
 
-bool CSSNumberishTime::operator<(const Seconds& other) const
+bool WebAnimationTime::operator<(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value < other.seconds();
 }
 
-bool CSSNumberishTime::operator<=(const Seconds& other) const
+bool WebAnimationTime::operator<=(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value <= other.seconds();
 }
 
-bool CSSNumberishTime::operator>(const Seconds& other) const
+bool WebAnimationTime::operator>(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value > other.seconds();
 }
 
-bool CSSNumberishTime::operator>=(const Seconds& other) const
+bool WebAnimationTime::operator>=(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value >= other.seconds();
 }
 
-bool CSSNumberishTime::operator==(const Seconds& other) const
+bool WebAnimationTime::operator==(const Seconds& other) const
 {
     return m_type == Type::Time && m_value == other.seconds();
 }
 
-CSSNumberishTime CSSNumberishTime::operator*(double scalar) const
+WebAnimationTime WebAnimationTime::operator*(double scalar) const
 {
     return { m_type, m_value * scalar };
 }
 
-CSSNumberishTime CSSNumberishTime::operator/(double scalar) const
+WebAnimationTime WebAnimationTime::operator/(double scalar) const
 {
     return { m_type, m_value / scalar };
 }
 
-CSSNumberishTime::operator Seconds() const
+WebAnimationTime::operator Seconds() const
 {
     ASSERT(m_type == Type::Time);
     return Seconds(m_value);
 }
 
-CSSNumberishTime::operator CSSNumberish() const
+WebAnimationTime::operator CSSNumberish() const
 {
     if (m_type == Type::Time)
         return secondsToWebAnimationsAPITime(*this);
@@ -285,7 +285,7 @@ CSSNumberishTime::operator CSSNumberish() const
     return CSSNumericFactory::percent(m_value);
 }
 
-void CSSNumberishTime::dump(TextStream& ts) const
+void WebAnimationTime::dump(TextStream& ts) const
 {
     if (m_type == Type::Time) {
         ts << m_value * 1000;
@@ -296,7 +296,7 @@ void CSSNumberishTime::dump(TextStream& ts) const
     return;
 }
 
-TextStream& operator<<(TextStream& ts, const CSSNumberishTime& value)
+TextStream& operator<<(TextStream& ts, const WebAnimationTime& value)
 {
     value.dump(ts);
     return ts;

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -30,16 +30,16 @@
 
 namespace WebCore {
 
-class CSSNumberishTime {
+class WebAnimationTime {
 public:
-    CSSNumberishTime() = default;
-    WEBCORE_EXPORT CSSNumberishTime(std::optional<Seconds>, std::optional<double>);
+    WebAnimationTime() = default;
+    WEBCORE_EXPORT WebAnimationTime(std::optional<Seconds>, std::optional<double>);
 
-    CSSNumberishTime(const Seconds&);
-    CSSNumberishTime(const CSSNumberish&);
+    WebAnimationTime(const Seconds&);
+    WebAnimationTime(const CSSNumberish&);
 
-    static CSSNumberishTime fromMilliseconds(double);
-    static CSSNumberishTime fromPercentage(double);
+    static WebAnimationTime fromMilliseconds(double);
+    static WebAnimationTime fromPercentage(double);
 
     WEBCORE_EXPORT std::optional<Seconds> time() const;
     WEBCORE_EXPORT std::optional<double> percentage() const;
@@ -48,34 +48,34 @@ public:
     bool isInfinity() const;
     bool isZero() const;
 
-    CSSNumberishTime matchingZero() const;
-    CSSNumberishTime matchingEpsilon() const;
+    WebAnimationTime matchingZero() const;
+    WebAnimationTime matchingEpsilon() const;
 
-    bool approximatelyEqualTo(const CSSNumberishTime&) const;
-    bool approximatelyLessThan(const CSSNumberishTime&) const;
-    bool approximatelyGreaterThan(const CSSNumberishTime&) const;
+    bool approximatelyEqualTo(const WebAnimationTime&) const;
+    bool approximatelyLessThan(const WebAnimationTime&) const;
+    bool approximatelyGreaterThan(const WebAnimationTime&) const;
 
-    CSSNumberishTime operator+(const CSSNumberishTime&) const;
-    CSSNumberishTime operator-(const CSSNumberishTime&) const;
-    double operator/(const CSSNumberishTime&) const;
-    CSSNumberishTime& operator+=(const CSSNumberishTime&);
-    CSSNumberishTime& operator-=(const CSSNumberishTime&);
-    bool operator<(const CSSNumberishTime&) const;
-    bool operator<=(const CSSNumberishTime&) const;
-    bool operator>(const CSSNumberishTime&) const;
-    bool operator>=(const CSSNumberishTime&) const;
-    bool operator==(const CSSNumberishTime&) const;
+    WebAnimationTime operator+(const WebAnimationTime&) const;
+    WebAnimationTime operator-(const WebAnimationTime&) const;
+    double operator/(const WebAnimationTime&) const;
+    WebAnimationTime& operator+=(const WebAnimationTime&);
+    WebAnimationTime& operator-=(const WebAnimationTime&);
+    bool operator<(const WebAnimationTime&) const;
+    bool operator<=(const WebAnimationTime&) const;
+    bool operator>(const WebAnimationTime&) const;
+    bool operator>=(const WebAnimationTime&) const;
+    bool operator==(const WebAnimationTime&) const;
 
-    CSSNumberishTime operator+(const Seconds&) const;
-    CSSNumberishTime operator-(const Seconds&) const;
+    WebAnimationTime operator+(const Seconds&) const;
+    WebAnimationTime operator-(const Seconds&) const;
     bool operator<(const Seconds&) const;
     bool operator<=(const Seconds&) const;
     bool operator>(const Seconds&) const;
     bool operator>=(const Seconds&) const;
     bool operator==(const Seconds&) const;
 
-    CSSNumberishTime operator*(double) const;
-    CSSNumberishTime operator/(double) const;
+    WebAnimationTime operator*(double) const;
+    WebAnimationTime operator/(double) const;
 
     operator Seconds() const;
     operator CSSNumberish() const;
@@ -85,12 +85,12 @@ public:
 private:
     enum class Type : uint8_t { Unknown, Time, Percentage };
 
-    CSSNumberishTime(Type, double);
+    WebAnimationTime(Type, double);
 
     Type m_type { Type::Unknown };
     double m_value { 0 };
 };
 
-TextStream& operator<<(TextStream&, const CSSNumberishTime&);
+TextStream& operator<<(TextStream&, const WebAnimationTime&);
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "CSSNumberishTime.h"
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include "EventTarget.h"
 #include "TimelineRangeOffset.h"
+#include "WebAnimationTime.h"
 #include <wtf/BitSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -212,7 +212,7 @@ static Ref<Inspector::Protocol::Animation::Effect> buildObjectForEffect(Animatio
     effectPayload->setIterationCount(effect.iterations() == std::numeric_limits<double>::infinity() ? -1 : effect.iterations());
     effectPayload->setIterationStart(effect.iterationStart());
 
-    // FIXME: convert this to CSSNumberishTime.
+    // FIXME: convert this to WebAnimationTime.
     if (auto durationTime = effect.iterationDuration().time()) {
         if (auto iterationDuration = protocolValueForSeconds(*durationTime))
             effectPayload->setIterationDuration(iterationDuration.value());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6311,7 +6311,7 @@ struct WebCore::AcceleratedEffectValues {
     WebCore::FilterOperations backdropFilter;
 }
 
-class WebCore::CSSNumberishTime {
+class WebCore::WebAnimationTime {
     std::optional<Seconds> time();
     std::optional<double> percentage();
 };
@@ -6324,10 +6324,10 @@ struct WebCore::AnimationEffectTiming {
     double iterations;
     Seconds delay;
     Seconds endDelay;
-    WebCore::CSSNumberishTime iterationDuration;
-    WebCore::CSSNumberishTime intrinsicIterationDuration;
-    WebCore::CSSNumberishTime activeDuration;
-    WebCore::CSSNumberishTime endTime;
+    WebCore::WebAnimationTime iterationDuration;
+    WebCore::WebAnimationTime intrinsicIterationDuration;
+    WebCore::WebAnimationTime activeDuration;
+    WebCore::WebAnimationTime endTime;
 };
 
 header: <WebCore/AcceleratedEffect.h>


### PR DESCRIPTION
#### aa30e476b435875d2bdd3e86cdd63f8af841ffeb
<pre>
[web-animations] Rename `CSSNumberishTime` to `WebAnimationTime`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281819">https://bugs.webkit.org/show_bug.cgi?id=281819</a>
<a href="https://rdar.apple.com/138242355">rdar://138242355</a>

Reviewed by Anne van Kesteren.

The name `CSSNumberishTime` is pretty specific to the type of input for timing
values used throughout out the Web Animations codebase. It would be better to
use the name `WebAnimationTime`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::durationAPIValue):
(WebCore::AnimationEffect::resolutionData const):
(WebCore::AnimationEffect::getBasicTiming const):
(WebCore::AnimationEffect::getComputedTiming const):
(WebCore::AnimationEffect::normalizeSpecifiedTiming):
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::iterationDuration const):
(WebCore::AnimationEffect::activeDuration const):
(WebCore::AnimationEffect::endTime const):
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::updateComputedProperties):
(WebCore::AnimationEffectTiming::getBasicTiming const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/AnimationPlaybackEventInit.h:
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::AnimationTimeline):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::currentTime):
(WebCore::AnimationTimeline::duration const):
* Source/WebCore/animation/BasicEffectTiming.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::setBindingsStartTime):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/ComputedEffectTiming.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::currentTime):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::transformProgressDuration):
(WebCore::KeyframeInterpolation::interpolateKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):
(WebCore::ScrollTimeline::currentTime):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::bindingsStartTime const):
(WebCore::StyleOriginatedAnimation::bindingsCurrentTime const):
(WebCore::StyleOriginatedAnimation::cancel):
(WebCore::StyleOriginatedAnimation::effectTimeAtStart const):
(WebCore::StyleOriginatedAnimation::effectTimeAtIteration const):
(WebCore::StyleOriginatedAnimation::effectTimeAtEnd const):
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
(WebCore::StyleOriginatedAnimation::enqueueDOMEvent):
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::isTimeValid const):
(WebCore::WebAnimation::setBindingsStartTime):
(WebCore::WebAnimation::setStartTime):
(WebCore::WebAnimation::setBindingsCurrentTime):
(WebCore::WebAnimation::currentTime const):
(WebCore::WebAnimation::silentlySetCurrentTime):
(WebCore::WebAnimation::setCurrentTime):
(WebCore::WebAnimation::zeroTime const):
(WebCore::WebAnimation::effectEndTime const):
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::enqueueAnimationPlaybackEvent):
(WebCore::WebAnimation::finishNotificationSteps):
(WebCore::WebAnimation::autoAlignStartTime):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::bindingsStartTime const):
(WebCore::WebAnimation::startTime const):
(WebCore::WebAnimation::bindingsCurrentTime const):
(WebCore::WebAnimation::holdTime const):
* Source/WebCore/animation/WebAnimationTime.cpp: Renamed from Source/WebCore/animation/CSSNumberishTime.cpp.
(WebCore::WebAnimationTime::WebAnimationTime):
(WebCore::WebAnimationTime::fromMilliseconds):
(WebCore::WebAnimationTime::fromPercentage):
(WebCore::WebAnimationTime::time const):
(WebCore::WebAnimationTime::percentage const):
(WebCore::WebAnimationTime::isValid const):
(WebCore::WebAnimationTime::isInfinity const):
(WebCore::WebAnimationTime::isZero const):
(WebCore::WebAnimationTime::matchingZero const):
(WebCore::WebAnimationTime::matchingEpsilon const):
(WebCore::WebAnimationTime::approximatelyEqualTo const):
(WebCore::WebAnimationTime::approximatelyLessThan const):
(WebCore::WebAnimationTime::approximatelyGreaterThan const):
(WebCore::WebAnimationTime::operator+ const):
(WebCore::WebAnimationTime::operator- const):
(WebCore::WebAnimationTime::operator/ const):
(WebCore::WebAnimationTime::operator+=):
(WebCore::WebAnimationTime::operator-=):
(WebCore::WebAnimationTime::operator&lt; const):
(WebCore::WebAnimationTime::operator&lt;= const):
(WebCore::WebAnimationTime::operator&gt; const):
(WebCore::WebAnimationTime::operator&gt;= const):
(WebCore::WebAnimationTime::operator== const):
(WebCore::WebAnimationTime::operator* const):
(WebCore::WebAnimationTime::operator Seconds const):
(WebCore::WebAnimationTime::operator CSSNumberish const):
(WebCore::WebAnimationTime::dump const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/animation/WebAnimationTime.h: Renamed from Source/WebCore/animation/CSSNumberishTime.h.
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/285481@main">https://commits.webkit.org/285481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1ee1365595741015b6a9462e131294808b2a48c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57237 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20121 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64966 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6925 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48017 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2804 "Found 1 new failure in animation/WebAnimationTime.cpp and found 1 fixed file: animation/CSSNumberishTime.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->