### PR TITLE
Twitch.tv ASSERTION FAILED: mode == Verify => !geometryChanged.

### DIFF
--- a/LayoutTests/fast/layers/hidden-scroller-layer-position-crash-expected.txt
+++ b/LayoutTests/fast/layers/hidden-scroller-layer-position-crash-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/fast/layers/hidden-scroller-layer-position-crash.html
+++ b/LayoutTests/fast/layers/hidden-scroller-layer-position-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html>
+<body onload="runTest()">
+
+  <p>This test should not crash.</p>
+
+  <div id="scroller" style="overflow:hidden; width:200px; height:200px; visibility: hidden">
+    <div style="height: 250px; background: red; position: relative"></div>
+    <div style="height: 1000px; background: blue"></div>
+  </div>
+
+  <div id="sibling" style="width: 200px; height: 200px; position: relative; background: red"></div>
+
+  <script>
+    if (window.testRunner)
+      testRunner.dumpAsText();
+
+    function runTest() {
+      document.getElementById("scroller").scrollTop = 200;
+      document.getElementById("sibling").style.backgroundColor = "green";
+   }
+  </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -354,6 +354,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     }
 
     m_scrollPosition = newPosition;
+    m_layer.setSelfAndDescendantsNeedPositionUpdate();
 
     auto& renderer = m_layer.renderer();
     if (auto* element = renderer.element())


### PR DESCRIPTION
#### ae547fbaa071a7b2d64593e90cb71be632ec4333
<pre>
Twitch.tv ASSERTION FAILED: mode == Verify =&gt; !geometryChanged.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281839">https://bugs.webkit.org/show_bug.cgi?id=281839</a>
&lt;<a href="https://rdar.apple.com/138286002">rdar://138286002</a>&gt;

Reviewed by Simon Fraser.

Scroll requests are normally handled asynchronously, or their RenderLayers get position updates from an immediate call to updateLayerPositionsAfterOverflowScroll from within RenderLayerScrollableArea::scrollTo.
In rare cases neither of those work (overflow:hidden to prevent async, and visibility:hidden to hit an early return RenderLayer::recursiveUpdateLayerPositionsAfterScroll), and the scroll position changes without a layer update.

Mark the layer and descendants (their position relative to this layer might have changed) as needing an update.

* LayoutTests/fast/layers/hidden-scroller-layer-position-crash-expected.txt: Added.
* LayoutTests/fast/layers/hidden-scroller-layer-position-crash.html: Added.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):

Canonical link: <a href="https://commits.webkit.org/285549@main">https://commits.webkit.org/285549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d0f9f082b5adbe20ecfc157f79fbb3b35edc1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24073 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19656 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65717 "Found 1 new test failure: animations/additive-transform-animations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64993 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6958 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2849 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->