### PR TITLE
Add TextStream dumping for WebCore::KeyboardScroll[Parameters]

### DIFF
--- a/Source/WebCore/platform/KeyboardScroll.cpp
+++ b/Source/WebCore/platform/KeyboardScroll.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "KeyboardScroll.h"
 
+#include <wtf/text/TextStream.h>
+
 namespace WebCore {
 
 FloatSize unitVectorForScrollDirection(ScrollDirection direction)
@@ -42,6 +44,18 @@ FloatSize unitVectorForScrollDirection(ScrollDirection direction)
     }
 
     RELEASE_ASSERT_NOT_REACHED();
+}
+
+TextStream& operator<<(TextStream& ts, const KeyboardScroll& scrollData)
+{
+    return ts << "offset=" << scrollData.offset << " maximumVelocity=" << scrollData.maximumVelocity << " force=" << scrollData.force << " granularity=" << scrollData.granularity << " direction=" << scrollData.direction;
+}
+
+TextStream& operator<<(TextStream& ts, const KeyboardScrollParameters& parameters)
+{
+    return ts << "springMass=" << parameters.springMass << " springStiffness=" << parameters.springStiffness
+    << " springDamping=" << parameters.springDamping << " maximumVelocityMultiplier=" << parameters.maximumVelocityMultiplier
+    << " timeToMaximumVelocity=" << parameters.timeToMaximumVelocity << " rubberBandForce=" << parameters.rubberBandForce;
 }
 
 }

--- a/Source/WebCore/platform/KeyboardScroll.h
+++ b/Source/WebCore/platform/KeyboardScroll.h
@@ -28,6 +28,10 @@
 #include "FloatSize.h"
 #include "ScrollTypes.h"
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 WEBCORE_EXPORT FloatSize unitVectorForScrollDirection(ScrollDirection);
@@ -76,5 +80,8 @@ struct KeyboardScrollParameters {
 #endif
     }
 };
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const KeyboardScroll&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const KeyboardScrollParameters&);
 
 } // namespace WebCore


### PR DESCRIPTION
#### a12d6631c05f186dc6c16c884b1a57341777fce6
<pre>
Add TextStream dumping for WebCore::KeyboardScroll[Parameters]
<a href="https://bugs.webkit.org/show_bug.cgi?id=281868">https://bugs.webkit.org/show_bug.cgi?id=281868</a>
<a href="https://rdar.apple.com/138339031">rdar://138339031</a>

Reviewed by Wenson Hsieh.

This patch adds a TextStream operator&lt;&lt; overload for the structures in
WebCore/KeyboardScroll.h to aid with debugging some keyboard scrolling
codepaths.

* Source/WebCore/platform/KeyboardScroll.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/KeyboardScroll.h:

Canonical link: <a href="https://commits.webkit.org/285538@main">https://commits.webkit.org/285538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f493f18e4a79d09778a4a96d67b4c7e204bb7e15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60184 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62790 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22517 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78826 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62791 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16079 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->