### PR TITLE
Sometimes, WKTR installation does not succeed in the Simulator

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -23,6 +23,8 @@
 import atexit
 import json
 import logging
+import os
+import pathlib
 import re
 import time
 
@@ -643,6 +645,11 @@ class SimulatedDevice(object):
     def install_app(self, app_path, env=None):
         # Even after carousel is running, it takes a few seconds for watchOS to allow installs.
         for i in range(self.NUM_INSTALL_RETRIES):
+            # FIXME: remove this workaround when rdar://129789675 has been resolved.
+            eligibility_util = os.path.join(os.path.dirname(app_path), "WebKitEligibilityUtil")
+            exit_code = self.executive.run_command(['xcrun', 'simctl', 'spawn', self.udid, eligibility_util], return_exit_code=True)
+            _log.debug(u'WebKitEligibilityUtil returned {}'.format(exit_code))
+
             exit_code = self.executive.run_command(['xcrun', 'simctl', 'install', self.udid, app_path], return_exit_code=True)
             if exit_code == 0:
                 return True

--- a/Tools/WebKitTestRunner/Configurations/WebKitEligibilityUtil.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/WebKitEligibilityUtil.xcconfig
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "BaseTarget.xcconfig"
+
+PRODUCT_NAME = WebKitEligibilityUtil;
+PRODUCT_BUNDLE_IDENTIFIER = org.webkit.WebKitEligibilityUtil;
+TARGETED_DEVICE_FAMILY = 1,2,7;
+
+EXCLUDED_SOURCE_FILE_NAMES = *;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*] = ;
+
+SKIP_INSTALL = YES;
+SKIP_INSTALL[sdk=iphonesimulator*] = NO;
+
+CODE_SIGN_IDENTITY = -;

--- a/Tools/WebKitTestRunner/WebKitEligibilityUtil/main.cpp
+++ b/Tools/WebKitTestRunner/WebKitEligibilityUtil/main.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <xpc/xpc.h>
+
+int main(int argc, const char * argv[])
+{
+    xpc_object_t message = xpc_dictionary_create(nullptr, nullptr, 0);
+    xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.eligibilityd", nullptr, 0);
+    xpc_connection_set_event_handler(connection, ^(xpc_object_t) { });
+    xpc_connection_activate(connection);
+    xpc_object_t replyMessage = xpc_connection_send_message_with_reply_sync(connection, message);
+
+    xpc_type_t replyType = xpc_get_type(replyMessage);
+    if (!replyType || replyType == XPC_TYPE_ERROR) {
+        const char* error = xpc_dictionary_get_string(replyMessage, _xpc_error_key_description);
+        if (error)
+            fprintf(stderr, "%s", error);
+        return 1;
+    }
+    return 0;
+}

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				E3D8A94E2CC69CAF006B43E3 /* PBXTargetDependency */,
 				A115CCBC1B9D76C400E89159 /* PBXTargetDependency */,
 				A115CCBA1B9D76BF00E89159 /* PBXTargetDependency */,
 			);
@@ -165,6 +166,7 @@
 		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E3D8A94C2CC4B003006B43E3 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E17D422CC4447B0077C3AE /* main.cpp */; };
 		F4010B7E24DA205300A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B7C24DA204800A876E2 /* PoseAsClass.mm */; };
 		F415C22C27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h in Headers */ = {isa = PBXBuildFile; fileRef = F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */; };
 		F415C23527AF5B390028F505 /* UIPasteboardConsistencyEnforcer.mm in Sources */ = {isa = PBXBuildFile; fileRef = F415C22B27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.mm */; };
@@ -236,6 +238,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = BC952D7711F3BF5D003398B4;
 			remoteInfo = "Derived Sources";
+		};
+		E3D8A94D2CC69CAF006B43E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E3D8A9332CC4AFB3006B43E3;
+			remoteInfo = WebKitEligibilityUtil;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -479,6 +488,9 @@
 		E372BC372C08EB01006DFE67 /* GPUExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = GPUExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E372BC392C08F323006DFE67 /* WebContentExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = WebContentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3C2C0312C34DEFC000C7F2E /* WebKitTestRunnerApp-iOS-simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WebKitTestRunnerApp-iOS-simulator.entitlements"; sourceTree = "<group>"; };
+		E3D8A94A2CC4AFB3006B43E3 /* WebKitEligibilityUtil */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WebKitEligibilityUtil; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3E17D422CC4447B0077C3AE /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WebKitEligibilityUtil.xcconfig; sourceTree = "<group>"; };
 		F4010B7C24DA204800A876E2 /* PoseAsClass.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PoseAsClass.mm; path = ../TestRunnerShared/cocoa/PoseAsClass.mm; sourceTree = "<group>"; };
 		F4010B7D24DA204800A876E2 /* PoseAsClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PoseAsClass.h; path = ../TestRunnerShared/cocoa/PoseAsClass.h; sourceTree = "<group>"; };
 		F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIPasteboardConsistencyEnforcer.h; sourceTree = "<group>"; };
@@ -534,12 +546,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E3D8A9412CC4AFB3006B43E3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		08FB7794FE84155DC02AAC07 /* WebKitTestRunner */ = {
 			isa = PBXGroup;
 			children = (
+				E3E17D412CC4445D0077C3AE /* WebKitEligibilityUtil */,
 				E372BC392C08F323006DFE67 /* WebContentExtension.appex */,
 				E372BC372C08EB01006DFE67 /* GPUExtension.appex */,
 				E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */,
@@ -713,6 +733,7 @@
 				A18510271B9ADE4800744AEB /* libWebKitTestRunner.a */,
 				2EE52CE01890A9A80010ED21 /* WebKitTestRunnerApp.app */,
 				BC25186211D15D54002EBC01 /* WebKitTestRunnerInjectedBundle.bundle */,
+				E3D8A94A2CC4AFB3006B43E3 /* WebKitEligibilityUtil */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -941,6 +962,7 @@
 				0F2109C7189C650D00F879A3 /* BaseTarget.xcconfig */,
 				BC793427118F7DAF005EA8E2 /* DebugRelease.xcconfig */,
 				BC25197111D15E61002EBC01 /* InjectedBundle.xcconfig */,
+				E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */,
 				57A0062C22976E4D00AD08BD /* WebKitTestRunner.entitlements */,
 				A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */,
 				E3C2C0312C34DEFC000C7F2E /* WebKitTestRunnerApp-iOS-simulator.entitlements */,
@@ -1010,6 +1032,14 @@
 				9B36A270209453A0003E0651 /* WhatToDump.h */,
 			);
 			name = Shared;
+			sourceTree = "<group>";
+		};
+		E3E17D412CC4445D0077C3AE /* WebKitEligibilityUtil */ = {
+			isa = PBXGroup;
+			children = (
+				E3E17D422CC4447B0077C3AE /* main.cpp */,
+			);
+			path = WebKitEligibilityUtil;
 			sourceTree = "<group>";
 		};
 		F4B6C31620E84369008AC225 /* cocoa */ = {
@@ -1146,6 +1176,23 @@
 			productReference = BC25186211D15D54002EBC01 /* WebKitTestRunnerInjectedBundle.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		E3D8A9332CC4AFB3006B43E3 /* WebKitEligibilityUtil */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E3D8A9462CC4AFB3006B43E3 /* Build configuration list for PBXNativeTarget "WebKitEligibilityUtil" */;
+			buildPhases = (
+				E3D8A9362CC4AFB3006B43E3 /* Sources */,
+				E3D8A9412CC4AFB3006B43E3 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WebKitEligibilityUtil;
+			productInstallPath = "$(HOME)/bin";
+			productName = WebKitTestRunner;
+			productReference = E3D8A94A2CC4AFB3006B43E3 /* WebKitEligibilityUtil */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1185,6 +1232,7 @@
 				BC952D7711F3BF5D003398B4 /* Derived Sources */,
 				A18510261B9ADE4800744AEB /* WebKitTestRunner (Library) */,
 				5325BDD921DFF4F500A0DEE1 /* Apply Configuration to XCFileLists */,
+				E3D8A9332CC4AFB3006B43E3 /* WebKitEligibilityUtil */,
 			);
 		};
 /* End PBXProject section */
@@ -1405,6 +1453,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E3D8A9362CC4AFB3006B43E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E3D8A94C2CC4B003006B43E3 /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1437,6 +1493,11 @@
 			isa = PBXTargetDependency;
 			target = BC952D7711F3BF5D003398B4 /* Derived Sources */;
 			targetProxy = BC952ED611F3C38B003398B4 /* PBXContainerItemProxy */;
+		};
+		E3D8A94E2CC69CAF006B43E3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E3D8A9332CC4AFB3006B43E3 /* WebKitEligibilityUtil */;
+			targetProxy = E3D8A94D2CC69CAF006B43E3 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1629,6 +1690,27 @@
 			};
 			name = Release;
 		};
+		E3D8A9472CC4AFB3006B43E3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		E3D8A9482CC4AFB3006B43E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		E3D8A9492CC4AFB3006B43E3 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1708,6 +1790,16 @@
 				BC952D7811F3BF5E003398B4 /* Debug */,
 				BC952D7911F3BF5E003398B4 /* Release */,
 				BC646D70136A3A8700B35DED /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		E3D8A9462CC4AFB3006B43E3 /* Build configuration list for PBXNativeTarget "WebKitEligibilityUtil" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E3D8A9472CC4AFB3006B43E3 /* Debug */,
+				E3D8A9482CC4AFB3006B43E3 /* Release */,
+				E3D8A9492CC4AFB3006B43E3 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 99fde22c848d06a9d4524d99e42554c6f7f9a2ed
<pre>
Sometimes, WKTR installation does not succeed in the Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=281875">https://bugs.webkit.org/show_bug.cgi?id=281875</a>
<a href="https://rdar.apple.com/138351968">rdar://138351968</a>

Reviewed by Elliott Williams.

This is caused by a daemon involved in the installation being suspended. This patch works around this
issue by creating a small utility that sends a XPC message to the daemon in order to resume execution.
This issue is flaky, so it is hard to confirm the fix is sufficient, but local testing looks good.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDevice.install_app):
* Tools/WebKitTestRunner/Configurations/WebKitEligibilityUtil.xcconfig: Added.
* Tools/WebKitTestRunner/WebKitEligibilityUtil/main.cpp: Added.
(main):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285637@main">https://commits.webkit.org/285637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/948e8f98eb0a19a9a92a572774050190f9c7df80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57594 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38013 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72822 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44268 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20562 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79196 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/619 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66026 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65303 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7315 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11294 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/593 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->