### PR TITLE
[TextureMapper] Convert class-level WEBCORE_EXPORT to method-level

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -38,13 +38,13 @@ class GLFence;
 
 class TextureMapperGCGLPlatformLayer;
 
-class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GLContextWrapper, public GraphicsContextGLANGLE {
+class GraphicsContextGLTextureMapperANGLE : public GLContextWrapper, public GraphicsContextGLANGLE {
 public:
-    static RefPtr<GraphicsContextGLTextureMapperANGLE> create(WebCore::GraphicsContextGLAttributes&&);
+    WEBCORE_EXPORT static RefPtr<GraphicsContextGLTextureMapperANGLE> create(WebCore::GraphicsContextGLAttributes&&);
     virtual ~GraphicsContextGLTextureMapperANGLE();
 
     // GraphicsContextGLANGLE overrides.
-    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final;
+    WEBCORE_EXPORT RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final;
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, bool premultiplyAlpha, bool flipY) final;
 #endif

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -47,12 +47,12 @@ public:
     virtual void recordDamage(const FloatRect&) = 0;
 };
 
-class WEBCORE_EXPORT TextureMapperLayer : public CanMakeWeakPtr<TextureMapperLayer> {
+class TextureMapperLayer : public CanMakeWeakPtr<TextureMapperLayer> {
     WTF_MAKE_TZONE_ALLOCATED(TextureMapperLayer);
     WTF_MAKE_NONCOPYABLE(TextureMapperLayer);
 public:
-    TextureMapperLayer(Damage::ShouldPropagate = Damage::ShouldPropagate::No);
-    virtual ~TextureMapperLayer();
+    WEBCORE_EXPORT TextureMapperLayer(Damage::ShouldPropagate = Damage::ShouldPropagate::No);
+    WEBCORE_EXPORT virtual ~TextureMapperLayer();
 
 #if USE(COORDINATED_GRAPHICS)
     void setID(uint32_t id) { m_id = id; }
@@ -61,37 +61,37 @@ public:
 
     const Vector<TextureMapperLayer*>& children() const { return m_children; }
 
-    void setChildren(const Vector<TextureMapperLayer*>&);
-    void setMaskLayer(TextureMapperLayer*);
-    void setReplicaLayer(TextureMapperLayer*);
-    void setBackdropLayer(TextureMapperLayer*);
-    void setBackdropFiltersRect(const FloatRoundedRect&);
-    void setPosition(const FloatPoint&);
-    void setBoundsOrigin(const FloatPoint&);
-    void setSize(const FloatSize&);
-    void setAnchorPoint(const FloatPoint3D&);
-    void setPreserves3D(bool);
-    void setTransform(const TransformationMatrix&);
-    void setChildrenTransform(const TransformationMatrix&);
-    void setContentsRect(const FloatRect&);
-    void setMasksToBounds(bool);
-    void setDrawsContent(bool);
+    WEBCORE_EXPORT void setChildren(const Vector<TextureMapperLayer*>&);
+    WEBCORE_EXPORT void setMaskLayer(TextureMapperLayer*);
+    WEBCORE_EXPORT void setReplicaLayer(TextureMapperLayer*);
+    WEBCORE_EXPORT void setBackdropLayer(TextureMapperLayer*);
+    WEBCORE_EXPORT void setBackdropFiltersRect(const FloatRoundedRect&);
+    WEBCORE_EXPORT void setPosition(const FloatPoint&);
+    WEBCORE_EXPORT void setBoundsOrigin(const FloatPoint&);
+    WEBCORE_EXPORT void setSize(const FloatSize&);
+    WEBCORE_EXPORT void setAnchorPoint(const FloatPoint3D&);
+    WEBCORE_EXPORT void setPreserves3D(bool);
+    WEBCORE_EXPORT void setTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT void setChildrenTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT void setContentsRect(const FloatRect&);
+    WEBCORE_EXPORT void setMasksToBounds(bool);
+    WEBCORE_EXPORT void setDrawsContent(bool);
     bool drawsContent() const { return m_state.drawsContent; }
     bool contentsAreVisible() const { return m_state.contentsVisible; }
     FloatSize size() const { return m_state.size; }
     float opacity() const { return m_state.opacity; }
     TransformationMatrix transform() const { return m_state.transform; }
-    void setContentsVisible(bool);
-    void setContentsOpaque(bool);
-    void setBackfaceVisibility(bool);
-    void setOpacity(float);
-    void setSolidColor(const Color&);
-    void setBackgroundColor(const Color&);
-    void setContentsTileSize(const FloatSize&);
-    void setContentsTilePhase(const FloatSize&);
-    void setContentsClippingRect(const FloatRoundedRect&);
-    void setContentsRectClipsDescendants(bool);
-    void setFilters(const FilterOperations&);
+    WEBCORE_EXPORT void setContentsVisible(bool);
+    WEBCORE_EXPORT void setContentsOpaque(bool);
+    WEBCORE_EXPORT void setBackfaceVisibility(bool);
+    WEBCORE_EXPORT void setOpacity(float);
+    WEBCORE_EXPORT void setSolidColor(const Color&);
+    WEBCORE_EXPORT void setBackgroundColor(const Color&);
+    WEBCORE_EXPORT void setContentsTileSize(const FloatSize&);
+    WEBCORE_EXPORT void setContentsTilePhase(const FloatSize&);
+    WEBCORE_EXPORT void setContentsClippingRect(const FloatRoundedRect&);
+    WEBCORE_EXPORT void setContentsRectClipsDescendants(bool);
+    WEBCORE_EXPORT void setFilters(const FilterOperations&);
 
     bool hasFilters() const
     {
@@ -105,18 +105,18 @@ public:
     void setShowRepaintCounter(bool showRepaintCounter) { m_state.showRepaintCounter = showRepaintCounter; }
     void setRepaintCount(int repaintCount) { m_state.repaintCount = repaintCount; }
 
-    void setContentsLayer(TextureMapperPlatformLayer*);
+    WEBCORE_EXPORT void setContentsLayer(TextureMapperPlatformLayer*);
     void setAnimations(const TextureMapperAnimations&);
-    void setBackingStore(TextureMapperBackingStore*);
+    WEBCORE_EXPORT void setBackingStore(TextureMapperBackingStore*);
 #if USE(COORDINATED_GRAPHICS)
     void setAnimatedBackingStoreClient(CoordinatedAnimatedBackingStoreClient*);
 #endif
 
-    bool applyAnimationsRecursively(MonotonicTime);
+    WEBCORE_EXPORT bool applyAnimationsRecursively(MonotonicTime);
     bool syncAnimations(MonotonicTime);
-    bool descendantsOrSelfHaveRunningAnimations() const;
+    WEBCORE_EXPORT bool descendantsOrSelfHaveRunningAnimations() const;
 
-    void paint(TextureMapper&);
+    WEBCORE_EXPORT void paint(TextureMapper&);
 
     void addChild(TextureMapperLayer*);
 


### PR DESCRIPTION
#### f0294b5a9c38cb842b44bee7840b65db358dea13
<pre>
[TextureMapper] Convert class-level WEBCORE_EXPORT to method-level
<a href="https://bugs.webkit.org/show_bug.cgi?id=281899">https://bugs.webkit.org/show_bug.cgi?id=281899</a>

Reviewed by Carlos Garcia Campos.

check-webkit-style complains inline functions in class-level
WEBCORE_EXPORT. And, WebKit prefers method-level WEBCORE_EXPORT.

* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:

Canonical link: <a href="https://commits.webkit.org/285551@main">https://commits.webkit.org/285551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac941d0351b3a3b2a4d4ceaea1e7f0b595b1bab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60271 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15890 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22604 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78914 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65125 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7113 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11236 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->