### PR TITLE
webkitpy.test.markers.xfail(reason=...) throws

### DIFF
--- a/Tools/Scripts/webkitpy/conftest.py
+++ b/Tools/Scripts/webkitpy/conftest.py
@@ -20,19 +20,25 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import warnings
-import types
 import sys
+import types
+import warnings
 
 import pytest
-
 from webkitcorepy import AutoInstall
+
+from webkitpy.test import markers
 
 
 def pytest_configure(config):
+    markers._running_under_pytest = True
     config.addinivalue_line("markers", "serial: tests that must be run in serial")
     config.addinivalue_line("markers", "integration: integration tests")
     config.addinivalue_line("markers", "slow: tests that take a while to run")
+
+
+def pytest_unconfigure(config):
+    markers._running_under_pytest = False
 
 
 def pytest_addoption(parser):

--- a/Tools/Scripts/webkitpy/test/markers.py
+++ b/Tools/Scripts/webkitpy/test/markers.py
@@ -28,6 +28,9 @@ except ImportError:
     pass
 
 
+_running_under_pytest = False
+
+
 def xfail(*args, **kwargs):
     """a pytest.mark.xfail-like wrapper for unittest.expectedFailure
 
@@ -35,14 +38,17 @@ def xfail(*args, **kwargs):
 
     Note that this doesn't support raises or strict"""
 
+    if _running_under_pytest:
+        return pytest.mark.xfail(*args, **kwargs)
+
     # shortcut if we're being called as a decorator ourselves
     if len(args) == 1 and callable(args[0]) and not kwargs:
         return unittest.expectedFailure(args[0])
 
     def decorator(func):
         conditions = args
-        reason = kwargs.get(reason, None)
-        run = kwargs.get(run, True)
+        reason = kwargs.get("reason", None)
+        run = kwargs.get("run", True)
         if "raises" in kwargs:
             raise TypeError("xfail(raises=...) is not supported")
         if "strict" in kwargs:
@@ -60,10 +66,9 @@ def xfail(*args, **kwargs):
 
 
 def slow(func):
-    try:
+    if _running_under_pytest:
         return pytest.mark.slow(func)
-    except NameError:
-        return func
+    return func
 
 
 skip = unittest.skip


### PR DESCRIPTION
#### 3caa311d45c4b97622a25495d2e53162f5b6c246
<pre>
webkitpy.test.markers.xfail(reason=...) throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=281870">https://bugs.webkit.org/show_bug.cgi?id=281870</a>

Reviewed by Jonathan Bedard.

We need to actually quote the dict keys.

While we&apos;re at it, based on the recommendation of
<a href="https://docs.pytest.org/en/7.2.x/example/simple.html#detect-if-running-from-within-a-pytest-run">https://docs.pytest.org/en/7.2.x/example/simple.html#detect-if-running-from-within-a-pytest-run</a>
to detect whether or not we&apos;re running under pytest, rather than just
checking whether or not the pytest module can be imported.

* Tools/Scripts/webkitpy/test/markers.py:
(xfail):
(xfail.decorator):
(slow):

Canonical link: <a href="https://commits.webkit.org/285777@main">https://commits.webkit.org/285777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d19b5a704fcd8cce62ec266964ae99249131ccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60233 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57375 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37812 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72506 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78876 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65825 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65098 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7088 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11377 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->