### PR TITLE
[GTK][WPE][Skia] Fix assertion when drawing filters with a zero sourceImage in DisplayList mode

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -53,14 +53,15 @@ bool isValid(const Item& item)
 template<class T>
 inline static std::optional<RenderingResourceIdentifier> applyFilteredImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
 {
-    RELEASE_ASSERT(item.sourceImageIdentifier().has_value());
-    auto resourceIdentifier = item.sourceImageIdentifier().value();
-    if (auto* sourceImage = resourceHeap.getImageBuffer(resourceIdentifier)) {
-        FilterResults results;
-        item.apply(context, sourceImage, results);
-        return std::nullopt;
+    ImageBuffer* sourceImage = nullptr;
+    if (auto resourceIdentifier = item.sourceImageIdentifier(); resourceIdentifier.has_value()) {
+        if (sourceImage = resourceHeap.getImageBuffer(resourceIdentifier.value()); !sourceImage)
+            return resourceIdentifier;
     }
-    return resourceIdentifier;
+
+    FilterResults results;
+    item.apply(context, sourceImage, results);
+    return std::nullopt;
 }
 
 template<class T>


### PR DESCRIPTION
#### 21ef355cc6710679bcfd835a458b4e7d1cdb935e
<pre>
[GTK][WPE][Skia] Fix assertion when drawing filters with a zero sourceImage in DisplayList mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=281909">https://bugs.webkit.org/show_bug.cgi?id=281909</a>

Reviewed by Alejandro G. Castro.

applyFilteredImageBufferItem() contains a wrong assertion that a
sourceImageIdentifier must always be present -- however there are
legitimate use-cases in SVG when a sourceImage is a nullptr - handle that.

Covered by existings tests, when using multi-threaded CPU rendering.

* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyFilteredImageBufferItem):

Canonical link: <a href="https://commits.webkit.org/285619@main">https://commits.webkit.org/285619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/208769295e7c6d63b232bea006644e255a315352

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78964 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/512 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Running compile-webkit; Running compile-webkit-without-change") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65996 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16136 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7149 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3101 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->