### PR TITLE
[scroll-animations] setting the `timeline` property via the JS API should override any change to the `animation-timeline` CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -11,7 +11,7 @@ FAIL Transition from a scroll timeline to a document timeline on a reversed paus
 PASS Transitioning from a scroll timeline to a null timeline on a running animation preserves current progress.
 FAIL Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 FAIL Switching from one scroll timeline to another updates currentTime promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+PASS Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS.
 PASS Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
 FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
 FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: values do not match for "Animation's currentTime aligns with the scroll position" expected 0 +/- 0.125 but got 10

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -56,6 +56,8 @@ private:
     void syncPropertiesWithBackingAnimation() final;
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
 
+    AnimationTimeline* bindingsTimeline() const final;
+    void setBindingsTimeline(RefPtr<AnimationTimeline>&&) final;
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;
     void setBindingsEffect(RefPtr<AnimationEffect>&&) final;
@@ -72,7 +74,8 @@ private:
         Delay = 1 << 6,
         FillMode = 1 << 7,
         Keyframes = 1 << 8,
-        CompositeOperation = 1 << 9
+        CompositeOperation = 1 << 9,
+        Timeline = 1 << 10
     };
 
     String m_animationName;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -238,6 +238,11 @@ void WebAnimation::setEffectInternal(RefPtr<AnimationEffect>&& newEffect, bool d
     InspectorInstrumentation::didSetWebAnimationEffect(*this);
 }
 
+void WebAnimation::setBindingsTimeline(RefPtr<AnimationTimeline>&& timeline)
+{
+    setTimeline(WTFMove(timeline));
+}
+
 void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
 {
     // 3.4.1. Setting the timeline of an animation

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -82,6 +82,9 @@ public:
     virtual void setBindingsEffect(RefPtr<AnimationEffect>&&);
     AnimationEffect* effect() const { return m_effect.get(); }
     void setEffect(RefPtr<AnimationEffect>&&);
+
+    virtual AnimationTimeline* bindingsTimeline() const { return timeline(); }
+    virtual void setBindingsTimeline(RefPtr<AnimationTimeline>&&);
     AnimationTimeline* timeline() const { return m_timeline.get(); }
     virtual void setTimeline(RefPtr<AnimationTimeline>&&);
 

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -51,7 +51,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
     attribute DOMString id;
     [ImplementedAs=bindingsEffect] attribute AnimationEffect? effect;
-    attribute AnimationTimeline? timeline;
+    [ImplementedAs=bindingsTimeline] attribute AnimationTimeline? timeline;
     [ImplementedAs=bindingsStartTime] attribute CSSNumberish? startTime;
     [ImplementedAs=bindingsCurrentTime] attribute CSSNumberish? currentTime;
     [EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;


### PR DESCRIPTION
#### 313f0ca79b4a9525dee8db157b27ac6917665f8b
<pre>
[scroll-animations] setting the `timeline` property via the JS API should override any change to the `animation-timeline` CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=281847">https://bugs.webkit.org/show_bug.cgi?id=281847</a>
<a href="https://rdar.apple.com/138304343">rdar://138304343</a>

Reviewed by Tim Nguyen.

We make sure that the `animation-timeline` CSS property behaves like other properties related
to animations in that it should no longer affect the animation if the matching JS property, in
this case `timeline`, is set using the JS API.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::bindingsTimeline const):
(WebCore::CSSAnimation::setBindingsTimeline):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setBindingsTimeline):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::bindingsTimeline const):
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/285504@main">https://commits.webkit.org/285504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff15e2731dbf16161642e9dece7c3bd500baae0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57297 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15782 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65742 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65016 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6986 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11198 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2877 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->