### PR TITLE
[iOS] Control Center pause button does not work when playing videos on cnn.com

### DIFF
--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
@@ -47,7 +47,6 @@ private:
 
     void* m_commandHandler { nullptr };
 
-    const RemoteCommandsSet& defaultCommands();
     RemoteCommandsSet m_currentCommands;
 };
 

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -63,9 +63,9 @@ Ref<RemoteCommandListenerCocoa> RemoteCommandListenerCocoa::create(RemoteCommand
     return adoptRef(*new RemoteCommandListenerCocoa(client));
 }
 
-const RemoteCommandListener::RemoteCommandsSet& RemoteCommandListenerCocoa::defaultCommands()
+static RemoteCommandListener::RemoteCommandsSet& defaultCommands()
 {
-    static NeverDestroyed<RemoteCommandsSet> commands(std::initializer_list<PlatformMediaSession::RemoteControlCommandType> {
+    static NeverDestroyed<RemoteCommandListener::RemoteCommandsSet> commands(std::initializer_list<PlatformMediaSession::RemoteControlCommandType> {
         PlatformMediaSession::RemoteControlCommandType::PlayCommand,
         PlatformMediaSession::RemoteControlCommandType::PauseCommand,
         PlatformMediaSession::RemoteControlCommandType::TogglePlayPauseCommand,
@@ -76,6 +76,16 @@ const RemoteCommandListener::RemoteCommandsSet& RemoteCommandListenerCocoa::defa
         PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand,
         PlatformMediaSession::RemoteControlCommandType::SkipForwardCommand,
         PlatformMediaSession::RemoteControlCommandType::SkipBackwardCommand,
+    });
+
+    return commands;
+}
+
+static RemoteCommandListener::RemoteCommandsSet& minimalCommands()
+{
+    static NeverDestroyed<RemoteCommandListener::RemoteCommandsSet> commands(std::initializer_list<PlatformMediaSession::RemoteControlCommandType> {
+        PlatformMediaSession::RemoteControlCommandType::PlayCommand,
+        PlatformMediaSession::RemoteControlCommandType::PauseCommand,
     });
 
     return commands;
@@ -95,7 +105,7 @@ void RemoteCommandListenerCocoa::updateSupportedCommands()
     if (!isMediaRemoteFrameworkAvailable())
         return;
 
-    auto& currentCommands = !supportedCommands().isEmpty() ? supportedCommands() : defaultCommands();
+    auto currentCommands = !supportedCommands().isEmpty() ? supportedCommands().unionWith(minimalCommands()) : defaultCommands();
     if (m_currentCommands == currentCommands)
         return;
 


### PR DESCRIPTION
#### 0023194995639a5dd0bb0de13cc7ee2776dc16c6
<pre>
[iOS] Control Center pause button does not work when playing videos on cnn.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=281885">https://bugs.webkit.org/show_bug.cgi?id=281885</a>
<a href="https://rdar.apple.com/137242342">rdar://137242342</a>

Reviewed by Eric Carlson.

When a website sets a MediaSession action handler, WebKit unregisters its default set of
MediaRemote commands (which includes play and pause commands) and registers for only the commands
that correspond to action handlers set by the website. If a website sets action handlers not
including &quot;play&quot; and &quot;pause&quot; actions then Control Center on iOS continues to show a play/pause
button, but it&apos;s non-functional since WebKit has not registered support for -- and therefore is not
delivered -- its corresponding remote commands.

The MediaSession spec [1] says the following in 3.4:
&gt;It is RECOMMENDED for user agents to implement a default handler for the play and pause media
&gt;session actions if none was provided for the active media session.

This change adopts this recommendation by ensuring that when a website sets MediaSession action
handlers, play and pause commmands are registered with MediaRemote at a minimum. If the website did
not set action handlers for these commands then the default action is performed (i.e. play() or
pause() is called on the media element).

Added an API test.

[1] <a href="https://w3c.github.io/mediasession/#actions-model">https://w3c.github.io/mediasession/#actions-model</a>

* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h:
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::defaultCommands):
(WebCore::minimalCommands):
(WebCore::RemoteCommandListenerCocoa::updateSupportedCommands):
(WebCore::RemoteCommandListenerCocoa::defaultCommands): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm:
(TestWebKitAPI::MediaSessionTest::webViewPid):
(TestWebKitAPI::TEST_F(MediaSessionTest, MinimalCommands)):

Canonical link: <a href="https://commits.webkit.org/285546@main">https://commits.webkit.org/285546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843dc925fab6e0d397d91ee452238a3bdbd0ef11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/73035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/52464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77245 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/24273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/75150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/60269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/77245 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/24273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/76102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/60269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77245 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/60269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/60269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16089 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/25843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->