### PR TITLE
Convert enum to an enum class in HTMLCollection

### DIFF
--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -49,7 +49,7 @@ inline auto HTMLCollection::rootTypeFromCollectionType(CollectionType type) -> R
     case CollectionType::DocumentNamedItems:
     case CollectionType::DocumentAllNamedItems:
     case CollectionType::FormControls:
-        return HTMLCollection::IsRootedAtTreeScope;
+        return HTMLCollection::RootType::AtTreeScope;
     case CollectionType::AllDescendants:
     case CollectionType::ByClass:
     case CollectionType::ByTag:
@@ -64,10 +64,10 @@ inline auto HTMLCollection::rootTypeFromCollectionType(CollectionType type) -> R
     case CollectionType::SelectedOptions:
     case CollectionType::DataListOptions:
     case CollectionType::MapAreas:
-        return HTMLCollection::IsRootedAtNode;
+        return HTMLCollection::RootType::AtNode;
     }
     ASSERT_NOT_REACHED();
-    return HTMLCollection::IsRootedAtNode;
+    return HTMLCollection::RootType::AtNode;
 }
 
 static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(CollectionType type)
@@ -115,7 +115,7 @@ static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(Col
 HTMLCollection::HTMLCollection(ContainerNode& ownerNode, CollectionType type)
     : m_collectionType(static_cast<unsigned>(type))
     , m_invalidationType(static_cast<unsigned>(invalidationTypeExcludingIdAndNameAttributes(type)))
-    , m_rootType(rootTypeFromCollectionType(type))
+    , m_rootType(static_cast<unsigned>(rootTypeFromCollectionType(type)))
     , m_ownerNode(ownerNode)
 {
     ASSERT(m_rootType == static_cast<unsigned>(rootTypeFromCollectionType(type)));

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -101,7 +101,7 @@ protected:
 
     void invalidateNamedElementCache(Document&) const;
 
-    enum RootType { IsRootedAtNode, IsRootedAtTreeScope };
+    enum class RootType : bool { AtNode, AtTreeScope };
     static RootType rootTypeFromCollectionType(CollectionType);
 
     mutable Lock m_namedElementCacheAssignmentLock;

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -82,7 +82,7 @@ inline void CollectionNamedElementCache::append(StringToElementsMap& map, const 
 
 inline bool HTMLCollection::isRootedAtTreeScope() const
 {
-    return m_rootType == IsRootedAtTreeScope;
+    return static_cast<bool>(m_rootType) == static_cast<bool>(RootType::AtTreeScope);
 }
 
 inline NodeListInvalidationType HTMLCollection::invalidationType() const


### PR DESCRIPTION
#### fe507fa760b183f4595930c2176177d19ab00f4c
<pre>
Convert enum to an enum class in HTMLCollection
<a href="https://bugs.webkit.org/show_bug.cgi?id=281897">https://bugs.webkit.org/show_bug.cgi?id=281897</a>

Reviewed by Ryosuke Niwa.

Convert enum to an enum class in HTMLCollection

* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::rootTypeFromCollectionType):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::isRootedAtTreeScope const):

Canonical link: <a href="https://commits.webkit.org/285979@main">https://commits.webkit.org/285979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/160d8278a60fe773e2341f3b44457097af7b0ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58118 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7775 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3912 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->