### PR TITLE
Adopt more eventSender async mouse functions in fast/forms/

### DIFF
--- a/LayoutTests/fast/forms/disabled-mousedown-event.html
+++ b/LayoutTests/fast/forms/disabled-mousedown-event.html
@@ -14,20 +14,20 @@ async function rafPromise() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
 
-function clickOn(element)
+async function clickOn(element)
 {
     var x = element.offsetLeft + element.offsetWidth / 2;
     var y = element.offsetTop + element.offsetHeight / 2;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 }
 
 promise_test(async () => {
   const test = document.getElementById('test');
   test.parentNode.addEventListener('mousedown', () => assert_unreached('mousedown should not be fired.'));
 
-  clickOn(test);
+  await clickOn(test);
 
   await rafPromise();
   await rafPromise();

--- a/LayoutTests/fast/forms/disabled-search-input.html
+++ b/LayoutTests/fast/forms/disabled-search-input.html
@@ -14,32 +14,20 @@ function log(msg, success)
     logDiv.appendChild(document.createElement('div')).textContent = msg + ': ' + (!!success ? 'PASS' : 'FAIL');
 }
 
-function clickOn(element)
-{
-    if (!window.eventSender)
-        return;
-
-    var x = element.offsetLeft + element.offsetWidth / 2;
-    var y = element.offsetTop + element.offsetHeight / 2;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-}
-
 function runTest()
 {
     logDiv = document.getElementById('console');
     var input = document.getElementsByTagName('input')[0];
-    setTimeout(function() {
+    setTimeout(async function() {
         input.disabled = false;
         if (!window.eventSender)
             return;
 
         var x = input.offsetLeft + input.offsetWidth / 2;
         var y = input.offsetTop + input.offsetHeight / 2;
-        eventSender.mouseMoveTo(x, y);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(x, y);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
         eventSender.keyDown('a');
         log('The inner text element of the search input should never be 0-height', input.value == 'a');
         testRunner.notifyDone();

--- a/LayoutTests/fast/forms/drag-into-textarea.html
+++ b/LayoutTests/fast/forms/drag-into-textarea.html
@@ -1,6 +1,6 @@
 <script>
 
-function runTest() {
+async function runTest() {
     var input = document.getElementById("input");
     var x = input.offsetLeft + input.offsetWidth / 2;
     var y = input.offsetTop + input.offsetHeight / 2;
@@ -19,12 +19,12 @@ function runTest() {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
     
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
     // Leap the event time so that mouseMove will start a new drag instead of changing selection.
     eventSender.leapForward(400);
-    eventSender.mouseMoveTo(tx, ty);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(tx, ty);
+    await eventSender.asyncMouseUp();
 
     if (input.value == "" && textarea.value == "drag this text into the text area below")
         document.getElementById("result").innerText = "Test succeeded!";

--- a/LayoutTests/fast/forms/drag-out-of-textarea.html
+++ b/LayoutTests/fast/forms/drag-out-of-textarea.html
@@ -1,6 +1,6 @@
 <script>
 
-function runTest() {
+async function runTest() {
     var textarea = document.getElementById("textarea");
     var tx = textarea.offsetLeft + textarea.offsetWidth / 2;
     var ty = textarea.offsetTop + 4;
@@ -19,12 +19,12 @@ function runTest() {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    eventSender.mouseMoveTo(tx, ty);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(tx, ty);
+    await eventSender.asyncMouseDown();
     // Leap the event time so that mouseMove will start a new drag instead of changing selection.
     eventSender.leapForward(400);
-    eventSender.mouseMoveTo(ix, iy);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(ix, iy);
+    await eventSender.asyncMouseUp();
     
     if (input.value == "drag this text into the text field above" && textarea.value == "")
         document.getElementById("result").innerText = "Test succeeded!";

--- a/LayoutTests/fast/forms/focus-selection-input.html
+++ b/LayoutTests/fast/forms/focus-selection-input.html
@@ -2,7 +2,7 @@
 <script src="../../resources/js-test-pre.js"></script>
 
 <script>
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         return;
@@ -12,6 +12,7 @@ function runTest()
         accessKeyModifiers = ["ctrlKey", "altKey"];
 
     testRunner.dumpEditingCallbacks();
+    testRunner.waitUntilDone();
     testRunner.dumpAsText();
 
     shouldBe("first.selectionStart", "12");
@@ -34,18 +35,18 @@ function runTest()
 
     shouldBe("fourth.selectionStart", "12");
     shouldBe("fourth.selectionEnd", "19");
-    eventSender.mouseMoveTo(fourth.offsetLeft + 4, fourth.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(fourth.offsetLeft + 4, fourth.offsetTop + 4);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
     shouldBe("fourth.selectionStart", "0");
     shouldBe("fourth.selectionEnd", "0");
 
     shouldBe("fifth.selectionStart", "11");
     shouldBe("fifth.selectionEnd", "18");
     var fifthLabel = document.getElementById("fifthLabel");
-    eventSender.mouseMoveTo(fifthLabel.offsetLeft + 4, fifthLabel.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(fifthLabel.offsetLeft + 4, fifthLabel.offsetTop + 4);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
     shouldBe("fifth.selectionStart", "11");
     shouldBe("fifth.selectionEnd", "18");
 
@@ -74,7 +75,7 @@ function runTest()
     eventSender.keyDown("I", accessKeyModifiers);
     shouldBe("ninth.selectionStart", "11");
     shouldBe("ninth.selectionEnd", "18");
-
+    testRunner.notifyDone();
 }
 </script>
 

--- a/LayoutTests/fast/forms/focus-selection-textarea.html
+++ b/LayoutTests/fast/forms/focus-selection-textarea.html
@@ -2,7 +2,7 @@
 <script src="../../resources/js-test-pre.js"></script>
 
 <script>
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         return;
@@ -12,6 +12,7 @@ function runTest()
         accessKeyModifiers = ["ctrlKey", "altKey"];
 
     testRunner.dumpEditingCallbacks();
+    testRunner.waitUntilDone();
     testRunner.dumpAsText();
 
     shouldBe("first.selectionStart", "11");
@@ -34,18 +35,18 @@ function runTest()
 
     shouldBe("fourth.selectionStart", "11");
     shouldBe("fourth.selectionEnd", "18");
-    eventSender.mouseMoveTo(fourth.offsetLeft + 4, fourth.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(fourth.offsetLeft + 4, fourth.offsetTop + 4);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
     shouldBe("fourth.selectionStart", "0");
     shouldBe("fourth.selectionEnd", "0");
 
     shouldBe("fifth.selectionStart", "11");
     shouldBe("fifth.selectionEnd", "18");
     var fifthLabel = document.getElementById("fifthLabel");
-    eventSender.mouseMoveTo(fifthLabel.offsetLeft + 4, fifthLabel.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(fifthLabel.offsetLeft + 4, fifthLabel.offsetTop + 4);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
     shouldBe("fifth.selectionStart", "11");
     shouldBe("fifth.selectionEnd", "18");
 
@@ -74,7 +75,7 @@ function runTest()
     eventSender.keyDown("I", accessKeyModifiers);
     shouldBe("ninth.selectionStart", "11");
     shouldBe("ninth.selectionEnd", "18");
-
+    testRunner.notifyDone();
 }
 </script>
 

--- a/LayoutTests/fast/forms/input-appearance-preventDefault.html
+++ b/LayoutTests/fast/forms/input-appearance-preventDefault.html
@@ -1,13 +1,16 @@
 <html>
 <head>
 <script>
-function test()
-{    
-    if (window.testRunner) {
-        eventSender.mouseMoveTo(25, 55);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
-    }
+async function test()
+{
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    await eventSender.asyncMouseMoveTo(25, 55);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    testRunner.notifyDone();
 }
 
 function prevDefaultForEvent( evt ) {

--- a/LayoutTests/fast/forms/input-appearance-spinbutton-up.html
+++ b/LayoutTests/fast/forms/input-appearance-spinbutton-up.html
@@ -10,12 +10,16 @@
 <input type=number style="font-size: 18px;" id=number value=0>
 
 <script>
-if (window.eventSender) {
-    var input = document.getElementById('number');
-    eventSender.mouseMoveTo(input.offsetLeft + input.offsetWidth - 8, input.offsetTop + 6);
-    eventSender.mouseDown();
-} else {
-    document.getElementById('console').innerHTML = '<p>Manual test: Press the primary button of the pointing device on the upper button.  Check if the upper button is correctly highlighted.</p>';
+onload = async () => {
+    testRunner?.waitUntilDone();
+    if (window.eventSender) {
+        var input = document.getElementById('number');
+        await eventSender.asyncMouseMoveTo(input.offsetLeft + input.offsetWidth - 8, input.offsetTop + 6);
+        await eventSender.asyncMouseDown();
+    } else {
+        document.getElementById('console').innerHTML = '<p>Manual test: Press the primary button of the pointing device on the upper button.  Check if the upper button is correctly highlighted.</p>';
+    }
+    testRunner?.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/input-number-click-expected.txt
+++ b/LayoutTests/fast/forms/input-number-click-expected.txt
@@ -4,6 +4,9 @@ Test for the spin control behavior in a type=numnber input.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Initial value is 3.14, click the up button once
 PASS i.value is "4.14"
 Click the up button again.  The maximum value is 5.
@@ -16,7 +19,4 @@ Make the control "disabled" and click the up button
 PASS i.value is "0.14"
 Make the control "readOnly" and click the up button
 PASS i.value is "0.14"
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/forms/input-number-click.html
+++ b/LayoutTests/fast/forms/input-number-click.html
@@ -12,58 +12,62 @@
 <script>
 description('Test for the spin control behavior in a type=numnber input.');
 
-if (window.eventSender) {
-    debug('Initial value is 3.14, click the up button once');
-    // The spin control is at (130,-1) in the input element on Mac.
-    // The size is 15x22.
-    var i = document.getElementById('i1');
-    eventSender.mouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    // The up button has been clicked.
-    shouldBe('i.value', '"4.14"');
+var i = document.getElementById('i1');
+onload = async () => {
+    if (window.eventSender && window.testRunner) {
+        testRunner.waitUntilDone();
+        debug('Initial value is 3.14, click the up button once');
+        // The spin control is at (130,-1) in the input element on Mac.
+        // The size is 15x22.
+        await eventSender.asyncMouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        // The up button has been clicked.
+        shouldBe('i.value', '"4.14"');
 
-    debug('Click the up button again.  The maximum value is 5.');
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    // The maximum value is 5.  So the value is not changed.
-    shouldBe('i.value', '"4.14"');
+        debug('Click the up button again.  The maximum value is 5.');
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        // The maximum value is 5.  So the value is not changed.
+        shouldBe('i.value', '"4.14"');
 
-    debug('Click the down button four times');
-    eventSender.mouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 15);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('i.value', '"0.14"');
+        debug('Click the down button four times');
+        await eventSender.asyncMouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 15);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('i.value', '"0.14"');
 
-    debug('Click the down button again. The minimum value is 0.');
-    // The minimum value is 0.  So the value is not changed.
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('i.value', '"0.14"');
+        debug('Click the down button again. The minimum value is 0.');
+        // The minimum value is 0.  So the value is not changed.
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('i.value', '"0.14"');
 
-    debug('Make the control "disabled" and click the up button');
-    i.disabled = true;
-    eventSender.mouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('i.value', '"0.14"');
-    i.disabled = false;
+        debug('Make the control "disabled" and click the up button');
+        i.disabled = true;
+        await eventSender.asyncMouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('i.value', '"0.14"');
+        i.disabled = false;
 
-    debug('Make the control "readOnly" and click the up button');
-    i.readOnly = true;
-    eventSender.mouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('i.value', '"0.14"');
-    i.readOnly = false;
-} else {
-  document.getElementById('console').innerHTML = 'No eventSender';
+        debug('Make the control "readOnly" and click the up button');
+        i.readOnly = true;
+        await eventSender.asyncMouseMoveTo(i.offsetLeft + i.offsetWidth - 4, i.offsetTop + 4);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('i.value', '"0.14"');
+        i.readOnly = false;
+        testRunner.notifyDone();
+    } else {
+        document.getElementById('console').innerHTML = 'No eventSender or testRunner';
+    }
 }
 
 </script>

--- a/LayoutTests/fast/forms/input-readonly-autoscroll.html
+++ b/LayoutTests/fast/forms/input-readonly-autoscroll.html
@@ -8,24 +8,24 @@
                     setTimeout(autoscrollTestPart1, 0);
                 }
             }
-            function autoscrollTestPart1()
+            async function autoscrollTestPart1()
             {
                 var tf = document.getElementById('tf');
                 if (window.eventSender) {
                     tf.scrollIntoView();
                     var h = tf.offsetTop - document.scrollingElement.scrollTop + 10;
                     eventSender.dragMode = false;
-                    eventSender.mouseMoveTo(20, h);
-                    eventSender.mouseDown();
-                    eventSender.mouseMoveTo(20, h);
-                    eventSender.mouseMoveTo(300, h);
+                    await eventSender.asyncMouseMoveTo(20, h);
+                    await eventSender.asyncMouseDown();
+                    await eventSender.asyncMouseMoveTo(20, h);
+                    await eventSender.asyncMouseMoveTo(300, h);
                 }
                 setTimeout(autoscrollTestPart2, 100);
             }
-            function autoscrollTestPart2()
+            async function autoscrollTestPart2()
             {
                 if (window.eventSender)
-                    eventSender.mouseUp();
+                    await eventSender.asyncMouseUp();
                 log("ScrollLeft: " + document.getElementById('tf').scrollLeft);
                 if (window.testRunner)
                     testRunner.notifyDone();

--- a/LayoutTests/fast/forms/input-readonly-focus.html
+++ b/LayoutTests/fast/forms/input-readonly-focus.html
@@ -1,21 +1,24 @@
 <html>
 <head>
 <script>
-function runTest() {
+async function runTest() {
   window.testRunner.dumpAsText();
 
   var input = document.getElementById('i');
-  eventSender.mouseMoveTo(input.offsetLeft + input.offsetWidth / 2, input.offsetTop + input.offsetHeight / 2);
-  eventSender.mouseDown();
-  eventSender.mouseUp();
+  await eventSender.asyncMouseMoveTo(input.offsetLeft + input.offsetWidth / 2, input.offsetTop + input.offsetHeight / 2);
+  await eventSender.asyncMouseDown();
+  await eventSender.asyncMouseUp();
 }
-window.onload = function() {
+window.onload = async function() {
   var input = document.getElementById('i');
   input.onfocus = function(e) {
     document.body.innerHTML = 'PASS';
   }
-  if (window.testRunner)
-    runTest();
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    await runTest();
+    testRunner.notifyDone();
+  }
 }
 </script>
 </head>

--- a/LayoutTests/fast/forms/input-readonly-select-expected.txt
+++ b/LayoutTests/fast/forms/input-readonly-select-expected.txt
@@ -1,3 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 double clicking on normal input
 PASS selectEventFiredOnInput is true
 
@@ -16,7 +19,4 @@ PASS selectEventFiredOnReadonlyTextarea is true
 double clicking on disabled textarea
 PASS selectEventFiredOnDisabledTextarea is true
 
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/forms/input-readonly-select.html
+++ b/LayoutTests/fast/forms/input-readonly-select.html
@@ -14,16 +14,16 @@
 <pre id="console"></pre>
 
 <script>
-function doubleClickOn(element)
+async function doubleClickOn(element)
 {
     var x = element.offsetLeft + element.offsetWidth / 2;
     var y = element.offsetTop + element.offsetHeight / 2;
 
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 }
 
 var selectEventFiredOnInput = false;
@@ -53,37 +53,46 @@ disabledTextarea.addEventListener('select', function() {
     selectEventFiredOnDisabledTextarea = true;
 });
 
-debug('double clicking on normal input');
-doubleClickOn(input);
-shouldBeTrue('selectEventFiredOnInput');
-debug('');
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-debug('double clicking on readonly input');
-doubleClickOn(readonlyInput);
-shouldBeTrue('selectEventFiredOnReadonlyInput');
-debug('');
+    testRunner.waitUntilDone();
 
-debug('double clicking on disabled input');
-doubleClickOn(disabledInput);
-shouldBeTrue('selectEventFiredOnDisabledInput');
-debug('');
+    debug('double clicking on normal input');
+    await doubleClickOn(input);
+    shouldBeTrue('selectEventFiredOnInput');
+    debug('');
 
-debug('double clicking on normal textarea');
-doubleClickOn(textarea);
-shouldBeTrue('selectEventFiredOnTextarea');
-debug('');
+    debug('double clicking on readonly input');
+    await doubleClickOn(readonlyInput);
+    shouldBeTrue('selectEventFiredOnReadonlyInput');
+    debug('');
 
-debug('double clicking on readonly textarea');
-doubleClickOn(readonlyTextarea);
-shouldBeTrue('selectEventFiredOnReadonlyTextarea');
-debug('');
+    debug('double clicking on disabled input');
+    await doubleClickOn(disabledInput);
+    shouldBeTrue('selectEventFiredOnDisabledInput');
+    debug('');
 
-debug('double clicking on disabled textarea');
-doubleClickOn(disabledTextarea);
-shouldBeTrue('selectEventFiredOnDisabledTextarea');
-debug('');
+    debug('double clicking on normal textarea');
+    await doubleClickOn(textarea);
+    shouldBeTrue('selectEventFiredOnTextarea');
+    debug('');
 
-container.innerHTML = "";
+    debug('double clicking on readonly textarea');
+    await doubleClickOn(readonlyTextarea);
+    shouldBeTrue('selectEventFiredOnReadonlyTextarea');
+    debug('');
+
+    debug('double clicking on disabled textarea');
+    await doubleClickOn(disabledTextarea);
+    shouldBeTrue('selectEventFiredOnDisabledTextarea');
+    debug('');
+
+    container.innerHTML = "";
+
+    testRunner.notifyDone();
+}
 </script>
 
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/input-select-on-click.html
+++ b/LayoutTests/fast/forms/input-select-on-click.html
@@ -1,16 +1,18 @@
 <html>
 <head>
 <script>
-function test() {
-    if (window.testRunner)
+async function test() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
         testRunner.dumpAsText();
+    }
     var tf = document.getElementById('tf');
     var x = tf.offsetLeft + tf.offsetWidth / 2;
     var y = tf.offsetTop + tf.offsetHeight / 2;
     if (window.eventSender) {
-        eventSender.mouseMoveTo(x, y);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(x, y);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
     if (tf.selectionStart == 0 && tf.selectionEnd == 10) { // ;
         document.getElementById("result").innerHTML = "PASS";
@@ -18,6 +20,7 @@ function test() {
         document.getElementById("result").innerHTML = "FAIL: selection start is "
             + tf.selectionStart + " and end is " + tf.selectionEnd + ".";
     }
+    testRunner?.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/fast/forms/input-step-as-double-expected.txt
+++ b/LayoutTests/fast/forms/input-step-as-double-expected.txt
@@ -3,8 +3,8 @@ Test for a capturing spec change to consider .2 as valid real number for step
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS numberInput.value is "0.5"
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS numberInput.value is "0.5"
 

--- a/LayoutTests/fast/forms/input-step-as-double.html
+++ b/LayoutTests/fast/forms/input-step-as-double.html
@@ -12,17 +12,24 @@ document.body.appendChild(parent);
 parent.innerHTML = '<input type=number id=number value=0 step=".5">';
 var numberInput = document.getElementById('number');
 
-if (window.eventSender) {
-    // Move the cursor on the upper button of the input field.
-    eventSender.mouseMoveTo(numberInput.offsetLeft + numberInput.offsetWidth - 10, numberInput.offsetTop + numberInput.offsetHeight / 4);
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('numberInput.value', '"0.5"');
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        // Move the cursor on the upper button of the input field.
+        await eventSender.asyncMouseMoveTo(numberInput.offsetLeft + numberInput.offsetWidth - 10, numberInput.offsetTop + numberInput.offsetHeight / 4);
 
-    parent.innerHTML = '';
-} else {
-    document.getElementById('console').innerHTML = '<p>No eventSender. <p>Manual test instruction: Click the upper button of the input field.  Confirm that the input field value is 0.5';
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('numberInput.value', '"0.5"');
+
+        parent.innerHTML = '';
+    } else {
+        document.getElementById('console').innerHTML = '<p>No eventSender. <p>Manual test instruction: Click the upper button of the input field.  Confirm that the input field value is 0.5';
+    }
+    testRunner.notifyDone();
 }
 
 </script>

--- a/LayoutTests/fast/forms/input-text-click-inside.html
+++ b/LayoutTests/fast/forms/input-text-click-inside.html
@@ -1,9 +1,16 @@
 <div style="width: 400px; height: 50px; padding: 25px 0 0 25px; background: yellow;"><input></div>
 <p>This test clicks inside an input element, and must result in the element receiving focus. If the test succeeds the element should have a focus ring.</p>
 <script>
-if (window.eventSender) {
-    eventSender.mouseMoveTo(100, 45);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(100, 45);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
+    testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/input-text-click-outside.html
+++ b/LayoutTests/fast/forms/input-text-click-outside.html
@@ -1,9 +1,16 @@
 <div style="width: 400px; height: 50px; padding: 25px 0 0 25px; background: yellow;"><input></div>
 <p>This test clicks outside an input element, and must not result in the element receiving focus. If the test succeeds the element should not have a focus ring.</p>
 <script>
-if (window.eventSender) {
-    eventSender.mouseMoveTo(200, 45);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(200, 45);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
+    testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/input-text-double-click.html
+++ b/LayoutTests/fast/forms/input-text-double-click.html
@@ -1,11 +1,20 @@
 <input type="text" value="word another">
 <p>Tests double-clicking on a word. If the test succeeds, the word "word" should be selected.</p>
 <script>
-if (window.eventSender) {
-    eventSender.mouseMoveTo(15, 15);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(15, 15);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
+
+    testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/input-text-drag-down.html
+++ b/LayoutTests/fast/forms/input-text-drag-down.html
@@ -1,12 +1,19 @@
 <input type="text" value="This is a bunch of text.">
 <p>Tests drag-selecting down. If the test succeeds, the text from the center to the end of the text field should be selected.</p>
 <script>
-if (window.eventSender) {
-    eventSender.mouseMoveTo(50, 15);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(50, 40);
-    eventSender.mouseUp();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(50, 15);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(50, 40);
+        await eventSender.asyncMouseUp();
+    }
+    testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/input-text-self-emptying-click.html
+++ b/LayoutTests/fast/forms/input-text-self-emptying-click.html
@@ -1,9 +1,16 @@
 <input type="text" onfocus="this.value=''" value="click to edit">
 <p>Tests clicking on an input element that has a value that self-destructs. If the test succeeds, there should be a blinking caret in the text field.</p>
 <script>
-if (window.eventSender) {
-    eventSender.mouseMoveTo(15, 15);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(15, 15);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
+    testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/input-type-change-in-onfocus-mouse.html
+++ b/LayoutTests/fast/forms/input-type-change-in-onfocus-mouse.html
@@ -1,10 +1,11 @@
 <html>
 <head>
     <script>
-    function runTest() {
-        if (window.testRunner)
+    async function runTest() {
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
             testRunner.dumpAsText();
-        else {
+        } else {
             alert('This test does not work in Safari.');
             return;
         }
@@ -12,14 +13,15 @@
         onblurCalled = false;
 
         // Simulate a mouse click.
-        eventSender.mouseMoveTo(15, 15);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(15, 15);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
         
         if (onblurCalled) 
             return;
 
-        document.getElementById('result').innerHTML = 'SUCCESS';        
+        document.getElementById('result').innerHTML = 'SUCCESS';
+        testRunner?.notifyDone();
     }
     </script>
 </head>

--- a/LayoutTests/fast/forms/input-user-modify.html
+++ b/LayoutTests/fast/forms/input-user-modify.html
@@ -44,36 +44,42 @@ input::-webkit-calendar-picker-indicator {
 </div>
 
 <script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-    
-function focusAndType(id, key)
+async function focusAndType(id, key)
 {
     if (!window.eventSenver)
         return;
 
     var target = document.getElementById(id);
-    eventSender.mouseMoveTo(target.offsetLeft + 2, target.offsetTop + 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(target.offsetLeft + 2, target.offsetTop + 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
     eventSender.keyDown(key);
 }
 
-var container = document.getElementById("container");
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-focusAndType("search", "delete");
-focusAndType("file", "delete");
-focusAndType("range", "delete");
-focusAndType("color", "delete");
-focusAndType("number", "delete");
-focusAndType("placeholder", "delete");
-focusAndType("button", "delete");
-focusAndType("date", "delete");
-focusAndType("video", "delete");
-focusAndType("audio", "delete");
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
 
-if (window.testRunner)
+    var container = document.getElementById("container");
+
+    await focusAndType("search", "delete");
+    await focusAndType("file", "delete");
+    await focusAndType("range", "delete");
+    await focusAndType("color", "delete");
+    await focusAndType("number", "delete");
+    await focusAndType("placeholder", "delete");
+    await focusAndType("button", "delete");
+    await focusAndType("date", "delete");
+    await focusAndType("video", "delete");
+    await focusAndType("audio", "delete");
+
     container.innerHTML = "PASS";
+
+    testRunner.notifyDone();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/legend-overflow-hidden-hit-test.html
+++ b/LayoutTests/fast/forms/legend-overflow-hidden-hit-test.html
@@ -16,17 +16,24 @@ fieldset {
         <p id=log>Clicks: 0</p>
     </fieldset>
 <script>
-if (window.testRunner)
-    testRunner.dumpAsText();
 let index = 0;
 function updateCount() {
     log.innerHTML = `Clicks: ${++index}`;
 }
-button.addEventListener('click', updateCount);
-if (window.eventSender) {
-    eventSender.mouseMoveTo(button.offsetLeft + 5, button.offsetTop + 5)
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    button.addEventListener('click', updateCount);
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(button.offsetLeft + 5, button.offsetTop + 5)
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
+    testRunner.notifyDone();
 }
 </script>
 

--- a/LayoutTests/fast/forms/listbox-deselect-scroll-expected.txt
+++ b/LayoutTests/fast/forms/listbox-deselect-scroll-expected.txt
@@ -3,9 +3,9 @@ This tests that deselecting an option won't cause unnecessary scrolling.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS sl.scrollTop is scrollBeforeClick
-PASS selectionPattern(sl) is "11111110111"
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS sl.scrollTop is scrollBeforeClick
+PASS selectionPattern(sl) is "11111110111"
 

--- a/LayoutTests/fast/forms/listbox-deselect-scroll.html
+++ b/LayoutTests/fast/forms/listbox-deselect-scroll.html
@@ -9,15 +9,15 @@
 <script>
 description('This tests that deselecting an option won&apos;t cause unnecessary scrolling.');
 
-function mouseDownOnSelect(selId, index, modifier) {
+async function mouseDownOnSelect(selId, index, modifier) {
     var sl = document.getElementById(selId);
     var itemHeight = Math.floor(sl.offsetHeight / sl.size);
     var border = 1;
     var y = border + index * itemHeight - window.pageYOffset;
     if (window.eventSender) {
-        eventSender.mouseMoveTo(sl.offsetLeft + border, sl.offsetTop + y);
-        eventSender.mouseDown(0, [modifier]);
-        eventSender.mouseUp(0, [modifier]);
+        await eventSender.asyncMouseMoveTo(sl.offsetLeft + border, sl.offsetTop + y);
+        await eventSender.asyncMouseDown(0, [modifier]);
+        await eventSender.asyncMouseUp(0, [modifier]);
     }
 }
 
@@ -49,9 +49,18 @@ sl.focus();
 document.execCommand("SelectAll");
 sl.scrollTop = Math.floor(sl.offsetHeight / sl.size) * 4 + 6;
 var scrollBeforeClick = sl.scrollTop;
-mouseDownOnSelect("sl", 3, "addSelectionKey");
-shouldBe('sl.scrollTop', 'scrollBeforeClick');
-shouldBe('selectionPattern(sl)', '"11111110111"');
+
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+
+    await mouseDownOnSelect("sl", 3, "addSelectionKey");
+    shouldBe('sl.scrollTop', 'scrollBeforeClick');
+    shouldBe('selectionPattern(sl)', '"11111110111"');
+    testRunner.notifyDone();
+}
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/forms/listbox-scrollbar-hit-test.html
+++ b/LayoutTests/fast/forms/listbox-scrollbar-hit-test.html
@@ -12,16 +12,16 @@
     }
   </style>
   <script type="text/javascript" charset="utf-8">
-    function sendClick(element, clientX, clientY)
+    async function sendClick(element, clientX, clientY)
     {
       if (window.eventSender) {
-        eventSender.mouseMoveTo(clientX, clientY);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(clientX, clientY);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
       }
     }
 
-    function mouseDownOnSelect(selId, translateX, translateY)
+    async function mouseDownOnSelect(selId, translateX, translateY)
     {
       log('Testing clicks on ' + selId);
 
@@ -36,14 +36,14 @@
       var scrollbarTopArrowY = translateY + selectElement.offsetTop + selectElement.offsetHeight - border - scrollbarButtonHeight - 3;
       var scrollbarBottomArrowY = translateY + selectElement.offsetTop + selectElement.offsetHeight - border - 3;
       
-      sendClick(selectElement, scrollbarMidX, scrollbarBottomArrowY);
-      sendClick(selectElement, scrollbarMidX, scrollbarBottomArrowY);
+      await sendClick(selectElement, scrollbarMidX, scrollbarBottomArrowY);
+      await sendClick(selectElement, scrollbarMidX, scrollbarBottomArrowY);
       if (selectElement.scrollTop == 2 * itemHeight)
         log('Scrolled down by itemHeight on down arrow click: PASS');
       else
         log('Failed to scroll down - scrollTop is ' + selectElement.scrollTop + ': FAIL');
 
-      sendClick(selectElement, scrollbarMidX, scrollbarTopArrowY);
+      await sendClick(selectElement, scrollbarMidX, scrollbarTopArrowY);
       if (selectElement.scrollTop == itemHeight)
         log('Scrolled up by itemHeight on up arrow click: PASS');
       else
@@ -71,9 +71,9 @@
       
       // Have to wait for the select to be painted before the
       // scrollbar is sized correctly.
-      setTimeout(function() {
-        mouseDownOnSelect('select1', 0, 0);
-        mouseDownOnSelect('select2', 50, 50);
+      setTimeout(async function() {
+        await mouseDownOnSelect('select1', 0, 0);
+        await mouseDownOnSelect('select2', 50, 50);
         if (window.testRunner)
           testRunner.notifyDone();
       }, 0);

--- a/LayoutTests/fast/forms/multiple-form-submission-protection-mouse.html
+++ b/LayoutTests/fast/forms/multiple-form-submission-protection-mouse.html
@@ -7,24 +7,24 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-addEventListener('message', function(e) {
-    simulateClick('button2');
+addEventListener('message', async function(e) {
+    await simulateClick('button2');
 }, false);
 
-function runTest()
+async function runTest()
 {
     if (!eventSender)
         return;
 
-    simulateClick('button1');
+    await simulateClick('button1');
 }
 
-function simulateClick(id)
+async function simulateClick(id)
 {
     var rect = document.getElementById(id).getBoundingClientRect();
-    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 }
 
 function submitTo(target)

--- a/LayoutTests/fast/forms/option-mouseevents.html
+++ b/LayoutTests/fast/forms/option-mouseevents.html
@@ -43,44 +43,44 @@ function mouseeventverify2(event, x, y, offsetX, offsetY, target, type)
     shouldBe("event.x", event.x, x);
     shouldBe("event.y", event.y, y);
 }
-function test() {
+async function test() {
     if (window.testRunner) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
     }
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(22, 104);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(22, 104);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(22, 184);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(22, 184);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(22, 262);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(22, 262);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(22, 344);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(22, 344);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     if (window.eventSender) {
-        eventSender.mouseMoveTo(22, 448);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(22, 448);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 
     if (window.testRunner)

--- a/LayoutTests/fast/forms/password-doubleclick-selection.html
+++ b/LayoutTests/fast/forms/password-doubleclick-selection.html
@@ -1,21 +1,23 @@
 <html>
 <head>
     <script>
-    function test() {
+    async function test() {
         var pass = document.getElementById('tf');
         var res = document.getElementById('res');
 
         if (window.testRunner) {
             testRunner.dumpAsText();
-            eventSender.mouseMoveTo(45, 25);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            testRunner.waitUntilDone();
+            await eventSender.asyncMouseMoveTo(45, 25);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
             if (pass.selectionStart == 0 && pass.selectionEnd == 11)
                 res.innerHTML = "Test Passed.";
             else
                 res.innerHTML = "Test Failed.  SelectionStart index = " + pass.selectionStart + ".  SelectionEnd index = " + pass.selectionEnd + ".";
+            testRunner.notifyDone();
         }
     }
     </script>

--- a/LayoutTests/fast/forms/search-abs-pos-cancel-button.html
+++ b/LayoutTests/fast/forms/search-abs-pos-cancel-button.html
@@ -2,10 +2,6 @@
 <head>
     <title>Search Field with Transform</title>
     <script src="resources/common.js"></script>
-    <script type="text/javascript" charset="utf-8">
-      if (window.testRunner)
-        testRunner.dumpAsText();
-    </script>
 </head>
 <body>
     <p>
@@ -17,19 +13,27 @@
         Clicking the (x) button should clear the field.
     </p>
     <script>
-        if (window.eventSender) {
-            var target = document.getElementById("target");
-            var cancelPos = searchCancelButtonPosition(target);
-            eventSender.mouseMoveTo(cancelPos.x, cancelPos.y);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
-            var result = document.getElementById("result");
-            if (target.value == "")
-                result.innerText = "PASS";
-            else
-                result.innerText = "FAIL";
-            
-            target.value = "Some other text";
+        onload = async () => {
+            if (!window.testRunner)
+                return;
+
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+            if (window.eventSender) {
+                var target = document.getElementById("target");
+                var cancelPos = searchCancelButtonPosition(target);
+                await eventSender.asyncMouseMoveTo(cancelPos.x, cancelPos.y);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
+                var result = document.getElementById("result");
+                if (target.value == "")
+                    result.innerText = "PASS";
+                else
+                    result.innerText = "FAIL";
+                
+                target.value = "Some other text";
+            }
+            testRunner.notifyDone();
         }
     </script>
 </body>

--- a/LayoutTests/fast/forms/search-cancel-button-change-input.html
+++ b/LayoutTests/fast/forms/search-cancel-button-change-input.html
@@ -28,12 +28,12 @@ function changeType(e) {
     }, 0);
 }
 
-function clickCancel() {
+async function clickCancel() {
     var cancelButtonPosition = searchCancelButtonPosition(inputElement);
 
-    eventSender.mouseMoveTo(cancelButtonPosition.x, cancelButtonPosition.y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(cancelButtonPosition.x, cancelButtonPosition.y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 }
 
 function runTest() {
@@ -46,8 +46,8 @@ function runTest() {
 
     inputElement.addEventListener("input", changeType);
 
-    setTimeout(function() {
-        clickCancel();
+    setTimeout(async function() {
+        await clickCancel();
     }, 0);
 }
 </script>

--- a/LayoutTests/fast/forms/search-cancel-button-events-expected.txt
+++ b/LayoutTests/fast/forms/search-cancel-button-events-expected.txt
@@ -3,6 +3,9 @@ Test for event dipatching by search cancel button.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Initial state
 PASS changeEventCounter is 0
 PASS inputEventCounter is 0
@@ -13,7 +16,4 @@ PASS inputEventCounter is 1
 Focus on another field
 PASS changeEventCounter is 1
 PASS inputEventCounter is 1
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/forms/search-cancel-button-events.html
+++ b/LayoutTests/fast/forms/search-cancel-button-events.html
@@ -20,27 +20,34 @@ var changeEventCounter = 0;
 search.onchange = function() { changeEventCounter++; };
 search.oninput = function() { inputEventCounter++; };
 
-if (window.eventSender) {
-    debug('Initial state');
-    shouldBe('changeEventCounter', '0');
-    shouldBe('inputEventCounter', '0');
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-    debug('Click the cancel button');
-    eventSender.mouseMoveTo(search.offsetLeft + search.offsetWidth - 8, search.offsetTop + search.offsetHeight / 2);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    shouldBe('search.value', '""');
-    shouldBe('changeEventCounter', '0');
-    shouldBe('inputEventCounter', '1');
+    testRunner.waitUntilDone();
+    if (window.eventSender) {
+        debug('Initial state');
+        shouldBe('changeEventCounter', '0');
+        shouldBe('inputEventCounter', '0');
 
-    debug('Focus on another field');
-    anotherInput.focus();
-    shouldBe('changeEventCounter', '1');
-    shouldBe('inputEventCounter', '1');
+        debug('Click the cancel button');
+        await eventSender.asyncMouseMoveTo(search.offsetLeft + search.offsetWidth - 8, search.offsetTop + search.offsetHeight / 2);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+        shouldBe('search.value', '""');
+        shouldBe('changeEventCounter', '0');
+        shouldBe('inputEventCounter', '1');
 
-    parent.innerHTML = '';
-} else {
-  document.getElementById('console').innerHTML = 'No eventSender';
+        debug('Focus on another field');
+        anotherInput.focus();
+        shouldBe('changeEventCounter', '1');
+        shouldBe('inputEventCounter', '1');
+
+        parent.innerHTML = '';
+    } else {
+        document.getElementById('console').innerHTML = 'No eventSender';
+    }
+    testRunner.notifyDone();
 }
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/search-cancel-button-hover.html
+++ b/LayoutTests/fast/forms/search-cancel-button-hover.html
@@ -21,13 +21,18 @@ input[type="search"]::-webkit-search-cancel-button:hover {
 <body>
 <input type="search" id="search" value="foo"/>
 <script>
-if (window.testRunner) {
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
     var input = document.getElementById("search");
     var position = searchCancelButtonPosition(input);
-    eventSender.mouseMoveTo(position.x, position.y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseMoveTo(position.x + 1, position.y);
+    await eventSender.asyncMouseMoveTo(position.x, position.y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseMoveTo(position.x + 1, position.y);
+    testRunner.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/search-cancel-button-mouseup.html
+++ b/LayoutTests/fast/forms/search-cancel-button-mouseup.html
@@ -3,12 +3,13 @@
     <title></title>
     <script src="resources/common.js"></script>
     <script>
-        function test()
+        async function test()
         {
             if (!window.testRunner)
                 return;
 
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();
 
             var s1 = document.getElementById("search1");
             var s2 = document.getElementById("search2");
@@ -21,22 +22,22 @@
             var y2 = s2.offsetTop + s2.offsetHeight / 2;
             var y3 = s3.offsetTop + s3.offsetHeight / 2;
 
-            eventSender.mouseMoveTo(buttonX, s1cancelPos.y);
-            eventSender.mouseDown();
-            eventSender.mouseMoveTo(middleX, s1cancelPos.y);
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(buttonX, s1cancelPos.y);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseMoveTo(middleX, s1cancelPos.y);
+            await eventSender.asyncMouseUp();
             eventSender.leapForward(1000);
 
-            eventSender.mouseMoveTo(middleX, y2);
-            eventSender.mouseDown();
-            eventSender.mouseMoveTo(buttonX, y2);
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(middleX, y2);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseMoveTo(buttonX, y2);
+            await eventSender.asyncMouseUp();
             eventSender.leapForward(1000);
 
-            eventSender.mouseMoveTo(buttonX, y3);
-            eventSender.mouseDown();
-            eventSender.mouseMoveTo(buttonX, y3);
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(buttonX, y3);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseMoveTo(buttonX, y3);
+            await eventSender.asyncMouseUp();
 
             var result = document.getElementById("result");
             var values = s1.value + ", " + s2.value + ", " + s3.value;
@@ -44,6 +45,8 @@
                 result.innerText = "PASS";
             else
                 result.innerText = "FAIL (" + values + ")";
+
+            testRunner.notifyDone();
         }
     </script>
 </head>

--- a/LayoutTests/fast/forms/search-click-in-placeholder.html
+++ b/LayoutTests/fast/forms/search-click-in-placeholder.html
@@ -8,21 +8,24 @@
             document.getElementById("console").appendChild(document.createTextNode(message + "\n"));
         }
 
-        function test() {
-            if (!window.eventSender)
+        async function test() {
+            if (!window.eventSender || !window.testRunner)
                 return;
 
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();
 
             var target = document.getElementById("target");
             var x = target.offsetParent.offsetLeft + target.offsetLeft + target.offsetWidth / 2;
             var y = target.offsetParent.offsetTop + target.offsetTop + target.offsetHeight / 2;
 
-            eventSender.mouseMoveTo(x, y);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(x, y);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
 
             log(hasFocus ? "PASS" : "FAIL");
+
+            testRunner.notifyDone();
         }
     </script>
 </body>

--- a/LayoutTests/fast/forms/search-delete-while-cancel-button-clicked.html
+++ b/LayoutTests/fast/forms/search-delete-while-cancel-button-clicked.html
@@ -7,15 +7,15 @@
                 console.innerHTML = console.innerHTML + msg + "<br>";
             }
             
-            function buttonClick()
+            async function buttonClick()
             {
                 log("<br>clicking button");
 
                 // click the button
                 var button = document.getElementById('button');
-                eventSender.mouseMoveTo(button.offsetLeft + 20, button.offsetTop + 7);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(button.offsetLeft + 20, button.offsetTop + 7);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
 
                 testRunner.notifyDone();
             }
@@ -30,7 +30,7 @@
                 setTimeout(buttonClick, 10);
             }
             
-            function drag()
+            async function drag()
             {
                 if (!window.testRunner)
                     return;
@@ -44,8 +44,8 @@
 
                 // drag slider, leave the mouse down
                 log("clicking in cancel");
-                eventSender.mouseMoveTo(x, y);
-                eventSender.mouseDown();
+                await eventSender.asyncMouseMoveTo(x, y);
+                await eventSender.asyncMouseDown();
 
                 setTimeout(deleteSearch, 10);
             }

--- a/LayoutTests/fast/forms/search-disabled-readonly-expected.txt
+++ b/LayoutTests/fast/forms/search-disabled-readonly-expected.txt
@@ -4,6 +4,9 @@
 This tests the behavior of a cancel button in search input forms.
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Test on the input form with disabled=false and readonly=false
 Click the cancel button:
 PASS input.value is ""
@@ -44,7 +47,4 @@ PASS input.value is "foo"
 ... and then input one character:
 PASS input.value is "foo"
 
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/forms/search-disabled-readonly.html
+++ b/LayoutTests/fast/forms/search-disabled-readonly.html
@@ -12,13 +12,13 @@ This tests the behavior of a cancel button in search input forms.
 </p>
 </div>
 <script>
-function click(position) {
+async function click(position) {
     if (!eventSender)
         return;
-    eventSender.mouseMoveTo(position.x, position.y);
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(position.x, position.y);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(position.x, position.y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(position.x, position.y);
+    await eventSender.asyncMouseUp();
     eventSender.leapForward(1000);
 }
 
@@ -35,21 +35,26 @@ function setInputAttributes(input, value, disabled, readonly) {
     input.readOnly = !!readonly;
 }
 
-if (window.testRunner) {
-    var input = $("search_input");
-    var cancelButtonPosition = searchCancelButtonPosition(input);
-    var middleButtonPosition = {};
-    middleButtonPosition.x = input.offsetLeft + input.offsetWidth / 2;
-    middleButtonPosition.y = input.offsetTop + input.offsetHeight / 2;
-    var enabled = false;
-    var disabled = true;
-    var readonly = true;
+var input = $("search_input");
+var cancelButtonPosition = searchCancelButtonPosition(input);
+var middleButtonPosition = {};
+middleButtonPosition.x = input.offsetLeft + input.offsetWidth / 2;
+middleButtonPosition.y = input.offsetTop + input.offsetHeight / 2;
+var enabled = false;
+var disabled = true;
+var readonly = true;
+
+onload = async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
 
     debug("Test on the input form with disabled=false and readonly=false");
 
     setInputAttributes(input, "foo", enabled);
     debug("Click the cancel button:");
-    click(cancelButtonPosition);
+    await click(cancelButtonPosition);
     shouldBe('input.value', '""');
     debug("... and then input one character:");
     keydown("b");
@@ -57,7 +62,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", enabled);
     debug("Click the center of the form:");
-    click(middleButtonPosition);
+    await click(middleButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -68,7 +73,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", enabled, readonly);
     debug("Click the cancel button:");
-    click(cancelButtonPosition);
+    await click(cancelButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -76,7 +81,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", enabled, readonly);
     debug("Click the center of the form:");
-    click(middleButtonPosition);
+    await click(middleButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -87,7 +92,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", disabled);
     debug("Click the cancel button:");
-    click(cancelButtonPosition);
+    await click(cancelButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -95,7 +100,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", disabled);
     debug("Click the center of the form:");
-    click(middleButtonPosition);
+    await click(middleButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -106,7 +111,7 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", disabled, readonly);
     debug("Click the cancel button:");
-    click(cancelButtonPosition);
+    await click(cancelButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
@@ -114,13 +119,15 @@ if (window.testRunner) {
 
     setInputAttributes(input, "foo", disabled, readonly);
     debug("Click the center of the form:");
-    click(middleButtonPosition);
+    await click(middleButtonPosition);
     shouldBe('input.value', '"foo"');
     debug("... and then input one character:");
     keydown("b");
     shouldBe('input.value', '"foo"');
 
     debug("");
+
+    testRunner.notifyDone();
 }
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/search-hidden-cancel-button.html
+++ b/LayoutTests/fast/forms/search-hidden-cancel-button.html
@@ -6,12 +6,14 @@
             {
                 document.getElementById("console").appendChild(document.createTextNode(msg + "\n"));
             }
-            function test()
+            async function test()
             {
                 mouseDownCount = 0;
                 
-                if (window.testRunner)
+                if (window.testRunner) {
+                    testRunner.waitUntilDone();
                     testRunner.dumpAsText();
+                }
 
                 var sf = document.getElementById("search");
 
@@ -21,18 +23,19 @@
                 var y = sf.offsetTop + sf.offsetHeight / 2;
 
                 if (window.testRunner) {
-                    eventSender.mouseMoveTo(buttonX, y);
-                    eventSender.mouseDown();
-                    eventSender.mouseUp();
+                    await eventSender.asyncMouseMoveTo(buttonX, y);
+                    await eventSender.asyncMouseDown();
+                    await eventSender.asyncMouseUp();
 
-                    eventSender.mouseMoveTo(middleX, y);
-                    eventSender.mouseDown();
-                    eventSender.mouseUp();
+                    await eventSender.asyncMouseMoveTo(middleX, y);
+                    await eventSender.asyncMouseDown();
+                    await eventSender.asyncMouseUp();
                     
                     if (mouseDownCount == 2)
                         log("Test Passed");
                     else
                         log("Test Failed");
+                    testRunner.notifyDone();
                 }
             }
         </script>

--- a/LayoutTests/fast/forms/search-hide-cancel-on-cancel-expected.txt
+++ b/LayoutTests/fast/forms/search-hide-cancel-on-cancel-expected.txt
@@ -4,8 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 
-PASS mouseDownCount is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS mouseDownCount is 2
 

--- a/LayoutTests/fast/forms/search-hide-cancel-on-cancel.html
+++ b/LayoutTests/fast/forms/search-hide-cancel-on-cancel.html
@@ -25,17 +25,24 @@ function clearValue(event) {
     this.value = '';
 }
 input.addEventListener('focus', clearValue, false);
-// Click the cancel button.
-eventSender.mouseMoveTo(cancelX, middleY);
-eventSender.mouseDown();
-eventSender.mouseUp();
-// Click the input element. The event should not be captured by the cancel button.
-eventSender.mouseMoveTo(middleX, middleY);
-eventSender.mouseDown();
-eventSender.mouseUp();
 
-shouldBe('mouseDownCount', '2');
-input.removeEventListener('focus', clearValue, false);
+onload = async () => {
+    if (!window.testRunner)
+        return;
+    testRunner.waitUntilDone();
+    // Click the cancel button.
+    await eventSender.asyncMouseMoveTo(cancelX, middleY);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    // Click the input element. The event should not be captured by the cancel button.
+    await eventSender.asyncMouseMoveTo(middleX, middleY);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+
+    shouldBe('mouseDownCount', '2');
+    input.removeEventListener('focus', clearValue, false);
+    testRunner.notifyDone();
+}
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/forms/search-transformed.html
+++ b/LayoutTests/fast/forms/search-transformed.html
@@ -16,21 +16,27 @@
         Clicking the (x) button should clear the field.
     </p>
     <script>
-        if (window.testRunner)
+        onload = async () => {
+            if (!window.testRunner)
+                return;
+
             testRunner.dumpAsText();
-        if (window.eventSender) {
-            var target = document.getElementById("target");
-            var cancelPos = searchCancelButtonPosition(target);
-            eventSender.mouseMoveTo(cancelPos.x, cancelPos.y);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
-            var result = document.getElementById("result");
-            if (target.value == "")
-                result.innerText = "PASS";
-            else
-                result.innerText = "FAIL";
-            
-            target.value = "Some other text";
+            testRunner.waitUntilDone();
+            if (window.eventSender) {
+                var target = document.getElementById("target");
+                var cancelPos = searchCancelButtonPosition(target);
+                await eventSender.asyncMouseMoveTo(cancelPos.x, cancelPos.y);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
+                var result = document.getElementById("result");
+                if (target.value == "")
+                    result.innerText = "PASS";
+                else
+                    result.innerText = "FAIL";
+                
+                target.value = "Some other text";
+            }
+            testRunner.notifyDone();
         }
     </script>
 </body>

--- a/LayoutTests/fast/forms/search-zoomed.html
+++ b/LayoutTests/fast/forms/search-zoomed.html
@@ -21,21 +21,27 @@
         Clicking the (x) button should clear the field.
     </p>
     <script>
-        if (window.testRunner)
+        onload = async () => {
+            if (!window.testRunner)
+                return;
+
             testRunner.dumpAsText();
-        if (window.eventSender) {
-            var target = document.getElementById("target");
-            var cancelPos = searchCancelButtonPosition(target);
-            eventSender.mouseMoveTo(cancelPos.x * 1.2, cancelPos.y * 1.2);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
-            var result = document.getElementById("result");
-            if (target.value == "")
-                result.innerText = "PASS";
-            else
-                result.innerText = "FAIL";
-            
-            target.value = "Some other text";
+            testRunner.waitUntilDone();
+            if (window.eventSender) {
+                var target = document.getElementById("target");
+                var cancelPos = searchCancelButtonPosition(target);
+                await eventSender.asyncMouseMoveTo(cancelPos.x * 1.2, cancelPos.y * 1.2);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
+                var result = document.getElementById("result");
+                if (target.value == "")
+                    result.innerText = "PASS";
+                else
+                    result.innerText = "FAIL";
+                
+                target.value = "Some other text";
+            }
+            testRunner.notifyDone();
         }
     </script>
 </body>

--- a/LayoutTests/fast/forms/select-empty-list.html
+++ b/LayoutTests/fast/forms/select-empty-list.html
@@ -1,13 +1,15 @@
 <head>
 <script>
-function test()
+async function test()
 {
-    if (window.testRunner)
+    if (window.testRunner) {
         testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
     if (window.eventSender) {
-        eventSender.mouseMoveTo(20, 70);
-        eventSender.mouseDown();
-        eventSender.mouseUp();
+        await eventSender.asyncMouseMoveTo(20, 70);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
     }
 }
 
@@ -16,6 +18,7 @@ function selectClicked() {
     var paragraph = document.createElement('p');
     paragraph.appendChild(document.createTextNode(message));
     document.getElementById('console').appendChild(paragraph);
+    testRunner?.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/fast/forms/select-listbox-focus-displaynone-expected.txt
+++ b/LayoutTests/fast/forms/select-listbox-focus-displaynone-expected.txt
@@ -1,1 +1,1 @@
- PASS
+PASS

--- a/LayoutTests/fast/forms/select-listbox-focus-displaynone.html
+++ b/LayoutTests/fast/forms/select-listbox-focus-displaynone.html
@@ -9,23 +9,28 @@
 <input id="selectable">
 
 <script>
-if (window.testRunner)
-    window.testRunner.dumpAsText();
+onload = async () => {
+    if (!window.testRunner)
+        return;
 
-var selectable = document.getElementById('selectable');
-var multiselect = document.getElementById('multiselect');
-selectable.focus();
-selectable.onblur = function() {
-    multiselect.style.display='none';
-    document.write('PASS');
-};
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    var selectable = document.getElementById('selectable');
+    var multiselect = document.getElementById('multiselect');
+    selectable.focus();
+    selectable.onblur = function() {
+        multiselect.style.display='none';
+        document.write('PASS');
+    };
 
-if (window.eventSender) {
-    eventSender.mouseMoveTo(multiselect.offsetLeft + 5, multiselect.offsetTop + 5);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-} else {
-    document.write("To manually test, click on the 'a' option");
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(multiselect.offsetLeft + 5, multiselect.offsetTop + 5);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    } else {
+        document.write("To manually test, click on the 'a' option");
+    }
+    testRunner.notifyDone();
 }
 </script>
 

--- a/LayoutTests/fast/forms/select-listbox-multiple-no-focusring.html
+++ b/LayoutTests/fast/forms/select-listbox-multiple-no-focusring.html
@@ -7,14 +7,18 @@
 </select>
 
 <script>
-var multiselect = document.getElementById('multiselect');
+onload = async () => {
+    testRunner?.waitUntilDone();
+    var multiselect = document.getElementById('multiselect');
 
-if (window.eventSender) {
-    eventSender.mouseMoveTo(multiselect.offsetLeft + 5, multiselect.offsetTop + 5);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-} else {
-    document.write("To manually test, click on the 'a' option and no focus ring on the selected item should be seen.");
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(multiselect.offsetLeft + 5, multiselect.offsetTop + 5);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    } else {
+        document.write("To manually test, click on the 'a' option and no focus ring on the selected item should be seen.");
+    }
+    testRunner?.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size-expected.txt
+++ b/LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size-expected.txt
@@ -3,6 +3,9 @@ Select multiple options with mouse drag with no. of options less than the size a
 Also test mouse drag on select element without multiple attribute select only the option under mouse
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Test for select element with multiple attribute
 Dragging down
 PASS document.getElementById("selectId").options[0].selected is true
@@ -45,7 +48,4 @@ PASS document.getElementById("nonmultiple").options[0].selected is true
 PASS document.getElementById("nonmultiple").options[1].selected is false
 PASS document.getElementById("nonmultiple").options[2].selected is false
 PASS document.getElementById("nonmultiple").options[3].selected is false
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size.html
+++ b/LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size.html
@@ -27,7 +27,14 @@
 
 <div id="console"></div>
 <script>
-if (window.eventSender) {
+onload = async () => {
+    if (!window.testRunner || !window.eventSender) {
+        debug("Test manually if options are getting selected by dragging on the select element.");
+        return;
+    }
+
+    testRunner.waitUntilDone();
+
     debug("Test for select element with multiple attribute");
     var selectObject = document.getElementById("selectId");
 
@@ -36,38 +43,38 @@ if (window.eventSender) {
     var y = selectObject.offsetTop + optionHeight / 2;
 
     eventSender.dragMode = false;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
 
     debug("Dragging down");
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, y + (optionHeight * 3));
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 3));
+    await eventSender.asyncMouseUp();
     testOptionSelection(0, 4, "true", "selectId");
 
     debug("Dragging up");
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseUp();
     testOptionSelection(0, 4, "true", "selectId");
 
     debug("Dragging with addSelectionKey")
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseMoveTo(x, y + (optionHeight * 2));
-    eventSender.mouseDown(0, ["addSelectionKey"]);
-    eventSender.mouseMoveTo(x, y + (optionHeight * 4));
-    eventSender.mouseUp(0, ["addSelectionKey"]);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 2));
+    await eventSender.asyncMouseDown(0, ["addSelectionKey"]);
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 4));
+    await eventSender.asyncMouseUp(0, ["addSelectionKey"]);
     testOptionSelection(0, 1, "true", "selectId");
     testOptionSelection(2, 5, "true", "selectId");
 
     debug("Dragging with rangeSelectionKey");
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-    eventSender.mouseMoveTo(x, y + (optionHeight * 2));
-    eventSender.mouseDown(0, ["rangeSelectionKey"]);
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseUp(0, ["rangeSelectionKey"]);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 2));
+    await eventSender.asyncMouseDown(0, ["rangeSelectionKey"]);
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseUp(0, ["rangeSelectionKey"]);
     testOptionSelection(0, 4, "true", "selectId");
 
     debug("Test for select element without multiple attribute");
@@ -77,41 +84,40 @@ if (window.eventSender) {
     y = nonMultipleObject.offsetTop + optionHeight / 2;
 
     eventSender.dragMode = false;
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
 
     debug("Dragging down");
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, y + (optionHeight * 3));
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 3));
+    await eventSender.asyncMouseUp();
     testOptionSelection(0, 3, "false", "nonmultiple");
     testOptionSelection(3, 4, "true", "nonmultiple");
 
     debug("Dragging up");
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseUp();
     testOptionSelection(0, 1, "true", "nonmultiple");
     testOptionSelection(1, 4, "false", "nonmultiple");
 
     debug("Dragging with addSelectionKey")
-    eventSender.mouseDown();
-    eventSender.mouseDown(0, "addSelectionKey");
-    eventSender.mouseMoveTo(x, y + (optionHeight * 3));
-    eventSender.mouseUp(0, "addSelectionKey");
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseDown(0, "addSelectionKey");
+    await eventSender.asyncMouseMoveTo(x, y + (optionHeight * 3));
+    await eventSender.asyncMouseUp(0, "addSelectionKey");
     testOptionSelection(0, 3, "false", "nonmultiple");
     testOptionSelection(3, 4, "true", "nonmultiple");
 
     debug("Dragging with rangeSelectionKey");
-    eventSender.mouseDown();
-    eventSender.mouseDown(0, "rangeSelectionKey");
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseUp(0, "rangeSelectionKey");
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseDown(0, "rangeSelectionKey");
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseUp(0, "rangeSelectionKey");
     testOptionSelection(0, 1, "true", "nonmultiple");
     testOptionSelection(1, 4, "false", "nonmultiple");
 
-} else {
-    debug("Test manually if options are getting selected by dragging on the select element.");
+    testRunner.notifyDone();
 }
 
 function testOptionSelection(start, end, criteria, element) {

--- a/LayoutTests/fast/forms/switch/click-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-disabled.html
@@ -6,9 +6,11 @@
 <script>
 function end() {
     document.documentElement.removeAttribute("class");
+    testRunner?.notifyDone();
 }
 
-window.onload = () => {
+window.onload = async () => {
+    testRunner?.waitUntilDone();
     if (UIHelper.isIOSFamily()) {
         const eventStreamData = new UIHelper.EventStreamBuilder()
             .begin(10, 10)
@@ -16,8 +18,8 @@ window.onload = () => {
         UIHelper.sendEventStream(eventStreamData).then(() => end());
         return;
     }
-    window.eventSender.mouseMoveTo(10, 10);
-    window.eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(10, 10);
+    await eventSender.asyncMouseDown();
     end();
 }
 </script>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
@@ -3,7 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end() dir=rtl>
 <script>
-window.onload = () => {
+window.onload = async () => {
+    testRunner?.waitUntilDone();
     const input = document.querySelector("input");
     const x = input.offsetLeft;
     const y = input.offsetTop;
@@ -17,13 +18,15 @@ window.onload = () => {
             .end()
             .takeResult();
         UIHelper.sendEventStream(eventStreamData);
+        testRunner?.notifyDone();
         return;
     }
-    window.eventSender.mouseMoveTo(x + width - 1, y);
-    window.eventSender.mouseDown();
-    window.eventSender.mouseMoveTo(x, y);
-    window.eventSender.mouseMoveTo(x + width - 1, y);
-    window.eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x + width - 1, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseMoveTo(x + width - 1, y);
+    await eventSender.asyncMouseUp();
+    testRunner?.notifyDone();
 }
 function end() {
     setTimeout(() => document.documentElement.removeAttribute("class"), 200);


### PR DESCRIPTION
#### 99cf129766e240d20164abc4378cb1f6a2523502
<pre>
Adopt more eventSender async mouse functions in fast/forms/
<a href="https://bugs.webkit.org/show_bug.cgi?id=281929">https://bugs.webkit.org/show_bug.cgi?id=281929</a>
<a href="https://rdar.apple.com/138435211">rdar://138435211</a>

Reviewed by Alex Christensen.

This is needed for these tests to work correctly when using --site-isolation

* LayoutTests/fast/forms/disabled-mousedown-event.html:
* LayoutTests/fast/forms/disabled-search-input.html:
* LayoutTests/fast/forms/drag-into-textarea.html:
* LayoutTests/fast/forms/drag-out-of-textarea.html:
* LayoutTests/fast/forms/focus-selection-input.html:
* LayoutTests/fast/forms/focus-selection-textarea.html:
* LayoutTests/fast/forms/input-appearance-preventDefault.html:
* LayoutTests/fast/forms/input-appearance-spinbutton-up.html:
* LayoutTests/fast/forms/input-number-click-expected.txt:
* LayoutTests/fast/forms/input-number-click.html:
* LayoutTests/fast/forms/input-readonly-autoscroll.html:
* LayoutTests/fast/forms/input-readonly-focus.html:
* LayoutTests/fast/forms/input-readonly-select-expected.txt:
* LayoutTests/fast/forms/input-readonly-select.html:
* LayoutTests/fast/forms/input-select-on-click.html:
* LayoutTests/fast/forms/input-step-as-double-expected.txt:
* LayoutTests/fast/forms/input-step-as-double.html:
* LayoutTests/fast/forms/input-text-click-inside.html:
* LayoutTests/fast/forms/input-text-click-outside.html:
* LayoutTests/fast/forms/input-text-double-click.html:
* LayoutTests/fast/forms/input-text-drag-down.html:
* LayoutTests/fast/forms/input-text-self-emptying-click.html:
* LayoutTests/fast/forms/input-type-change-in-onfocus-mouse.html:
* LayoutTests/fast/forms/input-user-modify.html:
* LayoutTests/fast/forms/legend-overflow-hidden-hit-test.html:
* LayoutTests/fast/forms/listbox-deselect-scroll-expected.txt:
* LayoutTests/fast/forms/listbox-deselect-scroll.html:
* LayoutTests/fast/forms/listbox-scrollbar-hit-test.html:
* LayoutTests/fast/forms/multiple-form-submission-protection-mouse.html:
* LayoutTests/fast/forms/option-mouseevents.html:
* LayoutTests/fast/forms/password-doubleclick-selection.html:
* LayoutTests/fast/forms/search-abs-pos-cancel-button.html:
* LayoutTests/fast/forms/search-cancel-button-change-input.html:
* LayoutTests/fast/forms/search-cancel-button-events-expected.txt:
* LayoutTests/fast/forms/search-cancel-button-events.html:
* LayoutTests/fast/forms/search-cancel-button-hover.html:
* LayoutTests/fast/forms/search-cancel-button-mouseup.html:
* LayoutTests/fast/forms/search-click-in-placeholder.html:
* LayoutTests/fast/forms/search-delete-while-cancel-button-clicked.html:
* LayoutTests/fast/forms/search-disabled-readonly-expected.txt:
* LayoutTests/fast/forms/search-disabled-readonly.html:
* LayoutTests/fast/forms/search-hidden-cancel-button.html:
* LayoutTests/fast/forms/search-hide-cancel-on-cancel-expected.txt:
* LayoutTests/fast/forms/search-hide-cancel-on-cancel.html:
* LayoutTests/fast/forms/search-transformed.html:
* LayoutTests/fast/forms/search-zoomed.html:
* LayoutTests/fast/forms/select-empty-list.html:
* LayoutTests/fast/forms/select-listbox-focus-displaynone-expected.txt:
* LayoutTests/fast/forms/select-listbox-focus-displaynone.html:
* LayoutTests/fast/forms/select-listbox-multiple-no-focusring.html:
* LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size-expected.txt:
* LayoutTests/fast/forms/select-multiple-elements-with-mouse-drag-with-options-less-than-size.html:
* LayoutTests/fast/forms/switch/click-disabled.html:
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html:

Canonical link: <a href="https://commits.webkit.org/285662@main">https://commits.webkit.org/285662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0ae4504fd2491433117d756b69cb53b2846a1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24506 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16040 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47597 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63045 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79150 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/129 "Found 1 new test failure: http/tests/paymentrequest/ApplePayModifier-multiTokenContexts.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65278 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7286 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->