### PR TITLE
[scroll-animations] Refactor animationRange to be on Animation instead of StyleRareNonInheritedData

### DIFF
--- a/Source/WebCore/animation/TimelineRange.h
+++ b/Source/WebCore/animation/TimelineRange.h
@@ -64,6 +64,8 @@ struct TimelineRange {
     SingleTimelineRange start;
     SingleTimelineRange end;
 
+    bool operator==(const TimelineRange& other) const = default;
+
     static TimelineRange defaultForScrollTimeline();
     static TimelineRange defaultForViewTimeline();
     bool isDefault() const { return start.name == SingleTimelineRange::Name::Normal && end.name == SingleTimelineRange::Name::Normal; }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1560,11 +1560,13 @@
             }
         },
         "animation-range": {
+            "animatable": true,
             "codegen-properties": {
                 "longhands": [
                     "animation-range-start",
                     "animation-range-end"
                 ],
+                "separator": ",",
                 "settings-flag": "scrollDrivenAnimationsEnabled"
             },
             "specification": {
@@ -1573,8 +1575,10 @@
             }
         },
         "animation-range-start": {
+            "animatable": true,
             "codegen-properties": {
-                "converter": "AnimationRangeStart",
+                "separator": ",",
+                "name-for-methods": "RangeStart",
                 "parser-function": "consumeAnimationRangeStart",
                 "parser-grammar-unused": "[ normal | <length-percentage> | [ <custom-ident> || <length-percentage>?] ]#",
                 "parser-grammar-unused-reason": "Needs support for '||' groups.",
@@ -1586,8 +1590,10 @@
             }
         },
         "animation-range-end": {
+            "animatable": true,
             "codegen-properties": {
-                "converter": "AnimationRangeEnd",
+                "separator": ",",
+                "name-for-methods": "RangeEnd",
                 "parser-function": "consumeAnimationRangeEnd",
                 "parser-grammar-unused": "[ normal | <length-percentage> | [ <custom-ident> || <length-percentage>? ] ]#",
                 "parser-grammar-unused-reason": "Needs support for '||' groups.",

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -496,6 +496,20 @@ void CSSToStyleMap::mapAnimationAllowsDiscreteTransitions(Animation& layer, cons
         layer.setAllowsDiscreteTransitions(value.valueID() == CSSValueAllowDiscrete);
 }
 
+void CSSToStyleMap::mapAnimationRangeStart(Animation& animation, const CSSValue& value) const
+{
+    if (treatAsInitialValue(value, CSSPropertyAnimationRangeStart))
+        animation.setRangeStart(Animation::initialRangeStart());
+    animation.setRangeStart(SingleTimelineRange::range(value, SingleTimelineRange::Type::Start, &m_builderState));
+}
+
+void CSSToStyleMap::mapAnimationRangeEnd(Animation& animation, const CSSValue& value) const
+{
+    if (treatAsInitialValue(value, CSSPropertyAnimationRangeEnd))
+        animation.setRangeEnd(Animation::initialRangeEnd());
+    animation.setRangeEnd(SingleTimelineRange::range(value, SingleTimelineRange::Type::End, &m_builderState));
+}
+
 void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& image) const
 {
     // If we're not a value list, then we are "none" and don't need to alter the empty image at all.

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -72,6 +72,8 @@ public:
     void mapAnimationTimingFunction(Animation&, const CSSValue&) const;
     static void mapAnimationCompositeOperation(Animation&, const CSSValue&);
     static void mapAnimationAllowsDiscreteTransitions(Animation&, const CSSValue&);
+    void mapAnimationRangeStart(Animation&, const CSSValue&) const;
+    void mapAnimationRangeEnd(Animation&, const CSSValue&) const;
 
     void mapNinePieceImage(const CSSValue*, NinePieceImage&) const;
     void mapNinePieceImageSlice(const CSSValue&, NinePieceImage&) const;

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -36,6 +36,7 @@ Animation::Animation()
     , m_duration(initialDuration())
     , m_timeline(initialTimeline())
     , m_timingFunction(initialTimingFunction())
+    , m_range(initialRange())
     , m_direction(static_cast<unsigned>(initialDirection()))
     , m_fillMode(static_cast<unsigned>(initialFillMode()))
     , m_playState(static_cast<unsigned>(initialPlayState()))
@@ -53,6 +54,8 @@ Animation::Animation()
     , m_timingFunctionSet(false)
     , m_compositeOperationSet(false)
     , m_allowsDiscreteTransitionsSet(false)
+    , m_rangeStartSet(false)
+    , m_rangeEndSet(false)
     , m_isNone(false)
     , m_delayFilled(false)
     , m_directionFilled(false)
@@ -65,6 +68,8 @@ Animation::Animation()
     , m_timingFunctionFilled(false)
     , m_compositeOperationFilled(false)
     , m_allowsDiscreteTransitionsFilled(false)
+    , m_rangeStartFilled(false)
+    , m_rangeEndFilled(false)
 {
 }
 
@@ -77,6 +82,7 @@ Animation::Animation(const Animation& o)
     , m_duration(o.m_duration)
     , m_timeline(o.m_timeline)
     , m_timingFunction(o.m_timingFunction)
+    , m_range(o.m_range)
     , m_direction(o.m_direction)
     , m_fillMode(o.m_fillMode)
     , m_playState(o.m_playState)
@@ -94,6 +100,8 @@ Animation::Animation(const Animation& o)
     , m_timingFunctionSet(o.m_timingFunctionSet)
     , m_compositeOperationSet(o.m_compositeOperationSet)
     , m_allowsDiscreteTransitionsSet(o.m_allowsDiscreteTransitionsSet)
+    , m_rangeStartSet(o.m_rangeStartSet)
+    , m_rangeEndSet(o.m_rangeEndSet)
     , m_isNone(o.m_isNone)
     , m_delayFilled(o.m_delayFilled)
     , m_directionFilled(o.m_directionFilled)
@@ -106,6 +114,8 @@ Animation::Animation(const Animation& o)
     , m_timingFunctionFilled(o.m_timingFunctionFilled)
     , m_compositeOperationFilled(o.m_compositeOperationFilled)
     , m_allowsDiscreteTransitionsFilled(o.m_allowsDiscreteTransitionsFilled)
+    , m_rangeStartFilled(o.m_rangeStartFilled)
+    , m_rangeEndFilled(o.m_rangeEndFilled)
 {
 }
 
@@ -125,6 +135,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && *(m_timingFunction.get()) == *(other.m_timingFunction.get())
         && m_direction == other.m_direction
         && m_fillMode == other.m_fillMode
+        && m_range == other.m_range
         && m_delaySet == other.m_delaySet
         && m_directionSet == other.m_directionSet
         && m_durationSet == other.m_durationSet
@@ -135,6 +146,8 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_timingFunctionSet == other.m_timingFunctionSet
         && m_compositeOperationSet == other.m_compositeOperationSet
         && m_allowsDiscreteTransitionsSet == other.m_allowsDiscreteTransitionsSet
+        && m_rangeStartSet == other.m_rangeStartSet
+        && m_rangeEndSet == other.m_rangeEndSet
         && m_isNone == other.m_isNone;
 
     if (!result)

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -53,6 +53,8 @@ public:
     bool isTimingFunctionSet() const { return m_timingFunctionSet; }
     bool isCompositeOperationSet() const { return m_compositeOperationSet; }
     bool isAllowsDiscreteTransitionsSet() const { return m_allowsDiscreteTransitionsSet; }
+    bool isRangeStartSet() const { return m_rangeStartSet; }
+    bool isRangeEndSet() const { return m_rangeEndSet; }
 
     // Flags this to be the special "none" animation (animation-name: none)
     bool isNoneAnimation() const { return m_isNone; }
@@ -67,7 +69,8 @@ public:
             && !m_nameSet && !m_playStateSet && !m_iterationCountSet
             && !m_delaySet && !m_timingFunctionSet && !m_propertySet
             && !m_isNone && !m_compositeOperationSet && !m_timelineSet
-            && !m_allowsDiscreteTransitionsSet;
+            && !m_allowsDiscreteTransitionsSet && !m_rangeStartSet
+            && !m_rangeEndSet;
     }
 
     bool isEmptyOrZeroDuration() const
@@ -87,6 +90,8 @@ public:
     void clearTimingFunction() { m_timingFunctionSet = false; m_timingFunctionFilled = false; }
     void clearCompositeOperation() { m_compositeOperationSet = false; m_compositeOperationFilled = false; }
     void clearAllowsDiscreteTransitions() { m_allowsDiscreteTransitionsSet = false; m_allowsDiscreteTransitionsFilled = false; }
+    void clearRangeStart() { m_rangeStartSet = false; m_rangeStartFilled = false; }
+    void clearRangeEnd() { m_rangeEndSet = false; m_rangeEndFilled = false; }
 
     void clearAll()
     {
@@ -102,6 +107,8 @@ public:
         clearTimingFunction();
         clearCompositeOperation();
         clearAllowsDiscreteTransitions();
+        clearRangeStart();
+        clearRangeEnd();
     }
 
     double delay() const { return m_delay; }
@@ -145,6 +152,9 @@ public:
     const Timeline& timeline() const { return m_timeline; }
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
     TimingFunction* defaultTimingFunctionForKeyframes() const { return m_defaultTimingFunctionForKeyframes.get(); }
+    const SingleTimelineRange rangeStart() const { return m_range.start; }
+    const SingleTimelineRange rangeEnd() const { return m_range.end; }
+    const TimelineRange range() const { return m_range; }
 
     void setDelay(double c) { m_delay = c; m_delaySet = true; }
     void setDirection(Direction d) { m_direction = static_cast<unsigned>(d); m_directionSet = true; }
@@ -162,6 +172,9 @@ public:
     void setTimeline(Timeline timeline) { m_timeline = timeline; m_timelineSet = true; }
     void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_timingFunctionSet = true; }
     void setDefaultTimingFunctionForKeyframes(RefPtr<TimingFunction>&& function) { m_defaultTimingFunctionForKeyframes = WTFMove(function); }
+    void setRangeStart(SingleTimelineRange range) { m_range.start = range; m_rangeStartSet = true; }
+    void setRangeEnd(SingleTimelineRange range) { m_range.end = range; m_rangeEndSet = true; }
+    void setRange(TimelineRange range) { setRangeStart(range.start); setRangeEnd(range.end); }
 
     void setIsNoneAnimation(bool n) { m_isNone = n; }
 
@@ -176,6 +189,8 @@ public:
     void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_timingFunctionFilled = true; }
     void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_compositeOperationFilled = true; }
     void fillAllowsDiscreteTransitions(bool allowsDiscreteTransitionsFilled) { setAllowsDiscreteTransitions(allowsDiscreteTransitionsFilled); m_allowsDiscreteTransitionsFilled = true; }
+    void fillRangeStart(SingleTimelineRange range) { m_range.start = range; m_rangeStartFilled = true; }
+    void fillRangeEnd(SingleTimelineRange range) { m_range.end = range; m_rangeEndFilled = true; }
 
     bool isDelayFilled() const { return m_delayFilled; }
     bool isDirectionFilled() const { return m_directionFilled; }
@@ -188,6 +203,9 @@ public:
     bool isTimingFunctionFilled() const { return m_timingFunctionFilled; }
     bool isCompositeOperationFilled() const { return m_compositeOperationFilled; }
     bool isAllowsDiscreteTransitionsFilled() const { return m_allowsDiscreteTransitionsFilled; }
+    bool isRangeStartFilled() const { return m_rangeStartFilled; }
+    bool isRangeEndFilled() const { return m_rangeEndFilled; }
+    bool isRangeFilled() const { return isRangeStartFilled() || isRangeEndFilled(); }
 
     // return true if all members of this class match (excluding m_next)
     bool animationsMatch(const Animation&, bool matchProperties = true) const;
@@ -219,6 +237,7 @@ private:
     Timeline m_timeline;
     RefPtr<TimingFunction> m_timingFunction;
     RefPtr<TimingFunction> m_defaultTimingFunctionForKeyframes;
+    TimelineRange m_range;
 
     unsigned m_direction : 2; // Direction
     unsigned m_fillMode : 2; // AnimationFillMode
@@ -238,6 +257,8 @@ private:
     bool m_timingFunctionSet : 1;
     bool m_compositeOperationSet : 1;
     bool m_allowsDiscreteTransitionsSet : 1;
+    bool m_rangeStartSet : 1;
+    bool m_rangeEndSet : 1;
 
     bool m_isNone : 1;
 
@@ -252,6 +273,8 @@ private:
     bool m_timingFunctionFilled : 1;
     bool m_compositeOperationFilled : 1;
     bool m_allowsDiscreteTransitionsFilled : 1;
+    bool m_rangeStartFilled : 1;
+    bool m_rangeEndFilled : 1;
 
 public:
     static double initialDelay() { return 0; }
@@ -266,6 +289,9 @@ public:
     static Timeline initialTimeline() { return TimelineKeyword::Auto; }
     static Ref<TimingFunction> initialTimingFunction() { return CubicBezierTimingFunction::create(); }
     static bool initialAllowsDiscreteTransitions() { return false; }
+    static TimelineRange initialRange() { return { }; }
+    static SingleTimelineRange initialRangeStart() { return { }; }
+    static SingleTimelineRange initialRangeEnd() { return { }; }
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);

--- a/Source/WebCore/platform/animation/AnimationList.cpp
+++ b/Source/WebCore/platform/animation/AnimationList.cpp
@@ -60,6 +60,8 @@ void AnimationList::fillUnsetProperties()
     FILL_UNSET_PROPERTY(isPropertySet, property, fillProperty);
     FILL_UNSET_PROPERTY(isCompositeOperationSet, compositeOperation, fillCompositeOperation);
     FILL_UNSET_PROPERTY(isAllowsDiscreteTransitionsSet, allowsDiscreteTransitions, fillAllowsDiscreteTransitions);
+    FILL_UNSET_PROPERTY(isRangeStartSet, rangeStart, fillRangeStart);
+    FILL_UNSET_PROPERTY(isRangeEndSet, rangeEnd, fillRangeEnd);
 }
 
 bool AnimationList::operator==(const AnimationList& other) const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -990,14 +990,6 @@ public:
     inline const TimelineScope& timelineScope() const;
     inline void setTimelineScope(const TimelineScope&);
 
-    static inline const SingleTimelineRange initialAnimationRangeStart();
-    inline const SingleTimelineRange& animationRangeStart() const;
-    inline void setAnimationRangeStart(const SingleTimelineRange&);
-
-    static inline const SingleTimelineRange initialAnimationRangeEnd();
-    inline const SingleTimelineRange& animationRangeEnd() const;
-    inline void setAnimationRangeEnd(const SingleTimelineRange&);
-
     inline const AnimationList* animations() const;
     inline const AnimationList* transitions() const;
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -519,8 +519,6 @@ inline Vector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { r
 inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return Style::ViewTransitionName::createWithNone(); }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 inline const TimelineScope RenderStyle::initialTimelineScope() { return { }; }
-inline const SingleTimelineRange RenderStyle::initialAnimationRangeStart() { return { SingleTimelineRange::Name::Normal, Length() }; }
-inline const SingleTimelineRange RenderStyle::initialAnimationRangeEnd() { return { SingleTimelineRange::Name::Normal, Length() }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Length RenderStyle::initialLetterSpacing() { return zeroLength(); }
@@ -682,8 +680,6 @@ inline const Vector<ScrollAxis>& RenderStyle::viewTimelineAxes() const { return 
 inline const Vector<ViewTimelineInsets>& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
 inline const Vector<AtomString>& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
 inline const TimelineScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
-inline const SingleTimelineRange& RenderStyle::animationRangeStart() const { return m_nonInheritedData->rareData->animationRangeStart; }
-inline const SingleTimelineRange& RenderStyle::animationRangeEnd() const { return m_nonInheritedData->rareData->animationRangeEnd; }
 inline std::optional<ScrollbarColor> RenderStyle::scrollbarColor() const { return m_rareInheritedData->scrollbarColor.asOptional(); }
 inline const StyleColor& RenderStyle::scrollbarThumbColor() const { return m_rareInheritedData->scrollbarColor->thumbColor; }
 inline const StyleColor& RenderStyle::scrollbarTrackColor() const { return m_rareInheritedData->scrollbarColor->trackColor; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -281,8 +281,6 @@ inline void RenderStyle::setViewTimelineAxes(const Vector<ScrollAxis>& axes) { S
 inline void RenderStyle::setViewTimelineInsets(const Vector<ViewTimelineInsets>& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, insets); }
 inline void RenderStyle::setViewTimelineNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, names); }
 inline void RenderStyle::setTimelineScope(const TimelineScope& scope) { SET_NESTED(m_nonInheritedData, rareData, timelineScope, scope); }
-inline void RenderStyle::setAnimationRangeStart(const SingleTimelineRange& range) { SET_NESTED(m_nonInheritedData, rareData, animationRangeStart, range); }
-inline void RenderStyle::setAnimationRangeEnd(const SingleTimelineRange& range) { SET_NESTED(m_nonInheritedData, rareData, animationRangeEnd, range); }
 inline void RenderStyle::setScrollbarColor(const std::optional<ScrollbarColor>& color) { SET(m_rareInheritedData, scrollbarColor, color); }
 inline void RenderStyle::setScrollbarThumbColor(const StyleColor& color) { m_rareInheritedData.access().scrollbarColor->thumbColor = color; }
 inline void RenderStyle::setScrollbarTrackColor(const StyleColor& color) { m_rareInheritedData.access().scrollbarColor->trackColor = color; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -93,8 +93,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // viewTimelineInsets
     // viewTimelineNames
     // timelineScope
-    // animationRangeStart
-    // animationRangeEnd
     // scrollbarGutter
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
@@ -191,8 +189,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , viewTimelineInsets(o.viewTimelineInsets)
     , viewTimelineNames(o.viewTimelineNames)
     , timelineScope(o.timelineScope)
-    , animationRangeStart(o.animationRangeStart)
-    , animationRangeEnd(o.animationRangeEnd)
     , scrollbarGutter(o.scrollbarGutter)
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
@@ -294,8 +290,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && viewTimelineInsets == o.viewTimelineInsets
         && viewTimelineNames == o.viewTimelineNames
         && timelineScope == o.timelineScope
-        && animationRangeStart == o.animationRangeStart
-        && animationRangeEnd == o.animationRangeEnd
         && scrollbarGutter == o.scrollbarGutter
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -195,9 +195,6 @@ public:
 
     TimelineScope timelineScope;
 
-    SingleTimelineRange animationRangeStart;
-    SingleTimelineRange animationRangeEnd;
-
     ScrollbarGutter scrollbarGutter;
     ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -244,9 +244,6 @@ public:
 
     static TimelineScope convertTimelineScope(const BuilderState&, const CSSValue&);
 
-    static SingleTimelineRange convertAnimationRangeStart(const BuilderState&, const CSSValue&);
-    static SingleTimelineRange convertAnimationRangeEnd(const BuilderState&, const CSSValue&);
-
 private:
     friend class BuilderCustom;
 
@@ -2213,16 +2210,6 @@ inline TimelineScope BuilderConverter::convertTimelineScope(const BuilderState&,
     return { TimelineScope::Type::Ident, WTF::map(*list, [&](auto& item) {
         return AtomString { downcast<CSSPrimitiveValue>(item).stringValue() };
     }) };
-}
-
-inline SingleTimelineRange BuilderConverter::convertAnimationRangeStart(const BuilderState& state, const CSSValue& value)
-{
-    return SingleTimelineRange::range(value, SingleTimelineRange::Type::Start, &state);
-}
-
-inline SingleTimelineRange BuilderConverter::convertAnimationRangeEnd(const BuilderState& state, const CSSValue& value)
-{
-    return SingleTimelineRange::range(value, SingleTimelineRange::Type::End, &state);
 }
 
 } // namespace Style


### PR DESCRIPTION
#### e4d5669b38e02adac432d98a962d89cc3c68da89
<pre>
[scroll-animations] Refactor animationRange to be on Animation instead of StyleRareNonInheritedData
<a href="https://bugs.webkit.org/show_bug.cgi?id=281914">https://bugs.webkit.org/show_bug.cgi?id=281914</a>
<a href="https://rdar.apple.com/138426044">rdar://138426044</a>

Reviewed by Tim Nguyen.

Refactor animationRange to be on Animation, so that we can properly handle sequnces of animationRange
in a future patch, as well as update the underlying WebAnimation via CSSAnimation::syncPropertiesWithBackingAnimation.

* Source/WebCore/animation/TimelineRange.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationRangeStart const):
(WebCore::CSSToStyleMap::mapAnimationRangeEnd const):
* Source/WebCore/css/CSSToStyleMap.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForSingleAnimationRange):
(WebCore::valueForAnimationRange):
(WebCore::addValueForAnimationPropertyToList):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isRangeStartSet const):
(WebCore::Animation::isRangeEndSet const):
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearRangeStart):
(WebCore::Animation::clearRangeEnd):
(WebCore::Animation::clearAll):
(WebCore::Animation::rangeStart const):
(WebCore::Animation::rangeEnd const):
(WebCore::Animation::range const):
(WebCore::Animation::setRangeStart):
(WebCore::Animation::setRangeEnd):
(WebCore::Animation::setRange):
(WebCore::Animation::fillRangeStart):
(WebCore::Animation::fillRangeEnd):
(WebCore::Animation::isRangeStartFilled const):
(WebCore::Animation::isRangeEndFilled const):
(WebCore::Animation::isRangeFilled const):
(WebCore::Animation::initialRange):
(WebCore::Animation::initialRangeStart):
(WebCore::Animation::initialRangeEnd):
* Source/WebCore/platform/animation/AnimationList.cpp:
(WebCore::AnimationList::fillUnsetProperties):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialTimelineScope):
(WebCore::RenderStyle::timelineScope const):
(WebCore::RenderStyle::initialAnimationRangeStart): Deleted.
(WebCore::RenderStyle::initialAnimationRangeEnd): Deleted.
(WebCore::RenderStyle::animationRangeStart const): Deleted.
(WebCore::RenderStyle::animationRangeEnd const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTimelineScope):
(WebCore::RenderStyle::setAnimationRangeStart): Deleted.
(WebCore::RenderStyle::setAnimationRangeEnd): Deleted.
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/285609@main">https://commits.webkit.org/285609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20dfd75abbf7a2feebb91447645b569940db055a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15974 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79050 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/61 "Found 1 new test failure: http/tests/ssl/applepay/ApplePayPaymentDetailsModifier.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65931 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62973 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65215 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7207 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3184 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->