### PR TITLE
PAL::TextCodec::getUnencodableReplacement() should return std::span

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -56,7 +56,7 @@ public:
     // Fills a null-terminated string representation of the given
     // unencodable character into the given replacement buffer.
     // The length of the string (not including the null) will be returned.
-    static int getUnencodableReplacement(char32_t, UnencodableHandling, UnencodableReplacementArray&);
+    static std::span<char> getUnencodableReplacement(char32_t, UnencodableHandling, UnencodableReplacementArray& LIFETIME_BOUND);
 };
 
 Function<void(char32_t, Vector<uint8_t>&)> unencodableHandler(UnencodableHandling);

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -263,8 +263,8 @@ static void urlEscapedEntityCallback(const void* context, UConverterFromUnicodeA
     if (reason == UCNV_UNASSIGNED) {
         *error = U_ZERO_ERROR;
         UnencodableReplacementArray entity;
-        int entityLen = TextCodec::getUnencodableReplacement(codePoint, UnencodableHandling::URLEncodedEntities, entity);
-        ucnv_cbFromUWriteBytes(fromUArgs, entity.data(), entityLen, 0, error);
+        auto span = TextCodec::getUnencodableReplacement(codePoint, UnencodableHandling::URLEncodedEntities, entity);
+        ucnv_cbFromUWriteBytes(fromUArgs, span.data(), span.size(), 0, error);
     } else
         UCNV_FROM_U_CALLBACK_ESCAPE(context, fromUArgs, codeUnits, length, codePoint, reason, error);
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -219,8 +219,7 @@ static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, Unencodable
             }
             // No way to encode this character with Windows Latin-1.
             UnencodableReplacementArray replacement;
-            int replacementLength = TextCodec::getUnencodableReplacement(character, handling, replacement);
-            result.append(std::span(replacement.data(), replacementLength));
+            result.append(TextCodec::getUnencodableReplacement(character, handling, replacement));
             continue;
         }
     gotByte:

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -68,8 +68,7 @@ static Vector<uint8_t> encodeComplexUserDefined(StringView string, UnencodableHa
         else {
             // No way to encode this character with x-user-defined.
             UnencodableReplacementArray replacement;
-            int replacementLength = TextCodec::getUnencodableReplacement(character, handling, replacement);
-            result.append(std::span(replacement.data(), replacementLength));
+            result.append(TextCodec::getUnencodableReplacement(character, handling, replacement));
         }
     }
 


### PR DESCRIPTION
#### cccc626b78256728836f5124f6dd961dcfb3f0ac
<pre>
PAL::TextCodec::getUnencodableReplacement() should return std::span
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281892">https://bugs.webkit.org/show_bug.cgi?id=281892</a>&gt;
&lt;<a href="https://rdar.apple.com/138372354">rdar://138372354</a>&gt;

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
- Make changes to return std::span.
- Sanity check the return value from snprint() and add ASSERT().
- Use std::span::first() pattern to validate length.
* Source/WebCore/PAL/pal/text/TextCodec.h:
(PAL::TextCodec::getUnencodableReplacement):
- Update to return std::span.
- Add LIFETIME_BOUND for UnencodableReplacementArray reference argument.
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::urlEscapedEntityCallback):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::encodeComplexWindowsLatin1):
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::encodeComplexUserDefined):
- Update to use std::span&lt;char&gt; returned from
  TextCodec::getUnencodableReplacement().

Canonical link: <a href="https://commits.webkit.org/285580@main">https://commits.webkit.org/285580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8abb26a69b36468987143db4f78fb1f76ceb1e80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57450 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62902 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37866 "Found 1 new API test failure: /WPE/TestAuthentication:/webkit/Authentication/authentication-empty-realm (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78967 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14 "Found 1 new test failure: http/tests/paymentrequest/payment-response-payerName-attribute.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65881 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65158 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7152 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3104 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->