### PR TITLE
REGRESSION(284711@main) No media controls in In-Window Fullscreen

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/start-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/start-support.js
@@ -45,6 +45,13 @@ class StartSupport extends MediaControllerSupport
         super.enable();
 
         this._updateShowsStartButton();
+        this.mediaController.shadowRoot.addEventListener("fullscreenchange", this, true);
+    }
+
+    disable()
+    {
+        super.disable();
+        this.mediaController.shadowRoot.removeEventListener("fullscreenchange", this, true);
     }
 
     buttonWasPressed(control)


### PR DESCRIPTION
#### 62b10ce4776bcc0f6d08135163bf7fc6d60fa2a3
<pre>
REGRESSION(284711@main) No media controls in In-Window Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=281860">https://bugs.webkit.org/show_bug.cgi?id=281860</a>
<a href="https://rdar.apple.com/137678579">rdar://137678579</a>

Reviewed by Andy Estes.

Revert the partial revert from 284711@main and instead fix the underlying issue
causing the &quot;start playback&quot; button to appear when exiting fullscreen: the check
of whether controls are &quot;forced&quot; to be visible needs to happen after the
&quot;fullscreenchange&quot; event fires.

* Source/WebCore/Modules/modern-media-controls/media/start-support.js:
(StartSupport.prototype.get mediaEvents):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::shouldForceControlsDisplay const):

Canonical link: <a href="https://commits.webkit.org/285602@main">https://commits.webkit.org/285602@main</a>
</pre>
