### PR TITLE
[scroll-animations] setting `scroll-timeline-name` or `view-timeline-name` to an empty string should disassociate that timeline from any associated animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -7,10 +7,10 @@ PASS Changing computed value of animation-timeline changes effective timeline [i
 PASS Changing computed value of animation-timeline changes effective timeline [scroll]
 FAIL Changing to/from animation-timeline:none [immediate] assert_equals: expected "0px" but got "100px"
 FAIL Changing to/from animation-timeline:none [scroll] assert_equals: expected "0px" but got "100px"
-FAIL Reverse animation direction [immediate] assert_equals: expected "0px" but got "190px"
-FAIL Reverse animation direction [scroll] assert_equals: expected "0px" but got "190px"
-FAIL Change to timeline attachment while paused [immediate] assert_equals: expected "0px" but got "100px"
-FAIL Change to timeline attachment while paused [scroll] assert_equals: expected "0px" but got "100px"
+FAIL Reverse animation direction [immediate] assert_equals: expected "0px" but got "180px"
+FAIL Reverse animation direction [scroll] assert_equals: expected "0px" but got "180px"
+FAIL Change to timeline attachment while paused [immediate] assert_equals: expected "0px" but got "120px"
+FAIL Change to timeline attachment while paused [scroll] assert_equals: expected "0px" but got "120px"
 FAIL Switching timelines and pausing at the same time [immediate] assert_equals: expected "100px" but got "120px"
 FAIL Switching timelines and pausing at the same time [scroll] assert_equals: expected "100px" but got "120px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -3,7 +3,7 @@ FAIL Descendant can attach to deferred timeline promise_test: Unhandled rejectio
 PASS Deferred timeline with no attachments
 FAIL Inner timeline does not interfere with outer timeline assert_equals: expected "100px" but got "0px"
 PASS Deferred timeline with two attachments
-FAIL Dynamically re-attaching assert_equals: expected "50px" but got "100px"
+PASS Dynamically re-attaching
 FAIL Dynamically detaching assert_equals: expected "0px" but got "50px"
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
 PASS Ancestor attached element becoming display:none/block

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -34,6 +34,7 @@
 #include "Element.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderView.h"
+#include "WebAnimation.h"
 
 namespace WebCore {
 
@@ -230,6 +231,17 @@ std::optional<WebAnimationTime> ScrollTimeline::currentTime(const TimelineRange&
     auto distance = data.scrollOffset - data.rangeStart;
     auto progress = distance / range;
     return WebAnimationTime::fromPercentage(progress * 100);
+}
+
+void ScrollTimeline::wasUnregisteredFromStyle()
+{
+    // We make sure to copy m_animations here since its content will change
+    // as we set the timeline of each animations in it to null.
+    auto animations = m_animations;
+    for (auto& animation : animations) {
+        ASSERT(animation->timeline() == this);
+        animation->setTimeline(nullptr);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -67,6 +67,8 @@ public:
     std::optional<WebAnimationTime> currentTime(const TimelineRange&) override;
     TimelineRange defaultRange() const override;
 
+    void wasUnregisteredFromStyle();
+
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 


### PR DESCRIPTION
#### 477592b77ab03934d094d1e48093e42cabfa68b2
<pre>
[scroll-animations] setting `scroll-timeline-name` or `view-timeline-name` to an empty string should disassociate that timeline from any associated animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=281904">https://bugs.webkit.org/show_bug.cgi?id=281904</a>
<a href="https://rdar.apple.com/138399254">rdar://138399254</a>

Reviewed by NOBODY (OOPS!).

Ensure that unregistering a named scroll or view timeline also removes the
association it has with any animation.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::unregisterNamedScrollTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedViewTimelineForSubject):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::wasUnregisteredFromStyle):
* Source/WebCore/animation/ScrollTimeline.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/477592b77ab03934d094d1e48093e42cabfa68b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77270 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60289 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57425 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47435 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62878 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78934 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65862 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65139 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7128 "Passed tests") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3071 "Built successfully") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->