### PR TITLE
Add check to makeUniqueRef<T>() to make sure T is not ref-counted

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -40,10 +40,18 @@ UniqueRef<T> makeUniqueRefWithoutFastMallocCheck(Args&&... args)
     return UniqueRef<T>(*new T(std::forward<Args>(args)...));
 }
 
+template<class T, class... Args>
+UniqueRef<T> makeUniqueRefWithoutRefCountedCheck(Args&&... args)
+{
+    static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T sould use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    return makeUniqueRefWithoutFastMallocCheck<T>(std::forward<Args>(args)...);
+}
+
 template<typename T, class... Args>
 UniqueRef<T> makeUniqueRef(Args&&... args)
 {
     static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T sould use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    static_assert(!TypeHasRefMemberFunction<T>::value, "T should not be RefCounted");
     return makeUniqueRefWithoutFastMallocCheck<T>(std::forward<Args>(args)...);
 }
 

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -61,6 +61,7 @@ Ref<PaymentCoordinator> PaymentCoordinator::create(UniqueRef<PaymentCoordinatorC
 PaymentCoordinator::PaymentCoordinator(UniqueRef<PaymentCoordinatorClient>&& client)
     : m_client(WTFMove(client))
 {
+    m_client->setPaymentCoordinator(*this);
 }
 
 PaymentCoordinator::~PaymentCoordinator() = default;

--- a/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class Document;
+class PaymentCoordinator;
 class PaymentMerchantSession;
 struct ApplePayCouponCodeUpdate;
 struct ApplePayPaymentAuthorizationResult;
@@ -73,6 +74,8 @@ public:
     virtual void endApplePaySetup() { }
 
     virtual ~PaymentCoordinatorClient() = default;
+
+    virtual void setPaymentCoordinator(PaymentCoordinator&) { }
 };
 
 }

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -70,12 +70,12 @@ Ref<DOMAudioSession> DOMAudioSession::create(ScriptExecutionContext* context)
 DOMAudioSession::DOMAudioSession(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
 {
-    AudioSession::sharedSession().addInterruptionObserver(*this);
+    AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
 }
 
 DOMAudioSession::~DOMAudioSession()
 {
-    AudioSession::sharedSession().removeInterruptionObserver(*this);
+    AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
 }
 
 ExceptionOr<void> DOMAudioSession::setType(Type type)
@@ -90,7 +90,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     document->topDocument().setAudioSessionType(type);
 
     auto categoryOverride = fromDOMAudioSessionType(type);
-    AudioSession::sharedSession().setCategoryOverride(categoryOverride);
+    AudioSession::protectedSharedSession()->setCategoryOverride(categoryOverride);
 
     if (categoryOverride == AudioSessionCategory::None)
         PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary();

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -126,7 +126,7 @@ ExceptionOr<Ref<AudioContext>> AudioContext::create(Document& document, AudioCon
 
 AudioContext::AudioContext(Document& document, const AudioContextOptions& contextOptions)
     : BaseAudioContext(document)
-    , m_destinationNode(makeUniqueRef<DefaultAudioDestinationNode>(*this, contextOptions.sampleRate))
+    , m_destinationNode(makeUniqueRefWithoutRefCountedCheck<DefaultAudioDestinationNode>(*this, contextOptions.sampleRate))
     , m_mediaSession(PlatformMediaSession::create(PlatformMediaSessionManager::sharedManager(), *this))
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
 {

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OfflineAudioContext);
 
 OfflineAudioContext::OfflineAudioContext(Document& document, const OfflineAudioContextOptions& options)
     : BaseAudioContext(document)
-    , m_destinationNode(makeUniqueRef<OfflineAudioDestinationNode>(*this, options.numberOfChannels, options.sampleRate, AudioBuffer::create(options.numberOfChannels, options.length, options.sampleRate)))
+    , m_destinationNode(makeUniqueRefWithoutRefCountedCheck<OfflineAudioDestinationNode>(*this, options.numberOfChannels, options.sampleRate, AudioBuffer::create(options.numberOfChannels, options.length, options.sampleRate)))
     , m_length(options.length)
 {
     if (!renderTarget())

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -39,11 +39,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRInputSourceArray);
 
-UniqueRef<WebXRInputSourceArray> WebXRInputSourceArray::create(WebXRSession& session)
-{
-    return makeUniqueRef<WebXRInputSourceArray>(session);
-}
-
 WebXRInputSourceArray::WebXRInputSourceArray(WebXRSession& session)
     : m_session(session)
 {

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
@@ -43,8 +43,9 @@ class WebXRSession;
 
 class WebXRInputSourceArray final : public ScriptWrappable {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRInputSourceArray);
-    friend UniqueRef<WebXRInputSourceArray> WTF::makeUniqueRefWithoutFastMallocCheck<WebXRInputSourceArray, WebCore::WebXRSession&>(WebCore::WebXRSession&);
 public:
+    explicit WebXRInputSourceArray(WebXRSession&);
+
     using InputSourceList = Vector<PlatformXR::FrameData::InputSource>;
     static UniqueRef<WebXRInputSourceArray> create(WebXRSession&);
     ~WebXRInputSourceArray();
@@ -63,8 +64,6 @@ public:
     WebXRSession* session() const { return &m_session; }
 
 private:
-    WebXRInputSourceArray(WebXRSession&);
-
     void handleRemovedInputSources(const InputSourceList&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
     void handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -61,7 +61,7 @@ Ref<WebXRSession> WebXRSession::create(Document& document, WebXRSystem& system, 
 
 WebXRSession::WebXRSession(Document& document, WebXRSystem& system, XRSessionMode mode, PlatformXR::Device& device, FeatureList&& requestedFeatures)
     : ActiveDOMObject(&document)
-    , m_inputSources(WebXRInputSourceArray::create(*this))
+    , m_inputSources(makeUniqueRefWithoutRefCountedCheck<WebXRInputSourceArray>(*this))
     , m_xrSystem(system)
     , m_mode(mode)
     , m_device(device)

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -150,7 +150,6 @@ style/StyleSharingResolver.cpp
 style/Styleable.h
 svg/properties/SVGAnimatedProperty.h
 svg/properties/SVGPropertyOwnerRegistry.h
-testing/MockPaymentCoordinator.h
 workers/WorkerAnimationController.h
 workers/WorkerConsoleClient.h
 workers/WorkerMessagingProxy.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1332,7 +1332,6 @@ testing/Internals.mm
 testing/LegacyMockCDM.cpp
 testing/MockCDMFactory.cpp
 testing/MockPageOverlayClient.cpp
-testing/MockPaymentCoordinator.cpp
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/AbstractWorker.cpp

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1225,7 +1225,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         makeUniqueRef<EmptyProgressTrackerClient>(),
         PageConfiguration::LocalMainFrameCreationParameters {
             CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)> { [] (auto&, auto& frameLoader) {
-                return makeUniqueRef<EmptyFrameLoaderClient>(frameLoader);
+                return makeUniqueRefWithoutRefCountedCheck<EmptyFrameLoaderClient>(frameLoader);
             } },
             SandboxFlags::all(),
         },

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -159,7 +159,7 @@ static const LocalFrame& rootFrame(const LocalFrame& frame)
 
 LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags sandboxFlags, std::optional<ScrollbarMode> scrollingMode, HTMLFrameOwnerElement* ownerElement, Frame* parent, Frame* opener)
     : Frame(page, identifier, FrameType::Local, ownerElement, parent, opener)
-    , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(clientCreator)))
+    , m_loader(makeUniqueRefWithoutRefCountedCheck<FrameLoader>(*this, WTFMove(clientCreator)))
     , m_script(makeUniqueRef<ScriptController>(*this))
     , m_pageZoomFactor(parentPageZoomFactor(this))
     , m_textZoomFactor(parentTextZoomFactor(this))

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -32,6 +32,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Observer.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
@@ -100,15 +101,15 @@ public:
     virtual void sampleRateDidChange(const AudioSession&) { }
 };
 
-class WEBCORE_EXPORT AudioSession {
+class WEBCORE_EXPORT AudioSession : public ThreadSafeRefCounted<AudioSession> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioSession, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(AudioSession);
-    friend class UniqueRef<AudioSession>;
-    friend UniqueRef<AudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<AudioSession>();
 public:
-    static UniqueRef<AudioSession> create();
-    static void setSharedSession(UniqueRef<AudioSession>&&);
+    static Ref<AudioSession> create();
+    static void setSharedSession(Ref<AudioSession>&&);
     static AudioSession& sharedSession();
+    static Ref<AudioSession> protectedSharedSession() { return sharedSession(); }
+
     static bool enableMediaPlayback();
 
     using ChangedObserver = WTF::Observer<void(AudioSession&)>;

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -99,7 +99,8 @@ void GStreamerAudioDecoder::create(const String& codecName, const Config& config
         element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     }
 
-    auto decoder = makeUniqueRef<GStreamerAudioDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
+    // FIXME: GStreamerAudioDecoder subclasses ThreadSafeRefCounted but gets contructed using makeUniqueRef(), which doesn't seem right.
+    auto decoder = makeUniqueRefWithoutRefCountedCheck<GStreamerAudioDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
     auto internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal audio decoder failed to configure for codec %s", codecName.utf8().data());

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -41,7 +41,7 @@ namespace WebCore {
 class AudioSessionIOS final : public AudioSessionCocoa {
     WTF_MAKE_TZONE_ALLOCATED(AudioSessionIOS);
 public:
-    AudioSessionIOS();
+    static Ref<AudioSessionIOS> create();
     virtual ~AudioSessionIOS();
 
     void setHostProcessAttribution(audit_token_t) final;
@@ -51,6 +51,8 @@ public:
     WEBCORE_EXPORT static void addAudioSessionCategoryChangedObserver(const CategoryChangedObserver&);
 
 private:
+    AudioSessionIOS();
+
     // AudioSession
     CategoryType category() const final;
     Mode mode() const final;

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -114,6 +114,11 @@ void AudioSessionIOS::addAudioSessionCategoryChangedObserver(const CategoryChang
     observer(AudioSession::sharedSession(), AudioSession::sharedSession().category());
 }
 
+Ref<AudioSessionIOS> AudioSessionIOS::create()
+{
+    return adoptRef(*new AudioSessionIOS);
+}
+
 AudioSessionIOS::AudioSessionIOS()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -39,10 +39,12 @@ namespace WebCore {
 class AudioSessionMac final : public AudioSessionCocoa {
     WTF_MAKE_TZONE_ALLOCATED(AudioSessionMac);
 public:
-    AudioSessionMac() = default;
+    static Ref<AudioSessionMac> create();
     virtual ~AudioSessionMac() = default;
 
 private:
+    AudioSessionMac() = default;
+
     void addSampleRateObserverIfNeeded() const;
     void addBufferSizeObserverIfNeeded() const;
     void addDefaultDeviceObserverIfNeeded() const;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -82,6 +82,11 @@ static float defaultDeviceTransportIsBluetooth()
 }
 #endif
 
+Ref<AudioSessionMac> AudioSessionMac::create()
+{
+    return adoptRef(*new AudioSessionMac);
+}
+
 void AudioSessionMac::removePropertyListenersForDefaultDevice() const
 {
     if (m_hasBufferSizeObserver) {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -97,7 +97,8 @@ void GStreamerVideoDecoder::create(const String& codecName, const Config& config
     }
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
-    auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
+    // FIXME: GStreamerVideoDecoder subclasses ThreadSafeRefCounted but gets contructed using makeUniqueRef(), which doesn't seem right.
+    auto decoder = makeUniqueRefWithoutRefCountedCheck<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
     auto internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.utf8().data());

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -217,7 +217,7 @@ void LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded()
             return;
         }
 
-        outputDescription.mSampleRate = AudioSession::sharedSession().sampleRate();
+        outputDescription.mSampleRate = AudioSession::protectedSharedSession()->sampleRate();
         m_outputDescription = outputDescription;
     }
     error = PAL::AudioUnitSetProperty(remoteIOUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &m_outputDescription->streamDescription(), sizeof(m_outputDescription->streamDescription()));

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -73,7 +73,7 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
             return CaptureSourceOrError { CaptureSourceError { "Screen capture unavailable"_s, MediaAccessDenialReason::NoCaptureDevices } };
 
         return create([] (auto& source) {
-            return ReplayKitCaptureSource::create(source);
+            return makeUniqueRefWithoutRefCountedCheck<ReplayKitCaptureSource>(source);
         }, device, WTFMove(hashSalts), constraints, pageIdentifier);
 #elif HAVE(SCREEN_CAPTURE_KIT)
         FALLTHROUGH;
@@ -88,7 +88,7 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
             if (!deviceID)
                 return CaptureSourceOrError { WTFMove(deviceID).error() };
             return create([deviceID = deviceID.value(), &device] (auto& source) {
-                return ScreenCaptureKitCaptureSource::create(source, device, deviceID);
+                return makeUniqueRefWithoutRefCountedCheck<ScreenCaptureKitCaptureSource>(source, device, deviceID);
             }, device, WTFMove(hashSalts), constraints, pageIdentifier);
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
@@ -38,9 +38,7 @@ namespace WebCore {
 
 class ReplayKitCaptureSource final : public DisplayCaptureSourceCocoa::Capturer, public CanMakeWeakPtr<ReplayKitCaptureSource> {
 public:
-    static UniqueRef<DisplayCaptureSourceCocoa::Capturer> create(CapturerObserver&);
-
-    ReplayKitCaptureSource(CapturerObserver&);
+    explicit ReplayKitCaptureSource(CapturerObserver&);
     virtual ~ReplayKitCaptureSource();
 
     static bool isAvailable();

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
@@ -102,11 +102,6 @@ bool ReplayKitCaptureSource::isAvailable()
     return [PAL::getRPScreenRecorderClass() sharedRecorder].isAvailable;
 }
 
-UniqueRef<DisplayCaptureSourceCocoa::Capturer> ReplayKitCaptureSource::create(CapturerObserver& observer)
-{
-    return UniqueRef<DisplayCaptureSourceCocoa::Capturer>(makeUniqueRef<ReplayKitCaptureSource>(observer));
-}
-
 ReplayKitCaptureSource::ReplayKitCaptureSource(CapturerObserver& observer)
     : DisplayCaptureSourceCocoa::Capturer(observer)
     , m_captureWatchdogTimer(*this, &ReplayKitCaptureSource::verifyCaptureIsActive)

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 constexpr Seconds voiceActivityThrottlingDuration = 5_s;
 
 BaseAudioSharedUnit::BaseAudioSharedUnit()
-    : m_sampleRate(AudioSession::sharedSession().sampleRate())
+    : m_sampleRate(AudioSession::protectedSharedSession()->sampleRate())
     , m_voiceActivityThrottleTimer([] { })
 {
     RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -105,12 +105,12 @@ CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID,
 
 CoreAudioCaptureSourceFactory::CoreAudioCaptureSourceFactory()
 {
-    AudioSession::sharedSession().addInterruptionObserver(*this);
+    AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
 }
 
 CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory()
 {
-    AudioSession::sharedSession().removeInterruptionObserver(*this);
+    AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
 }
 
 void CoreAudioCaptureSourceFactory::beginInterruption()

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -57,7 +57,6 @@ class ScreenCaptureKitCaptureSource final
     , public ScreenCaptureSessionSourceObserver {
 public:
     static Expected<uint32_t, CaptureSourceError> computeDeviceID(const CaptureDevice&);
-    static UniqueRef<DisplayCaptureSourceCocoa::Capturer> create(CapturerObserver&, const CaptureDevice&, uint32_t deviceID);
 
     ScreenCaptureKitCaptureSource(CapturerObserver&, const CaptureDevice&, uint32_t);
     virtual ~ScreenCaptureKitCaptureSource();

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -189,11 +189,6 @@ Expected<uint32_t, CaptureSourceError> ScreenCaptureKitCaptureSource::computeDev
     return *deviceID;
 }
 
-UniqueRef<DisplayCaptureSourceCocoa::Capturer> ScreenCaptureKitCaptureSource::create(CapturerObserver& observer, const CaptureDevice& device, uint32_t deviceID)
-{
-    return UniqueRef<DisplayCaptureSourceCocoa::Capturer>(makeUniqueRef<ScreenCaptureKitCaptureSource>(observer, device, deviceID));
-}
-
 ScreenCaptureKitCaptureSource::ScreenCaptureKitCaptureSource(CapturerObserver& observer, const CaptureDevice& device, uint32_t deviceID)
     : DisplayCaptureSourceCocoa::Capturer(observer)
     , m_captureDevice(device)

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -267,7 +267,7 @@ public:
         case CaptureDevice::DeviceType::Window: {
 #if PLATFORM(COCOA)
             return DisplayCaptureSourceCocoa::create([this, &device, pageIdentifier] (auto& observer) {
-                auto capturer = makeUniqueRef<MockDisplayCapturer>(observer, device, pageIdentifier);
+                auto capturer = makeUniqueRefWithoutRefCountedCheck<MockDisplayCapturer>(observer, device, pageIdentifier);
                 m_capturer = capturer.get();
                 return capturer;
             }, device, WTFMove(hashSalts), constraints, pageIdentifier);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -731,7 +731,7 @@ Internals::Internals(Document& document)
 #if ENABLE(APPLE_PAY)
     auto* frame = document.frame();
     if (frame && frame->page() && frame->isMainFrame()) {
-        auto mockPaymentCoordinator = makeUniqueRef<MockPaymentCoordinator>(*frame->page());
+        auto mockPaymentCoordinator = makeUniqueRefWithoutRefCountedCheck<MockPaymentCoordinator>(*frame->page());
         frame->page()->setPaymentCoordinator(PaymentCoordinator::create(WTFMove(mockPaymentCoordinator)));
     }
 #endif

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -157,7 +157,7 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
 
     ASSERT(showCount == hideCount);
     ++showCount;
-    dispatchIfShowing([page = &m_page]() {
+    dispatchIfShowing([page = Ref { m_page.get() }]() {
         page->paymentCoordinator().validateMerchant(URL { "https://webkit.org/"_str });
     });
     return true;
@@ -165,7 +165,7 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
 
 void MockPaymentCoordinator::completeMerchantValidation(const PaymentMerchantSession&)
 {
-    dispatchIfShowing([page = &m_page, shippingAddress = m_shippingAddress]() mutable {
+    dispatchIfShowing([page = Ref { m_page.get() }, shippingAddress = m_shippingAddress]() mutable {
         page->paymentCoordinator().didSelectShippingContact(MockPaymentContact { WTFMove(shippingAddress) });
     });
 }
@@ -288,7 +288,7 @@ void MockPaymentCoordinator::completeCouponCodeChange(std::optional<ApplePayCoup
 
 void MockPaymentCoordinator::changeShippingOption(String&& shippingOption)
 {
-    dispatchIfShowing([page = &m_page, shippingOption = WTFMove(shippingOption)]() mutable {
+    dispatchIfShowing([page = Ref { m_page.get() }, shippingOption = WTFMove(shippingOption)]() mutable {
         ApplePayShippingMethod shippingMethod;
         shippingMethod.identifier = WTFMove(shippingOption);
         page->paymentCoordinator().didSelectShippingMethod(shippingMethod);
@@ -297,7 +297,7 @@ void MockPaymentCoordinator::changeShippingOption(String&& shippingOption)
 
 void MockPaymentCoordinator::changePaymentMethod(ApplePayPaymentMethod&& paymentMethod)
 {
-    dispatchIfShowing([page = &m_page, paymentMethod = WTFMove(paymentMethod)]() mutable {
+    dispatchIfShowing([page = Ref { m_page.get() }, paymentMethod = WTFMove(paymentMethod)]() mutable {
         page->paymentCoordinator().didSelectPaymentMethod(MockPaymentMethod { WTFMove(paymentMethod) });
     });
 }
@@ -306,7 +306,7 @@ void MockPaymentCoordinator::changePaymentMethod(ApplePayPaymentMethod&& payment
 
 void MockPaymentCoordinator::changeCouponCode(String&& couponCode)
 {
-    dispatchIfShowing([page = &m_page, couponCode = WTFMove(couponCode)]() mutable {
+    dispatchIfShowing([page = Ref { m_page.get() }, couponCode = WTFMove(couponCode)]() mutable {
         page->paymentCoordinator().didChangeCouponCode(WTFMove(couponCode));
     });
 }
@@ -315,7 +315,7 @@ void MockPaymentCoordinator::changeCouponCode(String&& couponCode)
 
 void MockPaymentCoordinator::acceptPayment()
 {
-    dispatchIfShowing([page = &m_page, shippingAddress = m_shippingAddress]() mutable {
+    dispatchIfShowing([page = Ref { m_page.get() }, shippingAddress = m_shippingAddress]() mutable {
         ApplePayPayment payment;
         payment.shippingContact = WTFMove(shippingAddress);
         page->paymentCoordinator().didAuthorizePayment(MockPayment { WTFMove(payment) });
@@ -324,7 +324,7 @@ void MockPaymentCoordinator::acceptPayment()
 
 void MockPaymentCoordinator::cancelPayment()
 {
-    dispatchIfShowing([page = &m_page] {
+    dispatchIfShowing([page = Ref { m_page.get() }] {
         page->paymentCoordinator().didCancelPaymentSession({ });
         ++hideCount;
         ASSERT(showCount == hideCount);
@@ -380,6 +380,21 @@ bool MockPaymentCoordinator::installmentConfigurationReturnsNil() const
 #else
     return true;
 #endif
+}
+
+void MockPaymentCoordinator::setPaymentCoordinator(PaymentCoordinator& paymentCoordinator)
+{
+    m_paymentCoordinator = paymentCoordinator;
+}
+
+void MockPaymentCoordinator::ref() const
+{
+    m_paymentCoordinator->ref();
+}
+
+void MockPaymentCoordinator::deref() const
+{
+    m_paymentCoordinator->deref();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -119,8 +119,10 @@ public:
 
     bool installmentConfigurationReturnsNil() const;
 
-    void ref() const { }
-    void deref() const { }
+    void setPaymentCoordinator(PaymentCoordinator&) final;
+
+    void ref() const;
+    void deref() const;
 
 private:
     std::optional<String> validatedPaymentNetwork(const String&) const final;
@@ -146,7 +148,8 @@ private:
 
     void dispatchIfShowing(Function<void()>&&);
 
-    Page& m_page;
+    WeakPtr<PaymentCoordinator> m_paymentCoordinator;
+    WeakRef<Page> m_page;
     bool m_canMakePayments { true };
     bool m_canMakePaymentsWithActiveCard { true };
     ApplePayPaymentContact m_shippingAddress;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -64,15 +64,15 @@ WebCore::ProcessIdentifier RemoteAudioSessionProxy::processIdentifier()
 
 RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
 {
-    auto& session = protectedAudioSessionManager()->session();
+    Ref session = protectedAudioSessionManager()->session();
     return {
-        session.routingContextUID(),
-        session.sampleRate(),
-        session.bufferSize(),
-        session.numberOfOutputChannels(),
-        session.maximumNumberOfOutputChannels(),
-        session.preferredBufferSize(),
-        session.isMuted(),
+        session->routingContextUID(),
+        session->sampleRate(),
+        session->bufferSize(),
+        session->numberOfOutputChannels(),
+        session->maximumNumberOfOutputChannels(),
+        session->preferredBufferSize(),
+        session->isMuted(),
         m_active,
         m_sceneIdentifier,
         m_soundStageSize,
@@ -120,7 +120,7 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 void RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride(std::optional<bool>&& value)
 {
     m_isPlayingToBluetoothOverrideChanged = true;
-    protectedAudioSessionManager()->session().setIsPlayingToBluetoothOverride(WTFMove(value));
+    protectedAudioSessionManager()->protectedSession()->setIsPlayingToBluetoothOverride(WTFMove(value));
 }
 
 void RemoteAudioSessionProxy::configurationChanged()
@@ -187,13 +187,13 @@ Ref<IPC::Connection> RemoteAudioSessionProxy::protectedConnection() const
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
     MESSAGE_CHECK(m_gpuConnection.get()->allowTestOnlyIPC());
-    AudioSession::sharedSession().beginInterruptionForTesting();
+    AudioSession::protectedSharedSession()->beginInterruptionForTesting();
 }
 
 void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
 {
     MESSAGE_CHECK(m_gpuConnection.get()->allowTestOnlyIPC());
-    AudioSession::sharedSession().endInterruptionForTesting();
+    AudioSession::protectedSharedSession()->endInterruptionForTesting();
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteAudioSessionProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -65,6 +65,8 @@ public:
 
     WebCore::AudioSession& session() { return WebCore::AudioSession::sharedSession(); }
     const WebCore::AudioSession& session() const { return WebCore::AudioSession::sharedSession(); }
+    Ref<WebCore::AudioSession> protectedSession() { return WebCore::AudioSession::sharedSession(); }
+    Ref<const WebCore::AudioSession> protectedSession() const { return WebCore::AudioSession::sharedSession(); }
 
     void updatePresentingProcesses();
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -175,7 +175,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
     , m_localUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::create(*this))
     , m_shouldRegisterAsSpeakerSamplesProducer(shouldRegisterAsSpeakerSamplesProducer)
 {
-    WebCore::AudioSession::sharedSession().addInterruptionObserver(*this);
+    WebCore::AudioSession::protectedSharedSession()->addInterruptionObserver(*this);
     protectedLocalUnit()->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)](auto&& description) mutable {
         if (!weakThis || !description) {
             RELEASE_LOG_IF(!description, WebRTC, "RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit unable to get format description");
@@ -191,7 +191,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit()
 {
-    WebCore::AudioSession::sharedSession().removeInterruptionObserver(*this);
+    WebCore::AudioSession::protectedSharedSession()->removeInterruptionObserver(*this);
     stop();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -114,8 +114,9 @@ public:
 
     void audioUnitWillStart() final
     {
-        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::VideoChat, RouteSharingPolicy::Default);
-        AudioSession::sharedSession().tryToSetActive(true);
+        Ref session = AudioSession::sharedSession();
+        session->setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::VideoChat, RouteSharingPolicy::Default);
+        session->tryToSetActive(true);
     }
 
     void start()
@@ -352,7 +353,7 @@ private:
             ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
             m_description = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
 
-            m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::sharedSession().preferredBufferSize());
+            m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::protectedSharedSession()->preferredBufferSize());
 
             // Allocate a ring buffer large enough to contain 2 seconds of audio.
             auto result = ProducerSharedCARingBuffer::allocate(*m_description, m_description->sampleRate() * 2);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -746,7 +746,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #if ENABLE(CONTEXT_MENUS)
     , m_contextMenuClient(makeUnique<API::ContextMenuClient>())
 #endif
-    , m_navigationState(makeUniqueRef<WebNavigationState>(*this))
+    , m_navigationState(makeUniqueRefWithoutRefCountedCheck<WebNavigationState>(*this))
     , m_generatePageLoadTimingTimer(RunLoop::main(), this, &WebPageProxy::didEndNetworkRequestsForPageLoadTimingTimerFired)
     , m_legacyMainFrameProcess(process)
     , m_pageGroup(*configuration->pageGroup())

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -42,9 +42,9 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSession);
 
-UniqueRef<RemoteAudioSession> RemoteAudioSession::create()
+Ref<RemoteAudioSession> RemoteAudioSession::create()
 {
-    return makeUniqueRef<RemoteAudioSession>();
+    return adoptRef(*new RemoteAudioSession);
 }
 
 RemoteAudioSession::RemoteAudioSession()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -50,7 +50,7 @@ class RemoteAudioSession final
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioSession);
 public:
-    static UniqueRef<RemoteAudioSession> create();
+    static Ref<RemoteAudioSession> create();
     ~RemoteAudioSession();
 
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::ref(); }
@@ -58,7 +58,6 @@ public:
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::controlBlock(); }
 
 private:
-    friend UniqueRef<RemoteAudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteAudioSession>();
     RemoteAudioSession();
     IPC::Connection& ensureConnection();
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    auto remoteCDM = makeUniqueRef<RemoteLegacyCDM>(*this, *identifier);
+    auto remoteCDM = makeUniqueRefWithoutRefCountedCheck<RemoteLegacyCDM>(*this, *identifier);
     m_cdms.set(*identifier, remoteCDM.get());
     return remoteCDM.moveToUniquePtr();
 }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -179,7 +179,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
 
         pageConfiguration.mainFrameCreationParameters = PageConfiguration::LocalMainFrameCreationParameters {
             CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&, WebCore::FrameLoader&)> { [webPageProxyID = m_webPageProxyID, pageID = m_pageID, effectiveUserAgent, serviceWorkerPageIdentifier = contextData.serviceWorkerPageIdentifier] (auto&, auto& frameLoader) mutable {
-                auto client = makeUniqueRef<RemoteWorkerFrameLoaderClient>(frameLoader, webPageProxyID, pageID, effectiveUserAgent);
+                auto client = makeUniqueRefWithoutRefCountedCheck<RemoteWorkerFrameLoaderClient>(frameLoader, webPageProxyID, pageID, effectiveUserAgent);
                 if (serviceWorkerPageIdentifier)
                     client->setServiceWorkerPageIdentifier(*serviceWorkerPageIdentifier);
                 return client;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -116,7 +116,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     pageConfiguration.storageProvider = makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt());
 
     pageConfiguration.mainFrameCreationParameters = WebCore::PageConfiguration::LocalMainFrameCreationParameters { CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&, WebCore::FrameLoader&)> { [webPageProxyID = m_webPageProxyID, pageID = m_pageID, userAgent = m_userAgent] (auto&, auto& frameLoader) mutable {
-        return makeUniqueRef<RemoteWorkerFrameLoaderClient>(frameLoader, webPageProxyID, pageID, userAgent);
+        return makeUniqueRefWithoutRefCountedCheck<RemoteWorkerFrameLoaderClient>(frameLoader, webPageProxyID, pageID, userAgent);
     } }, WebCore::SandboxFlags { } };
 
     Ref page = WebCore::Page::create(WTFMove(pageConfiguration));

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -51,7 +51,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeContext);
 
 RemoteLayerTreeContext::RemoteLayerTreeContext(WebPage& webPage)
     : m_webPage(webPage)
-    , m_backingStoreCollection(makeUniqueRef<RemoteLayerBackingStoreCollection>(*this))
+    , m_backingStoreCollection(makeUniqueRefWithoutRefCountedCheck<RemoteLayerBackingStoreCollection>(*this))
 {
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -140,7 +140,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
     auto frame = create(page, frameID);
     ASSERT(page.corePage());
     auto coreFrame = LocalFrame::createSubframe(*page.corePage(), [frame] (auto& localFrame, auto& frameLoader) {
-        return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, frameLoader, frame.get(), frame->makeInvalidator());
+        return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, frame.get(), frame->makeInvalidator());
     }, frameID, effectiveSandboxFlags, ownerElement);
     frame->m_coreFrame = coreFrame.get();
 
@@ -409,7 +409,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
 
     RefPtr parent = remoteFrame->tree().parent();
     auto clientCreator = [this, protectedThis = Ref { *this }] (auto& localFrame, auto& frameLoader) mutable {
-        return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(protectedThis), makeInvalidator());
+        return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(protectedThis), makeInvalidator());
     };
     auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.scrollingMode, *parent) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, nullptr);
     m_provisionalFrame = localFrame.ptr();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -530,7 +530,7 @@ static PageConfiguration::MainFrameCreationParameters mainFrameCreationParameter
     case Frame::FrameType::Local:
         return PageConfiguration::LocalMainFrameCreationParameters {
             { [mainFrame = WTFMove(mainFrame), invalidator = WTFMove(invalidator)] (auto& localFrame, auto& frameLoader) mutable {
-                return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(mainFrame), WTFMove(invalidator));
+                return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(mainFrame), WTFMove(invalidator));
             } },
             initialSandboxFlags
         };
@@ -594,13 +594,13 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_userContentController(WebUserContentController::getOrCreate(parameters.userContentControllerParameters.identifier))
     , m_screenOrientationManager(makeUniqueRef<WebScreenOrientationManager>(*this))
 #if ENABLE(GEOLOCATION)
-    , m_geolocationPermissionRequestManager(makeUniqueRef<GeolocationPermissionRequestManager>(*this))
+    , m_geolocationPermissionRequestManager(makeUniqueRefWithoutRefCountedCheck<GeolocationPermissionRequestManager>(*this))
 #endif
 #if ENABLE(MEDIA_STREAM)
-    , m_userMediaPermissionRequestManager { makeUniqueRef<UserMediaPermissionRequestManager>(*this) }
+    , m_userMediaPermissionRequestManager { makeUniqueRefWithoutRefCountedCheck<UserMediaPermissionRequestManager>(*this) }
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    , m_mediaKeySystemPermissionRequestManager { makeUniqueRef<MediaKeySystemPermissionRequestManager>(*this) }
+    , m_mediaKeySystemPermissionRequestManager { makeUniqueRefWithoutRefCountedCheck<MediaKeySystemPermissionRequestManager>(*this) }
 #endif
     , m_pageScrolledHysteresis([this](PAL::HysteresisState state) { if (state == PAL::HysteresisState::Stopped) pageStoppedScrolling(); }, pageScrollHysteresisDuration)
     , m_canRunBeforeUnloadConfirmPanel(parameters.canRunBeforeUnloadConfirmPanel)

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -315,7 +315,7 @@ WebView *getWebView(WebFrame *webFrame)
         effectiveSandboxFlags.add(parentLocalFrame->effectiveSandboxFlags());
 
     auto coreFrame = WebCore::LocalFrame::createSubframe(page, [frame] (auto&, auto& frameLoader) {
-        return makeUniqueRef<WebFrameLoaderClient>(frameLoader, frame.get());
+        return makeUniqueRefWithoutRefCountedCheck<WebFrameLoaderClient>(frameLoader, frame.get());
     }, WebCore::FrameIdentifier::generate(), effectiveSandboxFlags, ownerElement);
     frame->_private->coreFrame = coreFrame.ptr();
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1517,7 +1517,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         makeUniqueRef<WebProgressTrackerClient>(self),
         WebCore::PageConfiguration::LocalMainFrameCreationParameters {
             CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&, WebCore::FrameLoader&)> { [] (auto&, auto& frameLoader) {
-                return makeUniqueRef<WebFrameLoaderClient>(frameLoader);
+                return makeUniqueRefWithoutRefCountedCheck<WebFrameLoaderClient>(frameLoader);
             } },
             WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
         },
@@ -1783,7 +1783,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         makeUniqueRef<WebProgressTrackerClient>(self),
         WebCore::PageConfiguration::LocalMainFrameCreationParameters {
             CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&, WebCore::FrameLoader&)> { [] (auto&, auto& frameLoader) {
-                return makeUniqueRef<WebFrameLoaderClient>(frameLoader);
+                return makeUniqueRefWithoutRefCountedCheck<WebFrameLoaderClient>(frameLoader);
             } },
             WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
         },


### PR DESCRIPTION
#### bb010d9a1457e0b75f0b8e3ce04f1f954cffb2e3
<pre>
Add check to makeUniqueRef&lt;T&gt;() to make sure T is not ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281831">https://bugs.webkit.org/show_bug.cgi?id=281831</a>

Reviewed by Darin Adler.

Add check to makeUniqueRef&lt;T&gt;() to make sure T is not ref-counted, similarly
to what we already to for makeUnique&lt;T&gt;(). Introduce a makeUniqueRefWithoutRefCountedCheck&lt;T&gt;()
to bypass the check (in case of ref-counting forwarding).

Also fix the bugs that were found by the new check.

* Source/WTF/wtf/UniqueRef.h:
(WTF::makeUniqueRefWithoutRefCountedCheck):
(WTF::makeUniqueRef):
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::PaymentCoordinator):
* Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h:
(WebCore::PaymentCoordinatorClient::setPaymentCoordinator):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::AudioContext):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::OfflineAudioContext):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::sharedAudioSession):
(WebCore::dummyAudioSession):
(WebCore::AudioSession::create):
(WebCore::AudioSession::sharedSession):
(WebCore::AudioSession::setSharedSession):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::create):
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::create):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::create):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::create): Deleted.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::Internals):
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
(WebCore::MockPaymentCoordinator::completeMerchantValidation):
(WebCore::MockPaymentCoordinator::changeShippingOption):
(WebCore::MockPaymentCoordinator::changePaymentMethod):
(WebCore::MockPaymentCoordinator::changeCouponCode):
(WebCore::MockPaymentCoordinator::acceptPayment):
(WebCore::MockPaymentCoordinator::cancelPayment):
(WebCore::MockPaymentCoordinator::setPaymentCoordinator):
(WebCore::MockPaymentCoordinator::ref const):
(WebCore::MockPaymentCoordinator::deref const):
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::WebPageProxy):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::create):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::RemoteLayerTreeContext):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createProvisionalFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::mainFrameCreationParameters):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame _createFrameWithPage:frameName:frameView:ownerElement:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):

Canonical link: <a href="https://commits.webkit.org/285507@main">https://commits.webkit.org/285507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/683422975bffd2e63597eea998b38fa8099e46ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72880 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37731 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22443 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66013 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78751 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72136 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17126 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62734 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13340 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93915 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11200 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2890 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20662 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->