### PR TITLE
Parse SVG systemLanguage property as comma separated tokens

### DIFF
--- a/Source/WebCore/svg/SVGStringList.cpp
+++ b/Source/WebCore/svg/SVGStringList.cpp
@@ -63,6 +63,38 @@ bool SVGStringList::parse(StringView data, UChar delimiter)
     });
 }
 
+bool SVGStringList::resetCommaSeparatedTokens(StringView data)
+{
+    clearItems();
+
+    return readCharactersForParsing(data, [&](auto buffer) {
+
+        auto start = buffer.position();
+        auto end = start;
+
+        while (skipOptionalSVGSpaces(buffer)) {
+            start = buffer.position();
+            end = start;
+            while (buffer.hasCharactersRemaining()) {
+                auto ch = *buffer++;
+
+                if (ch == ',') {
+                    m_items.append(String({ start, end }));
+                    end = start;
+                    break;
+                }
+
+                if (!isASCIIWhitespace(ch))
+                    end = buffer.position();
+            }
+        }
+
+        m_items.append(String({ start, end }));
+
+        return buffer.atEnd();
+    });
+}
+
 String SVGStringList::valueAsString() const
 {
     StringBuilder builder;

--- a/Source/WebCore/svg/SVGStringList.h
+++ b/Source/WebCore/svg/SVGStringList.h
@@ -51,6 +51,8 @@ public:
             m_items.append(emptyString());
     }
 
+    bool resetCommaSeparatedTokens(StringView data);
+
     bool parse(StringView, UChar delimiter);
     String valueAsString() const override;
 };

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -103,7 +103,7 @@ void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomStri
         protectedRequiredExtensions()->reset(value);
         break;
     case AttributeNames::systemLanguageAttr:
-        protectedSystemLanguage()->reset(value);
+        protectedSystemLanguage()->resetCommaSeparatedTokens(value);
         break;
     default:
         break;


### PR DESCRIPTION
#### 5ded268e016800fed4aa0548ec28d655298d1f41
<pre>
Parse SVG systemLanguage property as comma separated tokens
<a href="https://bugs.webkit.org/show_bug.cgi?id=262146">https://bugs.webkit.org/show_bug.cgi?id=262146</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/svg/SVGStringList.cpp:
(WebCore::SVGStringList::resetCommaSeparatedTokens):
* Source/WebCore/svg/SVGStringList.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::parseAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ded268e016800fed4aa0548ec28d655298d1f41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/317 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57458 "Found 2 new test failures: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15940 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76173 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47474 "Found 1 new test failure: svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37874 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44113 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20391 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65970 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20746 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78985 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/514 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29 "Found 4 new test failures: http/tests/paymentrequest/ApplePayModifier-deferredPaymentRequest.https.html http/tests/paymentrequest/ApplePayModifier-recurringPaymentRequest.https.html imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65895 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65174 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9113 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7170 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/import/types-dom-06-f-manual.svg svg/dom/svg-list-properties-parser-leading-trailing-spaces.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3122 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/414 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->