### PR TITLE
Web Extensions fail to load Chinese localizations.

### DIFF
--- a/Source/WTF/wtf/Language.h
+++ b/Source/WTF/wtf/Language.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
 #import <CoreFoundation/CoreFoundation.h>
@@ -37,11 +38,18 @@ namespace WTF {
 
 enum class ShouldMinimizeLanguages : bool { No, Yes };
 
+struct LocaleComponents {
+    String languageCode;
+    String scriptCode;
+    String countryCode;
+};
+
 WTF_EXPORT_PRIVATE String defaultLanguage(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe.
 WTF_EXPORT_PRIVATE Vector<String> userPreferredLanguages(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe, returns BCP 47 language tags.
 WTF_EXPORT_PRIVATE void overrideUserPreferredLanguages(const Vector<String>&);
 WTF_EXPORT_PRIVATE size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<String>& languageList, bool& exactMatch);
 WTF_EXPORT_PRIVATE bool userPrefersSimplifiedChinese();
+WTF_EXPORT_PRIVATE LocaleComponents parseLocale(const String&);
 
 // Called from platform specific code when the user's preferred language(s) change.
 WTF_EXPORT_PRIVATE void languageDidChange();
@@ -68,6 +76,7 @@ using WTF::userPreferredLanguages;
 using WTF::overrideUserPreferredLanguages;
 using WTF::indexOfBestMatchingLanguageInList;
 using WTF::userPrefersSimplifiedChinese;
+using WTF::parseLocale;
 using WTF::addLanguageChangeObserver;
 using WTF::removeLanguageChangeObserver;
 using WTF::displayNameForLanguageLocale;

--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -54,6 +54,17 @@ size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<St
     return index;
 }
 
+LocaleComponents parseLocale(const String& localeIdentifier)
+{
+    auto locale = retainPtr([NSLocale localeWithLocaleIdentifier:localeIdentifier]);
+
+    return {
+        locale.get().languageCode,
+        locale.get().scriptCode,
+        locale.get().countryCode
+    };
+}
+
 bool canMinimizeLanguages()
 {
     static const bool result = []() -> bool {

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -526,6 +526,9 @@
 /* WKWebExtensionErrorInvalidManifestEntry description for default_icon in browser_action or page_action */
 "Empty or invalid `default_icon` for the `browser_action` or `page_action` manifest entry." = "Empty or invalid `default_icon` for the `browser_action` or `page_action` manifest entry.";
 
+/* WKWebExtensionErrorInvalidManifestEntry description for default_locale */
+"Empty or invalid `default_locale` manifest entry." = "Empty or invalid `default_locale` manifest entry.";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for invalid command description */
 "Empty or invalid `description` in the `commands` manifest entry." = "Empty or invalid `description` in the `commands` manifest entry.";
 
@@ -1623,6 +1626,9 @@
 
 /* WKWebExtensionErrorResourceNotFound description with invalid file path */
 "Unable to find \"%@\" in the extension’s resources. It is an invalid path." = "Unable to find \"%@\" in the extension’s resources. It is an invalid path.";
+
+/* WKWebExtensionErrorInvalidManifestEntry description for missing default_locale */
+"Unable to find `default_locale` in “_locales” folder." = "Unable to find `default_locale` in “_locales” folder.";
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequest description */
 "Unable to parse `declarativeNetRequest` rules because of an unexpected error." = "Unable to parse `declarativeNetRequest` rules because of an unexpected error.";

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
@@ -36,6 +36,7 @@
 #import "Logging.h"
 #import "WKWebExtensionInternal.h"
 #import "WebExtension.h"
+#import <wtf/Language.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
@@ -86,43 +87,40 @@ using namespace WebKit;
 
 - (instancetype)initWithWebExtension:(WebExtension&)webExtension
 {
-    NSString *defaultLocaleString = webExtension.defaultLocale().localeIdentifier;
-
-    if (!defaultLocaleString.length) {
+    auto defaultLocaleString = webExtension.defaultLocale();
+    if (defaultLocaleString.isEmpty()) {
         RELEASE_LOG_DEBUG(Extensions, "No default locale provided");
         return [self initWithRegionalLocalization:nil languageLocalization:nil defaultLocalization:nil withBestLocale:nil uniqueIdentifier:nil];
     }
 
-    NSLocale *currentLocale = NSLocale.autoupdatingCurrentLocale;
-    NSString *languageCode = currentLocale.languageCode;
-    NSString *countryCode = currentLocale.countryCode;
-
-    NSString *regionalLocaleString = [NSString stringWithFormat:@"%@_%@", languageCode, countryCode];
-    NSString *bestLocaleString;
-
-    LocalizationDictionary *defaultLocaleDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:defaultLocaleString];
-    if (defaultLocaleDictionary) {
-        RELEASE_LOG_DEBUG(Extensions, "Default locale available for %{public}@", defaultLocaleString);
-        bestLocaleString = defaultLocaleString;
+    auto *defaultLocaleDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:defaultLocaleString];
+    if (!defaultLocaleDictionary) {
+        RELEASE_LOG_DEBUG(Extensions, "No localization found for default locale %{public}@", static_cast<NSString *>(defaultLocaleString));
+        return [self initWithRegionalLocalization:nil languageLocalization:nil defaultLocalization:nil withBestLocale:nil uniqueIdentifier:nil];
     }
 
+    RELEASE_LOG_DEBUG(Extensions, "Loaded default locale %{public}@", static_cast<NSString *>(defaultLocaleString));
+
+    auto bestLocaleString = webExtension.bestMatchLocale();
+    auto defaultLocaleComponents = parseLocale(defaultLocaleString);
+    auto bestLocaleComponents = parseLocale(bestLocaleString);
+    auto bestLocaleLanguageOnlyString = bestLocaleComponents.languageCode;
+
+    RELEASE_LOG_DEBUG(Extensions, "Best locale is %{public}@", static_cast<NSString *>(bestLocaleString));
+
     LocalizationDictionary *languageDictionary;
-    if (![languageCode isEqualToString:defaultLocaleString]) {
-        if ((languageDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:languageCode])) {
-            RELEASE_LOG_DEBUG(Extensions, "Language locale available for %{public}@", languageCode);
-            bestLocaleString = languageCode;
-        }
+    if (!bestLocaleLanguageOnlyString.isEmpty() && bestLocaleLanguageOnlyString != defaultLocaleString) {
+        languageDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:bestLocaleLanguageOnlyString];
+        if (languageDictionary)
+            RELEASE_LOG_DEBUG(Extensions, "Loaded language-only locale %{public}@", static_cast<NSString *>(bestLocaleLanguageOnlyString));
     }
 
     LocalizationDictionary *regionalDictionary;
-    if (![regionalLocaleString isEqualToString:defaultLocaleString]) {
-        if ((regionalDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:regionalLocaleString])) {
-            RELEASE_LOG_DEBUG(Extensions, "Regional locale available for %{public}@", regionalLocaleString);
-            bestLocaleString = regionalLocaleString;
-        }
+    if (bestLocaleString != bestLocaleLanguageOnlyString && bestLocaleString != defaultLocaleString) {
+        regionalDictionary = [self _localizationDictionaryForWebExtension:webExtension withLocale:bestLocaleString];
+        if (regionalDictionary)
+            RELEASE_LOG_DEBUG(Extensions, "Loaded regional locale %{public}@", static_cast<NSString *>(bestLocaleString));
     }
-
-    RELEASE_LOG_DEBUG(Extensions, "Best locale is %{public}@", bestLocaleString ?: @"undefined");
 
     return [self initWithRegionalLocalization:regionalDictionary languageLocalization:languageDictionary defaultLocalization:defaultLocaleDictionary withBestLocale:bestLocaleString uniqueIdentifier:nil];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -186,7 +186,9 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (NSLocale *)defaultLocale
 {
-    return self._protectedWebExtension->defaultLocale();
+    if (auto *defaultLocale = nsStringNilIfEmpty(self._protectedWebExtension->defaultLocale()))
+        return [NSLocale localeWithLocaleIdentifier:defaultLocale];
+    return nil;
 }
 
 - (NSString *)displayName

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -96,6 +96,7 @@ public:
         InvalidContentScripts,
         InvalidContentSecurityPolicy,
         InvalidDeclarativeNetRequest,
+        InvalidDefaultLocale,
         InvalidDescription,
         InvalidExternallyConnectable,
         InvalidIcon,
@@ -197,6 +198,12 @@ public:
         String jsonPath;
     };
 
+    struct LocaleComponents {
+        String languageCode;
+        String scriptCode;
+        String countryCode;
+    };
+
     using CommandsVector = Vector<CommandData>;
     using InjectedContentVector = Vector<InjectedContentData>;
     using WebAccessibleResourcesVector = Vector<WebAccessibleResourceData>;
@@ -232,7 +239,10 @@ public:
     RefPtr<API::Data> resourceDataForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
 
     _WKWebExtensionLocalization *localization();
-    NSLocale *defaultLocale();
+
+    const Vector<String>& supportedLocales();
+    const String& defaultLocale();
+    String bestMatchLocale();
 
     const String& displayName();
     const String& displayShortName();
@@ -384,7 +394,8 @@ private:
     Ref<const JSON::Value> m_manifestJSON;
     Resources m_resources;
 
-    RetainPtr<NSLocale> m_defaultLocale;
+    String m_defaultLocale;
+    Vector<String> m_supportedLocales;
     RetainPtr<_WKWebExtensionLocalization> m_localization;
 
     Vector<Ref<API::Error>> m_errors;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
@@ -171,6 +171,9 @@ TEST(WKWebExtensionAPILocalization, i18n)
 
 TEST(WKWebExtensionAPILocalization, i18nWithFallback)
 {
+    // Temporarily set the current locale to US English for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"en-US" ] } forName:NSArgumentDomain];
+
     NSArray<NSString *> *preferredLocaleIdentifiers = NSLocale.preferredLanguages;
     NSMutableOrderedSet<NSString *> *acceptedLanguages = [NSMutableOrderedSet orderedSetWithCapacity:preferredLocaleIdentifiers.count];
     for (NSString *localeIdentifier in preferredLocaleIdentifiers) {
@@ -529,6 +532,712 @@ TEST(WKWebExtensionAPILocalization, CSSLocalization)
     [manager.get().defaultTab.webView loadRequest:[NSURLRequest requestWithURL:testPageURL]];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseSimplified)
+{
+    // Temporarily set the current locale to Simplified Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedOnly)
+{
+    // Temporarily set the current locale to Simplified Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedScript)
+{
+    // Temporarily set the current locale to Simplified Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-US", @"en-US", @"zh-HK" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_Hans/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_Hant/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseTraditional)
+{
+    // Temporarily set the current locale to Traditional Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hant-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '繁體中文擴展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedInTaiwan)
+{
+    // Temporarily set the current locale to Simplified Chinese with the Taiwan country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-TW" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalInChina)
+{
+    // Temporarily set the current locale to Traditional Chinese with the China country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hant-CN" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '繁體中文擴展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedInHongKong)
+{
+    // Temporarily set the current locale to Simplified Chinese with the Hong Kong country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-HK" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *cantoneseMessages = @{
+        @"extension_name": @{
+            @"message": @"香港擴展",
+            @"description": @"The name of the extension in Cantonese (Hong Kong)."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+        @"_locales/zh_HK/messages.json": cantoneseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalOnly)
+{
+    // Temporarily set the current locale to Traditional Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hant-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '繁體中文擴展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_TW/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalScript)
+{
+    // Temporarily set the current locale to Simplified Chinese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hant-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), '繁體中文擴展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *traditionalChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"繁體中文擴展",
+            @"description": @"The name of the extension in Traditional Chinese."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"extension_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh_Hans/messages.json": simplifiedChineseMessages,
+        @"_locales/zh_Hant/messages.json": traditionalChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nChineseLanguageFallback)
+{
+    // Temporarily set the current locale to Simplified Chinese in China for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"zh-Hans-CN" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('regional_name'), '简体中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('language_name'), '中文扩展')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *simplifiedChineseMessages = @{
+        @"regional_name": @{
+            @"message": @"简体中文扩展",
+            @"description": @"The name of the extension in Simplified Chinese."
+        }
+    };
+
+    auto *genericChineseMessages = @{
+        @"language_name": @{
+            @"message": @"中文扩展",
+            @"description": @"The name of the extension in generic Chinese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/zh/messages.json": genericChineseMessages,
+        @"_locales/zh_CN/messages.json": simplifiedChineseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseBrazilian)
+{
+    // Temporarily set the current locale to Brazilian Portuguese for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-BR" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensão Brasileira')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *brazilianPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Brasileira",
+            @"description": @"The name of the extension in Brazilian Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt_BR/messages.json": brazilianPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseEuropean)
+{
+    // Temporarily set the current locale to European Portuguese for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-PT" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensão Portuguesa')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *europeanPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Portuguesa",
+            @"description": @"The name of the extension in European Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt_PT/messages.json": europeanPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStates)
+{
+    // Temporarily set the current locale to Portuguese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensão Portuguesa')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *europeanPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Portuguesa",
+            @"description": @"The name of the extension in European Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt_PT/messages.json": europeanPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStatesFallbackToBrazilian)
+{
+    // Temporarily set the current locale to Portuguese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensão Brasileira')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *brazilianPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Brasileira",
+            @"description": @"The name of the extension in Brazilian Portuguese."
+        }
+    };
+
+    auto *europeanPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Portuguesa",
+            @"description": @"The name of the extension in European Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt_BR/messages.json": brazilianPortugueseMessages,
+        @"_locales/pt_PT/messages.json": europeanPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStatesFallbackToGeneric)
+{
+    // Temporarily set the current locale to Portuguese with the US country code for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-US" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensão Portuguesa Genérica')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *genericPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Portuguesa Genérica",
+            @"description": @"The name of the extension in generic Portuguese."
+        }
+    };
+
+    auto *europeanPortugueseMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensão Portuguesa",
+            @"description": @"The name of the extension in European Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt/messages.json": genericPortugueseMessages,
+        @"_locales/pt_PT/messages.json": europeanPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nPortugueseLanguageFallback)
+{
+    // Temporarily set the current locale to Brazilian Portuguese for the test.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"pt-BR" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('regional_name'), 'Extensão Brasileira')",
+        @"browser.test.assertEq(browser.i18n.getMessage('language_name'), 'Extensão Portuguesa Genérica')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *brazilianPortugueseMessages = @{
+        @"regional_name": @{
+            @"message": @"Extensão Brasileira",
+            @"description": @"The name of the extension in Brazilian Portuguese."
+        }
+    };
+
+    auto *genericPortugueseMessages = @{
+        @"language_name": @{
+            @"message": @"Extensão Portuguesa Genérica",
+            @"description": @"The name of the extension in generic Portuguese."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/pt/messages.json": genericPortugueseMessages,
+        @"_locales/pt_BR/messages.json": brazilianPortugueseMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 5cb898d5fbec7dca0ad41e125b5be9199cc2175d
<pre>
Web Extensions fail to load Chinese localizations.
<a href="https://webkit.org/b/281928">https://webkit.org/b/281928</a>
<a href="https://rdar.apple.com/problem/138435009">rdar://problem/138435009</a>

Reviewed by Brian Weinstein.

* Improve best match logic by using `indexOfBestMatchingLanguageInList()` with the extension&apos;s
  supported locales. This properly handles Chinese script codes.
* Add error handling for `default_locale` by validating it against the locales provided in the
  extension&apos;s `_locales` directory.

* Source/WTF/wtf/Language.cpp:
(WTF::canonicalLanguageIdentifier): Simplified to handle more than 2 parts.
(WTF::parseLocale): Added.
(WTF::indexOfBestMatchingLanguageInList): Simplified and use canonicalized input.
* Source/WTF/wtf/Language.h:
* Source/WTF/wtf/cocoa/LanguageCocoa.mm:
(WTF::parseLocale): Added.
* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization initWithWebExtension:]): Use new helpers from WebExtension
to load the three possible localization dictionaries.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension defaultLocale]): Make the `NSLocale` here.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest): Add error handling for `default_locale`.
(WebKit::WebExtension::preferredSystemLocales): Added.
(WebKit::WebExtension::parseLocale): Added.
(WebKit::WebExtension::defaultLocale): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::toAPI): Added InvalidDefaultLocale error.
(WebKit::WebExtension::createError): Ditto.
(WebKit::WebExtension::supportedLocales): Added.
(WebKit::WebExtension::defaultLocale): Added.
(WebKit::WebExtension::bestMatchLocale): Added.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, DefaultLocaleParsing)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithFallback)): Force `en-US` to match expectations.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseSimplified)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedOnly)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedScript)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseTraditional)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedInTaiwan)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalInChina)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedInHongKong)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalOnly)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalScript)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nChineseLanguageFallback)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseBrazilian)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseEuropean)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStates)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStatesFallbackToBrazilian)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseUnitedStatesFallbackToGeneric)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nPortugueseLanguageFallback)): Added.

Canonical link: <a href="https://commits.webkit.org/285633@main">https://commits.webkit.org/285633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f60c75ffa3150d61e868768c9908798609c31f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/534 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20574 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66457 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79204 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72579 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/627 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/161 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63104 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7325 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94359 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/601 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20747 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->