### PR TITLE
Make [JSManagedValue initWithValue:] more robust against clients using it from non-main threads

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCClass.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCClass.cpp
@@ -447,6 +447,7 @@ static void jsc_class_class_init(JSCClassClass* klass)
 
 GRefPtr<JSCClass> jscClassCreate(JSCContext* context, const char* name, JSCClass* parentClass, JSCClassVTable* vtable, GDestroyNotify destroyFunction)
 {
+    JSC::JSLockHolder locker(toJS(jscContextGetJSContext(context))->vm());
     GRefPtr<JSCClass> jscClass = adoptGRef(JSC_CLASS(g_object_new(JSC_TYPE_CLASS, "context", context, "name", name, "parent", parentClass, nullptr)));
 
     JSCClassPrivate* priv = jscClass->priv;

--- a/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
@@ -91,6 +91,7 @@ static void jscWeakValueInitialize(JSCWeakValue* weakValue, JSCValue* value)
     JSCWeakValuePrivate* priv = weakValue->priv;
     auto* jsContext = jscContextGetJSContext(jsc_value_get_context(value));
     JSC::JSGlobalObject* globalObject = toJS(jsContext);
+    JSC::JSLockHolder locker(globalObject->vm());
     auto& owner = weakValueHandleOwner();
     JSC::Weak<JSC::JSGlobalObject> weak(globalObject, &owner, weakValue);
     priv->globalObject.swap(weak);

--- a/Source/JavaScriptCore/heap/WeakSetInlines.h
+++ b/Source/JavaScriptCore/heap/WeakSetInlines.h
@@ -33,6 +33,7 @@ namespace JSC {
 inline WeakImpl* WeakSet::allocate(JSValue jsValue, WeakHandleOwner* weakHandleOwner, void* context)
 {
     CellContainer container = jsValue.asCell()->cellContainer();
+    ASSERT(container.vm().currentThreadIsHoldingAPILock());
     WeakSet& weakSet = container.weakSet();
     WeakBlock::FreeCell* allocator = weakSet.m_allocator;
     if (UNLIKELY(!allocator))

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1465,6 +1465,7 @@ void InspectorDebuggerAgent::didCreateNativeExecutable(JSC::NativeExecutable& na
     if (m_symbolicBreakpoints.isEmpty())
         return;
 
+    JSC::JSLockHolder apiLocker(vm);
     auto symbol = functionName(nativeExecutable);
     if (symbol.isEmpty())
         return;

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -55,6 +55,9 @@ class VM;
 class JSGlobalObject;
 class JSLock;
 
+// FIXME: We should either have a specialization of WTF::Locker for JSLock or only allow using JSLockHolder.
+// It's weird that WTF::Locker<JSLock> doesn't ref() the VM for the lifetime of the lock and it's unclear
+// there's any noticable performance difference.
 class JSLockHolder {
 public:
     JS_EXPORT_PRIVATE JSLockHolder(VM*);

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -210,6 +210,7 @@ RefPtr<JSLazyEventListener> JSLazyEventListener::create(CreationArguments&& argu
         sourceURL = arguments.document.url();
     }
 
+    JSLockHolder locker(arguments.document.vm());
     return adoptRef(*new JSLazyEventListener(WTFMove(arguments), sourceURL, position));
 }
 


### PR DESCRIPTION
#### 596c3527f5dd10be50fc1af5a0662ff0ab6cf5d9
<pre>
Make [JSManagedValue initWithValue:] more robust against clients using it from non-main threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=281648">https://bugs.webkit.org/show_bug.cgi?id=281648</a>
<a href="https://rdar.apple.com/138037948">rdar://138037948</a>

Reviewed by Mark Lam.

[JSManagedValue initWithValue:] does not currently acquire the JS API lock because it expects to
only be called on the JS main thread.  However, it&apos;s easy for clients to make mistakes can call
it from different threads.  We should make [JSManagedValue initWithValue:] more robust by simply
making it acquire the JS API lock for its VM.

Also change [JSManagedValue value:] to not acquire the JS API lock twice.  It was first acquiring
the lock with a WTF::Locker, and subsequently with a JSC::JSLockHolder.  The only added value of
the JSC::JSLockHolder is that it refs the VM using a RefPtr.  So, instead of using the
JSC::JSLockHolder, we can just use a RefPtr to store the VM instead of the raw VM* it was using
before.  With that, the use of the JSC::JSLockHolder becomes completely redundant.

This issue is caught by existing tests now that WeakSet::allocate asserts currentThreadIsHoldingAPILock.

* Source/JavaScriptCore/API/JSManagedValue.mm:
(-[JSManagedValue initWithValue:]):
(-[JSManagedValue value]):
* Source/JavaScriptCore/heap/WeakSetInlines.h:
(JSC::WeakSet::allocate):
* Source/JavaScriptCore/runtime/JSLock.h:

Canonical link: <a href="https://commits.webkit.org/285771@main">https://commits.webkit.org/285771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7186463b025562fa004601e36a1ea965e8bb61b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16286 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20834 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23192 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79509 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72878 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66250 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7570 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3652 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->