### PR TITLE
Adopt more eventSender async mouse functions in fast/events/

### DIFF
--- a/LayoutTests/fast/events/anchor-image-scrolled-x-y.html
+++ b/LayoutTests/fast/events/anchor-image-scrolled-x-y.html
@@ -1,6 +1,6 @@
 <head>
 <script>
-function test()
+async function test()
 {
     var queryIndex = document.URL.indexOf('?');
     if (queryIndex == -1) {
@@ -10,9 +10,9 @@ function test()
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
 
-            eventSender.mouseMoveTo(18, 18);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(18, 18);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
         }
     } else {
         document.write("<div>Form data: " + document.URL.substring(queryIndex + 1) + "</div>");

--- a/LayoutTests/fast/events/attribute-listener-deletion-crash.html
+++ b/LayoutTests/fast/events/attribute-listener-deletion-crash.html
@@ -1,18 +1,20 @@
 <html>
 <head>
 <script>
-function runTest() {
+async function runTest() {
   if (!window.testRunner)
     return;
 
   window.testRunner.dumpAsText();
+  testRunner.waitUntilDone();
 
   var span = document.getElementById("root");
-  eventSender.mouseMoveTo(span.offsetLeft + 10, span.offsetTop + span.offsetHeight / 2);
+  eventSender.asyncMouseMoveTo(span.offsetLeft + 10, span.offsetTop + span.offsetHeight / 2);
   for (var i = 0; i < 20; ++i) {
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
   }
+  testRunner.notifyDone();
 }
 window.addEventListener("DOMNodeRemoved", function(e) {
   document.body.setAttribute("onclick", "|");

--- a/LayoutTests/fast/events/autoscroll-in-overflow-hidden-html.html
+++ b/LayoutTests/fast/events/autoscroll-in-overflow-hidden-html.html
@@ -11,7 +11,7 @@
         var iframeDocument;
         var iframeScrollTopAfterAnchor = 0;
 
-        function test()
+        async function test()
         {
             if (window.testRunner) {
                 testRunner.waitUntilDone();
@@ -27,14 +27,14 @@
             var y = iframe.offsetTop + clickme.offsetTop + 7;
             if (window.eventSender) {
                 eventSender.dragMode = false;
-                eventSender.mouseMoveTo(x, y);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(x, y);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
             }
             setTimeout(autoscrollTestPart1, 0);
         }
 
-        function autoscrollTestPart1()
+        async function autoscrollTestPart1()
         {
             iframeScrollTopAfterAnchor = iframeDocument.body.scrollTop;
             if (iframeDocument.body.scrollTop == 0)
@@ -45,19 +45,19 @@
                 var x = iframe.offsetLeft + textInIframe.offsetLeft - iframeDocument.body.scrollLeft + 7;
                 var y = iframe.offsetTop + textInIframe.offsetTop - iframeDocument.body.scrollTop + 7;
                 eventSender.dragMode = false;
-                eventSender.mouseMoveTo(x, y);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(x, y - 10);
+                await eventSender.asyncMouseMoveTo(x, y);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(x, y - 10);
                 y = iframe.offsetTop;
-                eventSender.mouseMoveTo(x, y - 5);
+                await eventSender.asyncMouseMoveTo(x, y - 5);
             }
             setTimeout(autoscrollTestPart2, 100);
         }
 
-        function autoscrollTestPart2()
+        async function autoscrollTestPart2()
         {
             if (window.eventSender)
-                eventSender.mouseUp();
+                await eventSender.asyncMouseUp();
 
             if (iframeScrollTopAfterAnchor == iframeDocument.body.scrollTop)
                 log("PASSED: the autoscroll has not happened.");

--- a/LayoutTests/fast/events/autoscroll-in-textarea.html
+++ b/LayoutTests/fast/events/autoscroll-in-textarea.html
@@ -38,29 +38,34 @@ the selection should not jump down to the end.</p>
 <div id="log"></div>
 
 <script>
-if (window.testRunner)
+if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
 
-// The text area displays 6 lines of text. We scroll down to the end
-// and start dragging the cursor up from the first line that appears (the k line).
-// Therefore, the selection should contain the letter k.
-var textarea = document.getElementById("textarea");
-textarea.scrollTop = textarea.scrollHeight;
-if (window.eventSender) {
-    var x = textarea.offsetLeft + textarea.offsetWidth / 2;
-    var y = textarea.offsetTop + 1;
-    eventSender.dragMode = false;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, 0);
-    eventSender.mouseUp();
+onload = async () => {
+    // The text area displays 6 lines of text. We scroll down to the end
+    // and start dragging the cursor up from the first line that appears (the k line).
+    // Therefore, the selection should contain the letter k.
+    var textarea = document.getElementById("textarea");
+    textarea.scrollTop = textarea.scrollHeight;
+    if (window.eventSender) {
+        var x = textarea.offsetLeft + textarea.offsetWidth / 2;
+        var y = textarea.offsetTop + 1;
+        eventSender.dragMode = false;
+        await eventSender.asyncMouseMoveTo(x, y);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(x, 0);
+        await eventSender.asyncMouseUp();
 
-    var log = document.getElementById("log");
-    var selectedText = textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
-    if (selectedText.indexOf("k") != -1)
-        log.innerText = "PASSED the selection did not jump down.";
-    else
-        log.innerText = "FAILED the selection jumped down.";
+        var log = document.getElementById("log");
+        var selectedText = textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
+        if (selectedText.indexOf("k") != -1)
+            log.innerText = "PASSED the selection did not jump down.";
+        else
+            log.innerText = "FAILED the selection jumped down.";
+    }
+    testRunner?.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/autoscroll-in-textfield.html
+++ b/LayoutTests/fast/events/autoscroll-in-textfield.html
@@ -15,25 +15,25 @@
            }
        }
 
-       function autoscrollTestPart1()
+       async function autoscrollTestPart1()
        {
            var input = document.getElementById('shortTextField');
            if (window.eventSender) {
                var x = input.offsetLeft + 7;
                var y = input.offsetTop + 7;
                eventSender.dragMode = false;
-               eventSender.mouseMoveTo(x, y);
-               eventSender.mouseDown();
-               eventSender.mouseMoveTo(x + 20, y);
-               eventSender.mouseMoveTo(x + 600, y);
+               await eventSender.asyncMouseMoveTo(x, y);
+               await eventSender.asyncMouseDown();
+               await eventSender.asyncMouseMoveTo(x + 20, y);
+               await eventSender.asyncMouseMoveTo(x + 600, y);
            }
            setTimeout(autoscrollTestPart2, 100);
        }
 
-       function autoscrollTestPart2()
+       async function autoscrollTestPart2()
        {
            if (window.eventSender)
-               eventSender.mouseUp();
+               await eventSender.asyncMouseUp();
            
            var input = document.getElementById('shortTextField');
            if (input.scrollLeft == 0)

--- a/LayoutTests/fast/events/autoscroll-main-document.html
+++ b/LayoutTests/fast/events/autoscroll-main-document.html
@@ -25,10 +25,10 @@
         var end;
         var firstRange;
         
-        function testComplete()
+        async function testComplete()
         {
-            eventSender.mouseMoveTo(end.x, 0);
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(end.x, 0);
+            await eventSender.asyncMouseUp();
 
             firstRange = window.getSelection().getRangeAt(0);
             shouldBe('firstRange.startOffset', '18');
@@ -37,28 +37,28 @@
             finishJSTest();
         }
         
-        function waitForScrolledToTop()
+        async function waitForScrolledToTop()
         {
             if (window.scrollY == 0) {
-                testComplete();
+                await testComplete();
                 return;
             }
             
             window.setTimeout(waitForScrolledToTop, 2);
         }
         
-        function doOneScroll()
+        async function doOneScroll()
         {
             if (++scrollCount == eventCount) {
-                waitForScrolledToTop();
+                await waitForScrolledToTop();
                 return;
             }
 
-            eventSender.mouseMoveTo(end.x, end.y - scrollCount);
+            await eventSender.asyncMouseMoveTo(end.x, end.y - scrollCount);
             window.setTimeout(doOneScroll, 2);
         }
 
-        function doTest()
+        async function doTest()
         {
             if (!window.testRunner || !window.eventSender) {
                 debug('This test requires testRunner and eventSender');
@@ -75,10 +75,10 @@
             start = { x: containerRect.left + containerRect.width / 2, y: containerRect.bottom - lineHeight / 3 };
             end = { x: containerRect.left + containerRect.width / 3, y: 16 };
             
-            eventSender.mouseMoveTo(start.x, start.y);
-            eventSender.mouseDown();
+            await eventSender.asyncMouseMoveTo(start.x, start.y);
+            await eventSender.asyncMouseDown();
 
-            doOneScroll();
+            await doOneScroll();
         }
 
         window.addEventListener('load', doTest, false);

--- a/LayoutTests/fast/events/autoscroll-nonscrollable-iframe-in-scrollable-div.html
+++ b/LayoutTests/fast/events/autoscroll-nonscrollable-iframe-in-scrollable-div.html
@@ -15,7 +15,7 @@
            }
        }
 
-       function autoscrollTestPart1()
+       async function autoscrollTestPart1()
        {
            var iframe = document.getElementById('NoScrolliFrame');
            var iframeDocument = iframe.contentDocument;
@@ -24,17 +24,17 @@
                var x = iframe.offsetLeft + textInIframe.offsetLeft + 7;
                var y = iframe.offsetTop + textInIframe.offsetTop + 7;
                eventSender.dragMode = false;
-               eventSender.mouseMoveTo(x, y);
-               eventSender.mouseDown();
-               eventSender.mouseMoveTo(x + 220, y + 220);
+               await eventSender.asyncMouseMoveTo(x, y);
+               await eventSender.asyncMouseDown();
+               await eventSender.asyncMouseMoveTo(x + 220, y + 220);
            }
            setTimeout(autoscrollTestPart2, 100);
        }
 
-       function autoscrollTestPart2()
+       async function autoscrollTestPart2()
        {
            if (window.eventSender)
-               eventSender.mouseUp();
+               await eventSender.asyncMouseUp();
            var sd = document.getElementById('scrollableDiv');
            if (sd.scrollLeft != 0)
                log("PASSED : the autoscroll has worked !");

--- a/LayoutTests/fast/events/autoscroll-overflow-hidden-longhands.html
+++ b/LayoutTests/fast/events/autoscroll-overflow-hidden-longhands.html
@@ -15,25 +15,25 @@
            }
        }
 
-       function autoscrollTestPart1()
+       async function autoscrollTestPart1()
        {
            var textInDiv = document.getElementById('textInDiv');
            if (window.eventSender) {
                var x = textInDiv.offsetLeft + 17;
                var y = textInDiv.offsetTop + 7;
                eventSender.dragMode = false;
-               eventSender.mouseMoveTo(x, y);
-               eventSender.mouseDown();
-               eventSender.mouseMoveTo(x, y + 20);
-               eventSender.mouseMoveTo(x, y + 220);
+               await eventSender.asyncMouseMoveTo(x, y);
+               await eventSender.asyncMouseDown();
+               await eventSender.asyncMouseMoveTo(x, y + 20);
+               await eventSender.asyncMouseMoveTo(x, y + 220);
            }
            setTimeout(autoscrollTestPart2, 100);
        }
 
-       function autoscrollTestPart2()
+       async function autoscrollTestPart2()
        {
            if (window.eventSender)
-               eventSender.mouseUp();
+               await eventSender.asyncMouseUp();
            var sd = document.getElementById('nonScrollableDiv');
            if (sd.scrollTop == 0)
                log("PASSED : the autoscroll did not happen!");

--- a/LayoutTests/fast/events/autoscroll-should-not-stop-on-keypress.html
+++ b/LayoutTests/fast/events/autoscroll-should-not-stop-on-keypress.html
@@ -7,7 +7,7 @@
 window.jsTestIsAsync = true;
 
 var frame;
-function test() {
+async function test() {
     frame = document.getElementById('frame');
     var doc = frame.contentDocument.open();
     var htmlString = "Lots of text</br>Lots of text</br> \
@@ -72,9 +72,9 @@ function test() {
         var xPoint = frame.scrollLeft + 100;
         var yPoint = frame.scrollTop + 100;
         eventSender.dragMode = false;
-        eventSender.mouseMoveTo(xPoint, yPoint);
-        eventSender.mouseDown();
-        eventSender.mouseMoveTo(xPoint, frame.offsetHeight + 100);
+        await eventSender.asyncMouseMoveTo(xPoint, yPoint);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(xPoint, frame.offsetHeight + 100);
         setTimeout(testAutoScroll, 100);
         eventSender.keyDown('a');
     } else {

--- a/LayoutTests/fast/events/autoscroll-upwards-propagation.html
+++ b/LayoutTests/fast/events/autoscroll-upwards-propagation.html
@@ -28,28 +28,28 @@ function runTest() {
     setTimeout(startTest, 0);
 }
 
-function startTest()
+async function startTest()
 {
     var input = document.getElementById("input");
     var x = input.offsetLeft + input.offsetWidth / 2;
     var y = input.offsetTop + input.offsetHeight / 2;
 
     eventSender.dragMode = false;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
 
     // We do the dragging/selection in two steps here, because if we move
     // the mouse beyond the input boundary right way, it won't start the autoscroll
     // timer. See early return in AutoscrollController::startAutoscrollForSelection
     // after calling RenderBox::findAutoscrollable.
-    eventSender.mouseMoveTo(x + 48, y);
-    eventSender.mouseMoveTo(x + 55, y);
+    await eventSender.asyncMouseMoveTo(x + 48, y);
+    await eventSender.asyncMouseMoveTo(x + 55, y);
     setTimeout(finishTest, 100);
 }
 
-function finishTest()
+async function finishTest()
 {
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
     var div = document.getElementById("div");
     if (div.scrollTop == 0 && div.scrollLeft == 0)
         document.getElementById("result").innerText = "Test succeeded!";

--- a/LayoutTests/fast/events/autoscroll-when-zoomed.html
+++ b/LayoutTests/fast/events/autoscroll-when-zoomed.html
@@ -26,10 +26,10 @@
         var end;
         var firstRange;
         
-        function testComplete()
+        async function testComplete()
         {
-            eventSender.mouseMoveTo(pageScale * end.x, 0);
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(pageScale * end.x, 0);
+            await eventSender.asyncMouseUp();
 
             firstRange = window.getSelection().getRangeAt(0);
             shouldBe('firstRange.startOffset', '51');
@@ -38,24 +38,24 @@
             finishJSTest();
         }
         
-        function waitForScrolledToTop()
+        async function waitForScrolledToTop()
         {
             if (window.scrollY == 0) {
-                testComplete();
+                await testComplete();
                 return;
             }
             
             window.setTimeout(waitForScrolledToTop, 2);
         }
         
-        function doOneScroll()
+        async function doOneScroll()
         {
             if (++scrollCount == eventCount) {
-                waitForScrolledToTop();
+                await waitForScrolledToTop();
                 return;
             }
 
-            eventSender.mouseMoveTo(pageScale * end.x, pageScale * (end.y - scrollCount));
+            await eventSender.asyncMouseMoveTo(pageScale * end.x, pageScale * (end.y - scrollCount));
             window.setTimeout(doOneScroll, 2);
         }
 
@@ -77,10 +77,10 @@
             start = { x: containerRect.left + 10, y: 2 * lineHeight / 3 };
             end = { x: containerRect.right - 10, y: 16 };
             
-            eventSender.mouseMoveTo(pageScale * start.x, pageScale * start.y);
-            eventSender.mouseDown();
+            await eventSender.asyncMouseMoveTo(pageScale * start.x, pageScale * start.y);
+            await eventSender.asyncMouseDown();
 
-            doOneScroll();
+            await doOneScroll();
         }
 
         window.addEventListener('load', doTest, false);

--- a/LayoutTests/fast/events/autoscroll-with-non-scrollable-parent.html
+++ b/LayoutTests/fast/events/autoscroll-with-non-scrollable-parent.html
@@ -15,7 +15,7 @@
            }
        }
 
-       function autoscrollTestPart1()
+       async function autoscrollTestPart1()
        {
            var iframe = document.getElementById('NoScrolliFrame');
            var iframeDocument = iframe.contentDocument;
@@ -24,18 +24,18 @@
                var x = iframe.offsetLeft + input.offsetLeft + 7;
                var y = iframe.offsetTop + input.offsetTop + 7;
                eventSender.dragMode = false;
-               eventSender.mouseMoveTo(x, y);
-               eventSender.mouseDown();
-               eventSender.mouseMoveTo(x + 20, y);
-               eventSender.mouseMoveTo(x + 600, y);
+               await eventSender.asyncMouseMoveTo(x, y);
+               await eventSender.asyncMouseDown();
+               await eventSender.asyncMouseMoveTo(x + 20, y);
+               await eventSender.asyncMouseMoveTo(x + 600, y);
            }
            setTimeout(autoscrollTestPart2, 100);
        }
 
-       function autoscrollTestPart2()
+       async function autoscrollTestPart2()
        {
            if (window.eventSender)
-               eventSender.mouseUp();
+               await eventSender.asyncMouseUp();
            
            var iframe = document.getElementById('NoScrolliFrame');
            var iframeDocument = iframe.contentDocument;

--- a/LayoutTests/fast/events/before-input-events-prevent-drag-and-drop.html
+++ b/LayoutTests/fast/events/before-input-events-prevent-drag-and-drop.html
@@ -28,22 +28,6 @@
     <p>HTML content:</p>
     <div id="result"></div>
     <script type="text/javascript">
-        if (window.internals && window.testRunner)
-            testRunner.dumpAsText();
-
-        source.focus();
-        document.execCommand("selectAll");
-
-        if (window.eventSender) {
-            moveToCenter(source);
-            eventSender.leapForward(500);
-            eventSender.mouseDown();
-            eventSender.leapForward(1000);
-            moveToCenter(destination);
-            eventSender.leapForward(500);
-            eventSender.mouseUp();
-        }
-
         function handleBeforeInput(event)
         {
             if (event.inputType === "insertFromDrop") {
@@ -56,11 +40,31 @@
                 event.preventDefault();
         }
 
-        function moveToCenter(element)
+        async function moveToCenter(element)
         {
             let x = element.offsetParent.offsetLeft + element.offsetLeft + element.offsetWidth / 2;
             let y = element.offsetParent.offsetTop + element.offsetTop + element.offsetHeight / 2;
-            eventSender.mouseMoveTo(x, y);
+            await eventSender.asyncMouseMoveTo(x, y);
+        }
+
+        onload = async () => {
+            if (window.internals && window.testRunner) {
+                testRunner.dumpAsText();
+                testRunner.waitUntilDone();
+            }
+            source.focus();
+            document.execCommand("selectAll");
+
+            if (window.eventSender) {
+                await moveToCenter(source);
+                eventSender.leapForward(500);
+                await eventSender.asyncMouseDown();
+                eventSender.leapForward(1000);
+                await moveToCenter(destination);
+                eventSender.leapForward(500);
+                await eventSender.asyncMouseUp();
+            }
+            testRunner?.notifyDone();
         }
     </script>
 </body>

--- a/LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html
+++ b/LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html
@@ -15,8 +15,9 @@
     var consoleElm;
     var event;
 
-    window.onload = function()
+    window.onload = async function()
     {
+        testRunner?.waitUntilDone();
         dragMe = document.getElementById("dragMe");
         dropTarget = document.getElementById("dropTarget");
         consoleElm = document.getElementById("console");
@@ -31,7 +32,8 @@
         dropTarget.ondragover = dragOver;
         dropTarget.ondrop = drop;
 
-        runTest();
+        await runTest();
+        testRunner?.notifyDone();
     }
 
     function dragStart(e)
@@ -101,7 +103,7 @@
         e.preventDefault();
     }
 
-    function runTest()
+    async function runTest()
     {
         if (!window.eventSender)
             return;
@@ -114,11 +116,11 @@
         var endX = dropTarget.offsetLeft + 10;
         var endY = dropTarget.offsetTop + dropTarget.offsetHeight / 2;
 
-        eventSender.mouseMoveTo(startX, startY);
-        eventSender.mouseDown();
+        await eventSender.asyncMouseMoveTo(startX, startY);
+        await eventSender.asyncMouseDown();
         eventSender.leapForward(100);
-        eventSender.mouseMoveTo(endX, endY);
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(endX, endY);
+        await eventSender.asyncMouseUp();
 
         var testContainer = document.getElementById("test-container");
         if (testContainer)

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
@@ -17,7 +17,7 @@ function log(msg) {
     document.getElementById("log").appendChild(li);
 }
 
-window.onload = function() {
+window.onload = async function() {
     try {
         if (!frames[0] || !frames[0].document || !frames[0].document.getElementById("dragSource")) {
             log("Window.onload fired before subframe completed load.");
@@ -35,10 +35,10 @@ window.onload = function() {
         var startY = dragSource.offsetTop + sourceFrame.offsetTop + dragSource.offsetHeight / 2;
         var endX = targetFrame.offsetLeft + 10;
         var endY = targetFrame.offsetTop + 10;
-        eventSender.mouseMoveTo(startX, startY);
-        eventSender.mouseDown();
-        eventSender.mouseMoveTo(endX, endY);
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(startX, startY);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(endX, endY);
+        await eventSender.asyncMouseUp();
     } finally {
         if (mouseUpInOtherFrame || mouseMoveInOtherFrame)
             log("FAIL! Received unexpected mouse event on other frame.");

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
@@ -25,7 +25,7 @@ window.onmouseup = function() {
     log("FAIL! Received unexpected mouseup on root frame");
 }
 
-window.onload = function() {
+window.onload = async function() {
     try {
         if (!frames[0] || !frames[0].document) {
             log("Window.onload fired before subframe completed load.");
@@ -41,10 +41,10 @@ window.onload = function() {
         var startY = dragSource.offsetTop + dragSource.offsetHeight / 2;
         var endX = targetFrame.offsetLeft + 10;
         var endY = targetFrame.offsetTop + 10;
-        eventSender.mouseMoveTo(startX, startY);
-        eventSender.mouseDown();
-        eventSender.mouseMoveTo(endX, endY);
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(startX, startY);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(endX, endY);
+        await eventSender.asyncMouseUp();
     } finally {
         if (mouseUpInOtherFrame && mouseMoveInOtherFrame)
             log("PASS!");

--- a/LayoutTests/fast/events/capture-on-target.html
+++ b/LayoutTests/fast/events/capture-on-target.html
@@ -6,14 +6,14 @@ if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
-function test()
+async function test()
 {
     document.getElementById("target").addEventListener("click", targetClick, true);
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(52, 52);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(52, 52);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
 	window.setTimeout(finish, 0);
     }
 }

--- a/LayoutTests/fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html
+++ b/LayoutTests/fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html
@@ -8,10 +8,12 @@ if (window.testRunner)
 
 window.onload = runTest;
 
-function runTest()
+async function runTest()
 {
-    if (!window.eventSender)
+    if (!window.eventSender || !window.testRunner)
         return;
+
+    testRunner.waitUntilDone();
 
     var firstInput = document.getElementById("firstInput");
     var secondInput = document.getElementById("secondInput");
@@ -20,13 +22,14 @@ function runTest()
     beginRecordingEvents();
     firstInput.focus();
     eventSender.keyDown("A");
-    eventSender.mouseMoveTo(secondInput.offsetLeft + secondInput.offsetWidth / 2,
+    await eventSender.asyncMouseMoveTo(secondInput.offsetLeft + secondInput.offsetWidth / 2,
                             secondInput.offsetTop + secondInput.offsetHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp(); // Transfers focus to text field "second input".
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp(); // Transfers focus to text field "second input".
     endRecordingEvents();
     checkThatEventsFiredInOrder([["firstInput", "focus"], ["firstInput", "change"], ["firstInput", "blur"], ["secondInput", "focus"], ["secondInput", "click"]]);
     debug('<br /><span class="pass">TEST COMPLETE</span>');
+    testRunner.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/fast/events/clear-drag-state.html
+++ b/LayoutTests/fast/events/clear-drag-state.html
@@ -44,26 +44,31 @@ var span = document.querySelector('span');
 span.addEventListener('dragenter', log);
 span.addEventListener('dragleave', log);
 
-function dragSpan() {
+async function dragSpan() {
     var x = span.offsetLeft + span.offsetWidth / 2;
-    eventSender.mouseMoveTo(x, span.offsetTop + span.offsetHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, span.offsetTop + 2 * span.offsetHeight / 3);
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + span.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + 2 * span.offsetHeight / 3);
     eventSender.leapForward(200);
-    eventSender.mouseMoveTo(x, span.offsetTop + 3 * span.offsetHeight / 2);
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + 3 * span.offsetHeight / 2);
     eventSender.leapForward(200);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
 }
 
-if (window.eventSender) {
-    testRunner.dumpAsText();
-    dragSpan();
-    var firstLog = setLog('');
-    dragSpan();
-    var secondLog = setLog('PASS\n\n' + firstLog);
-    if (firstLog != secondLog)
-        setLog('FAIL:\nFirst drag:\n' + firstLog + '\nSecond drag:\n' + secondLog);
+onload = async () => {
+    if (window.eventSender && window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+        await dragSpan();
+        var firstLog = setLog('');
+        await dragSpan();
+        var secondLog = setLog('PASS\n\n' + firstLog);
+        if (firstLog != secondLog)
+            setLog('FAIL:\nFirst drag:\n' + firstLog + '\nSecond drag:\n' + secondLog);
+        testRunner.notifyDone();
+    }
 }
+
 
 </script>
 </body>

--- a/LayoutTests/fast/events/clear-edit-drag-state.html
+++ b/LayoutTests/fast/events/clear-edit-drag-state.html
@@ -42,26 +42,30 @@ var span = document.querySelector('span');
 span.addEventListener('dragenter', log);
 span.addEventListener('dragleave', log);
 
-function dragSpan() {
+async function dragSpan() {
     var x = span.offsetLeft + span.offsetWidth / 2;
-    eventSender.mouseMoveTo(x, span.offsetTop + span.offsetHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, span.offsetTop + 2 * span.offsetHeight / 3);
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + span.offsetHeight / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + 2 * span.offsetHeight / 3);
     eventSender.leapForward(200);
-    eventSender.mouseMoveTo(x, span.offsetTop + 3 * span.offsetHeight / 2);
+    await eventSender.asyncMouseMoveTo(x, span.offsetTop + 3 * span.offsetHeight / 2);
     eventSender.leapForward(200);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
 }
 
-if (window.eventSender) {
-    testRunner.dumpAsText();
-    getSelection().selectAllChildren(span);
-    dragSpan();
-    var firstLog = setLog('');
-    dragSpan();
-    var secondLog = setLog('PASS');
-    if (firstLog != secondLog)
-        setLog('FAIL:\nFirst drag:\n' + firstLog + '\nSecond drag:\n' + secondLog);
+onload = async () => {
+    if (window.eventSender && window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+        getSelection().selectAllChildren(span);
+        await dragSpan();
+        var firstLog = setLog('');
+        await dragSpan();
+        var secondLog = setLog('PASS');
+        if (firstLog != secondLog)
+            setLog('FAIL:\nFirst drag:\n' + firstLog + '\nSecond drag:\n' + secondLog);
+        testRunner.notifyDone();
+    }
 }
 
 </script>

--- a/LayoutTests/fast/events/click-after-mousedown-cancel.html
+++ b/LayoutTests/fast/events/click-after-mousedown-cancel.html
@@ -5,7 +5,7 @@
 <script>
 description('Mousedown without mouseup in a sub frame should not confuse a click in another frame.');
 jsTestIsAsync = true;
-window.onload = function() {
+window.onload = async function() {
     var button = document.querySelector('button');
     button.addEventListener('mousedown', function(event) {
         event.preventDefault();
@@ -17,15 +17,15 @@ window.onload = function() {
 
     var iframe = document.querySelector('iframe');
     // Mousedown on the iframe, but no mouseup.
-    eventSender.mouseMoveTo(iframe.offsetLeft + iframe.offsetWidth / 2, iframe.offsetTop + iframe.offsetHeight / 2);
-    eventSender.mouseDown(1);
+    await eventSender.asyncMouseMoveTo(iframe.offsetLeft + iframe.offsetWidth / 2, iframe.offsetTop + iframe.offsetHeight / 2);
+    await eventSender.asyncMouseDown(1);
     // Click on the button in the main document.
-    eventSender.mouseMoveTo(button.offsetLeft + button.offsetWidth / 2, button.offsetTop + button.offsetHeight / 2);
-    eventSender.mouseDown(0);
+    await eventSender.asyncMouseMoveTo(button.offsetLeft + button.offsetWidth / 2, button.offsetTop + button.offsetHeight / 2);
+    await eventSender.asyncMouseDown(0);
     setTimeout(function() {
         testFailed('Click event was not dispatched.');
         finishJSTest();
     }, 100);
-    eventSender.mouseUp(0);
+    await eventSender.asyncMouseUp(0);
 }
 </script>

--- a/LayoutTests/fast/events/click-count.html
+++ b/LayoutTests/fast/events/click-count.html
@@ -26,7 +26,7 @@ function mouseDoubleClick(evt)
     log("<span style='color:green'>[Mouse Double Click]</span> Button: " + evt.button + " Click Count: " + evt.detail + "<br>");
 }
 
-function test()
+async function test()
 {
     if (window.testRunner) {
         testRunner.dumpAsText();
@@ -34,18 +34,18 @@ function test()
     }
     if (window.eventSender) {
         var testEle = document.getElementById("testDiv");
-        eventSender.mouseMoveTo(testEle.offsetLeft+testEle.offsetWidth/2, testEle.offsetTop+testEle.offsetHeight/2);
-        testClick();
+        await eventSender.asyncMouseMoveTo(testEle.offsetLeft+testEle.offsetWidth/2, testEle.offsetTop+testEle.offsetHeight/2);
+        await testClick();
     }
 }
 
-function testClick()
+async function testClick()
 {
     for (var clickCount = 1; clickCount <= 5; clickCount++) {
         log("Clicking " + clickCount + " times<br>");
         for (var click = 0; click < clickCount; click++) {
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
         }
         // Skip forward 1 second so that the clicks are counted as distinct.
         eventSender.leapForward(1000);

--- a/LayoutTests/fast/events/click-focus-anchor.html
+++ b/LayoutTests/fast/events/click-focus-anchor.html
@@ -41,21 +41,24 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
-window.onload = function()
+window.onload = async function()
 {
     if (!window.testRunner)
         return;
 
+    testRunner.waitUntilDone();
+
     for (var i = 1; i <= 6; i++) {
         var aElement = document.getElementById('a' + i);
         aElement.onfocus = handleFocus;
-        eventSender.mouseMoveTo(aElement.offsetLeft + 2, aElement.offsetTop + 2);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(aElement.offsetLeft + 2, aElement.offsetTop + 2);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     var tc = document.getElementById('test-container');
     tc.parentNode.removeChild(tc);
+    testRunner.notifyDone();
 };
 
 </script>

--- a/LayoutTests/fast/events/click-focus-control.html
+++ b/LayoutTests/fast/events/click-focus-control.html
@@ -6,17 +6,19 @@
     <script type="text/javascript">
 
         var numberOfFocusedElements = 0;
-        function test()
+        async function test()
         {
             if (!window.testRunner)
                 return;
 
+            testRunner.waitUntilDone();
+
             for (var i = 1; i <= 5; i++) {
                 var aElement = document.getElementById('a' + i);
                 aElement.onfocus = handleFocus;
-                eventSender.mouseMoveTo(aElement.offsetLeft + 2, aElement.offsetTop + 2);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(aElement.offsetLeft + 2, aElement.offsetTop + 2);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
             }
 
             if(numberOfFocusedElements == 5)
@@ -26,6 +28,7 @@
 
             var tc = document.getElementById('test-container');
             tc.parentNode.removeChild(tc);
+            testRunner.notifyDone();
         };
 
         function handleFocus(e)

--- a/LayoutTests/fast/events/click-range-slider.html
+++ b/LayoutTests/fast/events/click-range-slider.html
@@ -18,10 +18,12 @@ function onClick(e)
     clickCount++;
 }
 
-window.onload = function()
+window.onload = async function()
 {
     if (!window.testRunner)
         return;
+
+    testRunner.waitUntilDone();
 
     slider = document.getElementById("slider");
     slider.addEventListener("click", onClick);
@@ -31,19 +33,20 @@ window.onload = function()
     var x = slider.offsetLeft + 1;
     var y = slider.offsetTop + slider.clientHeight / 2;
 
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
-    eventSender.mouseMoveTo(x + slider.clientWidth - 2, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x + slider.clientWidth - 2, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
-    eventSender.mouseMoveTo(x + slider.clientWidth / 2, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x + slider.clientWidth / 2, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     shouldBe("clickCount", "3");
+    testRunner.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/clientXY-in-zoom-and-scroll-expected.txt
+++ b/LayoutTests/fast/events/clientXY-in-zoom-and-scroll-expected.txt
@@ -1,3 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Base
 PASS event.clientX is 100
 PASS event.clientY is 100
@@ -21,7 +24,4 @@ PASS event.clientX is 84
 PASS event.clientY is 84
 PASS event.pageX is 133
 PASS event.pageY is 133
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/events/clientXY-in-zoom-and-scroll.html
+++ b/LayoutTests/fast/events/clientXY-in-zoom-and-scroll.html
@@ -20,12 +20,12 @@
 
     var event;
 
-    function sendClick()
+    async function sendClick()
     {
         if (window.eventSender) {
-            eventSender.mouseMoveTo(100, 100);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(100, 100);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
         }
     }
 
@@ -63,9 +63,6 @@
         shouldBe("event.pageX", "100");
         shouldBe("event.pageY", "100");
     }
-    window.addEventListener("click", base, false);
-    sendClick();
-    window.removeEventListener("click", base, false);
     
     // Just zoomed.
     function justZoomed(e)
@@ -77,11 +74,6 @@
         shouldBe("event.pageX", "83");
         shouldBe("event.pageY", "83");
     }
-    window.addEventListener("click", justZoomed, false);
-    zoomPageIn();
-    sendClick();
-    zoomPageOut();
-    window.removeEventListener("click", justZoomed, false);
 
     // Just scrolled.
     function justScrolled(e)
@@ -93,11 +85,6 @@
         shouldBe("event.pageX", "150");
         shouldBe("event.pageY", "150");
     }
-    window.addEventListener("click", justScrolled, false);
-    scrollPage(50, 50);
-    sendClick();
-    scrollPage(0, 0);
-    window.removeEventListener("click", justScrolled, false);
 
     // Zoomed and scrolled.
     function zoomedAndScrolled(e)
@@ -109,15 +96,38 @@
         shouldBe("event.pageX", "133");
         shouldBe("event.pageY", "133");
     }
-    window.addEventListener("click", zoomedAndScrolled, false);
-    zoomPageIn();
-    scrollPage(50, 50);
-    sendClick();
-    zoomPageOut();
-    scrollPage(0, 0);
-    window.removeEventListener("click", zoomedAndScrolled, false);
 
-    if (window.testRunner) {
+    onload = async () => {
+        if (!window.testRunner)
+            return;
+
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+
+        window.addEventListener("click", base, false);
+        await sendClick();
+        window.removeEventListener("click", base, false);
+
+        window.addEventListener("click", justZoomed, false);
+        zoomPageIn();
+        await sendClick();
+        zoomPageOut();
+        window.removeEventListener("click", justZoomed, false);
+
+        window.addEventListener("click", justScrolled, false);
+        scrollPage(50, 50);
+        await sendClick();
+        scrollPage(0, 0);
+        window.removeEventListener("click", justScrolled, false);
+
+        window.addEventListener("click", zoomedAndScrolled, false);
+        zoomPageIn();
+        scrollPage(50, 50);
+        await sendClick();
+        zoomPageOut();
+        scrollPage(0, 0);
+        window.removeEventListener("click", zoomedAndScrolled, false);
+
         var area = document.getElementById('testArea');
         area.parentNode.removeChild(area);
 

--- a/LayoutTests/fast/events/content-changed-during-drop-expected.txt
+++ b/LayoutTests/fast/events/content-changed-during-drop-expected.txt
@@ -3,9 +3,9 @@ This tests that we don't lose data dropped onto an input field that changes its 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
- PASS dragTarget.value is elementToDrag.href
-PASS Didn't crash.
-PASS successfullyParsed is true
+ PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS dragTarget.value is elementToDrag.href
+PASS Didn't crash.
 

--- a/LayoutTests/fast/events/content-changed-during-drop.html
+++ b/LayoutTests/fast/events/content-changed-during-drop.html
@@ -8,10 +8,11 @@
                 event.target.value = '';
             }
 
-            function runTest()
+            async function runTest()
             {
                 if (window.testRunner) {
                     testRunner.dumpAsText();
+                    testRunner.waitUntilDone();
                     
                     elementToDrag = document.getElementById("elementToDrag");
                     x1 = elementToDrag.offsetLeft + elementToDrag.offsetWidth / 2;
@@ -21,30 +22,30 @@
                     x2 = dragTarget.offsetLeft + dragTarget.offsetWidth / 2;
                     y2 = dragTarget.offsetTop + dragTarget.offsetHeight / 2;
 
-                    eventSender.mouseMoveTo(x1,y1);
-                    eventSender.mouseDown();
+                    await eventSender.asyncMouseMoveTo(x1,y1);
+                    await eventSender.asyncMouseDown();
                     eventSender.leapForward(400);
-                    eventSender.mouseMoveTo(x2, y2);
-                    eventSender.mouseUp();
+                    await eventSender.asyncMouseMoveTo(x2, y2);
+                    await eventSender.asyncMouseUp();
                     shouldBe("dragTarget.value", "elementToDrag.href");
                     testPassed("Didn't crash.");
                     //clean up output
                     elementToDrag.parentNode.removeChild(elementToDrag);
                     dragTarget.parentNode.removeChild(dragTarget);
+                    testRunner.notifyDone();
                 } else {
                     debug('<br>To test this manually drag the link into the text field.')
                 }   
             }
         </script>
     </head>
-    <body>
+    <body onload="runTest()">
         <p id="description"></p>
         <a id="elementToDrag" href="http://example.com">A link!</a>
         <input id="dragTarget" type="text" value="Original Text" onfocus="resetField()" />
         <div id="console"></div>
         <script>
              description("This tests that we don't lose data dropped onto an input field that changes its content during a drop event");
-             runTest();
         </script>
         <script src="../../resources/js-test-post.js"></script>
     </body>

--- a/LayoutTests/fast/events/context-activated-by-key-event.html
+++ b/LayoutTests/fast/events/context-activated-by-key-event.html
@@ -36,32 +36,36 @@ function onFocusedElementContextMenu(event) {
   event.stopPropagation();
 }
 
-window.addEventListener('contextmenu', onWindowContextMenu);
-document.getElementById('contenteditable').addEventListener('contextmenu', onContentEditableContextMenu);
-document.getElementById('link').addEventListener('contextmenu', onFocusedElementContextMenu);
+onload = async () => {
+    window.addEventListener('contextmenu', onWindowContextMenu);
+    document.getElementById('contenteditable').addEventListener('contextmenu', onContentEditableContextMenu);
+    document.getElementById('link').addEventListener('contextmenu', onFocusedElementContextMenu);
 
-if (window.testRunner) {
-  eventSender.keyDown('menu');
-  dismissContextMenu();
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+        eventSender.keyDown('menu');
+        dismissContextMenu();
 
-  var rect = document.getElementById('contenteditable').getBoundingClientRect();
-  var x = rect.left + rect.width / 2;
-  var y = rect.top + rect.height / 2;
-  eventSender.mouseMoveTo(x, y);
-  eventSender.mouseDown();
-  eventSender.mouseUp();
-  eventSender.keyDown('menu');
-  dismissContextMenu();
+        var rect = document.getElementById('contenteditable').getBoundingClientRect();
+        var x = rect.left + rect.width / 2;
+        var y = rect.top + rect.height / 2;
+        await eventSender.asyncMouseMoveTo(x, y);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        eventSender.keyDown('menu');
+        dismissContextMenu();
 
-  document.getElementById('link').focus();
-  eventSender.keyDown('menu');
-  dismissContextMenu();
+        document.getElementById('link').focus();
+        eventSender.keyDown('menu');
+        dismissContextMenu();
 
-  window.getSelection().selectAllChildren(document.getElementById('contenteditable'));
-  eventSender.keyDown('menu');
-  dismissContextMenu();
+        window.getSelection().selectAllChildren(document.getElementById('contenteditable'));
+        eventSender.keyDown('menu');
+        dismissContextMenu();
 
-  testRunner.dumpAsText();
+        testRunner.notifyDone();
+    }
 }
 
 </script>

--- a/LayoutTests/fast/events/context-no-deselect.html
+++ b/LayoutTests/fast/events/context-no-deselect.html
@@ -11,12 +11,16 @@ var input = document.getElementById("text");
 input.selectionStart = 5;
 input.selectionEnd = 15;
 
-if (window.testRunner) {
-    var x, y;
-    x = input.offsetParent.offsetLeft + input.offsetLeft + input.offsetWidth / 2;
-    y = input.offsetParent.offsetTop + input.offsetTop + input.offsetHeight / 2;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.contextClick();
-}
+onload = async () => {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        var x, y;
+        x = input.offsetParent.offsetLeft + input.offsetLeft + input.offsetWidth / 2;
+        y = input.offsetParent.offsetTop + input.offsetTop + input.offsetHeight / 2;
+        await eventSender.asyncMouseMoveTo(x, y);
+        eventSender.contextClick();
+        testRunner.notifyDone();
+    }
+} 
 
 </script>

--- a/LayoutTests/fast/events/context-onmousedown-event.html
+++ b/LayoutTests/fast/events/context-onmousedown-event.html
@@ -5,16 +5,21 @@
 </body>
 </html>
 
-
 <script>
-if (window.testRunner) {
-     var box, x, y;
-     box = document.getElementById("box");
-     x = box.offsetParent.offsetLeft + box.offsetLeft + box.offsetWidth / 2;
-     y = box.offsetParent.offsetTop + box.offsetTop + box.offsetHeight / 2;
-     eventSender.mouseMoveTo(x, y);
-     eventSender.contextClick();
-     testRunner.dumpAsText();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+
+    var box, x, y;
+    box = document.getElementById("box");
+    x = box.offsetParent.offsetLeft + box.offsetLeft + box.offsetWidth / 2;
+    y = box.offsetParent.offsetTop + box.offsetTop + box.offsetHeight / 2;
+    await eventSender.asyncMouseMoveTo(x, y);
+    eventSender.contextClick();
+    testRunner.notifyDone();
 }
 
 </script>

--- a/LayoutTests/fast/events/contextmenu-actions-in-selected-text-expected.html
+++ b/LayoutTests/fast/events/contextmenu-actions-in-selected-text-expected.html
@@ -26,17 +26,25 @@ function hasMenuItemContainingTitle(items, titleToQuery)
     return false;
 }
 
-let paragraph = document.querySelector("p");
-let boundingRect = paragraph.getBoundingClientRect();
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-eventSender.mouseMoveTo(boundingRect.left + boundingRect.width / 2, boundingRect.top + boundingRect.height / 2);
-items = eventSender.contextClick();
+    testRunner.waitUntilDone();
 
-document.getElementById("has-look-up").textContent = hasMenuItemContainingTitle(items, "Look Up");
-document.getElementById("has-translate").textContent = hasMenuItemContainingTitle(items, "Translate");
-document.getElementById("has-search").textContent = hasMenuItemContainingTitle(items, "Search the Web");
+    let paragraph = document.querySelector("p");
+    let boundingRect = paragraph.getBoundingClientRect();
 
-paragraph.remove();
+    await eventSender.asyncMouseMoveTo(boundingRect.left + boundingRect.width / 2, boundingRect.top + boundingRect.height / 2);
+    items = eventSender.contextClick();
+
+    document.getElementById("has-look-up").textContent = hasMenuItemContainingTitle(items, "Look Up");
+    document.getElementById("has-translate").textContent = hasMenuItemContainingTitle(items, "Translate");
+    document.getElementById("has-search").textContent = hasMenuItemContainingTitle(items, "Search the Web");
+
+    paragraph.remove();
+    testRunner.notifyDone();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/contextmenu-actions-in-selected-text.html
+++ b/LayoutTests/fast/events/contextmenu-actions-in-selected-text.html
@@ -26,17 +26,25 @@ function hasMenuItemContainingTitle(items, titleToQuery)
     return false;
 }
 
-let paragraph = document.querySelector("p");
-let boundingRect = paragraph.getBoundingClientRect();
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-eventSender.mouseMoveTo(boundingRect.left + boundingRect.width / 2, boundingRect.top + boundingRect.height / 2);
-items = eventSender.contextClick();
+    testRunner.waitUntilDone();
 
-document.getElementById("has-look-up").textContent = hasMenuItemContainingTitle(items, "Look Up");
-document.getElementById("has-translate").textContent = hasMenuItemContainingTitle(items, "Translate");
-document.getElementById("has-search").textContent = hasMenuItemContainingTitle(items, "Search the Web");
+    let paragraph = document.querySelector("p");
+    let boundingRect = paragraph.getBoundingClientRect();
 
-paragraph.remove();
+    await eventSender.asyncMouseMoveTo(boundingRect.left + boundingRect.width / 2, boundingRect.top + boundingRect.height / 2);
+    items = eventSender.contextClick();
+
+    document.getElementById("has-look-up").textContent = hasMenuItemContainingTitle(items, "Look Up");
+    document.getElementById("has-translate").textContent = hasMenuItemContainingTitle(items, "Translate");
+    document.getElementById("has-search").textContent = hasMenuItemContainingTitle(items, "Search the Web");
+
+    paragraph.remove();
+    testRunner.notifyDone();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/contextmenu-dismiss-blink-caret.html
+++ b/LayoutTests/fast/events/contextmenu-dismiss-blink-caret.html
@@ -4,23 +4,29 @@
 </body>
 </html>
 <script>
-    if (window.testRunner) {
-        var element = document.getElementById('contenteditable');
-        var rect = element.getBoundingClientRect();
-        eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
-        // contextClick() implementations in WK1 and WK2 have a subtle, but important difference.
-        // Under WK1, the mousedown is simulated but not the mouseup. Under WK2 both the mousedown
-        // and mouseup are simulated. It turns out the WK1 simulation more closely matches what
-        // happens in real life. This is relevant to this test (and the bug it covers) because,
-        // under WK2, the test will always pass, with or without the bug fix. Under WK1, the test
-        // fails without the bug fix and passes with the bug fix as expected.
-        //
-        // An alternative to using contextClick() would be mouseDown("ctrlKey"), but that is
-        // a Mac-specific way to bring up the context menu instead of a platform-neutral way
-        eventSender.contextClick();
-        // esc key to kill the context menu.
-        eventSender.keyDown(String.fromCharCode(0x001B), null);
-        element.innerText = window.internals.isCaretBlinkingSuspended() ? "FAIL" : "PASS";
-        testRunner.dumpAsText();
-    }
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+
+    var element = document.getElementById('contenteditable');
+    var rect = element.getBoundingClientRect();
+    await eventSender.asyncMouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    // contextClick() implementations in WK1 and WK2 have a subtle, but important difference.
+    // Under WK1, the mousedown is simulated but not the mouseup. Under WK2 both the mousedown
+    // and mouseup are simulated. It turns out the WK1 simulation more closely matches what
+    // happens in real life. This is relevant to this test (and the bug it covers) because,
+    // under WK2, the test will always pass, with or without the bug fix. Under WK1, the test
+    // fails without the bug fix and passes with the bug fix as expected.
+    //
+    // An alternative to using contextClick() would be mouseDown("ctrlKey"), but that is
+    // a Mac-specific way to bring up the context menu instead of a platform-neutral way
+    eventSender.contextClick();
+    // esc key to kill the context menu.
+    eventSender.keyDown(String.fromCharCode(0x001B), null);
+    element.innerText = window.internals.isCaretBlinkingSuspended() ? "FAIL" : "PASS";
+    testRunner.notifyDone();
+}
 </script>

--- a/LayoutTests/fast/events/contextmenu-lookup-action-for-image.html
+++ b/LayoutTests/fast/events/contextmenu-lookup-action-for-image.html
@@ -2,13 +2,19 @@
 <html>
 <head>
 <script>
-addEventListener("load", () => {
-    let image = document.querySelector("img");
-    eventSender.mouseMoveTo(130, 130);
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
     testRunner.dumpAsText();
+
+    let image = document.querySelector("img");
+    await eventSender.asyncMouseMoveTo(130, 130);
 
     let foundLookUpItem = eventSender.contextClick().some((item) => (item.title || item).includes?.("Look Up"));
     document.querySelector("pre").textContent = `Found lookup item? ${foundLookUpItem}`;
+    testRunner.notifyDone();
 });
 </script>
 </head>

--- a/LayoutTests/fast/events/contextmenu-on-scrollbars.html
+++ b/LayoutTests/fast/events/contextmenu-on-scrollbars.html
@@ -20,17 +20,19 @@
         document.getElementById('log').appendChild(document.createTextNode(msg + "\n"));
     }
 
-    if (window.testRunner)
+    onload = async () => {
+        if (!window.testRunner || !window.eventSender)
+            return;
+
         testRunner.dumpAsText();
+        testRunner.waitUntilDone();
 
-    var didSendContextMenu = false;
+        var didSendContextMenu = false;
+        document.oncontextmenu = function() { didSendContextMenu = true; }
 
-    document.oncontextmenu = function() { didSendContextMenu = true; }
-
-    if (window.eventSender) {
         var failed = false;
 
-        eventSender.mouseMoveTo(window.innerWidth - 4, window.innerHeight - 4);
+        await eventSender.asyncMouseMoveTo(window.innerWidth - 4, window.innerHeight - 4);
         eventSender.contextClick();
         if (didSendContextMenu) {
             log('FAILED: context menu event received on main frame scrollbar');
@@ -39,7 +41,7 @@
         }
 
         var div = document.querySelector('#scrollme');
-        eventSender.mouseMoveTo(div.offsetLeft + div.offsetWidth - 4, div.offsetTop + 1);
+        await eventSender.asyncMouseMoveTo(div.offsetLeft + div.offsetWidth - 4, div.offsetTop + 1);
         eventSender.contextClick();
         if (didSendContextMenu) {
             log('FAILED: context menu event received on div scrollbar');
@@ -47,6 +49,7 @@
         }
         if (!failed)
             log('SUCCESS');
+        testRunner.notifyDone();
     }
 </script>
 </body>

--- a/LayoutTests/fast/events/contextmenu-scrolled-page-with-frame.html
+++ b/LayoutTests/fast/events/contextmenu-scrolled-page-with-frame.html
@@ -12,17 +12,22 @@ frames.</p>
         document.getElementById('log').appendChild(document.createTextNode(msg + "\n"));
     }
 
-    if (window.testRunner)
+    onload = async () => {
+        if (!window.testRunner || !window.eventSender)
+            return;
+
         testRunner.dumpAsText();
+        testRunner.waitUntilDone();
 
-    var frame = document.getElementsByTagName('iframe')[0];
+        var frame = document.getElementsByTagName('iframe')[0];
 
-    document.oncontextmenu = function() { log('PASS: main document received a context menu event'); }
-    frame.contentDocument.oncontextmenu = function() { log('FAIL: subframe document received a context menu event'); }
+        document.oncontextmenu = function() { log('PASS: main document received a context menu event'); }
+        frame.contentDocument.oncontextmenu = function() { log('FAIL: subframe document received a context menu event'); }
 
-    if (window.eventSender) {
         window.scrollTo(0, frame.offsetTop);
-        eventSender.mouseMoveTo(frame.offsetLeft + (frame.offsetWidth / 2), frame.offsetHeight + 5);
+        await eventSender.asyncMouseMoveTo(frame.offsetLeft + (frame.offsetWidth / 2), frame.offsetHeight + 5);
         eventSender.contextClick();
+
+        testRunner.notifyDone();
     }
 </script>

--- a/LayoutTests/fast/events/controlclick-no-onclick.html
+++ b/LayoutTests/fast/events/controlclick-no-onclick.html
@@ -6,19 +6,23 @@
 </html>
 
 <script>
-if (window.testRunner) {
-  testRunner.dumpAsText();
+onload = async () => {
+    if (!window.testRunner || !window.eventSender)
+        return;
 
-  var isMacOSX = navigator.userAgent.indexOf("Mac OS X") != -1;
-  if (isMacOSX) {
-    var box = document.getElementById("box");
-    var x = box.offsetParent.offsetLeft + box.offsetLeft + box.offsetWidth / 2;
-    var y = box.offsetParent.offsetTop + box.offsetTop + box.offsetHeight / 2;
-    eventSender.dragMode = false;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown(0, ['ctrlKey']);
-    eventSender.mouseUp(0, ['ctrlKey']);
-  }
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    var isMacOSX = navigator.userAgent.indexOf("Mac OS X") != -1;
+    if (isMacOSX) {
+        var box = document.getElementById("box");
+        var x = box.offsetParent.offsetLeft + box.offsetLeft + box.offsetWidth / 2;
+        var y = box.offsetParent.offsetTop + box.offsetTop + box.offsetHeight / 2;
+        eventSender.dragMode = false;
+        await eventSender.asyncMouseMoveTo(x, y);
+        await eventSender.asyncMouseDown(0, ['ctrlKey']);
+        await eventSender.asyncMouseUp(0, ['ctrlKey']);
+    }
+    testRunner.notifyDone();
 }
-
 </script>

--- a/LayoutTests/fast/events/crash-on-mutate-during-drop.html
+++ b/LayoutTests/fast/events/crash-on-mutate-during-drop.html
@@ -7,11 +7,12 @@ function onDOMNodeInserted(event) {
         document.body.innerHTML = "PASSED";
 }
 
-function runTest() {
+async function runTest() {
     if (!window.testRunner)
       return;
 
     window.testRunner.dumpAsText();
+    testRunner.waitUntilDone();
 
     document.addEventListener("DOMNodeInserted", onDOMNodeInserted, true);
 
@@ -24,12 +25,13 @@ function runTest() {
     // Drag the source text to the target text.
     var source = document.getElementById('dragSource');
     var target = document.getElementById('dragTarget');
-    eventSender.mouseMoveTo(source.offsetLeft + 2, source.offsetTop + 2);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(source.offsetLeft + 2, source.offsetTop + 2);
+    await eventSender.asyncMouseDown();
     eventSender.leapForward(500);
-    eventSender.mouseMoveTo(target.offsetLeft + target.offsetWidth / 2,
+    await eventSender.asyncMouseMoveTo(target.offsetLeft + target.offsetWidth / 2,
                             target.offsetTop + target.offsetHeight / 2);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
+    testRunner.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/fast/events/data-transfer-files-attribute-identity-expected.txt
+++ b/LayoutTests/fast/events/data-transfer-files-attribute-identity-expected.txt
@@ -4,9 +4,9 @@ Test that the same object is returned for dataTransfer.files each time, as well 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS event.dataTransfer.files is event.dataTransfer.files
-PASS event.dataTransfer.files.item(0) is event.dataTransfer.files.item(0)
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS event.dataTransfer.files is event.dataTransfer.files
+PASS event.dataTransfer.files.item(0) is event.dataTransfer.files.item(0)
 

--- a/LayoutTests/fast/events/data-transfer-files-attribute-identity.html
+++ b/LayoutTests/fast/events/data-transfer-files-attribute-identity.html
@@ -4,20 +4,26 @@
 <meta charset="utf-8">
 <script src="../../resources/js-test-pre.js"></script>
 </head>
-<body>
+<body onload="runTest()">
 <input type="file" ondrop="dropped(event)"></input>
 <div id="console"></div>
 <script>
 
 description("Test that the same object is returned for dataTransfer.files each time, as well as for File objects in the FileList.");
 
-function runTest()
+async function runTest()
 {
+    if (!window.testRunner || !window.eventSender)
+        return;
+
+    testRunner.waitUntilDone();
+
     var inputElement = document.getElementsByTagName('input')[0];
     eventSender.beginDragWithFiles(['test.txt']);
-    eventSender.mouseMoveTo(inputElement.offsetLeft + inputElement.offsetWidth / 2,
+    await eventSender.asyncMouseMoveTo(inputElement.offsetLeft + inputElement.offsetWidth / 2,
                             inputElement.offsetTop + inputElement.offsetHeight / 2);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
+    testRunner.notifyDone();
 }
 
 function dropped(event)
@@ -25,9 +31,6 @@ function dropped(event)
     shouldBe("event.dataTransfer.files", "event.dataTransfer.files");
     shouldBe("event.dataTransfer.files.item(0)", "event.dataTransfer.files.item(0)");
 }
-
-runTest();
-
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/events/dblclick-addEventListener.html
+++ b/LayoutTests/fast/events/dblclick-addEventListener.html
@@ -21,18 +21,20 @@
 			event.stopPropagation();
 			event.preventDefault();
 		}
-		window.onload = function()
+		window.onload = async function()
 		{
 			var elem = document.getElementById("click_area");
             elem.addEventListener('dblclick', handler, false);
             
             if (window.testRunner) {
                 testRunner.dumpAsText();
-                eventSender.mouseMoveTo(50,50);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                testRunner.waitUntilDone();
+                await eventSender.asyncMouseMoveTo(50,50);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
+                testRunner.notifyDone();
             }
 		}
 	</script>

--- a/LayoutTests/fast/events/dblclick-event-getModifierState.html
+++ b/LayoutTests/fast/events/dblclick-event-getModifierState.html
@@ -40,19 +40,21 @@ function verify() {
     finishJSTest();
 }
 
-if (window.eventSender) {
-    eventSender.leapForward(1000); // drain dblclick timer
+onload = async () => {
+    if (window.eventSender) {
+        eventSender.leapForward(1000); // drain dblclick timer
 
-    eventSender.mouseMoveTo(1, 1);
-    eventSender.mouseMoveTo(target.offsetLeft + target.offsetWidth / 2, target.offsetTop + target.offsetHeight / 2);
+        await eventSender.asyncMouseMoveTo(1, 1);
+        await eventSender.asyncMouseMoveTo(target.offsetLeft + target.offsetWidth / 2, target.offsetTop + target.offsetHeight / 2);
 
-    eventSender.mouseDown(0, ['altKey', 'capsLockKey']);
-    eventSender.mouseUp(0, ['altKey', 'capsLockKey']);
-    eventSender.mouseDown(0, ['altKey', 'capsLockKey']);
-    eventSender.mouseUp(0, ['altKey', 'capsLockKey']);
-} else if (window.testRunner) {
-    testFailed('This test requires eventSender');
-    finishJSTest();
+        await eventSender.asyncMouseDown(0, ['altKey', 'capsLockKey']);
+        await eventSender.asyncMouseUp(0, ['altKey', 'capsLockKey']);
+        await eventSender.asyncMouseDown(0, ['altKey', 'capsLockKey']);
+        await eventSender.asyncMouseUp(0, ['altKey', 'capsLockKey']);
+    } else if (window.testRunner) {
+        testFailed('This test requires eventSender');
+        finishJSTest();
+    } 
 }
 
 </script>

--- a/LayoutTests/fast/events/display-none-on-focus-crash.html
+++ b/LayoutTests/fast/events/display-none-on-focus-crash.html
@@ -7,23 +7,26 @@
 </head>
 <body></body>
 <script>
-if (window.testRunner)
+if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
 var iframe1;
-function boom() {
+async function boom() {
     iframe1 = document.createElement('iframe');
     document.documentElement.appendChild(iframe1);
     document.documentElement.appendChild(document.createElement('li'));
     document.documentElement.appendChild(document.createElement('iframe'));
     iframe1.setAttribute('class', 'c3');
-    eventSender.mouseMoveTo(1000, 100);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseMoveTo(100, 100);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(1000, 100);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseMoveTo(100, 100);
+    await eventSender.asyncMouseDown();
     document.body.innerHTML = 'Test passes if it does not crash.'
+    testRunner.notifyDone();
 }
 window.onload = boom;
 </script>

--- a/LayoutTests/fast/events/domactivate-sets-underlying-click-event-as-handled.html
+++ b/LayoutTests/fast/events/domactivate-sets-underlying-click-event-as-handled.html
@@ -21,52 +21,60 @@ element. The anchor shouldn't be activated (i.e. you shouldn't see any "anchor a
 </pre>
 
 <script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-
 function log(message) { document.querySelector("pre").innerHTML += message + "\n"; }
 function formSubmitted() { log("form submitted\n"); }
 function anchorActivated() { log("anchor activated\n"); }
 
-document.forms[0].children[0].value = "blah";
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-for (var i=0; i < document.forms[0].children.length; i++) {
-    var element = document.forms[0].children[i];
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    
+    document.forms[0].children[0].value = "blah";
 
-    element.addEventListener("click", function () {
-        log("Activated " + this + " type=" + this.type);
-    }, false);
+    for (var i=0; i < document.forms[0].children.length; i++) {
+        var element = document.forms[0].children[i];
 
-    if (!window.eventSender)
-        continue;
+        element.addEventListener("click", function () {
+            log("Activated " + this + " type=" + this.type);
+        }, false);
 
-    if (element.type == "text") {
+        if (!window.eventSender)
+            continue;
+
+        if (element.type == "text") {
+            log("Focusing " + element + " type=" + element.type + " and pressing enter");
+            element.focus();
+            eventSender.keyDown("\n");
+            continue;
+        }
+
+        await eventSender.asyncMouseMoveTo(element.offsetLeft + element.clientWidth / 2, element.offsetTop + element.clientHeight / 2);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+
+        if (element.type == "radio" || element.type == "checkbox")
+            continue;
+
         log("Focusing " + element + " type=" + element.type + " and pressing enter");
         element.focus();
         eventSender.keyDown("\n");
-        continue;
     }
 
-    eventSender.mouseMoveTo(element.offsetLeft + element.clientWidth / 2, element.offsetTop + element.clientHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    if (window.eventSender) {
+        var details = document.querySelector("details");
+        await eventSender.asyncMouseMoveTo(details.offsetLeft + details.clientWidth / 2, details.offsetTop + details.clientHeight / 2);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        log("\nThe details element was " + (details.open ? "" : "not ") + "opened");
+    }
 
-    if (element.type == "radio" || element.type == "checkbox")
-        continue;
+    if (window.testRunner)
+        document.querySelector("a").style.display = "none";
 
-    log("Focusing " + element + " type=" + element.type + " and pressing enter");
-    element.focus();
-    eventSender.keyDown("\n");
+    testRunner.notifyDone();
 }
 
-if (window.eventSender) {
-    var details = document.querySelector("details");
-    eventSender.mouseMoveTo(details.offsetLeft + details.clientWidth / 2, details.offsetTop + details.clientHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    log("\nThe details element was " + (details.open ? "" : "not ") + "opened");
-}
-
-if (window.testRunner)
-    document.querySelector("a").style.display = "none";
 </script>

--- a/LayoutTests/fast/events/dont-loose-last-event.html
+++ b/LayoutTests/fast/events/dont-loose-last-event.html
@@ -5,7 +5,7 @@
     var targetElem;
     var consoleElm;
 
-    window.onload = function()
+    window.onload = async function()
     {
         startElem = document.getElementById("startElem");
         targetElem = document.getElementById("targetElem");
@@ -14,7 +14,7 @@
         if (!startElem || !targetElem || !consoleElm)
             return;
 
-        runTest();
+        await runTest();
     }
 
     function pass()
@@ -24,26 +24,29 @@
         div.innerHTML = "PASS";
     };
 
-    function runTest()
+    async function runTest()
     {
         if (!window.eventSender)
             return;
 
-        if (window.testRunner)
+        if (window.testRunner) {
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
 
         var startX = startElem.offsetLeft + 10;
         var startY = startElem.offsetTop + startElem.offsetHeight / 2;
         var endX = targetElem.offsetLeft + 10;
         var endY = targetElem.offsetTop + targetElem.offsetHeight / 2;
 
-        eventSender.mouseMoveTo(startX, startY);
+        await eventSender.asyncMouseMoveTo(startX, startY);
         eventSender.leapForward(100);
-        eventSender.mouseMoveTo(endX, endY);
+        await eventSender.asyncMouseMoveTo(endX, endY);
 
         var testContainer = document.getElementById("test-container");
         if (testContainer)
             document.body.removeChild(testContainer);
+        testRunner?.notifyDone();
     }
 </script>
 </head>

--- a/LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html
+++ b/LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html
@@ -13,7 +13,7 @@
 var x, y, middleTermScrollOffset;
 var iframe, iframeDocument, draggable;
 
-function setUpTest()
+async function setUpTest()
 {
     if (!window.eventSender) {
         log('Please run within DumpRenderTree');
@@ -22,10 +22,10 @@ function setUpTest()
 
     window.internals.settings.setAutoscrollForDragAndDropEnabled(true);
     testRunner.waitUntilDone();
-    testIt();
+    await testIt();
 }
 
-function testIt()
+async function testIt()
 {
     eventSender.dragMode = false;
 
@@ -39,27 +39,27 @@ function testIt()
     x = iframe.offsetLeft + draggable.offsetLeft + 7;
     y = iframe.offsetTop + draggable.offsetTop + 7;
 
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
 
     // Move mouse to the bottom autoscroll border belt.
     y = iframe.offsetTop + iframe.offsetHeight - 10;
-    eventSender.mouseMoveTo(x, y);
+    await eventSender.asyncMouseMoveTo(x, y);
 }
 
-function recordScroll(e)
+async function recordScroll(e)
 {
     iframeDocument.removeEventListener("scroll", recordScroll);
-    autoscrollTestPart1();
+    await autoscrollTestPart1();
 }
 
-function recordScroll2(e)
+async function recordScroll2(e)
 {
     iframeDocument.removeEventListener("scroll", recordScroll2);
-    autoscrollTestPart2();
+    await autoscrollTestPart2();
 }
 
-function autoscrollTestPart1()
+async function autoscrollTestPart1()
 {
     if (iframe.contentDocument.body.scrollTop == 0) {
         testFailed("Autoscroll should have scrolled the iframe downwards, but did not");
@@ -68,7 +68,7 @@ function autoscrollTestPart1()
     }
 
     testPassed("Autoscroll should have scrolled the iframe downwards, and did.");
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
     iframeDocument.addEventListener("scroll", recordScroll2);
 
     middleTermScrollOffset = iframe.contentDocument.body.scrollTop;
@@ -78,22 +78,22 @@ function autoscrollTestPart1()
     y = iframe.offsetTop + draggable.offsetTop + 7 - iframe.contentDocument.body.scrollTop ;
 
     // Move mouse to the upper autoscroll border belt.
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
 
     y = iframe.offsetTop + 10;
-    eventSender.mouseMoveTo(x, y);
+    await eventSender.asyncMouseMoveTo(x, y);
 }
 
-function autoscrollTestPart2()
+async function autoscrollTestPart2()
 {
     shouldBeTrue("iframe.contentDocument.body.scrollTop < middleTermScrollOffset")
-    finishTest();
+    await finishTest();
 }
 
-function finishTest()
+async function finishTest()
 {
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
     testRunner.notifyDone();
 }
 

--- a/LayoutTests/fast/events/drag-and-drop-autoscroll.html
+++ b/LayoutTests/fast/events/drag-and-drop-autoscroll.html
@@ -19,13 +19,13 @@
 <script>
 function $(id) { return document.getElementById(id); }
 
-function finishTest() {
-    eventSender.mouseUp();
+async function finishTest() {
+    await eventSender.asyncMouseUp();
     $('container').innerHTML = '';
     window.testRunner.notifyDone();
 }
 
-function testIt() {
+async function testIt() {
     var draggable = $('draggable');
     var scrollable = $('scrollable');
 
@@ -35,11 +35,11 @@ function testIt() {
     eventSender.dragMode = false;
 
     // Grab draggable
-    eventSender.mouseMoveTo(draggable.offsetLeft + 5, draggable.offsetTop + 5);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(draggable.offsetLeft + 5, draggable.offsetTop + 5);
+    await eventSender.asyncMouseDown();
 
     // Move mouse to autoscroll border belt.
-    eventSender.mouseMoveTo(scrollable.offsetLeft + 5, scrollable.offsetTop + scrollable.offsetHeight - 10);
+    await eventSender.asyncMouseMoveTo(scrollable.offsetLeft + 5, scrollable.offsetTop + scrollable.offsetHeight - 10);
 
     var retryCount = 0;
     var lastScrollTop = 0;

--- a/LayoutTests/fast/events/dragging-mouse-moves.html
+++ b/LayoutTests/fast/events/dragging-mouse-moves.html
@@ -9,18 +9,18 @@ function log(msg)
     document.getElementById('console').appendChild(document.createTextNode(msg + '\n'));
 }
 
-function test()
+async function test()
 {
     if (window.testRunner) {
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
-        testDragAndMove();
+        await testDragAndMove();
     } else
         log("testRunner is not available");
 
 }
 
-function testDragAndMove()
+async function testDragAndMove()
 {
     var draggable = document.getElementById("draggableForDiv");
 
@@ -30,12 +30,12 @@ function testDragAndMove()
     eventSender.dragMode = false;
 
     // Grab the draggable node
-    eventSender.mouseMoveTo(startX,startY);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(startX,startY);
+    await eventSender.asyncMouseDown();
     // Then drag it. OK not to crash.
-    eventSender.mouseMoveTo(startX + 10, startY + 10);
-    eventSender.mouseMoveTo(startX + 20, startY + 20);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(startX + 10, startY + 10);
+    await eventSender.asyncMouseMoveTo(startX + 20, startY + 20);
+    await eventSender.asyncMouseUp();
     document.getElementById("test").style.display = "none";
     log("PASS");
     testRunner.notifyDone();

--- a/LayoutTests/fast/events/fire-mousedown-while-pressing-mouse-button.html
+++ b/LayoutTests/fast/events/fire-mousedown-while-pressing-mouse-button.html
@@ -29,7 +29,7 @@ var LeftMouseButton = 0;
 var MiddleMouseButton = 1;
 var RightMouseButton = 2;
 
-window.onload = function()
+window.onload = async function()
 {
     firstMouseButtonElem = document.getElementById("firstMouseButton");
     secondMouseButtonElem = document.getElementById("secondMouseButton");
@@ -44,7 +44,9 @@ window.onload = function()
     square.onmouseup = checkIfDoneOnMouseUp;
     square.oncontextmenu = cancelContextMenu;
     resetTest();
-    runTest();
+    testRunner?.waitUntilDone();
+    await runTest();
+    testRunner?.notifyDone();
 }
 
 function toBitmaskMouseButton(w3cButton)
@@ -133,14 +135,14 @@ function disableIllogicalSecondMouseButtonOptions()
     previouslyChosenFirstMouseButton = firstMouseButtonElem.selectedIndex;
 }
 
-function runTest()
+async function runTest()
 {
     if (!window.eventSender)
         return;
 
     var numFirstMouseButtonOptions = firstMouseButtonElem.options.length;
     var numSecondMouseButtonOptions = secondMouseButtonElem.options.length;
-    eventSender.mouseMoveTo(square.offsetLeft + 10, square.offsetTop + 10);
+    await eventSender.asyncMouseMoveTo(square.offsetLeft + 10, square.offsetTop + 10);
     var firstMouseButton = 0;
     var secondMouseButton = 0;
     while (firstMouseButton < numFirstMouseButtonOptions) {
@@ -157,11 +159,11 @@ function runTest()
         secondMouseButtonElem.options[secondMouseButton].selected = true;
         if (secondMouseButton % numSecondMouseButtonOptions === 0)
             debug('<br />When pressing and holding the "' + mouseButtonName(firstMouseButton) + '"<br />');
-        eventSender.mouseDown(firstMouseButton);
+        await eventSender.asyncMouseDown(firstMouseButton);
         eventSender.leapForward(100);
-        eventSender.mouseDown(secondMouseButton);
-        eventSender.mouseUp(secondMouseButton);
-        eventSender.mouseUp(firstMouseButton);
+        await eventSender.asyncMouseDown(secondMouseButton);
+        await eventSender.asyncMouseUp(secondMouseButton);
+        await eventSender.asyncMouseUp(firstMouseButton);
         eventSender.leapForward(100);
         ++secondMouseButton;
         resetTest(); // We reset the test here in case neither a mousedown nor mouseup event was fired.

--- a/LayoutTests/fast/events/frame-click-focus.html
+++ b/LayoutTests/fast/events/frame-click-focus.html
@@ -5,9 +5,10 @@
             document.getElementById('log').appendChild(document.createTextNode(msg + '\n'));
         }
 
-        function test() {
+        async function test() {
             if (window.testRunner) {
                 testRunner.dumpAsText();
+                testRunner.waitUntilDone();
             }
 
             window.onfocus = function() { log('main frame focused'); }
@@ -18,23 +19,24 @@
             w.onblur = function() { log('iframe blurred'); }
 
             if (window.eventSender) {
-                eventSender.mouseMoveTo(1, 300);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(1, 300);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
 
                 // We need to "wait" a bit before the next click -- otherwise it is ignored
                 eventSender.leapForward(2000);
 
-                eventSender.mouseMoveTo(50, 50);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(50, 50);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
 
                 eventSender.leapForward(2000);
 
-                eventSender.mouseMoveTo(1, 300);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(1, 300);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
             }
+            testRunner?.notifyDone();
         }
     </script>
 </head>

--- a/LayoutTests/fast/events/frame-detached-in-mousedown.html
+++ b/LayoutTests/fast/events/frame-detached-in-mousedown.html
@@ -13,7 +13,7 @@ if (window.testRunner) {
 
 var iframe = document.getElementsByTagName("iframe")[0];
 
-function startTest()
+async function startTest()
 {
     var doc = iframe.contentDocument;
     var a = doc.createElement('a');
@@ -28,21 +28,21 @@ function startTest()
     if (window.eventSender) {
        var x = iframe.offsetLeft + a.offsetLeft + 7;
        var y = iframe.offsetTop + a.offsetTop + 7;
-       eventSender.mouseMoveTo(x, y);
-       eventSender.mouseDown();
-       eventSender.mouseUp();
+       await eventSender.asyncMouseMoveTo(x, y);
+       await eventSender.asyncMouseDown();
+       await eventSender.asyncMouseUp();
        setTimeout(click2, 10);
     }
 }
 
-function click2()
+async function click2()
 {
     var foo = document.getElementById("foo");
     var x = foo.offsetLeft + 7;
     var y = foo.offsetTop + 7;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 }
 
 function pass()

--- a/LayoutTests/fast/events/frame-scroll-fake-mouse-move.html
+++ b/LayoutTests/fast/events/frame-scroll-fake-mouse-move.html
@@ -24,9 +24,9 @@
         // WebKit schedules a fake mouse move event as part of installing the WebView in
         // a window. For the test to be valid, it must begin only after that event
         // gets dispatched.
-        setTimeout(function()
+        setTimeout(async function()
         {
-            eventSender.mouseMoveTo(50, 100);
+            await eventSender.asyncMouseMoveTo(50, 100);
             document.scrollingElement.scrollTop = 250;
             timeoutID = setTimeout(finish, 20000);
         }, 200);

--- a/LayoutTests/fast/events/ghostly-mousemoves-in-subframe.html
+++ b/LayoutTests/fast/events/ghostly-mousemoves-in-subframe.html
@@ -37,7 +37,7 @@ function logEvent(e) {
     debug(e.target.id + " got " + event.type + " at " + event.x + "," + event.y);
 }
 
-window.onload = function() {
+window.onload = async function() {
     window.onclick = function(event) {
         logEvent(event);
 
@@ -54,22 +54,22 @@ window.onload = function() {
     }
 
     // Move the mouse over clickable_div_in_subframe so it becomes the subframe document's hovered element.
-    eventSender.mouseMoveTo(15, 15);
-    setTimeout(function() {
+    await eventSender.asyncMouseMoveTo(15, 15);
+    setTimeout(async function() {
         // Fire the subframe's clickable_div_in_subframe.onclick handler.
         // This will cause a overlapping_div_in_main_frame to overlap the currently hovered element in the subframe.
-        eventSender.mouseDown();
-        eventSender.mouseUp();
-        setTimeout(function() {
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        setTimeout(async function() {
             // Jiggle the mouse inside the newly hovered element a bit.
-            eventSender.mouseMoveTo(16, 16);
-            setTimeout(function() {
-                eventSender.mouseMoveTo(400, 400);
-                setTimeout(function() {
+            await eventSender.asyncMouseMoveTo(16, 16);
+            setTimeout(async function() {
+                await eventSender.asyncMouseMoveTo(400, 400);
+                setTimeout(async function() {
                     // Cause a click in the main frame, so the above window.onclick handler will run,
                     // killing and then recreating clickable_div_in_subframe's renderer.
-                    eventSender.mouseDown();
-                    eventSender.mouseUp();
+                    await eventSender.asyncMouseDown();
+                    await eventSender.asyncMouseUp();
                     setTimeout(function() {
                         finishJSTest();
                     }, 500);

--- a/LayoutTests/fast/events/hittest-pointer-event-none-descendants.html
+++ b/LayoutTests/fast/events/hittest-pointer-event-none-descendants.html
@@ -11,7 +11,7 @@ async function test() {
 
     await new Promise(requestAnimationFrame);
 
-    eventSender.mouseMoveTo(100, 100);
+    await eventSender.asyncMouseMoveTo(100, 100);
 
     await new Promise(requestAnimationFrame);
     

--- a/LayoutTests/fast/events/iframe-onmousemove.html
+++ b/LayoutTests/fast/events/iframe-onmousemove.html
@@ -18,7 +18,7 @@ function done()
         testRunner.notifyDone();
 }
 
-function runTest()
+async function runTest()
 {
      if (!window.eventSender)
         return;
@@ -26,7 +26,7 @@ function runTest()
     var frame = document.getElementById("frame");
     var centerX = frame.offsetLeft + frame.offsetWidth / 2;
     var centerY = frame.offsetTop + frame.offsetHeight / 2;
-    eventSender.mouseMoveTo(centerX, centerY);
+    await eventSender.asyncMouseMoveTo(centerX, centerY);
 }
 
 window.onload = runTest;

--- a/LayoutTests/fast/events/mouse-click-different-mouseDown-mouseUp-nodes.html
+++ b/LayoutTests/fast/events/mouse-click-different-mouseDown-mouseUp-nodes.html
@@ -43,11 +43,11 @@ document.getElementById("childDiv").onclick = function() {
     childGotClickEvent = true;
 };
 
-onload = function() {
+onload = async function() {
     if (window.eventSender) {
-        eventSender.mouseMoveTo(10, 300);
-        eventSender.mouseDown();
-        eventSender.mouseUp();    
+        await eventSender.asyncMouseMoveTo(10, 300);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();    
     }
 
     setTimeout(function() {

--- a/LayoutTests/fast/events/mouse-click-events-expected.txt
+++ b/LayoutTests/fast/events/mouse-click-events-expected.txt
@@ -3,6 +3,9 @@ This tests what mouse events we send.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Left Mouse Button
 PASS eventLog is "mousedown(0) mouseup(0) click(0) mousedown(0) mouseup(0) click(0) dblclick(0) "
 Middle Mouse Button
@@ -11,7 +14,4 @@ Right Mouse Button
 PASS eventLog is "mousedown(2) mouseup(2) auxclick(2) mousedown(2) mouseup(2) auxclick(2) "
 4th Mouse Button
 PASS eventLog is "mousedown(1) mouseup(1) auxclick(1) mousedown(1) mouseup(1) auxclick(1) "
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/events/mouse-click-events.html
+++ b/LayoutTests/fast/events/mouse-click-events.html
@@ -33,45 +33,47 @@ function dismissContextMenu() {
     }
 }
 
-
-div.addEventListener("auxclick", appendEventLog, false);
-div.addEventListener("click", appendEventLog, false);
-div.addEventListener("dblclick", appendEventLog, false);
-div.addEventListener("mousedown", appendEventLog, false);
-div.addEventListener("mouseup", appendEventLog, false);
-document.body.insertBefore(div, document.body.firstChild);
-
-if (window.eventSender)
-    eventSender.mouseMoveTo(10, 10);
-
-function sendEvents(button) {
+async function sendEvents(button) {
     if (!window.eventSender) {
         debug("This test requires DumpRenderTree.  Click on the blue rect with different mouse buttons to log.")
         return;
     }
-    eventSender.mouseDown(button);
+    await eventSender.asyncMouseDown(button);
     if (button == 2)
         dismissContextMenu();
-    eventSender.mouseUp(button);
-    eventSender.mouseDown(button);
+    await eventSender.asyncMouseUp(button);
+    await eventSender.asyncMouseDown(button);
     if (button == 2)
         dismissContextMenu();
-    eventSender.mouseUp(button);
+    await eventSender.asyncMouseUp(button);
     // could test dragging here too
 }
 
-function testEvents(description, button, expectedString) {
+async function testEvents(description, button, expectedString) {
     debug(description);
-    sendEvents(button);
+    await sendEvents(button);
     shouldBeEqualToString("eventLog", expectedString);
     clearEventLog();
 }
 
-if (window.eventSender) {
-    testEvents("Left Mouse Button", 0, "mousedown(0) mouseup(0) click(0) mousedown(0) mouseup(0) click(0) dblclick(0) ");
-    testEvents("Middle Mouse Button", 1, "mousedown(1) mouseup(1) auxclick(1) mousedown(1) mouseup(1) auxclick(1) ");
-    testEvents("Right Mouse Button", 2, "mousedown(2) mouseup(2) auxclick(2) mousedown(2) mouseup(2) auxclick(2) ");
-    testEvents("4th Mouse Button", 3, "mousedown(1) mouseup(1) auxclick(1) mousedown(1) mouseup(1) auxclick(1) ");
+onload = async () => {
+    testRunner?.waitUntilDone();
+
+    div.addEventListener("auxclick", appendEventLog, false);
+    div.addEventListener("click", appendEventLog, false);
+    div.addEventListener("dblclick", appendEventLog, false);
+    div.addEventListener("mousedown", appendEventLog, false);
+    div.addEventListener("mouseup", appendEventLog, false);
+    document.body.insertBefore(div, document.body.firstChild);
+
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(10, 10);
+        await testEvents("Left Mouse Button", 0, "mousedown(0) mouseup(0) click(0) mousedown(0) mouseup(0) click(0) dblclick(0) ");
+        await testEvents("Middle Mouse Button", 1, "mousedown(1) mouseup(1) auxclick(1) mousedown(1) mouseup(1) auxclick(1) ");
+        await testEvents("Right Mouse Button", 2, "mousedown(2) mouseup(2) auxclick(2) mousedown(2) mouseup(2) auxclick(2) ");
+        await testEvents("4th Mouse Button", 3, "mousedown(1) mouseup(1) auxclick(1) mousedown(1) mouseup(1) auxclick(1) ");
+    }
+    testRunner?.notifyDone();
 }
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/events/mouse-cursor-change.html
+++ b/LayoutTests/fast/events/mouse-cursor-change.html
@@ -26,8 +26,8 @@ if (window.testRunner) {
     window.jsTestIsAsync = true;
 }
 
-function runTest(prepare, next) {
-    prepare();
+async function runTest(prepare, next) {
+    await prepare();
     setTimeout(function() {
         debug('Cursor Info: ' + window.internals.getCurrentCursorInfo());
         debug('');
@@ -41,35 +41,37 @@ function testsDone() {
     finishJSTest();
 }
 
-// Can't do anything useful here without eventSender
-if (window.eventSender) {
-    var target = document.getElementById('target');
-    eventSender.dragMode = false;
-    var tests = [
-        function() {
-            debug('Mouse move');
-            eventSender.mouseMoveTo(target.offsetLeft + 3, target.offsetTop + 3);
-        }, function() {
-            debug('Mouse down');
-            eventSender.mouseDown();
-        }, function() {
-            debug('Mouse hold down, move');
-            eventSender.mouseMoveTo(target.offsetLeft + 13, target.offsetTop + 3);
-        }, function() {
-            debug('Mouse up');
-            eventSender.mouseUp();
-        }
-    ];
+onload = async () => {
+    // Can't do anything useful here without eventSender
+    if (window.eventSender) {
+        var target = document.getElementById('target');
+        eventSender.dragMode = false;
+        var tests = [
+            async function() {
+                debug('Mouse move');
+                await eventSender.asyncMouseMoveTo(target.offsetLeft + 3, target.offsetTop + 3);
+            }, async function() {
+                debug('Mouse down');
+                await eventSender.asyncMouseDown();
+            }, async function() {
+                debug('Mouse hold down, move');
+                await eventSender.asyncMouseMoveTo(target.offsetLeft + 13, target.offsetTop + 3);
+            }, async function() {
+                debug('Mouse up');
+                await eventSender.asyncMouseUp();
+            }
+        ];
 
-    var i = 0;
-    function nextTest() {
-        if (i < tests.length) {
-            runTest(tests[i++], nextTest);
-        } else {
-            testsDone();
+        var i = 0;
+        async function nextTest() {
+            if (i < tests.length) {
+                await runTest(tests[i++], nextTest);
+            } else {
+                testsDone();
+            }
         }
+        await nextTest();
     }
-    nextTest();
 }
 
 </script>

--- a/LayoutTests/fast/events/mouse-cursor-image-set.html
+++ b/LayoutTests/fast/events/mouse-cursor-image-set.html
@@ -28,7 +28,7 @@
 var imagesLeftToLoad = 0;
 var testContainer = document.getElementById('test-container');
 
-function checkCursors() {
+async function checkCursors() {
     debug('Checking cursors with device pixel ratio of ' + window.devicePixelRatio);  
     debug('----------------------------------------------');
 	
@@ -38,7 +38,7 @@ function checkCursors() {
         debug('TEST CASE: ' + node.textContent);
         // Make sure the node is visible and move the mouse over top of it.
         document.scrollingElement.scrollTop = node.offsetTop - 50;
-        eventSender.mouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
+        await eventSender.asyncMouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
 
         // Get details of the current mouse cursor.
         // Note that we could return structured data which we then validate, but that's a lot more
@@ -49,14 +49,14 @@ function checkCursors() {
     }
 }
 
-function runTests() {
+async function runTests() {
     if (window.eventSender) {
-        checkCursors();
+        await checkCursors();
         // Repeat in high-dpi mode
         testRunner.setBackingScaleFactor(2, function() {
             // Failed images are apparently reset on scale factor change. 
-            loadImages([{ url: 'doesntexist.png', error: true }], function() {
-                checkCursors();
+            loadImages([{ url: 'doesntexist.png', error: true }], async function() {
+                await checkCursors();
                 testContainer.style.display = 'none';
                 finishJSTest();
             });

--- a/LayoutTests/fast/events/mouse-cursor-multiframecur.html
+++ b/LayoutTests/fast/events/mouse-cursor-multiframecur.html
@@ -19,7 +19,7 @@
 var imagesLeftToLoad = 0;
 var testContainer = document.getElementById('test-container');
 
-function runTests() {
+async function runTests() {
     // Can't do anything useful here without eventSender
     if (window.eventSender) {
         var nodesToTest = document.querySelectorAll('#test-container > div');
@@ -29,7 +29,7 @@ function runTests() {
 
             // Make sure the node is visible and move the mouse over top of it.
             document.scrollingElement.scrollTop = node.offsetTop - 50;
-            eventSender.mouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
+            await eventSender.asyncMouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
 
             // Get details of the current mouse cursor.
             // Note that we could return structured data which we then validate, but that's a lot more

--- a/LayoutTests/fast/events/mouse-cursor-no-mousemove.html
+++ b/LayoutTests/fast/events/mouse-cursor-no-mousemove.html
@@ -35,7 +35,7 @@ if (window.testRunner) {
 
     var node = document.getElementById('target');
     debug('TEST CASE: ' + node.textContent);
-    eventSender.mouseMoveTo(node.offsetLeft + 3, node.offsetTop + 3);
+    await eventSender.asyncMouseMoveTo(node.offsetLeft + 3, node.offsetTop + 3);
     debug('Cursor Info: ' + window.internals.getCurrentCursorInfo());
     node.addEventListener('mousemove', function() {
         testFailed('Mousemove event should not be fired when changing cursor');

--- a/LayoutTests/fast/events/mouse-cursor-udpate-during-raf.html
+++ b/LayoutTests/fast/events/mouse-cursor-udpate-during-raf.html
@@ -31,7 +31,7 @@ if (window.testRunner) {
         return;
 
     const target = document.getElementById("target");
-    eventSender.mouseMoveTo(target.offsetLeft + 3, target.offsetTop + 3);
+    await eventSender.asyncMouseMoveTo(target.offsetLeft + 3, target.offsetTop + 3);
     debug("Moved pointer over the target, cursor should be Pointer.");
     debug(`Cursor info: ${window.internals.getCurrentCursorInfo()}`);
 

--- a/LayoutTests/fast/events/mouse-cursor.html
+++ b/LayoutTests/fast/events/mouse-cursor.html
@@ -46,7 +46,7 @@
 
 var testContainer = document.getElementById('test-container');
 
-function runTests() {
+async function runTests() {
     // Can't do anything useful here without eventSender
     if (window.eventSender) {
         var nodesToTest = document.querySelectorAll('#test-container > div');
@@ -56,7 +56,7 @@ function runTests() {
 
             // Make sure the node is visible and move the mouse over top of it.
             document.scrollingElement.scrollTop = node.offsetTop - 50;
-            eventSender.mouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
+            await eventSender.asyncMouseMoveTo(node.offsetLeft + 3, node.offsetTop - document.scrollingElement.scrollTop + 3);
 
             // Get details of the current mouse cursor.
             // Note that we could return structured data which we then validate, but that's a lot more

--- a/LayoutTests/platform/glib/fast/events/clientXY-in-zoom-and-scroll-expected.txt
+++ b/LayoutTests/platform/glib/fast/events/clientXY-in-zoom-and-scroll-expected.txt
@@ -1,3 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Base
 PASS event.clientX is 100
 PASS event.clientY is 100
@@ -21,7 +24,4 @@ PASS event.clientX is 83
 PASS event.clientY is 83
 PASS event.pageX is 133
 PASS event.pageY is 133
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/platform/mac/fast/events/clientXY-in-zoom-and-scroll-expected.txt
+++ b/LayoutTests/platform/mac/fast/events/clientXY-in-zoom-and-scroll-expected.txt
@@ -1,3 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Base
 PASS event.clientX is 100
 PASS event.clientY is 100
@@ -21,7 +24,4 @@ PASS event.clientX is 83
 PASS event.clientY is 83
 PASS event.pageX is 133
 PASS event.pageY is 133
-PASS successfullyParsed is true
-
-TEST COMPLETE
 


### PR DESCRIPTION
#### 4c6e7afa6c38dc135b41123ecd565edd94869315
<pre>
Adopt more eventSender async mouse functions in fast/events/
<a href="https://bugs.webkit.org/show_bug.cgi?id=281891">https://bugs.webkit.org/show_bug.cgi?id=281891</a>
<a href="https://rdar.apple.com/138366238">rdar://138366238</a>

Reviewed by Alex Christensen.

This is needed for these tests to work correctly when using --site-isolation

* LayoutTests/fast/events/anchor-image-scrolled-x-y.html:
* LayoutTests/fast/events/attribute-listener-deletion-crash.html:
* LayoutTests/fast/events/autoscroll-in-overflow-hidden-html.html:
* LayoutTests/fast/events/autoscroll-in-textarea.html:
* LayoutTests/fast/events/autoscroll-in-textfield.html:
* LayoutTests/fast/events/autoscroll-main-document.html:
* LayoutTests/fast/events/autoscroll-nonscrollable-iframe-in-scrollable-div.html:
* LayoutTests/fast/events/autoscroll-overflow-hidden-longhands.html:
* LayoutTests/fast/events/autoscroll-should-not-stop-on-keypress.html:
* LayoutTests/fast/events/autoscroll-upwards-propagation.html:
* LayoutTests/fast/events/autoscroll-when-zoomed.html:
* LayoutTests/fast/events/autoscroll-with-non-scrollable-parent.html:
* LayoutTests/fast/events/before-input-events-prevent-drag-and-drop.html:
* LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html:
* LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html:
* LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html:
* LayoutTests/fast/events/capture-on-target.html:
* LayoutTests/fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html:
* LayoutTests/fast/events/clear-drag-state.html:
* LayoutTests/fast/events/clear-edit-drag-state.html:
* LayoutTests/fast/events/click-after-mousedown-cancel.html:
* LayoutTests/fast/events/click-count.html:
* LayoutTests/fast/events/click-focus-anchor.html:
* LayoutTests/fast/events/click-focus-control.html:
* LayoutTests/fast/events/click-range-slider.html:
* LayoutTests/fast/events/clientXY-in-zoom-and-scroll-expected.txt:
* LayoutTests/fast/events/clientXY-in-zoom-and-scroll.html:
* LayoutTests/fast/events/content-changed-during-drop-expected.txt:
* LayoutTests/fast/events/content-changed-during-drop.html:
* LayoutTests/fast/events/context-activated-by-key-event.html:
* LayoutTests/fast/events/context-no-deselect.html:
* LayoutTests/fast/events/context-onmousedown-event.html:
* LayoutTests/fast/events/contextmenu-actions-in-selected-text-expected.html:
* LayoutTests/fast/events/contextmenu-actions-in-selected-text.html:
* LayoutTests/fast/events/contextmenu-dismiss-blink-caret.html:
* LayoutTests/fast/events/contextmenu-lookup-action-for-image.html:
* LayoutTests/fast/events/contextmenu-on-scrollbars.html:
* LayoutTests/fast/events/contextmenu-scrolled-page-with-frame.html:
* LayoutTests/fast/events/controlclick-no-onclick.html:
* LayoutTests/fast/events/crash-on-mutate-during-drop.html:
* LayoutTests/fast/events/data-transfer-files-attribute-identity-expected.txt:
* LayoutTests/fast/events/data-transfer-files-attribute-identity.html:
* LayoutTests/fast/events/dblclick-addEventListener.html:
* LayoutTests/fast/events/dblclick-event-getModifierState.html:
* LayoutTests/fast/events/display-none-on-focus-crash.html:
* LayoutTests/fast/events/domactivate-sets-underlying-click-event-as-handled.html:
* LayoutTests/fast/events/dont-loose-last-event.html:
* LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html:
* LayoutTests/fast/events/drag-and-drop-autoscroll.html:
* LayoutTests/fast/events/dragging-mouse-moves.html:
* LayoutTests/fast/events/fire-mousedown-while-pressing-mouse-button.html:
* LayoutTests/fast/events/frame-click-focus.html:
* LayoutTests/fast/events/frame-detached-in-mousedown.html:
* LayoutTests/fast/events/frame-scroll-fake-mouse-move.html:
* LayoutTests/fast/events/ghostly-mousemoves-in-subframe.html:
* LayoutTests/fast/events/hittest-pointer-event-none-descendants.html:
* LayoutTests/fast/events/iframe-onmousemove.html:
* LayoutTests/fast/events/mouse-click-different-mouseDown-mouseUp-nodes.html:
* LayoutTests/fast/events/mouse-click-events-expected.txt:
* LayoutTests/fast/events/mouse-click-events.html:
* LayoutTests/fast/events/mouse-cursor-change.html:
* LayoutTests/fast/events/mouse-cursor-image-set.html:
* LayoutTests/fast/events/mouse-cursor-multiframecur.html:
* LayoutTests/fast/events/mouse-cursor-no-mousemove.html:
* LayoutTests/fast/events/mouse-cursor-udpate-during-raf.html:
* LayoutTests/fast/events/mouse-cursor.html:
* LayoutTests/platform/glib/fast/events/clientXY-in-zoom-and-scroll-expected.txt:
* LayoutTests/platform/mac/fast/events/clientXY-in-zoom-and-scroll-expected.txt:

Canonical link: <a href="https://commits.webkit.org/285564@main">https://commits.webkit.org/285564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cfd4a5b9e57a922d9c35df004ee0e10ac66206c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24254 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60250 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57389 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15878 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78893 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65833 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block.html (failure)") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65108 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7096 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11244 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->