### PR TITLE
REGRESSION (iOS 18): 5 WPT CSS layout tests are constantly failing (ImageOnlyFailure).

### DIFF
--- a/LayoutTests/fast/text/text-underline-position-under.html
+++ b/LayoutTests/fast/text/text-underline-position-under.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:ibooks="http://apple.com/ibooks/html-extensions" xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
+<meta name="fuzzy" content="maxDifference=0-36; totalPixels=0-2" />
 <style>
 p{
 text-decoration: underline;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-025.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-025.html
@@ -7,6 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-content-3/#quotes">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#quotes">
 <link rel=match href="reference/quotes-025-ref.html">
+<meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-1" />
 <style>
 body { font: 32px serif; }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-026.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-026.html
@@ -7,6 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-content-3/#quotes">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#quotes">
 <link rel=match href="reference/quotes-026-ref.html">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-4" />
 <style>
 body { font: 32px serif; }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-027.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-027.html
@@ -7,6 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-content-3/#quotes">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#quotes">
 <link rel=match href="reference/quotes-027-ref.html">
+<meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-1" />
 <style>
 body { font: 32px serif; }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht
@@ -15,6 +15,7 @@
 
   <meta name="DC.date.created" content="2017-01-26T09:54:03+11:00" scheme="W3CDTF" />
   <meta name="DC.date.modified" content="2017-02-18T09:54:03+11:00" scheme="W3CDTF" />
+  <meta name="fuzzy" content="maxDifference=0-147; totalPixels=0-5" />
 
   <style type="text/css"><![CDATA[
   div

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#text-transform" title="2.1 Case Transforms: the 'text-transform' property" />
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-combine-fullwidth" title="9.1.3.1 Full-width Characters" />
   <link rel="match" href="text-transform-fullwidth-005-ref.xht" />
+  <meta name="fuzzy" content="maxDifference=0-115; totalPixels=0-2" />
 
   <meta content="This test checks basic support of 'text-transform: full-width' in a vertical writing context. Since full-width digit characters are typeset upright, then both digit characters in the text sample should not be rotated toward the right but should be upright. This is furthermore the case since, in this test, there is no 'text-combine-upright' in effect or applying to such pair of digits." name="assert" />
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7411,14 +7411,6 @@ imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_point
 
 webkit.org/b/278353 http/tests/privateClickMeasurement/send-attribution-conversion-request.https.html [ Failure ]
 
-# webkit.org/b/277933 (REGRESSION (iOS 18): 5 WPT CSS layout tests are constantly failing (ImageOnlyFailure). (277933))
-imported/w3c/web-platform-tests/css/css-content/quotes-025.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-content/quotes-026.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-content/quotes-027.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht [ ImageOnlyFailure ]
-fast/text/text-underline-position-under.html [ ImageOnlyFailure ]
-
 # webkit.org/b/269496 [ iOS17 ] fast/forms/datalist/datalist-option-labels.html is a flaky timeout
 fast/forms/datalist/datalist-option-labels.html [ Pass Timeout ]
 


### PR DESCRIPTION
#### d0deb00521fc2aa767b8d92f00992f7bbdf7a0a9
<pre>
REGRESSION (iOS 18): 5 WPT CSS layout tests are constantly failing (ImageOnlyFailure).
<a href="https://bugs.webkit.org/show_bug.cgi?id=277933">https://bugs.webkit.org/show_bug.cgi?id=277933</a>
<a href="https://rdar.apple.com/133651925">rdar://133651925</a>

Reviewed by Tim Nguyen.

Allowing fuzzy tolerance to the following tests.

Tests diff by very few pixels (example: maxDifference=0-123; totalPixels=1).

I can just observe it when running our test suite. When opening the test file on
 Safari/Minibrowser I observe no apparent clipping or differences between test/expected.

I believe this is being introduced by anti-aliasing during test for some reason and it should not have user impact.

* LayoutTests/fast/text/text-underline-position-under.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-025.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-026.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/quotes-027.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/285585@main">https://commits.webkit.org/285585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24795808cccffff60fc7574ae4c958a18575156

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37887 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22705 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79017 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/45 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65908 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16115 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7183 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/417 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->