### PR TITLE
Remove web process history item maps and begin using session state stored in the UI process

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -615,18 +615,23 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
     });
 }
 
-void BackForwardCache::remove(HistoryItem& item)
+void BackForwardCache::remove(BackForwardItemIdentifier itemID)
 {
     // Safely ignore attempts to remove items not in the cache.
-    auto it = m_cachedPageMap.find(item.identifier());
+    auto it = m_cachedPageMap.find(itemID);
     if (it == m_cachedPageMap.end() || std::holds_alternative<PruningReason>(it->value))
         return;
 
-    m_items.remove(item.identifier());
+    m_items.remove(itemID);
     m_cachedPageMap.remove(it);
-    item.notifyChanged();
 
-    RELEASE_LOG(BackForwardCache, "BackForwardCache::remove item: %s, size: %u / %u", item.identifier().toString().utf8().data(), pageCount(), maxSize());
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::remove item: %s, size: %u / %u", itemID.toString().utf8().data(), pageCount(), maxSize());
+}
+
+void BackForwardCache::remove(HistoryItem& item)
+{
+    remove(item.identifier());
+    item.notifyChanged();
 }
 
 void BackForwardCache::prune(PruningReason pruningReason)

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -56,6 +56,7 @@ public:
 
     WEBCORE_EXPORT std::unique_ptr<CachedPage> suspendPage(Page&);
     WEBCORE_EXPORT bool addIfCacheable(HistoryItem&, Page*); // Prunes if maxSize() is exceeded.
+    WEBCORE_EXPORT void remove(BackForwardItemIdentifier);
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -65,10 +65,7 @@ HistoryItem::HistoryItem(Client& client, const String& urlString, const String& 
 {
 }
 
-HistoryItem::~HistoryItem()
-{
-    ASSERT(!BackForwardCache::singleton().isInBackForwardCache(m_identifier));
-}
+HistoryItem::~HistoryItem() = default;
 
 HistoryItem::HistoryItem(const HistoryItem& item)
     : RefCounted<HistoryItem>()
@@ -264,6 +261,7 @@ void HistoryItem::setPageScaleFactor(float scaleFactor)
 void HistoryItem::setDocumentState(const Vector<AtomString>& state)
 {
     m_documentState = state;
+    notifyChanged();
 }
 
 const Vector<AtomString>& HistoryItem::documentState() const
@@ -353,6 +351,7 @@ const Vector<Ref<HistoryItem>>& HistoryItem::children() const
 void HistoryItem::clearChildren()
 {
     m_children.clear();
+    notifyChanged();
 }
 
 // We do same-document navigation if going to a different item and if either of the following is true:
@@ -361,7 +360,7 @@ void HistoryItem::clearChildren()
 bool HistoryItem::shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const
 {
     // The following logic must be kept in sync with WebKit::WebBackForwardListItem::itemIsInSameDocument().
-    if (this == &otherItem)
+    if (m_identifier == otherItem.identifier())
         return false;
 
     if (stateObject() || otherItem.stateObject())

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2320,7 +2320,7 @@ void FrameLoader::commitProvisionalLoad()
         document->checkedEditor()->confirmOrCancelCompositionAndNotifyClient();
     }
 
-    if (!frame->tree().parent() && frame->history().currentItem() && frame->history().currentItem() != frame->history().provisionalItem()) {
+    if (!frame->tree().parent() && frame->history().currentItem() && (!frame->history().provisionalItem() || frame->history().currentItem()->identifier() != frame->history().provisionalItem()->identifier())) {
         // Check to see if we need to cache the page we are navigating away from into the back/forward cache.
         // We are doing this here because we know for sure that a new page is about to be loaded.
         BackForwardCache::singleton().addIfCacheable(*frame->history().protectedCurrentItem(), frame->protectedPage().get());

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -256,7 +256,7 @@ void HistoryController::restoreDocumentState()
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
         return;
-    if (frame->loader().requestedHistoryItem() != currentItem.get())
+    if (!frame->loader().requestedHistoryItem() || (frame->loader().requestedHistoryItem()->identifier() != currentItem->identifier()))
         return;
     RefPtr documentLoader = frame->loader().documentLoader();
     if (documentLoader->isClientRedirect())
@@ -855,7 +855,7 @@ bool HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2) c
     // new document and should not consider them clones.
     // (See http://webkit.org/b/35532 for details.)
     return item2
-        && &item1 != item2
+        && item1.identifier() != item2->identifier()
         && item1.itemSequenceNumber() == item2->itemSequenceNumber();
 }
 
@@ -968,6 +968,7 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     currentItem->setStateObject(WTFMove(stateObject));
     currentItem->setFormData(nullptr);
     currentItem->setFormContentType(String());
+    currentItem->notifyChanged();
 
     RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
     if (!frame)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -299,7 +299,7 @@ public:
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
-        if (page->checkedBackForward()->currentItem() == m_historyItem.ptr()) {
+        if (page->checkedBackForward()->currentItem() && page->checkedBackForward()->currentItem()->identifier() == m_historyItem->identifier()) {
             // Special case for go(0) from a frame -> reload only the frame
             // To follow Firefox and IE's behavior, history reload can only navigate the self frame.
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
@@ -352,7 +352,7 @@ public:
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
-        if (page->backForward().currentItem() == historyItem.ptr()) {
+        if (page->backForward().currentItem() && page->backForward().currentItem()->identifier() == historyItem->identifier()) {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
                 localFrame->protectedLoader()->changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -543,7 +543,7 @@ void Page::firstTimeInitialization()
     });
 }
 
-void Page::clearPreviousItemFromAllPages(HistoryItem* item)
+void Page::clearPreviousItemFromAllPages(BackForwardItemIdentifier itemID)
 {
     for (auto& page : allPages()) {
         RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
@@ -551,7 +551,7 @@ void Page::clearPreviousItemFromAllPages(HistoryItem* item)
             return;
 
         CheckedRef controller = localMainFrame->history();
-        if (item == controller->previousItem()) {
+        if (controller->previousItem() && controller->previousItem()->identifier() == itemID) {
             controller->clearPreviousItem();
             return;
         }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -22,6 +22,7 @@
 
 #include "ActivityState.h"
 #include "AnimationFrameRate.h"
+#include "BackForwardItemIdentifier.h"
 #include "Color.h"
 #include "ContentSecurityPolicy.h"
 #include "FindOptions.h"
@@ -335,7 +336,7 @@ public:
     WEBCORE_EXPORT ~Page();
 
     WEBCORE_EXPORT static void updateStyleForAllPagesAfterGlobalChangeInEnvironment();
-    WEBCORE_EXPORT static void clearPreviousItemFromAllPages(HistoryItem*);
+    WEBCORE_EXPORT static void clearPreviousItemFromAllPages(BackForwardItemIdentifier);
 
     WEBCORE_EXPORT void setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections>);
 

--- a/Source/WebKit/Shared/GoToBackForwardItemParameters.h
+++ b/Source/WebKit/Shared/GoToBackForwardItemParameters.h
@@ -27,8 +27,8 @@
 
 #include "NetworkResourceLoadIdentifier.h"
 #include "SandboxExtension.h"
+#include "SessionState.h"
 #include "WebsitePoliciesData.h"
-#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/PublicSuffix.h>
@@ -39,7 +39,7 @@ namespace WebKit {
 
 struct GoToBackForwardItemParameters {
     WebCore::NavigationIdentifier navigationID;
-    WebCore::BackForwardItemIdentifier backForwardItemID;
+    Ref<FrameState> frameState;
     WebCore::FrameLoadType backForwardType;
     WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad;
     std::optional<WebsitePoliciesData> websitePolicies;

--- a/Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in
+++ b/Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in
@@ -22,7 +22,7 @@
 
 [RValue] struct WebKit::GoToBackForwardItemParameters {
     WebCore::NavigationIdentifier navigationID;
-    WebCore::BackForwardItemIdentifier backForwardItemID;
+    Ref<WebKit::FrameState> frameState;
     WebCore::FrameLoadType backForwardType;
     WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad;
     std::optional<WebKit::WebsitePoliciesData> websitePolicies;

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -30,7 +30,7 @@
 
 namespace WebKit {
 
-FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> identifier, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction,
+FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> identifier, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>& policyContainer,
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
@@ -54,6 +54,8 @@ FrameState::FrameState(const String& urlString, const String& originalURLString,
     , shouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy)
     , sessionStateObject(WTFMove(sessionStateObject))
     , wasCreatedByJSWithoutUserInteraction(wasCreatedByJSWithoutUserInteraction)
+    , wasRestoredFromSession(wasRestoredFromSession)
+    , policyContainer(policyContainer)
 #if PLATFORM(IOS_FAMILY)
     , exposedContentRect(exposedContentRect)
     , unobscuredContentRect(unobscuredContentRect)
@@ -88,6 +90,8 @@ Ref<FrameState> FrameState::copy()
         shouldOpenExternalURLsPolicy,
         sessionStateObject.copyRef(),
         wasCreatedByJSWithoutUserInteraction,
+        wasRestoredFromSession,
+        policyContainer,
 #if PLATFORM(IOS_FAMILY)
         exposedContentRect,
         unobscuredContentRect,

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -31,6 +31,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
+#include <WebCore/PolicyContainer.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/RefCounted.h>
@@ -105,6 +106,8 @@ public:
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy { WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     RefPtr<WebCore::SerializedScriptValue> sessionStateObject;
     bool wasCreatedByJSWithoutUserInteraction { false };
+    bool wasRestoredFromSession { false };
+    std::optional<WebCore::PolicyContainer> policyContainer;
 
     // FIXME: These should not be per frame.
 #if PLATFORM(IOS_FAMILY)
@@ -119,7 +122,7 @@ public:
     Vector<Ref<FrameState>> children;
 
 private:
-    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction,
+    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -61,6 +61,8 @@ header: "SessionState.h"
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy;
     RefPtr<WebCore::SerializedScriptValue> sessionStateObject;
     bool wasCreatedByJSWithoutUserInteraction;
+    bool wasRestoredFromSession;
+    std::optional<WebCore::PolicyContainer> policyContainer;
 
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect;

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -43,7 +43,7 @@ public:
     static UncheckedKeyHashMap<WebCore::BackForwardItemIdentifier, WeakRef<WebBackForwardListFrameItem>>& allItems();
 
     FrameState& frameState() const { return m_frameState; }
-    void setFrameState(Ref<FrameState>&& frameState) { m_frameState = WTFMove(frameState); }
+    void setFrameState(Ref<FrameState>&&);
 
     std::optional<WebCore::FrameIdentifier> frameID() const;
     WebCore::BackForwardItemIdentifier identifier() const;
@@ -55,10 +55,14 @@ public:
     WebBackForwardListItem* backForwardListItem() const;
     RefPtr<WebBackForwardListItem> protectedBackForwardListItem() const;
 
-    void addChild(Ref<FrameState>&&);
+    void setChild(Ref<FrameState>&&);
+
+    void setWasRestoredFromSession();
 
 private:
     WebBackForwardListFrameItem(WebBackForwardListItem*, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
+
+    void updateChildFrameState(Ref<FrameState>&&);
 
     WeakPtr<WebBackForwardListItem> m_backForwardListItem;
     Ref<FrameState> m_frameState;

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -195,7 +195,7 @@ WebCore::BackForwardItemIdentifier WebBackForwardListItem::itemID() const
 
 void WebBackForwardListItem::setRootFrameState(Ref<FrameState>&& mainFrameState)
 {
-    m_rootFrameItem->setFrameState(WTFMove(mainFrameState));
+    protectedRootFrameItem()->setFrameState(WTFMove(mainFrameState));
 }
 
 FrameState& WebBackForwardListItem::rootFrameState() const
@@ -227,6 +227,16 @@ const String& WebBackForwardListItem::title() const
 bool WebBackForwardListItem::wasCreatedByJSWithoutUserInteraction() const
 {
     return m_rootFrameItem->frameState().wasCreatedByJSWithoutUserInteraction;
+}
+
+void WebBackForwardListItem::setWasRestoredFromSession()
+{
+    protectedRootFrameItem()->setWasRestoredFromSession();
+}
+
+Ref<WebBackForwardListFrameItem> WebBackForwardListItem::protectedRootFrameItem()
+{
+    return m_rootFrameItem.get();
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -97,9 +97,12 @@ public:
     WebBackForwardListItem* childItemForProcessID(WebCore::ProcessIdentifier) const;
 
     WebBackForwardListFrameItem& rootFrameItem() { return m_rootFrameItem.get(); }
+    Ref<WebBackForwardListFrameItem> protectedRootFrameItem();
 
     void setIsRemoteFrameNavigation(bool isRemoteFrameNavigation) { m_isRemoteFrameNavigation = isRemoteFrameNavigation; }
     bool isRemoteFrameNavigation() const { return m_isRemoteFrameNavigation; }
+
+    void setWasRestoredFromSession();
 
 #if !LOG_DISABLED
     String loggingString();

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -137,9 +137,6 @@ struct WebPageCreationParameters {
     
     String userAgent { };
 
-    bool itemStatesWereRestoredByAPIRequest { false };
-    Vector<Ref<FrameState>> itemStates { };
-
     VisitedLinkTableIdentifier visitedLinkTableID;
     bool canRunBeforeUnloadConfirmPanel { false };
     bool canRunModal { false };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -63,9 +63,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     String userAgent;
 
-    bool itemStatesWereRestoredByAPIRequest;
-    Vector<Ref<WebKit::FrameState>> itemStates;
-
     WebKit::VisitedLinkTableIdentifier visitedLinkTableID;
     bool canRunBeforeUnloadConfirmPanel;
     bool canRunModal;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -494,20 +494,19 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
     LOG(BackForward, "(Back/Forward) WebBackForwardList %p restored from state (has %zu entries)", this, m_entries.size());
 }
 
-Vector<Ref<FrameState>> WebBackForwardList::filteredItemStates(Function<bool(WebBackForwardListItem&)>&& functor) const
+void WebBackForwardList::setItemsAsRestoredFromSession()
 {
-    return WTF::compactMap(m_entries, [&](auto& entry) -> std::optional<Ref<FrameState>> {
-        if (functor(entry))
-            return entry->rootFrameState();
-        return std::nullopt;
+    setItemsAsRestoredFromSessionIf([](WebBackForwardListItem&) {
+        return true;
     });
 }
 
-Vector<Ref<FrameState>> WebBackForwardList::itemStates() const
+void WebBackForwardList::setItemsAsRestoredFromSessionIf(Function<bool(WebBackForwardListItem&)>&& functor)
 {
-    return filteredItemStates([](WebBackForwardListItem&) {
-        return true;
-    });
+    for (auto& entry : m_entries) {
+        if (functor(entry))
+            entry->setWasRestoredFromSession();
+    }
 }
 
 void WebBackForwardList::didRemoveItem(WebBackForwardListItem& backForwardListItem)

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -84,8 +84,8 @@ public:
     BackForwardListState backForwardListState(WTF::Function<bool (WebBackForwardListItem&)>&&) const;
     void restoreFromState(BackForwardListState);
 
-    Vector<Ref<FrameState>> itemStates() const;
-    Vector<Ref<FrameState>> filteredItemStates(Function<bool(WebBackForwardListItem&)>&&) const;
+    void setItemsAsRestoredFromSession();
+    void setItemsAsRestoredFromSessionIf(Function<bool(WebBackForwardListItem&)>&&);
 
     void goToProvisionalItem(WebBackForwardListItem&);
     void clearProvisionalItem(WebBackForwardListFrameItem&);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2798,7 +2798,7 @@ private:
     void backForwardSetChildItem(WebCore::BackForwardItemIdentifier, Ref<FrameState>&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
-    void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
+    void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardClear();
     void backForwardGoToProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -203,7 +203,7 @@ messages -> WebPageProxy {
     BackForwardAddItem(WebCore::FrameIdentifier targetFrameID, Ref<WebKit::FrameState> rootFrameState)
     BackForwardSetChildItem(WebCore::BackForwardItemIdentifier identifier, Ref<WebKit::FrameState> frameState)
     BackForwardGoToItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (std::optional<WebCore::BackForwardItemIdentifier> itemID) Synchronous
+    BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (RefPtr<WebKit::FrameState> frameState) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClear()

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -97,6 +97,8 @@ Ref<FrameState> toFrameState(const HistoryItem& historyItem)
     frameState->shouldOpenExternalURLsPolicy = historyItem.shouldOpenExternalURLsPolicy();
     frameState->sessionStateObject = historyItem.stateObject();
     frameState->wasCreatedByJSWithoutUserInteraction = historyItem.wasCreatedByJSWithoutUserInteraction();
+    frameState->wasRestoredFromSession = historyItem.wasRestoredFromSession();
+    frameState->policyContainer = historyItem.policyContainer();
 
     static constexpr auto maxTitleLength = 1000u; // Closest power of 10 above the W3C recommendation for Title length.
     frameState->title = historyItem.title().left(maxTitleLength);
@@ -164,6 +166,10 @@ static void applyFrameState(HistoryItemClient& client, HistoryItem& historyItem,
 
     historyItem.setShouldOpenExternalURLsPolicy(frameState.shouldOpenExternalURLsPolicy);
     historyItem.setStateObject(frameState.sessionStateObject.get());
+    historyItem.setWasCreatedByJSWithoutUserInteraction(frameState.wasCreatedByJSWithoutUserInteraction);
+    historyItem.setWasRestoredFromSession(frameState.wasRestoredFromSession);
+    if (auto policyContainer = frameState.policyContainer)
+        historyItem.setPolicyContainer(*policyContainer);
 
 #if PLATFORM(IOS_FAMILY)
     historyItem.setExposedContentRect(frameState.exposedContentRect);

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -39,11 +39,7 @@ class WebBackForwardListProxy : public WebCore::BackForwardClient {
 public: 
     static Ref<WebBackForwardListProxy> create(WebPage& page) { return adoptRef(*new WebBackForwardListProxy(page)); }
 
-    static WebCore::HistoryItem* itemForID(const WebCore::BackForwardItemIdentifier&);
     static void removeItem(const WebCore::BackForwardItemIdentifier&);
-
-    enum class OverwriteExistingItem : bool { No, Yes };
-    void addItemFromUIProcess(const WebCore::BackForwardItemIdentifier&, Ref<WebCore::HistoryItem>&&, WebCore::PageIdentifier, OverwriteExistingItem);
 
     void clear();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1848,6 +1848,8 @@ public:
 
     void updateOpener(WebCore::FrameIdentifier, WebCore::FrameIdentifier);
 
+    WebHistoryItemClient& historyItemClient() const { return m_historyItemClient.get(); }
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2025,11 +2027,7 @@ private:
     void loadURLInFrame(URL&&, const String& referrer, WebCore::FrameIdentifier);
     void loadDataInFrame(std::span<const uint8_t>, String&& MIMEType, String&& encodingName, URL&& baseURL, WebCore::FrameIdentifier);
 
-    enum class WasRestoredByAPIRequest : bool { No, Yes };
-    void restoreSessionInternal(const Vector<Ref<FrameState>>&, WasRestoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem);
-    void restoreSession(const Vector<Ref<FrameState>>&);
     void didRemoveBackForwardItem(const WebCore::BackForwardItemIdentifier&);
-    void updateBackForwardListForReattach(const Vector<Ref<FrameState>>&);
     void setCurrentHistoryItemForReattach(Ref<FrameState>&&);
 
     void requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -208,8 +208,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     StopLoading()
     StopLoadingDueToProcessSwap()
 
-    RestoreSession(Vector<Ref<WebKit::FrameState>> frameStates)
-    UpdateBackForwardListForReattach(Vector<Ref<WebKit::FrameState>> frameStates)
     SetCurrentHistoryItemForReattach(Ref<WebKit::FrameState> frameState)
 
     DidRemoveBackForwardItem(WebCore::BackForwardItemIdentifier backForwardItemID)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1994,11 +1994,7 @@ void WebProcess::setBackForwardCacheCapacity(unsigned capacity)
 
 void WebProcess::clearCachedPage(BackForwardItemIdentifier backForwardItemID, CompletionHandler<void()>&& completionHandler)
 {
-    HistoryItem* item = WebBackForwardListProxy::itemForID(backForwardItemID);
-    if (!item)
-        return completionHandler();
-
-    BackForwardCache::singleton().remove(*item);
+    BackForwardCache::singleton().remove(backForwardItemID);
     completionHandler();
 }
 


### PR DESCRIPTION
#### be5caf9bf0c4db410091fd1dc0d655780f3b7b4e
<pre>
Remove web process history item maps and begin using session state stored in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=281844">https://bugs.webkit.org/show_bug.cgi?id=281844</a>
<a href="https://rdar.apple.com/138295365">rdar://138295365</a>

Reviewed by Alex Christensen.

This patch removes the hash maps that store all history items in the web process, replacing them with the
session state stored in the UI process. Now, instead of the UI process using `BackForwardItemIdentifier`
to reference history items in the web process, the full history state is sent over IPC. This change will
make the implementation of navigation and session history with site isolation much simpler.

I needed to make the following changes to make this work correctly:
 - Compare history items using `BackForwardItemIdentifier` instead of their addresses in memory. Since
   history items are now constructed using state retrieved from the UI process, they can no longer be
   compared using their addresses. `BackForwardItemIdentifier` is unique per history item, and preserved
   when sent between processes.

 - Track back/forward state restored from another session in the UI process. Previously, when restoring
   session state, the state was sent to the web process to be stored in the history maps, and a boolean
   was set to indicate that the history item was restored.

 - Add state to `FrameState` that previously only existed on `HistoryItem`.

 - Update session state on `WebBackForwardListFrameItem` when its corresponding `HistoryItem` in the web
   process changes.

More details provided below.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::remove):
* Source/WebCore/history/BackForwardCache.h:
Add a remove function that takes a `BackForwardItemIdentifier`, so the UI process can remove back/forward
cache state without a `HistoryItem`.

* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::clearChildren):
Notify the UI process when a history item’s children have been cleared.

(WebCore::HistoryItem::setDocumentState):
Notify the UI process when a history item&apos;s document state has been updated.

(WebCore::HistoryItem::shouldDoSameDocumentNavigationTo const):

(WebCore::HistoryItem::~HistoryItem): Deleted.
HistoryItem can now be destroyed without removing its back/forward cache state, so remove this assertion.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::restoreDocumentState):
(WebCore::HistoryController::itemsAreClones const):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearPreviousItemFromAllPages):
* Source/WebCore/page/Page.h:
* Source/WebKit/Shared/GoToBackForwardItemParameters.h:
* Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in:

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::FrameState):
(WebKit::FrameState::copy):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in:
Add `wasRestoredFromSession` to `FrameState`, since this state is now stored in the UI process and needs
to be included when sent to the web process.

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::setWasRestoredFromSession):

(WebKit::WebBackForwardListFrameItem::setChild):
(WebKit::WebBackForwardListFrameItem::updateChildFrameState):
(WebKit::WebBackForwardListFrameItem::setFrameState):
(WebKit::WebBackForwardListFrameItem::addChild): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::setFrameState): Deleted.
Update these functions to correctly update their state when a history item that does not correspond to a
root frame is updated in the web process.

* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::protectedRootFrameItem):
(WebKit::WebBackForwardListItem::setRootFrameState):
(WebKit::WebBackForwardListItem::setWasRestoredFromSession):
* Source/WebKit/Shared/WebBackForwardListItem.h:

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
`itemStates` no longer needs to be sent to the web process on page creation.

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
Mark items that are being restored from another session in the UI process, and remove the IPC message
that did the same for the items in the web process.

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::setItemsAsRestoredFromSession):
(WebKit::WebBackForwardList::setItemsAsRestoredFromSessionIf):
(WebKit::WebBackForwardList::filteredItemStates const): Deleted.
(WebKit::WebBackForwardList::itemStates const): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::restoreFromSessionState):
(WebKit::WebPageProxy::backForwardAddItemShared):
(WebKit::WebPageProxy::backForwardSetChildItem):
(WebKit::WebPageProxy::backForwardItemAtIndex):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
(WebKit::WebProcessProxy::updateBackForwardItem):
Change this function to be able to update session state for non-root frames.

* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFrameState):
(WebKit::applyFrameState):
Update session state conversion to include `wasRestoredFromSession`. Also add a missing call to
`setWasCreatedByJSWithoutUserInteraction` when converting from `FrameState` to `HistoryItem`.

* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::removeItem):
(WebKit::WebBackForwardListProxy::addItem):
(WebKit::WebBackForwardListProxy::itemAtIndex):
(WebKit::WebBackForwardListProxy::containsItem const):
(WebKit::idToHistoryItemMap): Deleted.
(WebKit::WebBackForwardListProxy::addItemFromUIProcess): Deleted.
(WebKit::WebBackForwardListProxy::itemForID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
Remove all code needed to interact with the history item hash maps.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::goToBackForwardItem):
Use `toHistoryItem()` to convert from `FrameState`. UI process session state should not be updated during
this conversion.

(WebKit::WebPage::setCurrentHistoryItemForReattach):
(WebKit::WebPage::restoreSessionInternal): Deleted.
(WebKit::WebPage::restoreSession): Deleted.
(WebKit::WebPage::updateBackForwardListForReattach): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Remove now unneeded functions used to add history items from another session.

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::clearCachedPage):

Canonical link: <a href="https://commits.webkit.org/285517@main">https://commits.webkit.org/285517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/201fa3c27d778c454718a42f7c46f745091bf4fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72859 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15777 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78729 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65010 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6978 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11210 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2869 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->