### PR TITLE
Allow upgrade requests in mixed content if the scheme is handled by scheme handler.

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "FetchOptions.h"
+#include "ResourceLoaderOptions.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -54,6 +55,8 @@ bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOp
 bool shouldBlockRequestForDisplayableContent(LocalFrame&, const URL&, ContentType, IsUpgradable = IsUpgradable::No);
 bool shouldBlockRequestForRunnableContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
 void checkFormForMixedContent(LocalFrame&, const URL&);
+
+WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator, bool shouldUpgradeIPAddressAndLocalhostForTesting);
 
 } // namespace MixedContentChecker
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -209,6 +209,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/LayoutUnitTests.cpp
         Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
+        Tests/WebCore/MixedContentChecker.cpp
         Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp
         Tests/WebCore/ParsedContentRange.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		E589183C252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */; };
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
+		EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */; };
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
 		ECA680CE1E68CC0900731D20 /* StringUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECA680CD1E68CC0900731D20 /* StringUtilities.mm */; };
@@ -3617,6 +3618,7 @@
 		EB230D3E245E726300C66AD1 /* IDBCheckpointWAL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IDBCheckpointWAL.mm; sourceTree = "<group>"; };
 		EB4D320727C045430081A8E4 /* TestNotificationProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestNotificationProvider.cpp; sourceTree = "<group>"; };
 		EB4D320827C045440081A8E4 /* TestNotificationProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNotificationProvider.h; sourceTree = "<group>"; };
+		EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MixedContentChecker.cpp; sourceTree = "<group>"; };
 		EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PushDatabase.cpp; sourceTree = "<group>"; };
 		EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PushMessageCrypto.cpp; sourceTree = "<group>"; };
 		EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryFootprintThreshold.mm; sourceTree = "<group>"; };
@@ -4653,6 +4655,7 @@
 				CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */,
 				512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */,
 				A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */,
+				EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */,
 				E38EDC2F2B1D673A00963F9B /* MonospaceFontTests.cpp */,
 				5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */,
 				CD225C071C45A69200140761 /* ParsedContentRange.cpp */,
@@ -7034,6 +7037,7 @@
 				51EB126224CA6B66000CB030 /* MicrosoftXboxOne.mm in Sources */,
 				512F29102BA1D03100F1C326 /* MIMESniffer.cpp in Sources */,
 				A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */,
+				EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */,
 				1CF087D825ED7F73004148CB /* MobileAssetSandboxCheck.mm in Sources */,
 				7C83E0B61D0A64B300FEBCF3 /* ModalAlertsSPI.cpp in Sources */,
 				E38EDC372B1D673A00963F9B /* MonospaceFontTests.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/LegacySchemeRegistry.h>
+#include <WebCore/MixedContentChecker.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+TEST(MixedContentChecker, CanModifyRequest)
+{
+    URL url { "http://example.com/cat.jpg"_s };
+    FetchOptions::Destination destination = FetchOptions::Destination::Image;
+    Initiator initiator = Initiator::EmptyString;
+    bool shouldUpgradeIPAddressAndLocalhostForTesting = false;
+
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    // 4.1.1 request’s URL is a potentially trustworthy URL.
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "https://example.com/cat.jpg"_s },
+        destination,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    // 4.1.2 request’s URL’s host is an IP address.
+    URL ipAddressURL { "http://192.0.1.36"_s };
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        ipAddressURL,
+        destination,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        ipAddressURL,
+        destination,
+        initiator,
+        true
+    ));
+
+    // 4.1.4 request’s destination is not "image", "audio", or "video".
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        url,
+        FetchOptions::Destination::Audio,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        url,
+        FetchOptions::Destination::Video,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        url,
+        FetchOptions::Destination::Font,
+        initiator,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        Initiator::Imageset,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    // But if the scheme is handled by the handler, it is modifiable even if the initiator is "imageset".
+    LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler("custom"_s);
+
+    ASSERT_TRUE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom"_s));
+
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        URL { "custom://example.com/cat.jpg"_s },
+        destination,
+        Initiator::Imageset,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+
+    // This exception won't apply if the cheme is not registered.
+    ASSERT_FALSE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom2"_s));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "custom2://example.com/cat.jpg"_s },
+        destination,
+        Initiator::Imageset,
+        shouldUpgradeIPAddressAndLocalhostForTesting
+    ));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2408b78fe65465e82a7b3b00a80f2327938fb3f1
<pre>
Allow upgrade requests in mixed content if the scheme is handled by scheme handler.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281883">https://bugs.webkit.org/show_bug.cgi?id=281883</a>
<a href="https://rdar.apple.com/131077815">rdar://131077815</a>

Reviewed by Matthew Finkel.

In 274409@main, request upgrade in mixed content was implemented strictly following the spec.
<a href="https://www.w3.org/TR/mixed-content/#upgrade-algorithm">https://www.w3.org/TR/mixed-content/#upgrade-algorithm</a>

But for the compatibility of WKWebView, request upgrade should be allowed when the request is handled by special scheme handler.

This patch adds exception for the upgradable check in MixedContentChecker::shouldUpgradeInsecureContent().

Also adding first API test for MixedContentChecker by extracting the check for easier unit testing.

* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::destinationIsImageAndInitiatorIsImageset):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
* Source/WebCore/loader/MixedContentChecker.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp: Added.
(TestWebKitAPI::TEST(MixedContentChecker, CanModifyRequest)):

Canonical link: <a href="https://commits.webkit.org/285709@main">https://commits.webkit.org/285709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e7f46fb7b8f55c928124bc6c77dd333e7a5ee47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/784 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76637 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63302 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/44568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63311 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9342 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/851 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->