### PR TITLE
REGRESSION(285115@main): [ Mac Debug ] TestWebKitAPI.WebKit.AudioBufferSize is a constant crash

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -253,10 +253,6 @@ void BaseAudioSharedUnit::stopRunning()
 {
     stopInternal();
     cleanupAudioUnit();
-
-    auto callbacks = std::exchange(m_whenNotRunningCallbacks, { });
-    for (auto& callback : callbacks)
-        callback();
 }
 
 void BaseAudioSharedUnit::reconfigure()
@@ -336,15 +332,6 @@ void BaseAudioSharedUnit::audioSamplesAvailable(const MediaTime& time, const Pla
         if (client->isProducingData())
             client->audioSamplesAvailable(time, data, description, numberOfFrames);
     }
-}
-
-void BaseAudioSharedUnit::whenAudioCaptureUnitIsNotRunning(Function<void()>&& callback)
-{
-    if (!isProducingData()) {
-        callback();
-        return;
-    }
-    m_whenNotRunningCallbacks.append(WTFMove(callback));
 }
 
 void BaseAudioSharedUnit::handleNewCurrentMicrophoneDevice(CaptureDevice&& device)

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -89,7 +89,6 @@ public:
     virtual LongCapabilityRange sampleRateCapacities() const = 0;
     virtual int actualSampleRate() const { return sampleRate(); }
 
-    void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     bool isRenderingAudio() const { return m_isRenderingAudio; }
     bool hasClients() const { return !m_clients.isEmptyIgnoringNullReferences(); }
 
@@ -165,7 +164,6 @@ private:
 
     bool m_isCapturingWithDefaultMicrophone { false };
     bool m_isProducingMicrophoneSamples { true };
-    Vector<Function<void()>> m_whenNotRunningCallbacks;
     Function<void()> m_voiceActivityCallback;
     Timer m_voiceActivityThrottleTimer;
 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -182,11 +182,6 @@ bool CoreAudioCaptureSourceFactory::isAudioCaptureUnitRunning()
     return CoreAudioSharedUnit::singleton().isRunning();
 }
 
-void CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning(Function<void()>&& callback)
-{
-    return CoreAudioSharedUnit::singleton().whenAudioCaptureUnitIsNotRunning(WTFMove(callback));
-}
-
 bool CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio()
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -137,7 +137,6 @@ public:
     WEBCORE_EXPORT void registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT bool isAudioCaptureUnitRunning();
-    WEBCORE_EXPORT void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
 
 private:
@@ -147,8 +146,8 @@ private:
 
     // AudioCaptureFactory
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>) override;
-    CaptureDeviceManager& audioCaptureDeviceManager() final;
-    const Vector<CaptureDevice>& speakerDevices() const final;
+    CaptureDeviceManager& audioCaptureDeviceManager() override;
+    const Vector<CaptureDevice>& speakerDevices() const override;
     void enableMutedSpeechActivityEventListener(Function<void()>&&) final;
     void disableMutedSpeechActivityEventListener() final;
 

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -301,7 +301,12 @@ private:
 #endif
 };
 
-class MockRealtimeAudioSourceFactory final : public AudioCaptureFactory
+class MockRealtimeAudioSourceFactory final
+#if PLATFORM(COCOA)
+    : public CoreAudioCaptureSourceFactory
+#else
+    : public AudioCaptureFactory
+#endif
 {
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier) final
@@ -320,11 +325,6 @@ public:
 private:
     CaptureDeviceManager& audioCaptureDeviceManager() final { return MockRealtimeMediaSourceCenter::singleton().audioCaptureDeviceManager(); }
     const Vector<CaptureDevice>& speakerDevices() const final { return MockRealtimeMediaSourceCenter::speakerDevices(); }
-#if PLATFORM(COCOA)
-    void enableMutedSpeechActivityEventListener(Function<void()>&& callback) final {
-        CoreAudioSharedUnit::singleton().enableMutedSpeechActivityEventListener(WTFMove(callback)); }
-    void disableMutedSpeechActivityEventListener() final { CoreAudioSharedUnit::singleton().disableMutedSpeechActivityEventListener(); }
-#endif
 };
 
 static Vector<MockMediaDevice>& devices()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -124,15 +124,6 @@ void RemoteAudioSessionProxyManager::updateCategory()
 
 void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
 {
-#if ENABLE(MEDIA_STREAM)
-    if (CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning()) {
-        CoreAudioCaptureSourceFactory::singleton().whenAudioCaptureUnitIsNotRunning([weakThis = WeakPtr { *this }] {
-            if (weakThis)
-                weakThis->updatePreferredBufferSizeForProcess();
-        });
-        return;
-    }
-#endif
     size_t preferredBufferSize = std::numeric_limits<size_t>::max();
     for (Ref proxy : m_proxies) {
         if (proxy->preferredBufferSize() && proxy->preferredBufferSize() < preferredBufferSize)


### PR DESCRIPTION
#### c294acb61de6e6bb24783f3ad4014c51c1437a05
<pre>
REGRESSION(285115@main): [ Mac Debug ] TestWebKitAPI.WebKit.AudioBufferSize is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=281530">https://bugs.webkit.org/show_bug.cgi?id=281530</a>
<a href="https://rdar.apple.com/137999573">rdar://137999573</a>

Reviewed by Jer Noble.

After 285115@main, we are using CoreAudioSharedUnit (with a mock inside) instead of a different mock unit for capture.
This makes RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess aware that capture is ongoing, which delays updating the buffer size until capture is stopped.
This was introduced as a workaround to unbreak AirPods playback when buffer size was changing.
This is no longer an issue so we can remove the workaround.

We update MockRealtimeAudioSourceFactory to be deriving from CoreAudioCaptureSourceFactory so that it reacts to AudioSession testing interruptions.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::stopRunning):
(WebCore::BaseAudioSharedUnit::audioSamplesAvailable):
(WebCore::BaseAudioSharedUnit::whenAudioCaptureUnitIsNotRunning): Deleted.
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSourceFactory::isAudioCaptureUnitRunning):
(WebCore::CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess):

Canonical link: <a href="https://commits.webkit.org/285661@main">https://commits.webkit.org/285661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40a542b3582b211221790b17acc2d1190c6a5f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/61987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57693 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22998 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/745 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/240 "Found 1 new test failure: http/tests/paymentrequest/payment-response-payerPhone-attribute.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66099 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65377 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9226 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7401 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11307 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/708 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/738 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->