### PR TITLE
[Static Analyzer CI] Support reporting static analyzer results to results.webkit.org

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -25,14 +25,23 @@ import os
 import subprocess
 import argparse
 import json
+import sys
+
+from webkitpy.results.upload import Upload
+from webkitpy.results.options import upload_args
+from libraries.webkitscmpy.webkitscmpy import Commit
+from libraries.webkitscmpy.webkitscmpy import local, log, remote
 
 CHECKERS = ['NoUncountedMemberChecker', 'NoUncheckedPtrMemberChecker', 'RefCntblBaseVirtualDtor', 'UncountedCallArgsChecker', 'UncountedLocalVarsChecker']
 PROJECTS = ['WebCore', 'WebKit']
 STATIC_ANALYZER_UNEXPECTED = 'StaticAnalyzerUnexpectedRegressions'
+UNEXPECTED_PASS = {'actual': 'PASS', 'expected': 'FAIL'}
+UNEXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'PASS'}
+EXPECTED_FAILURE = {'actual': 'FAIL', 'expected': 'FAIL'}
 
 
 def parser():
-    parser = argparse.ArgumentParser(description='Finds new regressions and fixes between two smart pointer static analysis results')
+    parser = argparse.ArgumentParser(parents=[upload_args()], description='Finds new regressions and fixes between two smart pointer static analysis results')
     parser.add_argument(
         'new_dir',
         help='Path to directory of results from new build'
@@ -66,18 +75,26 @@ def parser():
         default=False,
         help='Delete static analyzer results'
     )
+    config_options = parser.add_argument_group('Configuration options')
+    config_options.add_argument('--architecture')
+    config_options.add_argument('--platform')
+    config_options.add_argument('--version')
+    config_options.add_argument('--version-name')
+    config_options.add_argument('--style')
+    config_options.add_argument('--sdk')
+
     return parser.parse_args()
 
 
 def find_diff(args, file1, file2):
+    # Create empty file if the corresponding one doesn't exist - this happens if a checker is added or removed
     if not args.check_expectations:
-        # Create empty file if the corresponding one doesn't exist - this happens if a checker is added or removed
         if not os.path.exists(file1):
             f = open(file1, 'a')
             f.close()
-        if not os.path.exists(file2):
-            f = open(file2, 'a')
-            f.close()
+    if not os.path.exists(file2):
+        f = open(file2, 'a')
+        f.close()
 
     with open(file1) as baseline_file, open(file2) as new_file:
         baseline_list = [line for line in baseline_file.read().splitlines() if not line.startswith('//') and line.strip()]  # Remove lines from the copyright
@@ -87,7 +104,7 @@ def find_diff(args, file1, file2):
         # Find fixes
         diff_baseline_from_new = set(baseline_list) - set(new_file_list)
 
-    return set(diff_new_from_baseline), set(diff_baseline_from_new)
+    return set(diff_new_from_baseline), set(diff_baseline_from_new), new_file_list
 
 
 def create_filtered_results_dir(args, project, result_paths, category='StaticAnalyzerRegressions'):
@@ -110,11 +127,12 @@ def compare_project_results_to_expectations(args, new_path, project):
     unexpected_clean_files = set()
     project_results_passes = {}
     project_results_failures = {}
+    project_results_for_upload = {}
 
     # Compare the list of dirty files to the expectations list of files
     for checker in CHECKERS:
         # Get unexpected clean and buggy files per checker
-        buggy_files, clean_files = find_diff(args, os.path.abspath(f'Source/{project}/SaferCPPExpectations/{checker}Expectations'), f'{new_path}/{project}/{checker}Files')
+        buggy_files, clean_files, current_results = find_diff(args, os.path.join(os.path.dirname(__file__), f'../../Source/{project}/SaferCPPExpectations/{checker}Expectations'), f'{new_path}/{project}/{checker}Files')
         unexpected_clean_files.update(clean_files)
         unexpected_buggy_files.update(buggy_files)
 
@@ -151,13 +169,25 @@ def compare_project_results_to_expectations(args, new_path, project):
         else:
             print('    No unexpected results')
 
+        for file in current_results:
+            if not file in project_results_for_upload.keys():
+                project_results_for_upload[file] = {}
+            if file in buggy_files:
+                project_results_for_upload[file][checker] = UNEXPECTED_FAILURE
+            else:
+                project_results_for_upload[file][checker] = EXPECTED_FAILURE
+        for file in clean_files:
+            if not file in project_results_for_upload.keys():
+                project_results_for_upload[file] = {}
+            project_results_for_upload[file][checker] = UNEXPECTED_PASS
+
     if unexpected_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, unexpected_result_paths_total, STATIC_ANALYZER_UNEXPECTED)
 
     if not unexpected_buggy_files and not unexpected_clean_files and not unexpected_issues_total:
         print('No unexpected results!')
 
-    return unexpected_buggy_files, unexpected_clean_files, unexpected_issues_total, project_results_passes, project_results_failures
+    return unexpected_buggy_files, unexpected_clean_files, unexpected_issues_total, project_results_passes, project_results_failures, project_results_for_upload
 
 
 def compare_project_results_by_run(args, archive_path, new_path, project):
@@ -206,6 +236,45 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
     return new_issues_total, new_files_total, fixed_files_total, fixed_issues_total, project_results_passes, project_results_failures
 
 
+def upload_results(options, results):
+    print('\nPreparing to upload results...')
+
+    config = Upload.create_configuration(
+        architecture=options.architecture,
+        platform=options.platform,
+        version=options.version,
+        version_name=options.version_name,
+        style=options.style,
+        sdk=options.sdk
+    )
+
+    repo = os.getcwd()
+    if repo.startswith(('https://', 'http://')):
+        repository = remote.Scm.from_url(repo)
+    else:
+        try:
+            repository = local.Scm.from_path(path=repo,)
+        except OSError:
+            log.warning("No repository found at '{}'".format(repo))
+            repository = None
+
+    commit = repository.commit()
+    commit = commit.Encoder().default(commit)
+    commit['repository_id'] = 'webkit'
+
+    upload = Upload(
+        suite=options.suite or 'safer-cpp-checks',
+        configuration=config,
+        details=Upload.create_details(options=options),
+        commits=[commit],
+        run_stats=Upload.create_run_stats(), results=results,
+    )
+
+    for url in options.report_urls:
+        if not upload.upload(url):
+            sys.stderr.write(f'Failed to upload results\n')
+
+
 def main():
     args = parser()
     new_issues_total = set()
@@ -216,12 +285,13 @@ def main():
     unexpected_failures_total = set()
     unexpected_issues_total = set()
     unexpected_results_data = {'passes': {}, 'failures': {}}
+    results_for_upload = {}
 
     for project in PROJECTS:
         print(f'\n------ {project} ------')
         new_path = os.path.abspath(f'{args.new_dir}')
         if args.check_expectations:
-            unexpected_failures, unexpected_passes, unexpected_issues, project_results_passes, project_results_failures = compare_project_results_to_expectations(args, new_path, project)
+            unexpected_failures, unexpected_passes, unexpected_issues, project_results_passes, project_results_failures, project_results_for_upload = compare_project_results_to_expectations(args, new_path, project)
             unexpected_failures_total.update(unexpected_failures)
             unexpected_passes_total.update(unexpected_passes)
             unexpected_issues_total.update(unexpected_issues)
@@ -235,6 +305,7 @@ def main():
         # JSON
         unexpected_results_data['passes'][project] = project_results_passes
         unexpected_results_data['failures'][project] = project_results_failures
+        results_for_upload[project] = project_results_for_upload
 
     results_data_file = os.path.abspath(f'{args.build_output}/unexpected_results.json')
     with open(results_data_file, "w") as f:
@@ -253,6 +324,9 @@ def main():
     }.items():
         if type_total:
             print(f'Total {type}: {len(type_total)}')
+
+    if args.report_urls:
+        upload_results(args, results_for_upload)
 
     # We don't need the full results for EWS runs. Delete full results if option enabled.
     if args.delete_results:

--- a/Tools/Scripts/webkitpy/results/options.py
+++ b/Tools/Scripts/webkitpy/results/options.py
@@ -21,15 +21,27 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import optparse
+import argparse
+
+
+def add_optargs(func, suite_name_flag='suite'):
+    return [
+        func('--report', action='append', dest='report_urls', help='URL (or URLs) to report test results to'),
+        func('--buildbot-master', help='The url of the buildbot master.'),
+        func('--builder-name', help='The name of the buildbot builder tests were run on.'),
+        func('--build-number', help='The buildbot build number tests are associated with.'),
+        func('--buildbot-worker', help='The buildbot worker tests were run on.'),
+        func('--result-report-flavor', help='Optional flag for categorizing test runs which do not fit into other configuration options.'),
+        func('--' + suite_name_flag, help='Optional flag for overriding reported suite name.', default=None),
+    ]
 
 
 def upload_options(suite_name_flag='suite'):
-    return [
-        optparse.make_option('--report', action='append', dest='report_urls', help='URL (or URLs) to report test results to'),
-        optparse.make_option('--buildbot-master', help='The url of the buildbot master.'),
-        optparse.make_option('--builder-name', help='The name of the buildbot builder tests were run on.'),
-        optparse.make_option('--build-number', help='The buildbot build number tests are associated with.'),
-        optparse.make_option('--buildbot-worker', help='The buildbot worker tests were run on.'),
-        optparse.make_option('--result-report-flavor', help='Optional flag for categorizing test runs which do not fit into other configuration options.'),
-        optparse.make_option('--' + suite_name_flag, help='Optional flag for overriding reported suite name.', default=None),
-    ]
+    return add_optargs(optparse.make_option)
+
+
+def upload_args(suite_name_flag='suite'):
+    parser = argparse.ArgumentParser(add_help=False)
+    upload_options = parser.add_argument_group('Upload options')
+    add_optargs(upload_options.add_argument)
+    return parser


### PR DESCRIPTION
#### f167dc39b8298efca1aa742a21c7fc976ebd9024
<pre>
[Static Analyzer CI] Support reporting static analyzer results to results.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=281925">https://bugs.webkit.org/show_bug.cgi?id=281925</a>
<a href="https://rdar.apple.com/138433382">rdar://138433382</a>

Reviewed by Jonathan Bedard.

Take parsed results and format them for the resultsdb API to upload.
Config and build details are provided from buildbot as arguments.
Then, use webkitpy.results.upload to results.webkit.org.

* Tools/Scripts/compare-static-analysis-results:
(parser): Add new options.
(find_diff): Fix empty file logic and return list of all files with issues.
(compare_project_results_to_expectations): Assign an actual and expected result to each file.
(upload_results): Create the results object for upload. Check repo for the current commit. Upload results.
(main): Call upload_results if the upload arguments are passed.

* Tools/Scripts/webkitpy/results/options.py: Support both optparse and argparse!
(add_optargs):
(upload_options):
(upload_args):

Canonical link: <a href="https://commits.webkit.org/285799@main">https://commits.webkit.org/285799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d919f6f68a5858afea9dfc997ece8cd50acef515

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26704 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76010 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/62455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1107 "Failed to checkout and rebase branch from PR 35588") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/62455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/73401 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/62455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/62455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79782 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/1210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/1107 "Failed to checkout and rebase branch from PR 35588") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/1353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11390 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/1174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->