### PR TITLE
Use byteCast<>() in place of spanReinterpretCast<>()

### DIFF
--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -165,7 +165,7 @@ ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName
     double index = jsToNumber(propertyName);
     NumberToStringBuffer buffer;
     auto span = WTF::numberToStringAndSize(index, buffer);
-    return equal(propertyName, spanReinterpretCast<const LChar>(span));
+    return equal(propertyName, byteCast<LChar>(span));
 }
 
 } // namespace JSC

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -64,7 +64,7 @@ public:
 
     constexpr const char* characters() const { return m_charactersWithNullTerminator.data(); }
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
-    std::span<const LChar> span8() const { return spanReinterpretCast<const LChar>(m_charactersWithNullTerminator.first(length())); }
+    std::span<const LChar> span8() const { return byteCast<LChar>(m_charactersWithNullTerminator.first(length())); }
     std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
@@ -142,7 +142,7 @@ constexpr ASCIILiteral operator"" _s(const char* characters, size_t)
 
 constexpr std::span<const LChar> operator"" _span(const char* characters, size_t n)
 {
-    auto span = spanReinterpretCast<const LChar>(unsafeForgeSpan(characters, n));
+    auto span = byteCast<LChar>(unsafeForgeSpan(characters, n));
 #if ASSERT_ENABLED
     for (size_t i = 0, size = span.size(); i < size; ++i)
         ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -109,20 +109,20 @@ AtomString AtomString::number(float number)
 {
     NumberToStringBuffer buffer;
     auto span = numberToStringAndSize(number, buffer);
-    return AtomString { spanReinterpretCast<const LChar>(span) };
+    return AtomString { byteCast<LChar>(span) };
 }
 
 AtomString AtomString::number(double number)
 {
     NumberToStringBuffer buffer;
     auto span = numberToStringAndSize(number, buffer);
-    return AtomString { spanReinterpretCast<const LChar>(span) };
+    return AtomString { byteCast<LChar>(span) };
 }
 
 AtomString AtomString::fromUTF8Internal(std::span<const char> characters)
 {
     ASSERT(!characters.empty());
-    return AtomStringImpl::add(spanReinterpretCast<const char8_t>(characters));
+    return AtomStringImpl::add(byteCast<char8_t>(characters));
 }
 
 #ifndef NDEBUG

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -133,7 +133,7 @@ struct HashedUTF8CharactersTranslator {
             return Unicode::equal(string->span16(), characters.characters);
         }
 
-        auto charactersLatin1 = spanReinterpretCast<const LChar>(characters.characters);
+        auto charactersLatin1 = byteCast<LChar>(characters.characters);
         if (string->is8Bit())
             return WTF::equal(string->span8().data(), charactersLatin1);
         return WTF::equal(string->span16().data(), charactersLatin1);
@@ -148,7 +148,7 @@ struct HashedUTF8CharactersTranslator {
         RELEASE_ASSERT(result.code == Unicode::ConversionResultCode::Success);
 
         if (result.isAllASCII)
-            newString = StringImpl::create(spanReinterpretCast<const LChar>(characters.characters));
+            newString = StringImpl::create(byteCast<LChar>(characters.characters));
 
         auto* pointer = &newString.leakRef();
         pointer->setHash(hash);
@@ -476,7 +476,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char8_t> characters)
 {
-    HashedUTF8Characters buffer { characters, computeUTF16LengthWithHash(spanReinterpretCast<const char8_t>(characters)) };
+    HashedUTF8Characters buffer { characters, computeUTF16LengthWithHash(characters) };
     if (!buffer.length.hash)
         return nullptr;
     return addToStringTable<HashedUTF8Characters, HashedUTF8CharactersTranslator>(buffer);

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -81,7 +81,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, span()); }
 
 private:
-    std::span<const LChar> span() const { return spanReinterpretCast<const LChar>(std::span { m_buffer }).first(m_length); }
+    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
     NumberToStringBuffer m_buffer;
     unsigned m_length;
@@ -106,7 +106,7 @@ public:
 
     unsigned length() const { return m_length; }
     const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
-    std::span<const LChar> span() const { return spanReinterpretCast<const LChar>(std::span { m_buffer }).first(m_length); }
+    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
 private:
     NumberToStringBuffer m_buffer;
@@ -140,7 +140,7 @@ public:
 
     unsigned length() const { return m_length; }
     const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
-    std::span<const LChar> span() const { return spanReinterpretCast<const LChar>(std::span { m_buffer }).first(m_length); }
+    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
 private:
     NumberToCSSStringBuffer m_buffer;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -472,7 +472,7 @@ String fromUTF8Impl(std::span<const char8_t> string)
         return emptyString();
 
     if (charactersAreAllASCII(string))
-        return StringImpl::create(spanReinterpretCast<const LChar>(string));
+        return StringImpl::create(byteCast<LChar>(string));
 
     Vector<UChar, 1024> buffer(string.size());
  
@@ -506,7 +506,7 @@ String String::fromUTF8WithLatin1Fallback(std::span<const char8_t> string)
     if (!utf8) {
         // Do this assertion before chopping the size_t down to unsigned.
         RELEASE_ASSERT(string.size() <= String::MaxLength);
-        return spanReinterpretCast<const LChar>(string);
+        return byteCast<LChar>(string);
     }
     return utf8;
 }


### PR DESCRIPTION
#### ae29f8516d88b24dbeb15d2b489eb4c64526ff79
<pre>
Use byteCast&lt;&gt;() in place of spanReinterpretCast&lt;&gt;()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281944">https://bugs.webkit.org/show_bug.cgi?id=281944</a>&gt;
&lt;<a href="https://rdar.apple.com/138444837">rdar://138444837</a>&gt;

Reviewed by Darin Adler.

Replace spanReinterpretCast&lt;&gt;() with byteCast&lt;&gt;() for one-byte character
types.

* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::isCanonicalNumericIndexString):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator _span):
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::number):
(WTF::AtomString::fromUTF8Internal):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashedUTF8CharactersTranslator::equal):
(WTF::HashedUTF8CharactersTranslator::translate):
(WTF::AtomStringImpl::add):
- Remove unneeded spanReinterpretCast&lt;&gt;() here.
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::FormattedNumber::span const):
(WTF::FormattedCSSNumber::span const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::fromUTF8Impl):
(WTF::String::fromUTF8WithLatin1Fallback):

Canonical link: <a href="https://commits.webkit.org/285599@main">https://commits.webkit.org/285599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/651920120c1f9140f17db2ccacb1b7ec5de3dc4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22733 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66301 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79048 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72423 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/59 "Found 2 new test failures: http/tests/paymentrequest/payment-response-complete-method.https.html http/tests/ssl/applepay/ApplePayPaymentDetailsModifier.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65927 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65209 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94202 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/445 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20715 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->