### PR TITLE
Fix -Wdeprecated-literal-operator warnings in upstream clang

### DIFF
--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -254,62 +254,62 @@ struct Seconds::MarkableTraits {
 
 inline namespace seconds_literals {
 
-constexpr Seconds operator"" _min(long double minutes)
+constexpr Seconds operator""_min(long double minutes)
 {
     return Seconds::fromMinutes(minutes);
 }
 
-constexpr Seconds operator"" _h(long double hours)
+constexpr Seconds operator""_h(long double hours)
 {
     return Seconds::fromHours(hours);
 }
 
-constexpr Seconds operator"" _s(long double seconds)
+constexpr Seconds operator""_s(long double seconds)
 {
     return Seconds(seconds);
 }
 
-constexpr Seconds operator"" _ms(long double milliseconds)
+constexpr Seconds operator""_ms(long double milliseconds)
 {
     return Seconds::fromMilliseconds(milliseconds);
 }
 
-constexpr Seconds operator"" _us(long double microseconds)
+constexpr Seconds operator""_us(long double microseconds)
 {
     return Seconds::fromMicroseconds(microseconds);
 }
 
-constexpr Seconds operator"" _ns(long double nanoseconds)
+constexpr Seconds operator""_ns(long double nanoseconds)
 {
     return Seconds::fromNanoseconds(nanoseconds);
 }
 
-constexpr Seconds operator"" _min(unsigned long long minutes)
+constexpr Seconds operator""_min(unsigned long long minutes)
 {
     return Seconds::fromMinutes(minutes);
 }
 
-constexpr Seconds operator"" _h(unsigned long long hours)
+constexpr Seconds operator""_h(unsigned long long hours)
 {
     return Seconds::fromHours(hours);
 }
 
-constexpr Seconds operator"" _s(unsigned long long seconds)
+constexpr Seconds operator""_s(unsigned long long seconds)
 {
     return Seconds(seconds);
 }
 
-constexpr Seconds operator"" _ms(unsigned long long milliseconds)
+constexpr Seconds operator""_ms(unsigned long long milliseconds)
 {
     return Seconds::fromMilliseconds(milliseconds);
 }
 
-constexpr Seconds operator"" _us(unsigned long long microseconds)
+constexpr Seconds operator""_us(unsigned long long microseconds)
 {
     return Seconds::fromMicroseconds(microseconds);
 }
 
-constexpr Seconds operator"" _ns(unsigned long long nanoseconds)
+constexpr Seconds operator""_ns(unsigned long long nanoseconds)
 {
     return Seconds::fromNanoseconds(nanoseconds);
 }

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -133,14 +133,14 @@ inline ASCIILiteral ASCIILiteral::deletedValue()
 
 inline namespace StringLiterals {
 
-constexpr ASCIILiteral operator"" _s(const char* characters, size_t)
+constexpr ASCIILiteral operator""_s(const char* characters, size_t)
 {
     auto result = ASCIILiteral::fromLiteralUnsafe(characters);
     ASSERT_UNDER_CONSTEXPR_CONTEXT(result.characters() == characters);
     return result;
 }
 
-constexpr std::span<const LChar> operator"" _span(const char* characters, size_t n)
+constexpr std::span<const LChar> operator""_span(const char* characters, size_t n)
 {
     auto span = byteCast<LChar>(unsafeForgeSpan(characters, n));
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -563,13 +563,13 @@ inline namespace StringLiterals {
 #ifndef __swift__
 // Swift will import this as global and then all literals will be WTF.String
 // instead of Swift.String
-inline String operator"" _str(const char* characters, size_t)
+inline String operator""_str(const char* characters, size_t)
 {
     return ASCIILiteral::fromLiteralUnsafe(characters);
 }
 
 // FIXME: rdar://136156228
-inline String operator"" _str(const UChar* characters, size_t length)
+inline String operator""_str(const UChar* characters, size_t length)
 {
     return String({ characters, length });
 }

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -815,7 +815,7 @@ inline bool isIntegerValue(const LayoutUnit value)
 
 inline namespace StringLiterals {
 
-inline LayoutUnit operator"" _lu(unsigned long long value)
+inline LayoutUnit operator""_lu(unsigned long long value)
 {
     return LayoutUnit(value);
 }

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-constexpr uint64_t operator"" _kbps(unsigned long long kilobytesPerSecond)
+constexpr uint64_t operator""_kbps(unsigned long long kilobytesPerSecond)
 {
     return kilobytesPerSecond * 1024;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
@@ -31,7 +31,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/PriorityQueue.h>
 
-constexpr std::size_t operator "" _z ( unsigned long long n ) { return n; }
+constexpr std::size_t operator""_z(unsigned long long n) { return n; }
 
 template<typename T, bool (*isHigherPriority)(const T&, const T&)>
 static void enqueue(PriorityQueue<T, isHigherPriority>& queue, T element)


### PR DESCRIPTION
#### f3b5d02f49b0ef4d71cb4f301b86977e82eb5704
<pre>
Fix -Wdeprecated-literal-operator warnings in upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281948">https://bugs.webkit.org/show_bug.cgi?id=281948</a>&gt;
&lt;<a href="https://rdar.apple.com/138330214">rdar://138330214</a>&gt;

Unreviewed build fix.

* Source/WTF/wtf/Seconds.h:
(WTF::seconds_literals::operator&quot;&quot;_min):
(WTF::seconds_literals::operator&quot;&quot;_h):
(WTF::seconds_literals::operator&quot;&quot;_s):
(WTF::seconds_literals::operator&quot;&quot;_ms):
(WTF::seconds_literals::operator&quot;&quot;_us):
(WTF::seconds_literals::operator&quot;&quot;_ns):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator&quot;&quot;_s):
(WTF::StringLiterals::operator&quot;&quot;_span):
* Source/WTF/wtf/text/WTFString.h:
(WTF::StringLiterals::operator&quot;&quot;_str):
* Source/WebCore/platform/LayoutUnit.h:
(WebCore::StringLiterals::operator&quot;&quot;_lu):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
(WebKit::operator&quot;&quot;_kbps):
* Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp:
(operator_&quot;&quot;z):
- Remove spaces to fix the warnings.

Canonical link: <a href="https://commits.webkit.org/285607@main">https://commits.webkit.org/285607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4a2a1df597b42b12d0b5fda07116d9df686a4ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->