### PR TITLE
[Unified PDF] Using down arrow to scroll after zooming in when in discrete single page mode moves to next page

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -112,8 +112,6 @@ bool PDFDiscretePresentationController::handleKeyboardEvent(const WebKeyboardEve
     if (handleKeyboardCommand(event))
         return true;
 
-    // FIXME: <https://webkit.org/b/276981> Need to check for scrollability first.
-
     if (handleKeyboardEventForPageNavigation(event))
         return true;
 #endif
@@ -129,28 +127,10 @@ bool PDFDiscretePresentationController::handleKeyboardCommand(const WebKeyboardE
 
 bool PDFDiscretePresentationController::handleKeyboardEventForPageNavigation(const WebKeyboardEvent& event)
 {
-//    if (m_isScrollingWithAnimationToPageExtent)
-//        return false;
-
     if (event.type() == WebEventType::KeyUp)
         return false;
 
     auto key = event.key();
-    if (key == "ArrowLeft"_s || key == "ArrowUp"_s || key == "PageUp"_s) {
-        if (!canGoToPreviousRow())
-            return false;
-
-        goToPreviousRow(Animated::No);
-        return true;
-    }
-
-    if (key == "ArrowRight"_s || key == "ArrowDown"_s || key == "PageDown"_s) {
-        if (!canGoToNextRow())
-            return false;
-
-        goToNextRow(Animated::No);
-        return true;
-    }
 
     if (key == "Home"_s) {
         if (!m_visibleRowIndex)
@@ -166,6 +146,39 @@ bool PDFDiscretePresentationController::handleKeyboardEventForPageNavigation(con
             return false;
 
         goToRowIndex(lastRowIndex, Animated::No);
+        return true;
+    }
+
+    auto maximumScrollPosition = m_plugin->maximumScrollPosition();
+
+    bool isHorizontallyScrollable = !!maximumScrollPosition.x();
+    bool isVerticallyScrollable = !!maximumScrollPosition.y();
+
+    if (key == "ArrowLeft"_s || key == "ArrowUp"_s || key == "PageUp"_s) {
+        if (key == "ArrowLeft"_s) {
+            if (isHorizontallyScrollable)
+                return false;
+        } else if (isVerticallyScrollable)
+            return false;
+
+        if (!canGoToPreviousRow())
+            return false;
+
+        goToPreviousRow(Animated::No);
+        return true;
+    }
+
+    if (key == "ArrowRight"_s || key == "ArrowDown"_s || key == "PageDown"_s) {
+        if (key == "ArrowRight"_s) {
+            if (isHorizontallyScrollable)
+                return false;
+        } else if (isVerticallyScrollable)
+            return false;
+
+        if (!canGoToNextRow())
+            return false;
+
+        goToNextRow(Animated::No);
         return true;
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -49,7 +49,6 @@ class TextStream;
 
 namespace WebCore {
 class FrameView;
-class KeyboardScrollingAnimator;
 class PageOverlay;
 class PlatformWheelEvent;
 
@@ -321,8 +320,6 @@ private:
     void selectAll();
     [[maybe_unused]] bool performCopyEditingOperation() const;
     void performCopyLinkOperation(const WebCore::IntPoint& contextMenuEventRootViewPoint) const;
-
-    void animatedScrollDidEnd() final;
 
     void setDisplayMode(PDFDocumentLayout::DisplayMode);
     void setDisplayModeAndUpdateLayout(PDFDocumentLayout::DisplayMode);
@@ -624,11 +621,6 @@ private:
 
     RefPtr<PDFPluginPasswordField> m_passwordField;
     RefPtr<PDFPluginPasswordForm> m_passwordForm;
-
-#if PLATFORM(MAC)
-    bool m_isScrollingWithAnimationToPageExtent { false };
-    std::optional<WebCore::ScrollDirection> m_animatedKeyboardScrollingDirection;
-#endif
 
     PDFPageCoverage m_findMatchRects;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2021,14 +2021,6 @@ bool UnifiedPDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
 #endif // ENABLE(CONTEXT_MENUS)
 }
 
-void UnifiedPDFPlugin::animatedScrollDidEnd()
-{
-#if PLATFORM(MAC)
-    m_isScrollingWithAnimationToPageExtent = false;
-    m_animatedKeyboardScrollingDirection = std::nullopt;
-#endif
-}
-
 bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent& event)
 {
     return m_presentationController->handleKeyboardEvent(event);


### PR DESCRIPTION
#### 511fa1c3b375af8a5eac34f1d336fe16283bd2f6
<pre>
[Unified PDF] Using down arrow to scroll after zooming in when in discrete single page mode moves to next page
<a href="https://bugs.webkit.org/show_bug.cgi?id=281900">https://bugs.webkit.org/show_bug.cgi?id=281900</a>
<a href="https://rdar.apple.com/137608233">rdar://137608233</a>

Reviewed by Abrar Rahman Protyasha.

Currently, using the arrow keys while in discrete single page mode always
attempts to change the current page. Prior to Unified PDF, using arrow keys
when the page is scrollable (zoomed in) would not change the page, and would
instead scroll around the current page.

This patch restores the pre-Unified PDF behavior, using a non-zero
`maximumScrollPosition` as a proxy to detect scrollability. Additionally
horizontal and vertical scrollability are considered separately, matching the
old behavior.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::handleKeyboardEvent):
(WebKit::PDFDiscretePresentationController::handleKeyboardEventForPageNavigation):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:

Remove dead code.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::animatedScrollDidEnd): Deleted.

Canonical link: <a href="https://commits.webkit.org/285576@main">https://commits.webkit.org/285576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4b4e3b674a082d0ffdf032608bbe6b0a11cd5fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24278 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60274 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57408 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15894 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44059 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78917 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65850 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65127 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7114 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11259 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3056 "Built successfully") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->