### PR TITLE
Make FileReaderLoader Ref Counted

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -346,7 +346,7 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::invokeCompletionH
 void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob(ScriptExecutionContext& context, Ref<Blob>&& blob)
 {
     ASSERT(!m_blobLoader);
-    m_blobLoader = makeUnique<FileReaderLoader>(readTypeForMIMEType(m_type), this);
+    m_blobLoader = FileReaderLoader::create(readTypeForMIMEType(m_type), this);
     m_blobLoader->start(&context, WTFMove(blob));
 }
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -90,7 +90,7 @@ private:
 
         String m_type;
         BufferOrString m_data;
-        std::unique_ptr<FileReaderLoader> m_blobLoader;
+        RefPtr<FileReaderLoader> m_blobLoader;
         CompletionHandler<void()> m_completionHandler;
         WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_writingDestination;
     };

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -324,7 +324,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
     class BlobStreamSource : public FileReaderLoaderClient, public RefCountedReadableStreamSource {
     public:
         BlobStreamSource(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
-            : m_loader(makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))
+            : m_loader(FileReaderLoader::create(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))
         {
             m_loader->start(&scriptExecutionContext, blob);
         }
@@ -419,7 +419,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
             return didSucceed;
         }
 
-        UniqueRef<FileReaderLoader> m_loader;
+        Ref<FileReaderLoader> m_loader;
         Deque<Ref<FragmentedSharedBuffer>> m_queue;
         std::optional<Exception> m_exception;
         enum class StreamState : uint8_t { NotStarted, Started, Waiting };

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -63,7 +63,7 @@ private:
     void didFail(ExceptionCode errorCode) final;
     void complete();
 
-    std::unique_ptr<FileReaderLoader> m_loader;
+    RefPtr<FileReaderLoader> m_loader;
     CompleteCallback m_completeCallback;
 };
 
@@ -88,14 +88,14 @@ inline void BlobLoader::cancel()
 inline void BlobLoader::start(Blob& blob, ScriptExecutionContext* context, FileReaderLoader::ReadType readType)
 {
     ASSERT(!m_loader);
-    m_loader = makeUnique<FileReaderLoader>(readType, this);
+    m_loader = FileReaderLoader::create(readType, this);
     m_loader->start(context, blob);
 }
 
 inline void BlobLoader::start(const URL& blobURL, ScriptExecutionContext* context, FileReaderLoader::ReadType readType)
 {
     ASSERT(!m_loader);
-    m_loader = makeUnique<FileReaderLoader>(readType, this);
+    m_loader = FileReaderLoader::create(readType, this);
     m_loader->start(context, blobURL);
 }
 

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -125,7 +125,7 @@ ExceptionOr<void> FileReader::readInternal(Blob& blob, FileReaderLoader::ReadTyp
     m_state = LOADING;
     m_error = nullptr;
 
-    m_loader = makeUnique<FileReaderLoader>(m_readType, static_cast<FileReaderLoaderClient*>(this));
+    m_loader = FileReaderLoader::create(m_readType, static_cast<FileReaderLoaderClient*>(this));
     m_loader->setEncoding(m_encoding);
     m_loader->setDataType(m_blob->type());
     m_loader->start(scriptExecutionContext(), blob);

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -106,7 +106,7 @@ private:
     RefPtr<Blob> m_blob;
     FileReaderLoader::ReadType m_readType { FileReaderLoader::ReadAsBinaryString };
     String m_encoding;
-    std::unique_ptr<FileReaderLoader> m_loader;
+    RefPtr<FileReaderLoader> m_loader;
     RefPtr<DOMException> m_error;
     MonotonicTime m_lastProgressNotificationTime { MonotonicTime::nan() };
     HashMap<uint64_t, Function<void()>> m_pendingTasks;

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -58,6 +58,13 @@ namespace WebCore {
 
 const int defaultBufferLength = 32768;
 
+
+Ref<FileReaderLoader> FileReaderLoader::create(ReadType readType, FileReaderLoaderClient* client)
+{
+    return adoptRef(*new FileReaderLoader(readType, client));
+}
+
+
 FileReaderLoader::FileReaderLoader(ReadType readType, FileReaderLoaderClient* client)
     : m_readType(readType)
     , m_client(client)

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -52,7 +52,7 @@ class ScriptExecutionContext;
 class TextResourceDecoder;
 class ThreadableLoader;
 
-class FileReaderLoader final : public ThreadableLoaderClient {
+class FileReaderLoader final : public RefCounted<FileReaderLoader>, public ThreadableLoaderClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileReaderLoader);
 public:
@@ -65,8 +65,7 @@ public:
         ReadAsBinaryChunks
     };
 
-    // If client is given, do the loading asynchronously. Otherwise, load synchronously.
-    WEBCORE_EXPORT FileReaderLoader(ReadType, FileReaderLoaderClient*);
+    WEBCORE_EXPORT static Ref<FileReaderLoader> create(ReadType, FileReaderLoaderClient*);
     ~FileReaderLoader();
 
     WEBCORE_EXPORT void start(ScriptExecutionContext*, Blob&);
@@ -93,6 +92,8 @@ public:
     bool isCompleted() const;
 
 private:
+    // If client is given, do the loading asynchronously. Otherwise, load synchronously.
+    FileReaderLoader(ReadType, FileReaderLoaderClient*);
     void terminate();
     void cleanup();
     void failed(ExceptionCode);

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -45,30 +45,30 @@ FileReaderSync::FileReaderSync()
 
 ExceptionOr<RefPtr<ArrayBuffer>> FileReaderSync::readAsArrayBuffer(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsArrayBuffer, nullptr);
+    Ref<FileReaderLoader> loader = FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, nullptr);
     auto result = startLoading(scriptExecutionContext, loader, blob);
     if (result.hasException())
         return result.releaseException();
-    return loader.arrayBufferResult();
+    return loader->arrayBufferResult();
 }
 
 ExceptionOr<String> FileReaderSync::readAsBinaryString(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsBinaryString, nullptr);
+    Ref<FileReaderLoader> loader = FileReaderLoader::create(FileReaderLoader::ReadAsBinaryString, nullptr);
     return startLoadingString(scriptExecutionContext, loader, blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsText(ScriptExecutionContext& scriptExecutionContext, Blob& blob, const String& encoding)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsText, nullptr);
-    loader.setEncoding(encoding);
+    Ref<FileReaderLoader> loader = FileReaderLoader::create(FileReaderLoader::ReadAsText, nullptr);
+    loader->setEncoding(encoding);
     return startLoadingString(scriptExecutionContext, loader, blob);
 }
 
 ExceptionOr<String> FileReaderSync::readAsDataURL(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
 {
-    FileReaderLoader loader(FileReaderLoader::ReadAsDataURL, nullptr);
-    loader.setDataType(blob.type());
+    Ref<FileReaderLoader> loader = FileReaderLoader::create(FileReaderLoader::ReadAsDataURL, nullptr);
+    loader->setDataType(blob.type());
     return startLoadingString(scriptExecutionContext, loader, blob);
 }
 

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -767,7 +767,7 @@ public:
 private:
     PendingImageBitmap(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
         : ActiveDOMObject(&scriptExecutionContext)
-        , m_blobLoader(FileReaderLoader::ReadAsArrayBuffer, this)
+        , m_blobLoader(FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, this))
         , m_blob(WTFMove(blob))
         , m_options(WTFMove(options))
         , m_rect(WTFMove(rect))
@@ -778,7 +778,7 @@ private:
     void start(ScriptExecutionContext& scriptExecutionContext)
     {
         m_pendingActivity = makePendingActivity(*this); // Prevent destruction until the load has finished.
-        m_blobLoader.start(&scriptExecutionContext, *m_blob);
+        m_blobLoader->start(&scriptExecutionContext, *m_blob);
     }
 
     // ActiveDOMObject
@@ -789,7 +789,7 @@ private:
     void didReceiveData() final { }
     void didFinishLoading() final
     {
-        createImageBitmapAndCallCompletionHandlerSoon(m_blobLoader.arrayBufferResult());
+        createImageBitmapAndCallCompletionHandlerSoon(m_blobLoader->arrayBufferResult());
     }
     void didFail(ExceptionCode) final
     {
@@ -814,10 +814,10 @@ private:
             return;
         }
 
-        ImageBitmap::createFromBuffer(*scriptExecutionContext(), m_arrayBufferToProcess.releaseNonNull(), m_blob->type(), m_blob->size(), m_blobLoader.url(), WTFMove(m_options), WTFMove(m_rect), WTFMove(m_completionHandler));
+        ImageBitmap::createFromBuffer(*scriptExecutionContext(), m_arrayBufferToProcess.releaseNonNull(), m_blob->type(), m_blob->size(), m_blobLoader->url(), WTFMove(m_options), WTFMove(m_rect), WTFMove(m_completionHandler));
     }
 
-    FileReaderLoader m_blobLoader;
+    RefPtr<FileReaderLoader> m_blobLoader;
     RefPtr<Blob> m_blob;
     ImageBitmapOptions m_options;
     std::optional<IntRect> m_rect;

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -789,7 +789,7 @@ void WebSocketChannel::processOutgoingFrameQueue()
                 ref(); // Will be derefed after didFinishLoading() or didFail().
                 ASSERT(!m_blobLoader);
                 ASSERT(frame->blobData);
-                m_blobLoader = makeUnique<FileReaderLoader>(FileReaderLoader::ReadAsArrayBuffer, this);
+                m_blobLoader = FileReaderLoader::create(FileReaderLoader::ReadAsArrayBuffer, this);
                 m_blobLoaderStatus = BlobLoaderStarted;
                 m_blobLoader->start(m_document.get(), *frame->blobData);
                 m_outgoingFrameQueue.prepend(WTFMove(frame));

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -210,7 +210,7 @@ private:
     OutgoingFrameQueueStatus m_outgoingFrameQueueStatus { OutgoingFrameQueueOpen };
 
     // FIXME: Load two or more Blobs simultaneously for better performance.
-    std::unique_ptr<FileReaderLoader> m_blobLoader;
+    RefPtr<FileReaderLoader> m_blobLoader;
     BlobLoaderStatus m_blobLoaderStatus { BlobLoaderNotStarted };
 
     WebSocketDeflateFramer m_deflateFramer;


### PR DESCRIPTION
#### b37b62cd2fffbbf5bda74796b9a87b3df263e761
<pre>
Make FileReaderLoader Ref Counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281833">https://bugs.webkit.org/show_bug.cgi?id=281833</a>

Reviewed by NOBODY (OOPS!).

Make FileReaderLoader Ref Counted

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didResolveToBlob):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/fileapi/BlobLoader.h:
(WebCore::BlobLoader::start):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::readInternal):
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::create):
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processOutgoingFrameQueue):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Source/WebCore/fileapi/FileReaderSync.cpp:
(WebCore::FileReaderSync::readAsText):
(WebCore::FileReaderSync::readAsDataURL):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37b62cd2fffbbf5bda74796b9a87b3df263e761

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64981 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6944 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2833 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->