### PR TITLE
[iOS] Selection disappears on login.live.com when SelectionHonorsOverflowScrolling is enabled

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt
@@ -1,0 +1,15 @@
+position: static
+Verifies that the selection remains visible when the element containing the selection becomes composited. To run manually, select the text field and tap the button; the selection should remain visible
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS rectsBeforeStyleChange.length is 1
+PASS rectsBeforeStyleChange.length is rectsAfterStyleChange.length
+PASS rectsBeforeStyleChange[0].top is rectsAfterStyleChange[0].top
+PASS rectsBeforeStyleChange[0].left is rectsAfterStyleChange[0].left
+PASS rectsBeforeStyleChange[0].width is rectsAfterStyleChange[0].width
+PASS rectsBeforeStyleChange[0].height is rectsAfterStyleChange[0].height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html
+++ b/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    margin: 0;
+}
+
+input, button {
+    font-size: 18px;
+    outline: none;
+}
+
+#container {
+    width: 300px;
+    height: 200px;
+    border: 2px solid black;
+    border-radius: 1em;
+    padding: 1em;
+    position: fixed;
+    margin: 1em;
+    line-height: 50px;
+    text-align: center;
+    background-color: white;
+}
+
+#description, #console {
+    position: absolute;
+    z-index: -1;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection remains visible when the element containing the selection becomes composited. To run manually, select the text field and tap the button; the selection should remain visible");
+    document.querySelector("button").addEventListener("mousedown", (event) => {
+        container.style.position = "static";
+        event.preventDefault();
+    });
+
+    const container = document.getElementById("container");
+    const input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    input.select();
+    await UIHelper.ensurePresentationUpdate();
+    rectsBeforeStyleChange = await UIHelper.waitForSelectionToAppear();
+
+    container.style.position = "static";
+    await UIHelper.ensurePresentationUpdate();
+    rectsAfterStyleChange = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("rectsBeforeStyleChange.length", "1");
+    shouldBe("rectsBeforeStyleChange.length", "rectsAfterStyleChange.length");
+    shouldBe("rectsBeforeStyleChange[0].top", "rectsAfterStyleChange[0].top");
+    shouldBe("rectsBeforeStyleChange[0].left", "rectsAfterStyleChange[0].left");
+    shouldBe("rectsBeforeStyleChange[0].width", "rectsAfterStyleChange[0].width");
+    shouldBe("rectsBeforeStyleChange[0].height", "rectsAfterStyleChange[0].height");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <input value="WebKit" /><button id="toggle-position">position: static</button>
+    </div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -263,6 +263,7 @@ struct WKSelectionDrawingInfo {
     WebCore::Color caretColor;
     Vector<WebCore::SelectionGeometry> selectionGeometries;
     WebCore::IntRect selectionClipRect;
+    std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WKSelectionDrawingInfo&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -396,12 +396,14 @@ WKSelectionDrawingInfo::WKSelectionDrawingInfo(const EditorState& editorState)
     type = SelectionType::Range;
     if (!editorState.postLayoutData)
         return;
+
     auto& postLayoutData = *editorState.postLayoutData;
     auto& visualData = *editorState.visualData;
     caretRect = visualData.caretRectAtEnd;
     caretColor = postLayoutData.caretColor;
     selectionGeometries = visualData.selectionGeometries;
     selectionClipRect = visualData.selectionClipRect;
+    enclosingLayerID = visualData.enclosingLayerID;
 }
 
 inline bool operator==(const WKSelectionDrawingInfo& a, const WKSelectionDrawingInfo& b)
@@ -437,6 +439,9 @@ inline bool operator==(const WKSelectionDrawingInfo& a, const WKSelectionDrawing
     if (a.type != WKSelectionDrawingInfo::SelectionType::None && a.selectionClipRect != b.selectionClipRect)
         return false;
 
+    if (a.enclosingLayerID != b.enclosingLayerID)
+        return false;
+
     return true;
 }
 
@@ -459,6 +464,7 @@ TextStream& operator<<(TextStream& stream, const WKSelectionDrawingInfo& info)
     stream.dumpProperty("caret color", info.caretColor);
     stream.dumpProperty("selection geometries", info.selectionGeometries);
     stream.dumpProperty("selection clip rect", info.selectionClipRect);
+    stream.dumpProperty("layer", info.enclosingLayerID);
     return stream;
 }
 


### PR DESCRIPTION
#### 43c15c8949412ea14aecc29a5e182be908d861ef
<pre>
[iOS] Selection disappears on login.live.com when SelectionHonorsOverflowScrolling is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=281828">https://bugs.webkit.org/show_bug.cgi?id=281828</a>
<a href="https://rdar.apple.com/138255535">rdar://138255535</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

When SelectionHonorsOverflowScrolling is enabled, it&apos;s possible for selection views to be removed
from the view hierarchy, even though the selection still exists in the DOM. If the layer
corresponding to an element containing one of the selection endpoints goes from being composited to
non-composited but the selection otherwise remains in the same place (i.e. same selection rects), we
currently bail from `-[WKContentView _updateChangedSelection:]`. However, an update here is
necessary in order to reparent the text selection display interaction&apos;s managed views in its new
compositing layer.

To fix this, we add a member to `WKSelectionDrawingInfo` to keep track of the platform layer where
the selection is being displayed; if this changes, then we&apos;ll consider the selection drawing info
changed, and update the selection accordingly.

* LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html: Added.

Add a test to exercise the change (the button and event handler are for manual testing only).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):
(WebKit::operator==):

Implement the main fix here, by invalidating selection drawing info when the compositing layer ID
changes.

(WebKit::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/285483@main">https://commits.webkit.org/285483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaf0fe2d99923c97c2e9ca2c08616bd49cd9ff01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24036 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15734 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43870 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20125 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78671 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64968 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6929 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48025 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2812 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->