### PR TITLE
[css-anchor-position-1] Support animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() responds to position-anchor change assert_equals: expected 50 but got 200
+PASS Animation with anchor() responds to position-anchor change
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() responds to anchor-name change assert_equals: expected 50 but got 200
+FAIL Animation with anchor() responds to anchor-name change assert_equals: expected 150 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() assert_equals: expected 100 but got 200
+PASS Animation with anchor()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition of anchor() when changing target anchor element name assert_equals: expected 300 but got 0
+FAIL Transition of anchor() when changing target anchor element name assert_equals: expected 300 but got 400
 FAIL Transition of anchor-size() when changing target anchor element name assert_equals: expected 150 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 300
+FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 400
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when position-anchor changes assert_equals: expected 0 but got 140
+FAIL Transition when position-anchor changes assert_equals: expected 50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Transition when the result of anchor() changes assert_equals: expected 110 but got 0
+FAIL Transition when the result of anchor() changes assert_equals: expected 120 but got 130
 FAIL Transition when the result of anchor-size() changes assert_equals: expected 50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when the dereferenced anchor name changes assert_equals: expected 0 but got 140
+FAIL Transition when the dereferenced anchor name changes assert_equals: expected 50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition to a flipped state assert_equals: expected 275 but got 0
+FAIL Transition to a flipped state assert_equals: expected 275 but got 300
 FAIL Transition to an unflipped state assert_equals: expected 250 but got 300
 

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -31,6 +31,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include "CompositeOperation.h"
+#include "ComputedStyleDependencies.h"
 #include "Element.h"
 #include "KeyframeEffect.h"
 #include "RenderObject.h"
@@ -52,6 +53,7 @@ void BlendingKeyframes::clear()
     m_propertiesSetToCurrentColor.clear();
     m_usesRelativeFontWeight = false;
     m_containsCSSVariableReferences = false;
+    m_usesAnchorFunctions = false;
 }
 
 bool BlendingKeyframes::operator==(const BlendingKeyframes& o) const
@@ -311,6 +313,11 @@ void BlendingKeyframes::updatePropertiesMetadata(const StyleProperties& properti
                 m_propertiesSetToCurrentColor.add(propertyReference.id());
             else if (!m_usesRelativeFontWeight && propertyReference.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
                 m_usesRelativeFontWeight = true;
+            if (CSSProperty::isInsetProperty(propertyReference.id())) {
+                auto dependencies = cssValue->computedStyleDependencies();
+                if (dependencies.anchors)
+                    m_usesAnchorFunctions = true;
+            }
         } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
             if (customPropertyValue->isInherit())
                 m_propertiesSetToInherit.add(customPropertyValue->name());

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -130,6 +130,7 @@ public:
     bool hasHeightDependentTransform() const { return m_hasHeightDependentTransform; }
     bool hasDiscreteTransformInterval() const { return m_hasDiscreteTransformInterval; }
     bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
+    bool usesAnchorFunctions() const { return m_usesAnchorFunctions; }
 
 private:
     void analyzeKeyframe(const BlendingKeyframe&);
@@ -143,6 +144,7 @@ private:
     HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
     bool m_usesRelativeFontWeight { false };
     bool m_containsCSSVariableReferences { false };
+    bool m_usesAnchorFunctions { false };
     bool m_hasWidthDependentTransform { false };
     bool m_hasHeightDependentTransform { false };
     bool m_hasDiscreteTransformInterval { false };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1912,7 +1912,9 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
         return false;
     }();
 
-    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged()) {
+    auto usesAnchorFunctions = m_blendingKeyframes.usesAnchorFunctions();
+
+    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged() || usesAnchorFunctions) {
         switch (m_animationType) {
         case WebAnimationType::CSSTransition:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSProperty.cpp
+++ b/Source/WebCore/css/CSSProperty.cpp
@@ -44,4 +44,22 @@ CSSPropertyID StylePropertyMetadata::shorthandID() const
     return shorthands[m_indexInShorthandsVector].id();
 }
 
+// FIXME: Generate from logical property groups.
+bool CSSProperty::isInsetProperty(CSSPropertyID propertyID)
+{
+    switch (propertyID) {
+    case CSSPropertyLeft:
+    case CSSPropertyRight:
+    case CSSPropertyTop:
+    case CSSPropertyBottom:
+    case CSSPropertyInsetInlineStart:
+    case CSSPropertyInsetInlineEnd:
+    case CSSPropertyInsetBlockStart:
+    case CSSPropertyInsetBlockEnd:
+        return true;
+    default:
+        return false;
+    }
+};
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -85,6 +85,7 @@ public:
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
+    static bool isInsetProperty(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
     static bool isColorProperty(CSSPropertyID propertyId)

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -49,23 +49,6 @@ namespace WebCore::Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AnchorPositionedState);
 
-static bool isInsetProperty(CSSPropertyID propertyID)
-{
-    switch (propertyID) {
-    case CSSPropertyLeft:
-    case CSSPropertyRight:
-    case CSSPropertyTop:
-    case CSSPropertyBottom:
-    case CSSPropertyInsetInlineStart:
-    case CSSPropertyInsetInlineEnd:
-    case CSSPropertyInsetBlockStart:
-    case CSSPropertyInsetBlockEnd:
-        return true;
-    default:
-        return false;
-    }
-};
-
 static BoxAxis mapInsetPropertyToPhysicalAxis(CSSPropertyID id, const RenderStyle& style)
 {
     switch (id) {
@@ -408,12 +391,8 @@ std::optional<double> AnchorPositionEvaluator::evaluate(const BuilderState& buil
         if (style.pseudoElementType() != PseudoId::None)
             return false;
 
-        // FIXME: Support animations and transitions.
-        if (style.hasAnimationsOrTransitions())
-            return false;
-
         // It’s being used in an inset property...
-        if (!isInsetProperty(propertyID))
+        if (!CSSProperty::isInsetProperty(propertyID))
             return false;
 
         // ...on an absolutely-positioned element.


### PR DESCRIPTION
#### 9d89836c54083add399369a4bd71c52f42f70707
<pre>
[css-anchor-position-1] Support animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=281852">https://bugs.webkit.org/show_bug.cgi?id=281852</a>
<a href="https://rdar.apple.com/138312664">rdar://138312664</a>

Reviewed by Antoine Quint.

Enable animations and transition with anchor().

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::clear):
(WebCore::BlendingKeyframes::updatePropertiesMetadata):

Check if a keyframe value uses anchor().

* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::usesAnchorFunctions const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::recomputeKeyframesIfNecessary):

Recommpute the keyframes if there are anchor functions (similar to using &apos;inherit&apos;) as their values may change.

* Source/WebCore/css/CSSProperty.cpp:
(WebCore::CSSProperty::isInsetProperty):

Move here for general use.

* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::isInsetProperty): Deleted.

Canonical link: <a href="https://commits.webkit.org/285508@main">https://commits.webkit.org/285508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd7e58ad622b8d700ee87d153d5d9d05b2617da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57305 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6993 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2886 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->