### PR TITLE
Smart pointer adoption in WebGPU/Adapter.mm etc.

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -90,6 +90,7 @@ public:
     const Vector<BindableResources>& resources() const { return m_resources; }
 
     Device& device() const { return m_device; }
+    Ref<Device> protectedDevice() const { return m_device; }
     static bool allowedUsage(const OptionSet<BindGroupEntryUsage>&);
     static NSString* usageName(const OptionSet<BindGroupEntryUsage>&);
     static uint64_t makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect);

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -94,6 +94,7 @@ public:
     State state() const { return m_state; }
 
     Device& device() const { return m_device; }
+    Ref<Device> protectedDevice() const { return m_device; }
     bool isDestroyed() const;
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     std::span<uint8_t> getBufferContents();

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -63,8 +63,9 @@ public:
     Device& device() const { return m_device; }
     void makeInvalid(NSString*);
     void makeInvalidDueToCommit(NSString*);
-    void setBufferMapCount(int);
-    int bufferMapCount() const;
+    void setBufferMapCount(int bufferMapCount) { m_bufferMapCount = bufferMapCount; }
+    int bufferMapCount() const { return m_bufferMapCount; }
+
     NSString* lastError() const;
     bool waitForCompletion();
 

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -48,7 +48,7 @@ CommandBuffer::CommandBuffer(Device& device)
 
 CommandBuffer::~CommandBuffer()
 {
-    m_device->getQueue().removeMTLCommandBuffer(m_commandBuffer);
+    m_device->protectedQueue()->removeMTLCommandBuffer(m_commandBuffer);
 }
 
 void CommandBuffer::setLabel(String&& label)
@@ -62,7 +62,7 @@ void CommandBuffer::makeInvalid(NSString* lastError)
         return;
 
     m_lastErrorString = lastError;
-    m_device->getQueue().removeMTLCommandBuffer(m_commandBuffer);
+    m_device->protectedQueue()->removeMTLCommandBuffer(m_commandBuffer);
     m_commandBuffer = nil;
 }
 
@@ -83,16 +83,6 @@ void CommandBuffer::makeInvalidDueToCommit(NSString* lastError)
 NSString* CommandBuffer::lastError() const
 {
     return m_lastErrorString;
-}
-
-void CommandBuffer::setBufferMapCount(int bufferMapCount)
-{
-    m_bufferMapCount = bufferMapCount;
-}
-
-int CommandBuffer::bufferMapCount() const
-{
-    return m_bufferMapCount;
 }
 
 bool CommandBuffer::waitForCompletion()

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -86,11 +86,13 @@ public:
     void setLabel(String&&);
 
     Device& device() const SWIFT_RETURNS_INDEPENDENT_VALUE { return m_device; }
+    Ref<Device> protectedDevice() const SWIFT_RETURNS_INDEPENDENT_VALUE { return m_device; }
 
     bool isValid() const { return m_commandBuffer; }
     void lock(bool);
-    bool isLocked() const;
-    bool isFinished() const;
+    bool isLocked() const { return m_state == EncoderState::Locked; }
+
+    bool isFinished() const { return m_state == EncoderState::Ended; }
 
     id<MTLBlitCommandEncoder> ensureBlitCommandEncoder();
     void finalizeBlitCommandEncoder();
@@ -106,7 +108,7 @@ public:
     void setLastError(NSString*);
     bool waitForCommandBufferCompletion();
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
-    bool submitWillBeInvalid() const;
+    bool submitWillBeInvalid() const { return m_makeSubmitInvalid; }
     void addBuffer(id<MTLBuffer>);
     void addTexture(const Texture&);
     id<MTLCommandBuffer> commandBuffer() const;
@@ -129,6 +131,8 @@ private:
     NSString* errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
     NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
     void discardCommandBuffer();
+
+    RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
 
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLSharedEvent> m_abortCommandBuffer { nil };

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -89,6 +89,9 @@ private:
     void executePreDispatchCommands(const Buffer* = nullptr);
     id<MTLBuffer> runPredispatchIndirectCallValidation(const Buffer&, uint64_t);
 
+    Ref<CommandEncoder> protectedParentEncoder() { return m_parentEncoder; }
+    Ref<Device> protectedDevice() const { return m_device; }
+
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 
     struct PendingTimestampWrites {

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -41,11 +41,11 @@ namespace WebGPU {
 
 #define RETURN_IF_FINISHED() \
 if (!m_parentEncoder->isLocked() || m_parentEncoder->isFinished()) { \
-    m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
+    protectedDevice()->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
     m_computeCommandEncoder = nil; \
     return; \
 } \
-if (!m_computeCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder->encoderIsCurrent(m_computeCommandEncoder)) { \
+if (!m_computeCommandEncoder || !m_parentEncoder->isValid() || !protectedParentEncoder()->encoderIsCurrent(m_computeCommandEncoder)) { \
     m_computeCommandEncoder = nil; \
     return; \
 }
@@ -57,7 +57,7 @@ ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeComma
     , m_device(device)
     , m_parentEncoder(parentEncoder)
 {
-    m_parentEncoder->lock(true);
+    protectedParentEncoder()->lock(true);
 }
 
 ComputePassEncoder::ComputePassEncoder(CommandEncoder& parentEncoder, Device& device, NSString* errorString)
@@ -65,13 +65,13 @@ ComputePassEncoder::ComputePassEncoder(CommandEncoder& parentEncoder, Device& de
     , m_parentEncoder(parentEncoder)
     , m_lastErrorString(errorString)
 {
-    m_parentEncoder->lock(true);
+    protectedParentEncoder()->lock(true);
 }
 
 ComputePassEncoder::~ComputePassEncoder()
 {
     if (m_computeCommandEncoder)
-        m_parentEncoder->makeInvalid(@"GPUComputePassEncoder.finish was never called");
+        protectedParentEncoder()->makeInvalid(@"GPUComputePassEncoder.finish was never called");
     m_computeCommandEncoder = nil;
 }
 
@@ -159,22 +159,23 @@ static bool addResourceToActiveResources(const BindGroupEntryUsageData::Resource
 
 void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer)
 {
-    if (!m_pipeline) {
+    auto pipeline = m_pipeline;
+    if (!pipeline) {
         makeInvalid(@"pipeline is not set prior to dispatch");
         return;
     }
 
-    if (NSString *error = m_pipeline->pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups)) {
+    if (NSString *error = pipeline->protectedPipelineLayout()->errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return;
     }
-    [computeCommandEncoder() setComputePipelineState:m_pipeline->computePipelineState()];
+    [computeCommandEncoder() setComputePipelineState:pipeline->computePipelineState()];
 
     EntryMapContainer usagesForResource;
     if (indirectBuffer)
         addResourceToActiveResources(indirectBuffer, indirectBuffer->buffer(), BindGroupEntryUsage::Input, usagesForResource, BindGroupId { INT32_MAX });
 
-    auto& pipelineLayout = m_pipeline->pipelineLayout();
+    auto& pipelineLayout = pipeline->pipelineLayout();
     auto pipelineLayoutCount = pipelineLayout.numberOfBindGroupLayouts();
     for (auto& kvp : m_bindGroups) {
         auto bindGroupIndex = kvp.key;
@@ -187,7 +188,7 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
         const Vector<uint32_t>* dynamicOffsets = nullptr;
         if (auto it = m_bindGroupDynamicOffsets.find(bindGroupIndex); it != m_bindGroupDynamicOffsets.end())
             dynamicOffsets = &it->value;
-        if (NSString* error = errorValidatingBindGroup(group, m_pipeline->minimumBufferSizes(bindGroupIndex), dynamicOffsets)) {
+        if (NSString* error = errorValidatingBindGroup(group, pipeline->minimumBufferSizes(bindGroupIndex), dynamicOffsets)) {
             makeInvalid(error);
             return;
         }
@@ -228,7 +229,7 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
         return;
 
     for (auto& kvp : m_bindGroupDynamicOffsets) {
-        auto& pipelineLayout = m_pipeline->pipelineLayout();
+        auto& pipelineLayout = pipeline->pipelineLayout();
         auto bindGroupIndex = kvp.key;
         auto* pcomputeOffsets = pipelineLayout.computeOffsets(bindGroupIndex, kvp.value);
         if (pcomputeOffsets && pcomputeOffsets->size()) {
@@ -262,7 +263,7 @@ void ComputePassEncoder::dispatch(uint32_t x, uint32_t y, uint32_t z)
 id<MTLBuffer> ComputePassEncoder::runPredispatchIndirectCallValidation(const Buffer& indirectBuffer, uint64_t indirectOffset)
 {
     static id<MTLFunction> function = nil;
-    id<MTLDevice> device = m_device->device();
+    id<MTLDevice> mtlDevice = m_device->device();
     if (!function) {
         auto dimensionMax = m_device->limits().maxComputeWorkgroupsPerDimension;
         MTLCompileOptions* options = [MTLCompileOptions new];
@@ -270,7 +271,7 @@ id<MTLBuffer> ComputePassEncoder::runPredispatchIndirectCallValidation(const Buf
         options.fastMathEnabled = YES;
         ALLOW_DEPRECATED_DECLARATIONS_END
         NSError *error = nil;
-        id<MTLLibrary> library = [device newLibraryWithSource:[NSString stringWithFormat:@"[[kernel]] void cs(device const uint* indirectBuffer, device uint* dispatchCallBuffer, uint index [[thread_position_in_grid]]) { dispatchCallBuffer[index] = metal::select(indirectBuffer[index], 0u, indirectBuffer[index] > %u); }", dimensionMax] options:options error:&error];
+        id<MTLLibrary> library = [mtlDevice newLibraryWithSource:[NSString stringWithFormat:@"[[kernel]] void cs(device const uint* indirectBuffer, device uint* dispatchCallBuffer, uint index [[thread_position_in_grid]]) { dispatchCallBuffer[index] = metal::select(indirectBuffer[index], 0u, indirectBuffer[index] > %u); }", dimensionMax] options:options error:&error];
         if (error)
             return nil;
 
@@ -279,8 +280,9 @@ id<MTLBuffer> ComputePassEncoder::runPredispatchIndirectCallValidation(const Buf
             return nil;
     }
 
-    id<MTLComputePipelineState> computePipelineState = m_device->dispatchCallPipelineState(function);
-    id<MTLBuffer> dispatchCallBuffer = m_device->dispatchCallBuffer();
+    auto device = m_device;
+    id<MTLComputePipelineState> computePipelineState = device->dispatchCallPipelineState(function);
+    id<MTLBuffer> dispatchCallBuffer = device->dispatchCallBuffer();
     [computeCommandEncoder() setComputePipelineState:computePipelineState];
     [computeCommandEncoder() setBuffer:indirectBuffer.buffer() offset:indirectOffset atIndex:0];
     [computeCommandEncoder() setBuffer:dispatchCallBuffer offset:0 atIndex:1];
@@ -316,24 +318,26 @@ void ComputePassEncoder::dispatchIndirect(const Buffer& indirectBuffer, uint64_t
 void ComputePassEncoder::endPass()
 {
     if (m_passEnded) {
-        m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as pass is already ended", __PRETTY_FUNCTION__]);
+        protectedDevice()->generateAValidationError([NSString stringWithFormat:@"%s: failed as pass is already ended", __PRETTY_FUNCTION__]);
         return;
     }
     m_passEnded = true;
 
     RETURN_IF_FINISHED();
 
+    auto parentEncoder = m_parentEncoder;
+
     auto passIsValid = isValid();
     if (m_debugGroupStackSize || !passIsValid) {
-        m_parentEncoder->endEncoding(m_computeCommandEncoder);
+        parentEncoder->endEncoding(m_computeCommandEncoder);
         m_computeCommandEncoder = nil;
-        m_parentEncoder->makeInvalid([NSString stringWithFormat:@"ComputePassEncoder.endPass failure, m_debugGroupStackSize = %llu, isValid = %d, error = %@", m_debugGroupStackSize, passIsValid, m_lastErrorString]);
+        parentEncoder->makeInvalid([NSString stringWithFormat:@"ComputePassEncoder.endPass failure, m_debugGroupStackSize = %llu, isValid = %d, error = %@", m_debugGroupStackSize, passIsValid, m_lastErrorString]);
         return;
     }
 
-    m_parentEncoder->endEncoding(m_computeCommandEncoder);
+    parentEncoder->endEncoding(m_computeCommandEncoder);
     m_computeCommandEncoder = nil;
-    m_parentEncoder->lock(false);
+    parentEncoder->lock(false);
 }
 
 void ComputePassEncoder::insertDebugMarker(String&& markerLabel)
@@ -362,13 +366,15 @@ void ComputePassEncoder::makeInvalid(NSString* errorString)
 {
     m_lastErrorString = errorString;
 
+    auto parentEncoder = m_parentEncoder;
+
     if (!m_computeCommandEncoder) {
-        m_parentEncoder->makeInvalid(@"RenderPassEncoder.makeInvalid");
+        parentEncoder->makeInvalid(@"RenderPassEncoder.makeInvalid");
         return;
     }
 
-    m_parentEncoder->setLastError(errorString);
-    m_parentEncoder->endEncoding(m_computeCommandEncoder);
+    parentEncoder->setLastError(errorString);
+    parentEncoder->endEncoding(m_computeCommandEncoder);
     m_computeCommandEncoder = nil;
 }
 
@@ -468,7 +474,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
     }
 
     m_pipeline = &pipeline;
-    m_computeDynamicOffsets.resize(m_pipeline->pipelineLayout().sizeOfComputeDynamicOffsets());
+    m_computeDynamicOffsets.resize(m_pipeline->protectedPipelineLayout()->sizeOfComputeDynamicOffsets());
 
     ASSERT(pipeline.computePipelineState());
     m_threadsPerThreadgroup = pipeline.threadsPerThreadgroup();

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -70,7 +70,9 @@ public:
     Device& device() const { return m_device; }
     MTLSize threadsPerThreadgroup() const { return m_threadsPerThreadgroup; }
 
-    PipelineLayout& pipelineLayout() const;
+    PipelineLayout& pipelineLayout() const { return m_pipelineLayout; }
+    Ref<PipelineLayout> protectedPipelineLayout() const { return m_pipelineLayout; }
+
     const BufferBindingSizesForBindGroup* minimumBufferSizes(uint32_t) const;
 
 private:

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -187,11 +187,6 @@ void ComputePipeline::setLabel(String&&)
     // MTLComputePipelineState's labels are read-only.
 }
 
-PipelineLayout& ComputePipeline::pipelineLayout() const
-{
-    return m_pipelineLayout;
-}
-
 const BufferBindingSizesForBindGroup* ComputePipeline::minimumBufferSizes(uint32_t index) const
 {
     auto it = m_minimumBufferSizes.find(index);

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -108,7 +108,8 @@ public:
     void destroy();
     size_t enumerateFeatures(WGPUFeatureName* features);
     bool getLimits(WGPUSupportedLimits&);
-    Queue& getQueue();
+    Queue& getQueue() const { return m_defaultQueue; }
+    Ref<Queue> protectedQueue() const { return m_defaultQueue; }
     bool hasFeature(WGPUFeatureName) const;
     bool popErrorScope(CompletionHandler<void(WGPUErrorType, String&&)>&& callback);
     void pushErrorScope(WGPUErrorFilter);
@@ -116,7 +117,7 @@ public:
     void setUncapturedErrorCallback(Function<void(WGPUErrorType, String&&)>&&);
     void setLabel(String&&);
 
-    bool isValid() const;
+    bool isValid() const { return m_device; }
     bool isLost() const { return m_isLost; }
     const WGPULimits& limits() const { return m_capabilities.limits; }
     const Vector<WGPUFeatureName>& features() const { return m_capabilities.features; }
@@ -133,7 +134,7 @@ public:
 
     uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
     uint32_t maxBuffersForFragmentStage() const;
-    uint32_t maxBuffersForComputeStage() const;
+    uint32_t maxBuffersForComputeStage() const { return m_capabilities.limits.maxBindGroups; }
     uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
     id<MTLBuffer> newBufferWithBytes(const void*, size_t, MTLResourceOptions) const;
     id<MTLBuffer> newBufferWithBytesNoCopy(void*, size_t, MTLResourceOptions) const;

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -323,11 +323,6 @@ id<MTLTexture> Device::placeholderTexture(WGPUTextureFormat format) const
     return Texture::isDepthOrStencilFormat(format) ? m_placeholderDepthStencilTexture : m_placeholderTexture;
 }
 
-Queue& Device::getQueue()
-{
-    return m_defaultQueue;
-}
-
 bool Device::hasFeature(WGPUFeatureName feature) const
 {
     return m_capabilities.features.contains(feature);
@@ -408,11 +403,6 @@ uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
 }
 
 uint32_t Device::maxBuffersForFragmentStage() const
-{
-    return m_capabilities.limits.maxBindGroups;
-}
-
-uint32_t Device::maxBuffersForComputeStage() const
 {
     return m_capabilities.limits.maxBindGroups;
 }
@@ -504,11 +494,6 @@ void Device::setDeviceLostCallback(Function<void(WGPUDeviceLostReason, String&&)
         loseTheDevice(WGPUDeviceLostReason_Destroyed);
     else if (!m_adapter->isValid())
         loseTheDevice(WGPUDeviceLostReason_Undefined);
-}
-
-bool Device::isValid() const
-{
-    return m_device;
 }
 
 void Device::setUncapturedErrorCallback(Function<void(WGPUErrorType, String&&)>&& callback)


### PR DESCRIPTION
#### 5d5797f2c90f26393f60171a79aed5d6717bbe4b
<pre>
Smart pointer adoption in WebGPU/Adapter.mm etc.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281921">https://bugs.webkit.org/show_bug.cgi?id=281921</a>
&lt;<a href="https://rdar.apple.com/problem/138431535">rdar://problem/138431535</a>&gt;

Reviewed by Mike Wyrzykowski.

Static analysis told me to.

* Source/WebGPU/WebGPU/BindGroup.h:
(WebGPU::BindGroup::protectedDevice const):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const):
(WebGPU::Device::createBindGroup):
(WebGPU::BindGroup::updateExternalTextures):
* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::protectedDevice const):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::mapAsync):
(WebGPU::Buffer::unmap):
* Source/WebGPU/WebGPU/CommandBuffer.h:
(WebGPU::CommandBuffer::setBufferMapCount):
(WebGPU::CommandBuffer::bufferMapCount const):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::~CommandBuffer):
(WebGPU::CommandBuffer::makeInvalid):
(WebGPU::CommandBuffer::setBufferMapCount): Deleted.
(WebGPU::CommandBuffer::bufferMapCount const): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::protectedCachedCommandBuffer const):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
(WebGPU::CommandEncoder::~CommandEncoder):
(WebGPU::CommandEncoder::ensureBlitCommandEncoder):
(WebGPU::errorValidatingTimestampWrites):
(WebGPU::CommandEncoder::setExistingEncoder):
(WebGPU::CommandEncoder::discardCommandBuffer):
(WebGPU::CommandEncoder::endEncoding):
(WebGPU::CommandEncoder::runClearEncoder):
(WebGPU::CommandEncoder::encoderIsCurrent const):
(WebGPU::CommandEncoder::makeInvalid):
(WebGPU::CommandEncoder::makeSubmitInvalid):
(WebGPU::CommandEncoder::clearBuffer):
(WebGPU::CommandEncoder::finish):
(WebGPU::CommandEncoder::writeTimestamp):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::getQueue const):
(WebGPU::Device::protectedQueue const):
(WebGPU::Device::isValid const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::getQueue): Deleted.
(WebGPU::Device::isValid const): Deleted.

Canonical link: <a href="https://commits.webkit.org/285584@main">https://commits.webkit.org/285584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be775240f8b3ef3b4d5d8c0af0c1196e5abd5ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/24405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/24405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44153 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22734 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79049 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/60 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65208 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16114 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/446 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/475 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->