### PR TITLE
[GStreamer][WebCodecs] Decoders should not inherit from ThreadSafeRefCounted

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -99,8 +99,7 @@ void GStreamerAudioDecoder::create(const String& codecName, const Config& config
         element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     }
 
-    // FIXME: GStreamerAudioDecoder subclasses ThreadSafeRefCounted but gets contructed using makeUniqueRef(), which doesn't seem right.
-    auto decoder = makeUniqueRefWithoutRefCountedCheck<GStreamerAudioDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
+    auto decoder = makeUniqueRef<GStreamerAudioDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
     auto internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal audio decoder failed to configure for codec %s", codecName.utf8().data());

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -24,13 +24,12 @@
 #include "AudioDecoder.h"
 #include "GRefPtrGStreamer.h"
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
 class GStreamerInternalAudioDecoder;
 
-class GStreamerAudioDecoder : public ThreadSafeRefCounted<GStreamerAudioDecoder>, public AudioDecoder {
+class GStreamerAudioDecoder final : public AudioDecoder {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerAudioDecoder);
 
 public:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -97,8 +97,7 @@ void GStreamerVideoDecoder::create(const String& codecName, const Config& config
     }
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
-    // FIXME: GStreamerVideoDecoder subclasses ThreadSafeRefCounted but gets contructed using makeUniqueRef(), which doesn't seem right.
-    auto decoder = makeUniqueRefWithoutRefCountedCheck<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
+    auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
     auto internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.utf8().data());

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
@@ -25,13 +25,12 @@
 #include "VideoDecoder.h"
 
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
 class GStreamerInternalVideoDecoder;
 
-class GStreamerVideoDecoder : public ThreadSafeRefCounted<GStreamerVideoDecoder>, public VideoDecoder {
+class GStreamerVideoDecoder final : public VideoDecoder {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerVideoDecoder);
 
 public:


### PR DESCRIPTION
#### 1f1e09a446317e8edd2ff3a63ceeaea1561cc421
<pre>
[GStreamer][WebCodecs] Decoders should not inherit from ThreadSafeRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281858">https://bugs.webkit.org/show_bug.cgi?id=281858</a>

Reviewed by Chris Dumez.

The audio/video decoder state is managed with a private/internal class so there is no good reason
for the AudioDecoder and VideoDecoder sub-classes to be ThreadSafeRefCounted, instances of those
classes are not captured in any closure.

* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerAudioDecoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerVideoDecoder::create):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/285550@main">https://commits.webkit.org/285550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95e28c1b6c150f206b2a6a186f12ad0eb45b4f76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57312 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20203 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65754 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16091 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7004 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->