### PR TITLE
[scroll-animations] scroll timelines with an `overflow: hidden` source should yield a resolved current time

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7410,7 +7410,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-whe
 
 # webkit.org/b/263870 [scroll-animations] some WPT tests are timing out
 imported/w3c/web-platform-tests/scroll-animations/css/deferred-timeline-composited.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update-reversed-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-overflow-hidden.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
@@ -7433,15 +7432,11 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/update-playba
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 
 # webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
-imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-multiple.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html [ Pass Failure ]
-imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-timeline.html [ Pass Failure ]
-imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode.html [ Pass Failure ]
-imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-sampling.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state.html [ Pass Failure ]
@@ -7475,6 +7470,9 @@ imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-update-reversed-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-bounds-update.html [ Skip ]
+
+# webkit.org/b/281837 [scroll-animations] calc() values in `view-timeline-inset` lead to a failed assertion under `ViewTimeline::computeTimelineData()`
+imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html [ Skip ]
 
 # CSS @scope with shadow DOM
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-duration-auto.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-duration-auto.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL A value of auto can be specified for animation-duration assert_equals: expected "0" but got "-1"
+PASS A value of auto can be specified for animation-duration
 PASS e.style['animation-duration'] = "auto" should set the property value
 PASS Property animation-duration value 'auto'
 PASS e.style['animation'] = "auto cubic-bezier(0, -2, 1, 3) -3s 4 reverse both paused anim" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Changing animation-timeline changes the timeline (sanity check) assert_equals: expected "120px" but got "0px"
-FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS) assert_equals: expected "120px" but got "0px"
-FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS) assert_equals: expected "120px" but got "0px"
+FAIL Changing animation-timeline changes the timeline (sanity check) assert_equals: expected "140px" but got "0px"
+FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS) assert_equals: expected "180px" but got "0px"
+FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS) assert_equals: expected "140px" but got "0px"
 FAIL animation-timeline ignored after setting timeline with JS (document timeline) assert_equals: expected "120px" but got "0px"
 FAIL animation-timeline ignored after setting timeline with JS (null) assert_equals: expected "120px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-multiple-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL animation-timeline works with multiple timelines assert_equals: expected "120px" but got "auto"
+PASS animation-timeline works with multiple timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-timeline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL progress based animation timeline works promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+PASS progress based animation timeline works
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Initial axis assert_equals: expected "175px" but got "0px"
-FAIL Vertical axis assert_equals: expected "175px" but got "0px"
-FAIL Horizontal axis assert_equals: expected "125px" but got "0px"
-FAIL Block axis in horizontal writing-mode assert_equals: expected "175px" but got "0px"
-FAIL Inline axis in horizontal writing-mode assert_equals: expected "125px" but got "0px"
-FAIL Block axis in vertical writing-mode assert_equals: expected "125px" but got "0px"
-FAIL Inline axis in vertical writing-mode assert_equals: expected "175px" but got "0px"
+PASS Initial axis
+FAIL Vertical axis assert_equals: expected "175px" but got "100px"
+PASS Horizontal axis
+PASS Block axis in horizontal writing-mode
+PASS Inline axis in horizontal writing-mode
+FAIL Block axis in vertical writing-mode assert_equals: expected "125px" but got "100px"
+FAIL Inline axis in vertical writing-mode assert_equals: expected "175px" but got "100px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -1,18 +1,16 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Switching between document and scroll timelines [immediate] assert_equals: expected "120px" but got "0px"
-FAIL Switching between document and scroll timelines [scroll] assert_equals: expected "120px" but got "0px"
-TIMEOUT Switching pending animation from document to scroll timelines [immediate] Test timed out
-NOTRUN Switching pending animation from document to scroll timelines [scroll]
-NOTRUN Changing computed value of animation-timeline changes effective timeline [immediate]
-NOTRUN Changing computed value of animation-timeline changes effective timeline [scroll]
-NOTRUN Changing to/from animation-timeline:none [immediate]
-NOTRUN Changing to/from animation-timeline:none [scroll]
-NOTRUN Reverse animation direction [immediate]
-NOTRUN Reverse animation direction [scroll]
-NOTRUN Change to timeline attachment while paused [immediate]
-NOTRUN Change to timeline attachment while paused [scroll]
-NOTRUN Switching timelines and pausing at the same time [immediate]
-NOTRUN Switching timelines and pausing at the same time [scroll]
+PASS Switching between document and scroll timelines [immediate]
+PASS Switching between document and scroll timelines [scroll]
+PASS Switching pending animation from document to scroll timelines [immediate]
+PASS Switching pending animation from document to scroll timelines [scroll]
+PASS Changing computed value of animation-timeline changes effective timeline [immediate]
+PASS Changing computed value of animation-timeline changes effective timeline [scroll]
+FAIL Changing to/from animation-timeline:none [immediate] assert_equals: expected "0px" but got "100px"
+FAIL Changing to/from animation-timeline:none [scroll] assert_equals: expected "0px" but got "100px"
+FAIL Reverse animation direction [immediate] assert_equals: expected "0px" but got "190px"
+FAIL Reverse animation direction [scroll] assert_equals: expected "0px" but got "190px"
+FAIL Change to timeline attachment while paused [immediate] assert_equals: expected "0px" but got "100px"
+FAIL Change to timeline attachment while paused [scroll] assert_equals: expected "0px" but got "100px"
+FAIL Switching timelines and pausing at the same time [immediate] assert_equals: expected "100px" but got "120px"
+FAIL Switching timelines and pausing at the same time [scroll] assert_equals: expected "100px" but got "120px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-sampling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-sampling-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroll position is sampled once per frame assert_equals: expected "100px" but got "0px"
+PASS Scroll position is sampled once per frame
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -3,10 +3,10 @@ FAIL Descendant can attach to deferred timeline promise_test: Unhandled rejectio
 PASS Deferred timeline with no attachments
 FAIL Inner timeline does not interfere with outer timeline assert_equals: expected "100px" but got "0px"
 PASS Deferred timeline with two attachments
-FAIL Dynamically re-attaching assert_equals: expected "100px" but got "0px"
-FAIL Dynamically detaching assert_equals: expected "100px" but got "0px"
-FAIL Removing/inserting element with attaching timeline assert_equals: expected "100px" but got "0px"
-FAIL Ancestor attached element becoming display:none/block assert_equals: expected "100px" but got "0px"
-FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
+FAIL Dynamically re-attaching assert_equals: expected "50px" but got "100px"
+FAIL Dynamically detaching assert_equals: expected "0px" but got "50px"
+FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
+PASS Ancestor attached element becoming display:none/block
+FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "0px" but got "100px"
 FAIL Animations prefer non-deferred timelines assert_equals: expected "150px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Use the last value from view-timeline-axis if omitted assert_equals: expected "25" but got "-1"
-FAIL Use the last value from view-timeline-inset if omitted assert_equals: expected "0" but got "-1"
+FAIL Use the last value from view-timeline-axis if omitted assert_equals: expected "35" but got "45"
+FAIL Use the last value from view-timeline-inset if omitted assert_equals: expected "50" but got "100"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL currentTime handles direction: rtl correctly promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL currentTime handles writing-mode: vertical-rl correctly promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL currentTime handles writing-mode: sideways-rl correctly promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL currentTime handles writing-mode: vertical-lr correctly promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL currentTime handles writing-mode: sideways-lr correctly promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+FAIL currentTime handles direction: rtl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
+FAIL currentTime handles writing-mode: vertical-rl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
+FAIL currentTime handles writing-mode: sideways-rl correctly assert_approx_equals: values do not match for "Unscrolled inline timeline" expected 0 +/- 0.125 but got 100
+FAIL currentTime handles writing-mode: vertical-lr correctly assert_approx_equals: values do not match for "Scrolled block timeline" expected 20 +/- 0.125 but got 10
+FAIL currentTime handles writing-mode: sideways-lr correctly assert_approx_equals: values do not match for "Scrolled block timeline" expected 20 +/- 0.125 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt
@@ -1,30 +1,28 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Scroll based animation effect fill mode should return 'auto' for getTiming() and should return 'none' for getComputedTiming().
-TIMEOUT Applied effect value before start delay with fill: none Test timed out
-NOTRUN Applied effect value at start delay with fill: none
-NOTRUN Applied effect value at midpoint with fill: none
-NOTRUN Applied effect value at effect end with fill: none
-NOTRUN Applied effect value after effect end with fill: none
-NOTRUN Applied effect value before start delay with fill: backwards
-NOTRUN Applied effect value at start delay with fill: backwards
-NOTRUN Applied effect value at midpoint with fill: backwards
-NOTRUN Applied effect value at effect end with fill: backwards
-NOTRUN Applied effect value after effect end with fill: backwards
-NOTRUN Applied effect value before timeline start with fill: forwards
-NOTRUN Applied effect value at timeline start with fill: forwards
-NOTRUN Applied effect value in timeline range with fill: forwards
-NOTRUN Applied effect value at timeline end with fill: forwards
-NOTRUN Applied effect value after timeline end with fill: forwards
-NOTRUN Applied effect value before timeline start with fill: both
-NOTRUN Applied effect value at timeline start with fill: both
-NOTRUN Applied effect value in timeline range with fill: both
-NOTRUN Applied effect value at timeline end with fill: both
-NOTRUN Applied effect value after timeline end with fill: both
-NOTRUN Applied effect value before timeline start with fill: auto
-NOTRUN Applied effect value at timeline start with fill: auto
-NOTRUN Applied effect value in timeline range with fill: auto
-NOTRUN Applied effect value at timeline end with fill: auto
-NOTRUN Applied effect value after timeline end with fill: auto
+FAIL Applied effect value before start delay with fill: none assert_equals: animation effect applied property value expected 1 but got 0.34
+FAIL Applied effect value at start delay with fill: none assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at midpoint with fill: none
+FAIL Applied effect value at effect end with fill: none assert_equals: animation effect applied property value expected 1 but got 0.6
+FAIL Applied effect value after effect end with fill: none assert_equals: animation effect applied property value expected 1 but got 0.66
+FAIL Applied effect value before start delay with fill: backwards assert_equals: animation effect applied property value expected 0.3 but got 0.34
+FAIL Applied effect value at start delay with fill: backwards assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at midpoint with fill: backwards
+FAIL Applied effect value at effect end with fill: backwards assert_equals: animation effect applied property value expected 1 but got 0.6
+FAIL Applied effect value after effect end with fill: backwards assert_equals: animation effect applied property value expected 1 but got 0.66
+FAIL Applied effect value before timeline start with fill: forwards assert_equals: animation effect applied property value expected 1 but got 0.34
+FAIL Applied effect value at timeline start with fill: forwards assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value in timeline range with fill: forwards
+FAIL Applied effect value at timeline end with fill: forwards assert_equals: animation effect applied property value expected 0.7 but got 0.6
+FAIL Applied effect value after timeline end with fill: forwards assert_equals: animation effect applied property value expected 0.7 but got 0.66
+FAIL Applied effect value before timeline start with fill: both assert_equals: animation effect applied property value expected 0.3 but got 0.34
+FAIL Applied effect value at timeline start with fill: both assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value in timeline range with fill: both
+FAIL Applied effect value at timeline end with fill: both assert_equals: animation effect applied property value expected 0.7 but got 0.6
+FAIL Applied effect value after timeline end with fill: both assert_equals: animation effect applied property value expected 0.7 but got 0.66
+FAIL Applied effect value before timeline start with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.34
+FAIL Applied effect value at timeline start with fill: auto assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value in timeline range with fill: auto
+FAIL Applied effect value at timeline end with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.6
+FAIL Applied effect value after timeline end with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.66
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
@@ -1,34 +1,32 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Current times and effect phase at start when delay = 0 and endDelay = 0 | Test timed out
-NOTRUN Current times and effect phase in active range when delay = 0 and endDelay = 0 |
-NOTRUN Current times and effect phase at effect end time when delay = 0 and endDelay = 0 |
-NOTRUN Current times and effect phase at timeline start when delay = 500 and endDelay = 0 |
-NOTRUN Current times and effect phase before start delay when delay = 500 and endDelay = 0 |
-NOTRUN Current times and effect phase at start delay when delay = 500 and endDelay = 0 |
-NOTRUN Current times and effect phase in active range when delay = 500 and endDelay = 0 |
-NOTRUN Current times and effect phase at effect end time when delay = 500 and endDelay = 0 |
-NOTRUN Current times and effect phase at timeline start when delay = 0 and endDelay = 500 |
-NOTRUN Current times and effect phase in active range when delay = 0 and endDelay = 500 |
-NOTRUN Current times and effect phase at effect end time when delay = 0 and endDelay = 500 |
-NOTRUN Current times and effect phase after effect end time when delay = 0 and endDelay = 500 |
-NOTRUN Current times and effect phase at timeline boundary when delay = 0 and endDelay = 500 |
-NOTRUN Current times and effect phase at timeline start when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase before start delay when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase at start delay when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase in active range when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase at effect end time when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase after effect end time when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase at timeline boundary when delay = 250 and endDelay = 250 |
-NOTRUN Current times and effect phase at timeline start when delay = -125 and endDelay = -125 |
-NOTRUN Current times and effect phase in active range when delay = -125 and endDelay = -125 |
-NOTRUN Current times and effect phase at timeline end when delay = -125 and endDelay = -125 |
-NOTRUN Playback rate affects whether active phase boundary is inclusive.
-NOTRUN Verify that (play -> pause -> play) doesn't change phase/progress.
-NOTRUN Pause in before phase, scroll timeline into active phase, animation should remain in the before phase
-NOTRUN Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect.
-NOTRUN Make scroller inactive, then set current time to an in range time
-NOTRUN Animation effect is still applied after pausing and making timeline inactive.
-NOTRUN Make timeline inactive, force style update then pause the animation. No crashing indicates test success.
+PASS Current times and effect phase at start when delay = 0 and endDelay = 0 |
+PASS Current times and effect phase in active range when delay = 0 and endDelay = 0 |
+PASS Current times and effect phase at effect end time when delay = 0 and endDelay = 0 |
+FAIL Current times and effect phase at timeline start when delay = 500 and endDelay = 0 | assert_equals: animation effect progress expected (object) null but got (number) 0
+FAIL Current times and effect phase before start delay when delay = 500 and endDelay = 0 | assert_equals: animation effect progress expected (object) null but got (number) 0.25
+FAIL Current times and effect phase at start delay when delay = 500 and endDelay = 0 | assert_approx_equals: animation effect progress expected 0 +/- 0.001 but got 0.5
+FAIL Current times and effect phase in active range when delay = 500 and endDelay = 0 | assert_approx_equals: animation effect progress expected 0.5 +/- 0.001 but got 0.75
+PASS Current times and effect phase at effect end time when delay = 500 and endDelay = 0 |
+PASS Current times and effect phase at timeline start when delay = 0 and endDelay = 500 |
+FAIL Current times and effect phase in active range when delay = 0 and endDelay = 500 | assert_approx_equals: animation effect progress expected 0.5 +/- 0.001 but got 0.25
+FAIL Current times and effect phase at effect end time when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 0.5
+FAIL Current times and effect phase after effect end time when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 0.75
+FAIL Current times and effect phase at timeline boundary when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 1
+FAIL Current times and effect phase at timeline start when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0
+FAIL Current times and effect phase before start delay when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.1
+FAIL Current times and effect phase at start delay when delay = 250 and endDelay = 250 | assert_approx_equals: animation effect progress expected 0 +/- 0.001 but got 0.25
+PASS Current times and effect phase in active range when delay = 250 and endDelay = 250 |
+FAIL Current times and effect phase at effect end time when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.75
+FAIL Current times and effect phase after effect end time when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.9
+FAIL Current times and effect phase at timeline boundary when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 1
+FAIL Current times and effect phase at timeline start when delay = -125 and endDelay = -125 | assert_approx_equals: animation effect progress expected 0.25 +/- 0.001 but got 0
+PASS Current times and effect phase in active range when delay = -125 and endDelay = -125 |
+FAIL Current times and effect phase at timeline end when delay = -125 and endDelay = -125 | assert_approx_equals: animation effect progress expected 0.75 +/- 0.001 but got 1
+FAIL Playback rate affects whether active phase boundary is inclusive. assert_equals: Animation effect is in before phase when current time is 0% (progress is null with 'none' fill mode) expected (object) null but got (number) 0
+FAIL Verify that (play -> pause -> play) doesn't change phase/progress. assert_equals: expected (object) null but got (number) 0
+FAIL Pause in before phase, scroll timeline into active phase, animation should remain in the before phase assert_equals: expected (object) null but got (number) 0
+FAIL Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect. assert_equals: expected (object) null but got (number) 0
+PASS Make scroller inactive, then set current time to an in range time
+PASS Animation effect is still applied after pausing and making timeline inactive.
+PASS Make timeline inactive, force style update then pause the animation. No crashing indicates test success.
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -179,7 +179,7 @@ ScrollableArea* ScrollTimeline::scrollableAreaForSourceRenderer(RenderElement* r
     if (renderer->element() == document->documentElement())
         return &renderer->view().frameView();
 
-    return (renderBox->canBeScrolledAndHasScrollableArea() && renderBox->hasLayer()) ? renderBox->layer()->scrollableArea() : nullptr;
+    return renderBox->hasLayer() ? renderBox->layer()->scrollableArea() : nullptr;
 }
 
 float ScrollTimeline::floatValueForOffset(const Length& offset, float maxValue)


### PR DESCRIPTION
#### 551cd734139ee7262bf0f9e51e4f6bf23e0a7373
<pre>
[scroll-animations] scroll timelines with an `overflow: hidden` source should yield a resolved current time
<a href="https://bugs.webkit.org/show_bug.cgi?id=281845">https://bugs.webkit.org/show_bug.cgi?id=281845</a>
<a href="https://rdar.apple.com/138296912">rdar://138296912</a>

Reviewed by Antti Koivisto.

No need to check `canBeScrolledAndHasScrollableArea()` when trying to obtain
the `ScrollableArea` of a scroll timeline&apos;s source.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-duration-auto.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-multiple-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-timeline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-axis-writing-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-sampling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::scrollableAreaForSourceRenderer):

Canonical link: <a href="https://commits.webkit.org/285500@main">https://commits.webkit.org/285500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fe4473b70f55031ec6617e3d1b0c7fcfb8f8139

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25668 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/24102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23918 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/77066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/24102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17162 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/13327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11195 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48091 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/49158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/50453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48903 "Failed to checkout and rebase branch from PR 35510") | | | 
<!--EWS-Status-Bubble-End-->