### PR TITLE
LAYER_POSITIONS_ASSERT(*repaintRects() == renderer().rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes)); on https://gregbenzphotography.com/hdr-gain-map-gallery

### DIFF
--- a/LayoutTests/fast/layers/overflow-change-crash-expected.html
+++ b/LayoutTests/fast/layers/overflow-change-crash-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+  div {
+    position: relative;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+</head>
+<body>
+
+<p>This test should not crash.</p>
+
+<div style="background-color: green; overflow: clip">
+  <div>
+    <div style="background-color: blue; left: 100px; top: 100px"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/layers/overflow-change-crash.html
+++ b/LayoutTests/fast/layers/overflow-change-crash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+  div {
+    position: relative;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+</head>
+<body>
+
+<p>This test should not crash.</p>
+
+<div style="background-color: green" id="outer">
+  <div>
+    <div style="background-color: blue; left: 100px; top: 100px"></div>
+  </div>
+</div>
+
+<script>
+  function doTest() {
+    document.getElementById("outer").style.overflow = "clip";
+  }
+
+  window.addEventListener('load', doTest, false);
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5868,6 +5868,9 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
                 m_scrollableArea->computeHasCompositedScrollableOverflow(diff <= StyleDifference::RepaintLayer ? LayoutUpToDate::Yes : LayoutUpToDate::No);
         }
 
+        if (oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
+            setSelfAndDescendantsNeedPositionUpdate();
+
         if (oldStyle->hasZeroOpacity() != renderer().style().hasZeroOpacity())
             setNeedsPositionUpdate();
     }


### PR DESCRIPTION
#### ecad604cdd3b06223d005e2fe8ad463b3b936a94
<pre>
LAYER_POSITIONS_ASSERT(*repaintRects() == renderer().rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes)); on <a href="https://gregbenzphotography.com/hdr-gain-map-gallery">https://gregbenzphotography.com/hdr-gain-map-gallery</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281946">https://bugs.webkit.org/show_bug.cgi?id=281946</a>
&lt;<a href="https://rdar.apple.com/138451742">rdar://138451742</a>&gt;

Reviewed by Simon Fraser.

Changing overflow visibility affects the repaints of all descendants (that share
the same repaint container, which isn&apos;t tracked by the current dirty bits). The
existing marking (based on layout) only marked the children of the changed
layer, not all descendants.

* LayoutTests/fast/layers/overflow-change-crash-expected.html: Added.
* LayoutTests/fast/layers/overflow-change-crash.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/285627@main">https://commits.webkit.org/285627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c6936357b7b2d724941f8827a2544f405240474

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16057 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63069 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20549 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79177 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16141 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7305 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/574 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->