### PR TITLE
[WASM] Fix consistency check in addBranchNull

### DIFF
--- a/JSTests/wasm/gc/bug138038945.js
+++ b/JSTests/wasm/gc/bug138038945.js
@@ -1,0 +1,25 @@
+//@ runWebAssemblySuite("--useWasmGC=true")
+import { instantiate } from "./wast-wrapper.js";
+
+try {
+    instantiate(`
+    (module
+      (func (export "myFunction") (param $p0 i32) (param $p1 i32) (param $p2 i32) (result i32)
+          ref.null func             
+          ref.cast (ref 0) (local.get 0)
+          local.set $p0               
+          ref.null func             
+          f32.const 1.0               
+          f32.const 5.0               
+          f32.ne                      
+          ref.null func             
+          br_on_null 0                
+          i32.const 0                 
+      )
+    )
+  `);
+} catch (e) {
+    if (!(e instanceof WebAssembly.CompileError))
+        throw new Error("bad");
+}
+

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1425,11 +1425,13 @@ auto LLIntGenerator::addBranch(ControlType& data, ExpressionType condition, Stac
 
 auto LLIntGenerator::addBranchNull(ControlType& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result) -> PartialResult
 {
+    checkConsistency();
+
     // Leave a hole for the reference and avoid overwriting it with the condition.
     if (!shouldNegate)
-        push();
+        push(NoConsistencyCheck);
 
-    auto condition = push();
+    auto condition = push(NoConsistencyCheck);
     WasmRefIsNull::emit(this, condition, reference);
 
     if (shouldNegate)
@@ -1440,8 +1442,10 @@ auto LLIntGenerator::addBranchNull(ControlType& data, ExpressionType reference, 
 
     WASM_FAIL_IF_HELPER_FAILS(addBranch(data, condition, returnValues));
 
+    checkConsistency();
+
     if (!shouldNegate) {
-        result = push();
+        result = push(NoConsistencyCheck);
         if (reference != result)
             WasmMov::emit(this, result, reference);
     }


### PR DESCRIPTION
#### 4643296068e547af9ad3d133f93d863affeb09f8
<pre>
[WASM] Fix consistency check in addBranchNull
<a href="https://bugs.webkit.org/show_bug.cgi?id=281934">https://bugs.webkit.org/show_bug.cgi?id=281934</a>
<a href="https://rdar.apple.com/138038945">rdar://138038945</a>

Reviewed by David Degazio.

In addBranchNull, when branching on null, the first push is used
to reserve a slot for the reference to avoid overwriting it with
the condition. Since this slot reservation is deliberate and the
expression-stack slot relationship doesn’t need to be preserved,
there’s no need for a consistency check after the first push in
this case.

The second push, used for the condition, is temporary and only
needed to perform the null check. It’s not part of WebAssembly&apos;s
core semantics, so no additional consistency checks are required.

This fix ensures that consistency checks are only applied where
necessary, avoiding redundant checks when pushing temporary
values or reserving slots.

* JSTests/wasm/gc/bug138038945.js: Added.
(catch):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addBranchNull):

Canonical link: <a href="https://commits.webkit.org/285705@main">https://commits.webkit.org/285705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6731b73b1412f8d2b25b37214f015dabde464ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23130 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66696 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79446 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72816 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/356 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16182 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7514 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94597 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/840 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20790 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->