### PR TITLE
Fix more miscellaneous smart pointer warnings across WebCore and WebKit on main

### DIFF
--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -280,11 +280,12 @@ void MediaSourcePrivate::setCDMSession(LegacyCDMSession* session)
 
 void MediaSourcePrivate::ensureOnDispatcher(Function<void()>&& function) const
 {
-    if (m_dispatcher->isCurrent()) {
+    Ref dispatcher = m_dispatcher;
+    if (dispatcher->isCurrent()) {
         function();
         return;
     }
-    m_dispatcher->dispatch(WTFMove(function));
+    dispatcher->dispatch(WTFMove(function));
 }
 
 MediaTime MediaSourcePrivate::currentTime() const

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -57,7 +57,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCVPXVideoDecoder);
 
-static WorkQueue& vpxDecoderQueue()
+static WorkQueue& vpxDecoderQueueSingleton()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("VPx VideoDecoder Queue"_s));
     return queue.get();
@@ -107,14 +107,14 @@ LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder()
 
 Ref<VideoDecoder::DecodePromise> LibWebRTCVPXVideoDecoder::decode(EncodedFrame&& frame)
 {
-    return invokeAsync(vpxDecoderQueue(), [value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder] {
+    return invokeAsync(vpxDecoderQueueSingleton(), [value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder] {
         return decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration);
     });
 }
 
 Ref<GenericPromise> LibWebRTCVPXVideoDecoder::flush()
 {
-    return invokeAsync(vpxDecoderQueue(), [] {
+    return invokeAsync(vpxDecoderQueueSingleton(), [] {
         return GenericPromise::createAndResolve();
     });
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -109,8 +109,8 @@ RemoteGraphicsContextGLProxy::~RemoteGraphicsContextGLProxy()
 
 void RemoteGraphicsContextGLProxy::initializeIPC(Ref<IPC::StreamClientConnection>&& streamConnection, RenderingBackendIdentifier renderingBackend, IPC::StreamServerConnection::Handle&& serverHandle, SerialFunctionDispatcher& dispatcher)
 {
-    m_streamConnection = WTFMove(streamConnection);
-    m_streamConnection->open(*this, dispatcher);
+    m_streamConnection = streamConnection.ptr();
+    streamConnection->open(*this, dispatcher);
     callOnMainRunLoopAndWait([&]() {
         auto& gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
         gpuProcessConnection.createGraphicsContextGL(m_identifier, contextAttributes(), renderingBackend, WTFMove(serverHandle));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -70,20 +70,25 @@ private:
 
 UniqueRef<WorkerClient> GPUProcessWebWorkerClient::createNestedWorkerClient(SerialFunctionDispatcher& dispatcher)
 {
-    assertIsCurrent(this->dispatcher());
+    assertIsCurrent(*this->dispatcher());
     return UniqueRef<WorkerClient> { *new GPUProcessWebWorkerClient { dispatcher, m_displayID } };
 }
 
 RemoteRenderingBackendProxy& GPUProcessWebWorkerClient::ensureRenderingBackend() const
 {
-    assertIsCurrent(dispatcher());
+    RefPtr dispatcher = this->dispatcher();
+    RELEASE_ASSERT(dispatcher);
+    assertIsCurrent(*dispatcher);
     if (!m_remoteRenderingBackendProxy)
-        m_remoteRenderingBackendProxy = RemoteRenderingBackendProxy::create(dispatcher());
+        m_remoteRenderingBackendProxy = RemoteRenderingBackendProxy::create(*dispatcher);
     return *m_remoteRenderingBackendProxy;
 }
 
 RefPtr<ImageBuffer> GPUProcessWebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
+    RefPtr dispatcher = this->dispatcher();
+    if (!dispatcher)
+        return nullptr;
     if (is<RemoteSerializedImageBufferProxy>(imageBuffer)) {
         auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
         return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), ensureRenderingBackend());
@@ -93,7 +98,8 @@ RefPtr<ImageBuffer> GPUProcessWebWorkerClient::sinkIntoImageBuffer(std::unique_p
 
 RefPtr<ImageBuffer> GPUProcessWebWorkerClient::createImageBuffer(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat, OptionSet<ImageBufferOptions> options) const
 {
-    assertIsCurrent(dispatcher());
+    if (RefPtr dispatcher = this->dispatcher())
+        assertIsCurrent(*dispatcher);
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose))
         return ensureRenderingBackend().createImageBuffer(size, purpose, resolutionScale, colorSpace, pixelFormat, options);
     return nullptr;
@@ -101,17 +107,23 @@ RefPtr<ImageBuffer> GPUProcessWebWorkerClient::createImageBuffer(const FloatSize
 
 RefPtr<GraphicsContextGL> GPUProcessWebWorkerClient::createGraphicsContextGL(const GraphicsContextGLAttributes& attributes) const
 {
-    assertIsCurrent(dispatcher());
+    RefPtr dispatcher = this->dispatcher();
+    if (!dispatcher)
+        return nullptr;
+    assertIsCurrent(*dispatcher);
     if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL())
-        return RemoteGraphicsContextGLProxy::create(attributes, ensureRenderingBackend(), *m_dispatcher.get());
+        return RemoteGraphicsContextGLProxy::create(attributes, ensureRenderingBackend(), *dispatcher);
     return WebWorkerClient::createGraphicsContextGL(attributes);
 }
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
 RefPtr<WebCore::WebGPU::GPU> GPUProcessWebWorkerClient::createGPUForWebGPU() const
 {
-    assertIsCurrent(dispatcher());
-    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), ensureRenderingBackend(), dispatcher());
+    RefPtr dispatcher = this->dispatcher();
+    if (!dispatcher)
+        return nullptr;
+    assertIsCurrent(*dispatcher);
+    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), ensureRenderingBackend(), *dispatcher);
 }
 #endif
 
@@ -139,32 +151,32 @@ WebWorkerClient::~WebWorkerClient() = default;
 
 UniqueRef<WorkerClient> WebWorkerClient::createNestedWorkerClient(SerialFunctionDispatcher& dispatcher)
 {
-    assertIsCurrent(this->dispatcher());
+    assertIsCurrent(*this->dispatcher().get());
     return UniqueRef<WorkerClient> { *new WebWorkerClient { dispatcher, m_displayID } };
 }
 
 PlatformDisplayID WebWorkerClient::displayID() const
 {
-    assertIsCurrent(dispatcher());
+    assertIsCurrent(*dispatcher().get());
     return m_displayID;
 }
 
 RefPtr<ImageBuffer> WebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
-    assertIsCurrent(dispatcher());
+    assertIsCurrent(*dispatcher().get());
     return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
 }
 
 RefPtr<ImageBuffer> WebWorkerClient::createImageBuffer(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat, OptionSet<ImageBufferOptions> options) const
 {
-    assertIsCurrent(dispatcher());
+    assertIsCurrent(*dispatcher().get());
     return nullptr;
 }
 
 #if ENABLE(WEBGL)
 RefPtr<GraphicsContextGL> WebWorkerClient::createGraphicsContextGL(const GraphicsContextGLAttributes& attributes) const
 {
-    assertIsCurrent(dispatcher());
+    assertIsCurrent(*dispatcher().get());
     return WebCore::createWebProcessGraphicsContextGL(attributes);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -72,8 +72,7 @@ protected:
     WebWorkerClient(SerialFunctionDispatcher&, WebCore::PlatformDisplayID);
 
     // m_dispatcher should stay alive as long as WebWorkerClient is alive.
-    // FIXME: We should use the equivalent of a WeakRef for m_dispatcher.
-    SerialFunctionDispatcher& dispatcher() const { return *m_dispatcher.get(); }
+    RefPtr<SerialFunctionDispatcher> dispatcher() const { return m_dispatcher.get(); }
 
     ThreadSafeWeakPtr<SerialFunctionDispatcher> m_dispatcher;
     const WebCore::PlatformDisplayID m_displayID;


### PR DESCRIPTION
#### 545961fde294a9ca9c941221b1ddd974ac7c15b4
<pre>
Fix more miscellaneous smart pointer warnings across WebCore and WebKit on main
<a href="https://bugs.webkit.org/show_bug.cgi?id=281772">https://bugs.webkit.org/show_bug.cgi?id=281772</a>

Reviewed by Chris Dumez.

* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::ensureOnDispatcher const):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::vpxDecoderQueueSingleton):
(WebCore::LibWebRTCVPXVideoDecoder::decode):
(WebCore::LibWebRTCVPXVideoDecoder::flush):
(WebCore::vpxDecoderQueue): Deleted.
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::dispatcher):
(IPC::Connection::SyncMessageStateRelease::operator() const):
(IPC::Connection::SyncMessageState::enqueueMatchingMessages):
(IPC::Connection::SyncMessageState::processIncomingMessage):
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::SyncMessageState::dispatchMessagesUntil):
(IPC::Connection::SyncMessageState::dispatchMessagesAndResetDidScheduleDispatchMessagesForConnection):
(IPC::Connection::dispatcher):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initializeIPC):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::GPUProcessWebWorkerClient::createNestedWorkerClient):
(WebKit::GPUProcessWebWorkerClient::ensureRenderingBackend const):
(WebKit::GPUProcessWebWorkerClient::sinkIntoImageBuffer):
(WebKit::GPUProcessWebWorkerClient::createImageBuffer const):
(WebKit::GPUProcessWebWorkerClient::createGraphicsContextGL const):
(WebKit::GPUProcessWebWorkerClient::createGPUForWebGPU const):
(WebKit::WebWorkerClient::createNestedWorkerClient):
(WebKit::WebWorkerClient::displayID const):
(WebKit::WebWorkerClient::sinkIntoImageBuffer):
(WebKit::WebWorkerClient::createImageBuffer const):
(WebKit::WebWorkerClient::createGraphicsContextGL const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
(WebKit::WebWorkerClient::dispatcher const):

Canonical link: <a href="https://commits.webkit.org/285494@main">https://commits.webkit.org/285494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd213ab270b1de10f5efa601bca580311dba46e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57275 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15759 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64992 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6961 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11190 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2848 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->