### PR TITLE
[scroll-animations] ready task isn't scheduled when switching between monotonic and progress-based timelines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -2,17 +2,17 @@
 PASS Setting a scroll timeline on a play-pending animation synchronizes currentTime of the animation with the scroll position.
 PASS Setting a scroll timeline on a pause-pending animation fixes the currentTime of the animation based on the scroll position once resumed
 PASS Setting a scroll timeline on a reversed play-pending animation synchronizes the currentTime of the animation with the scroll position.
-FAIL Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position. assert_true: expected true got false
-FAIL Setting a scroll timeline on a paused animation fixes the currentTime of the animation based on the scroll position when resumed assert_equals: expected "paused" but got "idle"
-FAIL Setting a scroll timeline on a reversed paused animation fixes the currentTime of the animation based on the scroll position when resumed assert_equals: expected "paused" but got "idle"
+FAIL Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position. assert_approx_equals: Timeline's currentTime aligns with the scroll position even when paused expected a number but got a "object"
+PASS Setting a scroll timeline on a paused animation fixes the currentTime of the animation based on the scroll position when resumed
+PASS Setting a scroll timeline on a reversed paused animation fixes the currentTime of the animation based on the scroll position when resumed
 PASS Transitioning from a scroll timeline to a document timeline on a running animation preserves currentTime
 PASS Transitioning from a scroll timeline to a document timeline on a pause-pending animation preserves currentTime
 FAIL Transition from a scroll timeline to a document timeline on a reversed paused animation maintains correct currentTime assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 90 +/- 0.125 but got -100
 PASS Transitioning from a scroll timeline to a null timeline on a running animation preserves current progress.
-FAIL Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state assert_equals: expected "running" but got "idle"
+FAIL Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 FAIL Switching from one scroll timeline to another updates currentTime promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 FAIL Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
 FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
 FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 0 +/- 0.125 but got 10
 


### PR DESCRIPTION
#### 53782b6c3b151cebfa41fd40e1c2edc2b23ef7c6
<pre>
[scroll-animations] ready task isn&apos;t scheduled when switching between monotonic and progress-based timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=281838">https://bugs.webkit.org/show_bug.cgi?id=281838</a>
<a href="https://rdar.apple.com/138282058">rdar://138282058</a>

Reviewed by Simon Fraser.

We made an ill-advised optimization when implementing the revised &quot;setting the timeline
of an animation&quot; procedure from Web Animations Level 2. Indeed, we must compute the
&quot;previous play state&quot; prior to updating the timeline member since doing so may change
that value. We now follow the spec more closely and this addresses some WPT test failures.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):

Canonical link: <a href="https://commits.webkit.org/285499@main">https://commits.webkit.org/285499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d395cc70c895fae639addf57cfad3eeea13b0d34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57256 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15751 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78698 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6948 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49119 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->