### PR TITLE
Unreviewed, reverting 285011@main.

### DIFF
--- a/Source/WebCore/platform/SourcesNicosia.txt
+++ b/Source/WebCore/platform/SourcesNicosia.txt
@@ -32,6 +32,7 @@ page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
 page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
 page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
 
+platform/graphics/nicosia/NicosiaBackingStore.cpp
 platform/graphics/nicosia/NicosiaScene.cpp
 platform/graphics/nicosia/NicosiaSceneIntegration.cpp
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -49,6 +49,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.cpp
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
@@ -63,6 +64,8 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
@@ -121,6 +124,7 @@ if (USE_NICOSIA)
         page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.h
         page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
 
+        platform/graphics/nicosia/NicosiaBackingStore.h
         platform/graphics/nicosia/NicosiaCompositionLayer.h
         platform/graphics/nicosia/NicosiaPlatformLayer.h
         platform/graphics/nicosia/NicosiaScene.h

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 Metrological Group B.V.
+ * Copyright (C) 2018 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NicosiaBackingStore.h"
+
+namespace Nicosia {
+
+void BackingStore::tiledBackingStoreHasPendingTileCreation()
+{
+    m_layerState.hasPendingTileCreation = true;
+}
+
+void BackingStore::createTile(uint32_t tileID, float scale)
+{
+    ASSERT(m_layerState.isFlushing);
+    auto& update = m_layerState.update;
+
+    // Assert no tile with this ID has been registered yet.
+#if ASSERT_ENABLED
+    auto matchesTile = [tileID](auto& tile) { return tile.tileID == tileID; };
+#endif
+    ASSERT(std::none_of(update.tilesToCreate.begin(), update.tilesToCreate.end(), matchesTile));
+    ASSERT(std::none_of(update.tilesToUpdate.begin(), update.tilesToUpdate.end(), matchesTile));
+    ASSERT(std::none_of(update.tilesToRemove.begin(), update.tilesToRemove.end(), matchesTile));
+
+    update.tilesToCreate.append({ tileID, scale });
+}
+
+void BackingStore::updateTile(uint32_t tileID, const WebCore::IntRect& updateRect, const WebCore::IntRect& tileRect, Ref<WebCore::CoordinatedTileBuffer>&& buffer)
+{
+    ASSERT(m_layerState.isFlushing);
+    auto& update = m_layerState.update;
+
+    // Assert no tile with this ID has been registered for removal yet. It might have
+    // already been created in a previous update, so it makes no sense to check tilesToCreate.
+    ASSERT(std::none_of(update.tilesToRemove.begin(), update.tilesToRemove.end(),
+        [tileID](auto& tile) { return tile.tileID == tileID; }));
+
+    update.tilesToUpdate.append({ tileID, updateRect, tileRect, WTFMove(buffer) });
+}
+
+void BackingStore::removeTile(uint32_t tileID)
+{
+    ASSERT(m_layerState.isFlushing || m_layerState.isPurging);
+    auto& update = m_layerState.update;
+
+    // Remove any creations or updates registered for this tile ID.
+    auto matchesTile = [tileID](auto& tile) { return tile.tileID == tileID; };
+    update.tilesToCreate.removeAllMatching(matchesTile);
+    update.tilesToUpdate.removeAllMatching(matchesTile);
+
+    // Assert no tile with this ID has been registered for removal yet.
+    ASSERT(std::none_of(update.tilesToRemove.begin(), update.tilesToRemove.end(), matchesTile));
+
+    update.tilesToRemove.append(TileUpdate::RemovalData { tileID });
+}
+
+void BackingStore::flushUpdate()
+{
+    ASSERT(!m_layerState.isFlushing);
+    m_layerState.hasPendingTileCreation = false;
+
+    // Incrementally store updates as they are being flushed from the layer-side.
+    {
+        Locker locker { m_update.lock };
+        m_update.pending.tilesToCreate.appendVector(m_layerState.update.tilesToCreate);
+        m_update.pending.tilesToUpdate.appendVector(m_layerState.update.tilesToUpdate);
+        m_update.pending.tilesToRemove.appendVector(m_layerState.update.tilesToRemove);
+    }
+
+    m_layerState.update = { };
+}
+
+auto BackingStore::takeUpdate() -> TileUpdate
+{
+    Locker locker { m_update.lock };
+    return WTFMove(m_update.pending);
+}
+
+} // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2018 Metrological Group B.V.
+ * Copyright (C) 2018 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CoordinatedBackingStore.h"
+#include "CoordinatedBackingStoreProxy.h"
+#include "CoordinatedBackingStoreProxyClient.h"
+#include "CoordinatedTileBuffer.h"
+#include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace Nicosia {
+
+class BackingStore final : public ThreadSafeRefCounted<BackingStore>, public WebCore::CoordinatedBackingStoreProxyClient {
+public:
+    static Ref<BackingStore> create()
+    {
+        return adoptRef(*new BackingStore());
+    }
+
+    // A move-only tile update container.
+    struct TileUpdate {
+        TileUpdate() = default;
+        TileUpdate(const TileUpdate&) = delete;
+        TileUpdate& operator=(const TileUpdate&) = delete;
+        TileUpdate(TileUpdate&&) = default;
+        TileUpdate& operator=(TileUpdate&&) = default;
+
+        struct CreationData {
+            uint32_t tileID;
+            float scale;
+        };
+        Vector<CreationData> tilesToCreate;
+
+        struct UpdateData {
+            uint32_t tileID;
+            WebCore::IntRect updateRect;
+            WebCore::IntRect tileRect;
+            Ref<WebCore::CoordinatedTileBuffer> buffer;
+        };
+        Vector<UpdateData> tilesToUpdate;
+
+        struct RemovalData {
+            uint32_t tileID;
+        };
+        Vector<RemovalData> tilesToRemove;
+    };
+
+    // An immutable layer-side state object. flushUpdate() prepares
+    // the current update for consumption by the composition-side.
+    struct LayerState {
+        LayerState() = default;
+        LayerState(const LayerState&) = delete;
+        LayerState& operator=(const LayerState&) = delete;
+        LayerState(LayerState&&) = delete;
+        LayerState& operator=(LayerState&&) = delete;
+
+        std::unique_ptr<WebCore::CoordinatedBackingStoreProxy> mainBackingStore;
+
+        TileUpdate update;
+        bool isFlushing { false };
+        bool isPurging { false };
+        bool hasPendingTileCreation { false };
+    };
+    LayerState& layerState() { return m_layerState; }
+
+    void flushUpdate();
+
+    // An immutable composition-side state object. takeUpdate() returns the accumulated
+    // tile update information that's to be fed to the CoordinatedBackingStore object.
+    struct CompositionState {
+        CompositionState() = default;
+        CompositionState(const CompositionState&) = delete;
+        CompositionState& operator=(const CompositionState&) = delete;
+        CompositionState(CompositionState&&) = delete;
+        CompositionState& operator=(CompositionState&&) = delete;
+
+        RefPtr<WebCore::CoordinatedBackingStore> backingStore;
+    };
+    CompositionState& compositionState() { return m_compositionState; }
+
+    TileUpdate takeUpdate();
+
+    // CoordinatedBackingStoreProxyClient
+    // FIXME: Move these to private once updateTile() is not called from CoordinatedGrahpicsLayer.
+    void tiledBackingStoreHasPendingTileCreation() override;
+    void createTile(uint32_t, float) override;
+    void updateTile(uint32_t, const WebCore::IntRect&, const WebCore::IntRect&, Ref<WebCore::CoordinatedTileBuffer>&&) override;
+    void removeTile(uint32_t) override;
+
+private:
+    LayerState m_layerState;
+    CompositionState m_compositionState;
+
+    struct {
+        Lock lock;
+        TileUpdate pending WTF_GUARDED_BY_LOCK(lock);
+    } m_update;
+};
+
+} // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaSceneIntegration.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaSceneIntegration.cpp
@@ -90,7 +90,7 @@ SceneIntegration::UpdateScope::~UpdateScope()
         [](Nicosia::Scene::State& state)
         {
             for (auto& compositionLayer : state.layers)
-                compositionLayer->flushState();
+                compositionLayer->flushState([](auto&) { });
         });
 
     auto& sceneIntegrationObj = m_sceneIntegration.get();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -29,8 +29,10 @@
 
 namespace WebCore {
 
-void CoordinatedBackingStore::createTile(uint32_t id)
+void CoordinatedBackingStore::createTile(uint32_t id, float scale)
 {
+    // FIXME: scale set shouldn't be done in createTile, it sould be moved to resize().
+    m_scale = scale;
     m_tiles.add(id, CoordinatedBackingStoreTile(m_scale));
 }
 
@@ -53,10 +55,9 @@ void CoordinatedBackingStore::processPendingUpdates(TextureMapper& textureMapper
         tile.processPendingUpdates(textureMapper);
 }
 
-void CoordinatedBackingStore::resize(const FloatSize& size, float scale)
+void CoordinatedBackingStore::resize(const FloatSize& size)
 {
     m_size = size;
-    m_scale = scale;
 }
 
 void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& transform, float opacity)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -37,9 +37,9 @@ public:
     }
     ~CoordinatedBackingStore() = default;
 
-    void resize(const FloatSize&, float scale);
+    void resize(const FloatSize&);
 
-    void createTile(uint32_t tileID);
+    void createTile(uint32_t tileID, float scale);
     void removeTile(uint32_t tileID);
     void updateTile(uint32_t tileID, const IntRect&, const IntRect&, RefPtr<CoordinatedTileBuffer>&&, const IntPoint&);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -1,373 +1,402 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
- * Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public License
- * along with this library; see the file COPYING.LIB.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301, USA.
+ Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+ 
+ You should have received a copy of the GNU Library General Public License
+ along with this library; see the file COPYING.LIB.  If not, write to
+ the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
  */
 
 #include "config.h"
 #include "CoordinatedBackingStoreProxy.h"
 
 #if USE(COORDINATED_GRAPHICS)
-#include "CoordinatedGraphicsLayer.h"
-#include "CoordinatedTileBuffer.h"
-#include "FloatRect.h"
+#include "CoordinatedBackingStoreProxyClient.h"
+#include "GraphicsContext.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MemoryPressureHandler.h>
-#include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
-
-static constexpr int s_defaultTileDimension = 512;
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CoordinatedBackingStoreProxy);
 
-static uint32_t generateTileID()
+static const int defaultTileDimension = 512;
+
+static IntPoint innerBottomRight(const IntRect& rect)
 {
-    static uint32_t id = 0;
-    // We may get a zero ID due to wrap-around on overflow.
-    if (++id)
-        return id;
-    return ++id;
+    // Actually, the rect does not contain rect.maxX(). Refer to IntRect::contain.
+    return IntPoint(rect.maxX() - 1, rect.maxY() - 1);
 }
 
-CoordinatedBackingStoreProxy::Update::Update(Vector<uint32_t>&& tilesToCreate, Vector<TileUpdate>&& tilesToUpdate, Vector<uint32_t>&& tilesToRemove)
-    : m_tilesToCreate(WTFMove(tilesToCreate))
-    , m_tilesToUpdate(WTFMove(tilesToUpdate))
-    , m_tilesToRemove(WTFMove(tilesToRemove))
+CoordinatedBackingStoreProxy::CoordinatedBackingStoreProxy(CoordinatedBackingStoreProxyClient& client, float contentsScale)
+    : m_client(client)
+    , m_tileSize(defaultTileDimension, defaultTileDimension)
+    , m_coverAreaMultiplier(2.0f)
+    , m_contentsScale(contentsScale)
+    , m_pendingTileCreation(false)
 {
 }
 
-CoordinatedBackingStoreProxy::Update::~Update() = default;
+CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy() = default;
 
-void CoordinatedBackingStoreProxy::Update::appendUpdate(RefPtr<Update>& other)
+void CoordinatedBackingStoreProxy::setTrajectoryVector(const FloatPoint& trajectoryVector)
 {
-    if (!other)
+    m_pendingTrajectoryVector = trajectoryVector;
+    m_pendingTrajectoryVector.normalize();
+}
+
+void CoordinatedBackingStoreProxy::createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect)
+{
+    IntRect scaledContentsRect = mapFromContents(contentsRect);
+    IntRect visibleRect = mapFromContents(unscaledVisibleRect);
+    float coverAreaMultiplier = MemoryPressureHandler::singleton().isUnderMemoryPressure() ? 1.0f : 2.0f;
+
+    bool didChange = m_trajectoryVector != m_pendingTrajectoryVector || m_visibleRect != visibleRect || m_rect != scaledContentsRect || m_coverAreaMultiplier != coverAreaMultiplier;
+    if (didChange || m_pendingTileCreation)
+        createTiles(visibleRect, scaledContentsRect, coverAreaMultiplier);
+}
+
+void CoordinatedBackingStoreProxy::invalidate(const IntRect& contentsDirtyRect)
+{
+    IntRect dirtyRect(mapFromContents(contentsDirtyRect));
+    IntRect keepRectFitToTileSize = tileRectForCoordinate(tileCoordinateForPoint(m_keepRect.location()));
+    keepRectFitToTileSize.unite(tileRectForCoordinate(tileCoordinateForPoint(innerBottomRight(m_keepRect))));
+
+    // Only iterate on the part of the rect that we know we might have tiles.
+    IntRect coveredDirtyRect = intersection(dirtyRect, keepRectFitToTileSize);
+    CoordinatedBackingStoreProxyTile::Coordinate topLeft = tileCoordinateForPoint(coveredDirtyRect.location());
+    CoordinatedBackingStoreProxyTile::Coordinate bottomRight = tileCoordinateForPoint(innerBottomRight(coveredDirtyRect));
+
+    for (int yCoordinate = topLeft.y(); yCoordinate <= bottomRight.y(); ++yCoordinate) {
+        for (int xCoordinate = topLeft.x(); xCoordinate <= bottomRight.x(); ++xCoordinate) {
+            CoordinatedBackingStoreProxyTile* currentTile = m_tiles.get(CoordinatedBackingStoreProxyTile::Coordinate(xCoordinate, yCoordinate));
+            if (!currentTile)
+                continue;
+            // Pass the full rect to each tile as coveredDirtyRect might not
+            // contain them completely and we don't want partial tile redraws.
+            currentTile->invalidate(dirtyRect);
+        }
+    }
+}
+
+Vector<std::reference_wrapper<CoordinatedBackingStoreProxyTile>> CoordinatedBackingStoreProxy::dirtyTiles()
+{
+    Vector<std::reference_wrapper<CoordinatedBackingStoreProxyTile>> tiles;
+    for (auto& tile : m_tiles.values()) {
+        if (tile->isDirty())
+            tiles.append(*tile);
+    }
+
+    return tiles;
+}
+
+double CoordinatedBackingStoreProxy::tileDistance(const IntRect& viewport, const CoordinatedBackingStoreProxyTile::Coordinate& tileCoordinate) const
+{
+    if (viewport.intersects(tileRectForCoordinate(tileCoordinate)))
+        return 0;
+
+    IntPoint viewCenter = viewport.location() + IntSize(viewport.width() / 2, viewport.height() / 2);
+    CoordinatedBackingStoreProxyTile::Coordinate centerCoordinate = tileCoordinateForPoint(viewCenter);
+
+    return std::max(std::abs(centerCoordinate.y() - tileCoordinate.y()), std::abs(centerCoordinate.x() - tileCoordinate.x()));
+}
+
+// Returns a ratio between 0.0f and 1.0f of the surface covered by rendered tiles.
+float CoordinatedBackingStoreProxy::coverageRatio(const WebCore::IntRect& dirtyRect) const
+{
+    float rectArea = dirtyRect.width() * dirtyRect.height();
+    float coverArea = 0.0f;
+
+    CoordinatedBackingStoreProxyTile::Coordinate topLeft = tileCoordinateForPoint(dirtyRect.location());
+    CoordinatedBackingStoreProxyTile::Coordinate bottomRight = tileCoordinateForPoint(innerBottomRight(dirtyRect));
+
+    for (int yCoordinate = topLeft.y(); yCoordinate <= bottomRight.y(); ++yCoordinate) {
+        for (int xCoordinate = topLeft.x(); xCoordinate <= bottomRight.x(); ++xCoordinate) {
+            CoordinatedBackingStoreProxyTile::Coordinate currentCoordinate(xCoordinate, yCoordinate);
+            CoordinatedBackingStoreProxyTile* currentTile = m_tiles.get(currentCoordinate);
+            if (currentTile && currentTile->isReadyToPaint()) {
+                IntRect coverRect = intersection(dirtyRect, currentTile->rect());
+                coverArea += coverRect.width() * coverRect.height();
+            }
+        }
+    }
+    return coverArea / rectArea;
+}
+
+bool CoordinatedBackingStoreProxy::visibleAreaIsCovered() const
+{
+    return coverageRatio(intersection(m_visibleRect, m_rect)) == 1.0f;
+}
+
+void CoordinatedBackingStoreProxy::createTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier)
+{
+    // Update our backing store geometry.
+    m_rect = scaledContentsRect;
+    m_trajectoryVector = m_pendingTrajectoryVector;
+    m_visibleRect = visibleRect;
+    m_coverAreaMultiplier = coverAreaMultiplier;
+
+    if (m_rect.isEmpty()) {
+        setCoverRect(IntRect());
+        setKeepRect(IntRect());
+        return;
+    }
+
+    /* We must compute cover and keep rects using the visibleRect, instead of the rect intersecting the visibleRect with m_rect,
+     * because TBS can be used as a backing store of GraphicsLayer and the visible rect usually does not intersect with m_rect.
+     * In the below case, the intersecting rect is an empty.
+     *
+     *  +---------------+
+     *  |               |
+     *  |   m_rect      |
+     *  |       +-------|-----------------------+
+     *  |       | HERE  |  cover or keep        |
+     *  +---------------+      rect             |
+     *          |         +---------+           |
+     *          |         | visible |           |
+     *          |         |  rect   |           |
+     *          |         +---------+           |
+     *          |                               |
+     *          |                               |
+     *          +-------------------------------+
+     *
+     * We must create or keep the tiles in the HERE region.
+     */
+
+    IntRect coverRect;
+    IntRect keepRect;
+    computeCoverAndKeepRect(m_visibleRect, coverRect, keepRect);
+
+    setCoverRect(coverRect);
+    setKeepRect(keepRect);
+
+    if (coverRect.isEmpty())
         return;
 
-    // Remove any creations or updates previously registered for tiles that are going to be removed now.
-    for (const auto& tileID : other->m_tilesToRemove) {
-        m_tilesToCreate.removeAll(tileID);
-        m_tilesToUpdate.removeAllMatching([tileID](auto& update) {
-            return update.tileID == tileID;
-        });
+    // Resize tiles at the edge in case the contents size has changed, but only do so
+    // after having dropped tiles outside the keep rect.
+    if (m_previousRect != m_rect) {
+        m_previousRect = m_rect;
+        resizeEdgeTiles();
     }
 
-    m_tilesToCreate.appendVector(WTFMove(other->m_tilesToCreate));
-    m_tilesToUpdate.appendVector(WTFMove(other->m_tilesToUpdate));
-    m_tilesToRemove.appendVector(WTFMove(other->m_tilesToRemove));
-}
+    // Search for the tile position closest to the viewport center that does not yet contain a tile.
+    // Which position is considered the closest depends on the tileDistance function.
+    double shortestDistance = std::numeric_limits<double>::infinity();
+    Vector<CoordinatedBackingStoreProxyTile::Coordinate> tilesToCreate;
+    unsigned requiredTileCount = 0;
 
-std::unique_ptr<CoordinatedBackingStoreProxy> CoordinatedBackingStoreProxy::create(float contentsScale, std::optional<IntSize> tileSize)
-{
-    return makeUnique<CoordinatedBackingStoreProxy>(contentsScale, tileSize.value_or(IntSize { s_defaultTileDimension, s_defaultTileDimension }));
-}
-
-CoordinatedBackingStoreProxy::CoordinatedBackingStoreProxy(float contentsScale, const IntSize& tileSize)
-    : m_contentsScale(contentsScale)
-    , m_tileSize(tileSize)
-{
-}
-
-bool CoordinatedBackingStoreProxy::setContentsScale(float contentsScale)
-{
-    if (m_contentsScale == contentsScale)
-        return false;
-
-    m_contentsScale = contentsScale;
-    m_coverAreaMultiplier = 2;
-    m_pendingTileCreation = false;
-    m_contentsRect = { };
-    m_visibleRect = { };
-    m_coverRect = { };
-    m_keepRect = { };
-
-    return true;
-}
-
-RefPtr<CoordinatedBackingStoreProxy::Update> CoordinatedBackingStoreProxy::updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, bool shouldCreateAndDestroyTiles, Vector<IntRect>&& dirtyRegion, CoordinatedGraphicsLayer& layer)
-{
-    invalidateRegion(dirtyRegion);
-
-    Vector<uint32_t> tilesToCreate;
-    Vector<TileUpdate> tilesToUpdate;
-    Vector<uint32_t> tilesToRemove;
-
-    auto createOrDestroyTiles = [&] {
-        auto contentsRect = mapFromContents(unscaledContentsRect);
-        auto visibleRect = mapFromContents(unscaledVisibleRect);
-        float coverAreaMultiplier = MemoryPressureHandler::singleton().isUnderMemoryPressure() ? 1.0f : 2.0f;
-
-        bool contentsRectChanged = m_contentsRect != contentsRect;
-        bool geometryChanged = contentsRectChanged || m_visibleRect != visibleRect || m_coverAreaMultiplier != coverAreaMultiplier;
-        if (!m_pendingTileCreation && !geometryChanged)
-            return;
-
-        if (geometryChanged) {
-            m_contentsRect = contentsRect;
-            m_visibleRect = visibleRect;
-            m_coverAreaMultiplier = coverAreaMultiplier;
-            if (m_contentsRect.isEmpty()) {
-                m_coverRect = { };
-                m_keepRect = { };
-                if (m_tiles.isEmpty())
-                    return;
-
-                auto tiles = WTFMove(m_tiles);
-                for (const auto& tile : tiles.values())
-                    tilesToRemove.append(tile.id);
-
-                return;
+    // Cover areas (in tiles) with minimum distance from the visible rect. If the visible rect is
+    // not covered already it will be covered first in one go, due to the distance being 0 for tiles
+    // inside the visible rect.
+    CoordinatedBackingStoreProxyTile::Coordinate topLeft = tileCoordinateForPoint(coverRect.location());
+    CoordinatedBackingStoreProxyTile::Coordinate bottomRight = tileCoordinateForPoint(innerBottomRight(coverRect));
+    for (int yCoordinate = topLeft.y(); yCoordinate <= bottomRight.y(); ++yCoordinate) {
+        for (int xCoordinate = topLeft.x(); xCoordinate <= bottomRight.x(); ++xCoordinate) {
+            CoordinatedBackingStoreProxyTile::Coordinate currentCoordinate(xCoordinate, yCoordinate);
+            if (m_tiles.contains(currentCoordinate))
+                continue;
+            ++requiredTileCount;
+            double distance = tileDistance(m_visibleRect, currentCoordinate);
+            if (distance > shortestDistance)
+                continue;
+            if (distance < shortestDistance) {
+                tilesToCreate.clear();
+                shortestDistance = distance;
             }
+            tilesToCreate.append(currentCoordinate);
         }
-
-        /* We must compute cover and keep rects using the visibleRect, instead of the rect intersecting the visibleRect with m_rect,
-         * because TBS can be used as a backing store of GraphicsLayer and the visible rect usually does not intersect with m_rect.
-         * In the below case, the intersecting rect is an empty.
-         *
-         *  +----------------+
-         *  |                |
-         *  | m_contentsRect |
-         *  |       +--------|---------------------+
-         *  |       |  HERE  |  cover or keep      |
-         *  +----------------+      rect           |
-         *          |         +---------+          |
-         *          |         | visible |          |
-         *          |         |  rect   |          |
-         *          |         +---------+          |
-         *          |                              |
-         *          |                              |
-         *          +------------------------------+
-         *
-         * We must create or keep the tiles in the HERE region.
-         */
-        auto [coverRect, keepRect] = computeCoverAndKeepRect();
-        m_coverRect = WTFMove(coverRect);
-        m_keepRect = WTFMove(keepRect);
-
-        // Drop tiles outside the new keepRect.
-        m_tiles.removeIf([&](auto& iter) {
-            if (!iter.value.rect.intersects(m_keepRect)) {
-                tilesToRemove.append(iter.value.id);
-                return true;
-            }
-            return false;
-        });
-
-        if (m_coverRect.isEmpty())
-            return;
-
-        // Resize tiles at the edge in case the contents size has changed.
-        if (contentsRectChanged) {
-            m_tiles.removeIf([&](auto& iter) {
-                auto& tile = iter.value;
-                auto expectedTileRect = tileRectForPosition(tile.position);
-                if (expectedTileRect.isEmpty()) {
-                    tilesToRemove.append(tile.id);
-                    return true;
-                }
-
-                if (expectedTileRect != tile.rect)
-                    tile.resize(expectedTileRect.size());
-
-                return false;
-            });
-        }
-
-        // Search for the tile position closest to the viewport center that does not yet contain a tile.
-        // Which position is considered the closest depends on the tileDistance function.
-        double shortestDistance = std::numeric_limits<double>::infinity();
-        unsigned requiredTileCount = 0;
-        IntPoint visibleCenterPosition = tilePositionForPoint(m_visibleRect.center());
-        auto tileDistance = [&] (const IntPoint& tilePosition) -> double {
-            if (m_visibleRect.intersects(tileRectForPosition(tilePosition)))
-                return 0;
-            return std::max(std::abs(visibleCenterPosition.y() - tilePosition.y()), std::abs(visibleCenterPosition.x() - tilePosition.x()));
-        };
-
-        // Cover areas (in tiles) with minimum distance from the visible rect. If the visible rect is
-        // not covered already it will be covered first in one go, due to the distance being 0 for tiles
-        // inside the visible rect.
-        Vector<IntPoint> tilePositionsToCreate;
-        auto topLeft = tilePositionForPoint(m_coverRect.minXMinYCorner());
-        auto innerBottomRight = tilePositionForPoint(m_coverRect.maxXMaxYCorner() - IntSize(1, 1));
-        for (int y = topLeft.y(); y <= innerBottomRight.y(); ++y) {
-            for (int x = topLeft.x(); x <= innerBottomRight.x(); ++x) {
-                IntPoint position(x, y);
-                if (m_tiles.contains(position))
-                    continue;
-
-                requiredTileCount++;
-                double distance = tileDistance(position);
-                if (distance > shortestDistance)
-                    continue;
-
-                if (distance < shortestDistance) {
-                    tilePositionsToCreate.clear();
-                    shortestDistance = distance;
-                }
-                tilePositionsToCreate.append(WTFMove(position));
-            }
-        }
-
-        if (requiredTileCount) {
-            requiredTileCount -= tilePositionsToCreate.size();
-
-            for (const auto& position : tilePositionsToCreate) {
-                auto tile = Tile(generateTileID(), position, tileRectForPosition(position));
-                tilesToCreate.append(tile.id);
-                m_tiles.add(position, WTFMove(tile));
-            }
-        }
-
-        // Re-call updateIfNeeded again to cover the visible area with the newest shortest distance.
-        m_pendingTileCreation = requiredTileCount;
-    };
-
-    if (shouldCreateAndDestroyTiles)
-        createOrDestroyTiles();
-
-    // Update the dirty tiles.
-    unsigned dirtyTilesCount = 0;
-    for (const auto& tile : m_tiles.values()) {
-        if (!tile.dirtyRect.isEmpty())
-            dirtyTilesCount++;
     }
 
-    WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %u", dirtyTilesCount);
-
-    unsigned dirtyTileIndex = 0;
-    for (auto& tile : m_tiles.values()) {
-        if (tile.dirtyRect.isEmpty())
-            continue;
-
-        WTFBeginSignpost(this, UpdateTile, "%u/%u, id: %d, rect: %ix%i+%i+%i, dirty: %ix%i+%i+%i", ++dirtyTileIndex, dirtyTilesCount, tile.id,
-            tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), tile.dirtyRect.x(), tile.dirtyRect.y(), tile.dirtyRect.width(), tile.dirtyRect.height());
-
-        auto buffer = layer.paintTile(tile.dirtyRect);
-        IntRect dirtyRect = WTFMove(tile.dirtyRect);
-        dirtyRect.move(-tile.rect.x(), -tile.rect.y());
-        tilesToUpdate.append({ tile.id, tile.rect, WTFMove(dirtyRect), WTFMove(buffer) });
-
-        WTFEndSignpost(this, UpdateTileBackingStore);
+    // Now construct the tile(s) within the shortest distance.
+    unsigned tilesToCreateCount = tilesToCreate.size();
+    for (unsigned n = 0; n < tilesToCreateCount; ++n) {
+        CoordinatedBackingStoreProxyTile::Coordinate coordinate = tilesToCreate[n];
+        m_tiles.add(coordinate, makeUnique<CoordinatedBackingStoreProxyTile>(*this, coordinate));
     }
+    requiredTileCount -= tilesToCreateCount;
 
-    WTFEndSignpost(this, UpdateTiles);
-
-    return Update::create(WTFMove(tilesToCreate), WTFMove(tilesToUpdate), WTFMove(tilesToRemove));
+    // Re-call createTiles on a timer to cover the visible area with the newest shortest distance.
+    m_pendingTileCreation = requiredTileCount;
+    if (m_pendingTileCreation)
+        m_client.tiledBackingStoreHasPendingTileCreation();
 }
 
-std::pair<IntRect, IntRect> CoordinatedBackingStoreProxy::computeCoverAndKeepRect() const
+void CoordinatedBackingStoreProxy::adjustForContentsRect(IntRect& rect) const
 {
-    IntRect coverRect = m_visibleRect;
-    IntRect keepRect = m_visibleRect;
+    IntRect bounds = m_rect;
+    IntSize candidateSize = rect.size();
+
+    rect.intersect(bounds);
+
+    if (rect.size() == candidateSize)
+        return;
+
+    /*
+     * In the following case, there is no intersection of the contents rect and the cover rect.
+     * Thus the latter should not be inflated.
+     *
+     *  +---------------+
+     *  |   m_rect      |
+     *  +---------------+
+     *
+     *          +-------------------------------+
+     *          |          cover rect           |
+     *          |         +---------+           |
+     *          |         | visible |           |
+     *          |         |  rect   |           |
+     *          |         +---------+           |
+     *          +-------------------------------+
+     */
+    if (rect.isEmpty())
+        return;
+
+    // Try to create a cover rect of the same size as the candidate, but within content bounds.
+    int pixelsCovered = 0;
+    if (!WTF::safeMultiply(candidateSize.width(), candidateSize.height(), pixelsCovered))
+        pixelsCovered = std::numeric_limits<int>::max();
+
+    if (rect.width() < candidateSize.width())
+        rect.inflateY(((pixelsCovered / rect.width()) - rect.height()) / 2);
+    if (rect.height() < candidateSize.height())
+        rect.inflateX(((pixelsCovered / rect.height()) - rect.width()) / 2);
+
+    rect.intersect(bounds);
+}
+
+void CoordinatedBackingStoreProxy::computeCoverAndKeepRect(const IntRect& visibleRect, IntRect& coverRect, IntRect& keepRect) const
+{
+    coverRect = visibleRect;
+    keepRect = visibleRect;
 
     // If we cover more that the actual viewport we can be smart about which tiles we choose to render.
     if (m_coverAreaMultiplier > 1) {
         // The initial cover area covers equally in each direction, according to the coverAreaMultiplier.
-        coverRect.inflateX(m_visibleRect.width() * (m_coverAreaMultiplier - 1) / 2);
-        coverRect.inflateY(m_visibleRect.height() * (m_coverAreaMultiplier - 1) / 2);
+        coverRect.inflateX(visibleRect.width() * (m_coverAreaMultiplier - 1) / 2);
+        coverRect.inflateY(visibleRect.height() * (m_coverAreaMultiplier - 1) / 2);
         keepRect = coverRect;
+
+        if (m_trajectoryVector != FloatPoint::zero()) {
+            // A null trajectory vector (no motion) means that tiles for the coverArea will be created.
+            // A non-null trajectory vector will shrink the covered rect to visibleRect plus its expansion from its
+            // center toward the cover area edges in the direction of the given vector.
+
+            // E.g. if visibleRect == (10,10)5x5 and coverAreaMultiplier == 3.0:
+            // a (0,0) trajectory vector will create tiles intersecting (5,5)15x15,
+            // a (1,0) trajectory vector will create tiles intersecting (10,10)10x5,
+            // and a (1,1) trajectory vector will create tiles intersecting (10,10)10x10.
+
+            // Multiply the vector by the distance to the edge of the cover area.
+            float trajectoryVectorMultiplier = (m_coverAreaMultiplier - 1) / 2;
+
+            // Unite the visible rect with a "ghost" of the visible rect moved in the direction of the trajectory vector.
+            coverRect = visibleRect;
+            coverRect.move(coverRect.width() * m_trajectoryVector.x() * trajectoryVectorMultiplier, coverRect.height() * m_trajectoryVector.y() * trajectoryVectorMultiplier);
+
+            coverRect.unite(visibleRect);
+        }
         ASSERT(keepRect.contains(coverRect));
     }
 
-    // Adjust the cover rect for contents rect.
-    IntSize candidateSize = coverRect.size();
-    coverRect.intersect(m_contentsRect);
-    if (!coverRect.isEmpty() && coverRect.size() != candidateSize) {
-        // Try to create a cover rect of the same size as the candidate, but within content bounds.
-        int pixelsCovered = 0;
-        if (!WTF::safeMultiply(candidateSize.width(), candidateSize.height(), pixelsCovered))
-            pixelsCovered = std::numeric_limits<int>::max();
-
-        if (coverRect.width() < candidateSize.width())
-            coverRect.inflateY(((pixelsCovered / coverRect.width()) - coverRect.height()) / 2);
-        if (coverRect.height() < candidateSize.height())
-            coverRect.inflateX(((pixelsCovered / coverRect.height()) - coverRect.width()) / 2);
-
-        coverRect.intersect(m_contentsRect);
-    }
+    adjustForContentsRect(coverRect);
 
     // The keep rect is an inflated version of the cover rect, inflated in tile dimensions.
     keepRect.unite(coverRect);
     keepRect.inflateX(m_tileSize.width() / 2);
     keepRect.inflateY(m_tileSize.height() / 2);
-    keepRect.intersect(m_contentsRect);
+    keepRect.intersect(m_rect);
 
     ASSERT(coverRect.isEmpty() || keepRect.contains(coverRect));
-    return { WTFMove(coverRect), WTFMove(keepRect) };
 }
 
-void CoordinatedBackingStoreProxy::invalidateRegion(const Vector<IntRect>& dirtyRegion)
+void CoordinatedBackingStoreProxy::resizeEdgeTiles()
 {
-    auto invalidate = [&](const IntRect& contentsDirtyRect) {
-        IntRect dirtyRect(mapFromContents(contentsDirtyRect));
-        IntRect keepRectFitToTileSize = tileRectForPosition(tilePositionForPoint(m_keepRect.minXMinYCorner()));
-        keepRectFitToTileSize.unite(tileRectForPosition(tilePositionForPoint(m_keepRect.maxXMaxYCorner() - IntSize(1, 1))));
+    Vector<CoordinatedBackingStoreProxyTile::Coordinate> tilesToRemove;
+    for (auto& tile : m_tiles.values()) {
+        CoordinatedBackingStoreProxyTile::Coordinate tileCoordinate = tile->coordinate();
+        IntRect tileRect = tile->rect();
+        IntRect expectedTileRect = tileRectForCoordinate(tileCoordinate);
+        if (expectedTileRect.isEmpty())
+            tilesToRemove.append(tileCoordinate);
+        else if (expectedTileRect != tileRect)
+            tile->resize(expectedTileRect.size());
+    }
 
-        // Only iterate on the part of the rect that we know we might have tiles.
-        IntRect coveredDirtyRect = intersection(dirtyRect, keepRectFitToTileSize);
-        auto topLeft = tilePositionForPoint(coveredDirtyRect.minXMinYCorner());
-        auto innerBottomRight = tilePositionForPoint(coveredDirtyRect.maxXMaxYCorner() - IntSize(1, 1));
+    for (auto& coordinateToRemove : tilesToRemove)
+        m_tiles.remove(coordinateToRemove);
+}
 
-        for (int y = topLeft.y(); y <= innerBottomRight.y(); ++y) {
-            for (int x = topLeft.x(); x <= innerBottomRight.x(); ++x) {
-                auto it = m_tiles.find(IntPoint(x, y));
-                if (it == m_tiles.end())
-                    continue;
+void CoordinatedBackingStoreProxy::setKeepRect(const IntRect& keepRect)
+{
+    // Drop tiles outside the new keepRect.
 
-                // Pass the full rect to each tile as coveredDirtyRect might not contain them completely and we don't want partial tile redraws.
-                it->value.addDirtyRect(dirtyRect);
-            }
-        }
-    };
+    FloatRect keepRectF = keepRect;
 
-    for (const auto& rect : dirtyRegion)
-        invalidate(rect);
+    Vector<CoordinatedBackingStoreProxyTile::Coordinate> toRemove;
+    for (auto& tile : m_tiles.values()) {
+        CoordinatedBackingStoreProxyTile::Coordinate coordinate = tile->coordinate();
+        FloatRect tileRect = tile->rect();
+        if (!tileRect.intersects(keepRectF))
+            toRemove.append(coordinate);
+    }
+
+    for (auto& coordinateToRemove : toRemove)
+        m_tiles.remove(coordinateToRemove);
+
+    m_keepRect = keepRect;
+}
+
+void CoordinatedBackingStoreProxy::removeAllNonVisibleTiles(const IntRect& unscaledVisibleRect, const IntRect& contentsRect)
+{
+    IntRect boundedVisibleRect = mapFromContents(intersection(unscaledVisibleRect, contentsRect));
+    setKeepRect(boundedVisibleRect);
 }
 
 IntRect CoordinatedBackingStoreProxy::mapToContents(const IntRect& rect) const
 {
-    FloatRect scaledRect(rect);
-    scaledRect.scale(1 / m_contentsScale);
-    return enclosingIntRect(scaledRect);
+    return enclosingIntRect(FloatRect(rect.x() / m_contentsScale,
+        rect.y() / m_contentsScale,
+        rect.width() / m_contentsScale,
+        rect.height() / m_contentsScale));
 }
 
 IntRect CoordinatedBackingStoreProxy::mapFromContents(const IntRect& rect) const
 {
-    FloatRect scaledRect(rect);
-    scaledRect.scale(m_contentsScale);
-    return enclosingIntRect(scaledRect);
+    return enclosingIntRect(FloatRect(rect.x() * m_contentsScale,
+        rect.y() * m_contentsScale,
+        rect.width() * m_contentsScale,
+        rect.height() * m_contentsScale));
 }
 
-IntRect CoordinatedBackingStoreProxy::tileRectForPosition(const IntPoint& position) const
+IntRect CoordinatedBackingStoreProxy::tileRectForCoordinate(const CoordinatedBackingStoreProxyTile::Coordinate& coordinate) const
 {
-    IntRect tileRect({ position.x() * m_tileSize.width(), position.y() * m_tileSize.height() }, m_tileSize);
-    tileRect.intersect(m_contentsRect);
-    return tileRect;
+    IntRect rect(coordinate.x() * m_tileSize.width(),
+        coordinate.y() * m_tileSize.height(),
+        m_tileSize.width(),
+        m_tileSize.height());
+
+    rect.intersect(m_rect);
+    return rect;
 }
 
-IntPoint CoordinatedBackingStoreProxy::tilePositionForPoint(const IntPoint& point) const
+CoordinatedBackingStoreProxyTile::Coordinate CoordinatedBackingStoreProxy::tileCoordinateForPoint(const IntPoint& point) const
 {
     int x = point.x() / m_tileSize.width();
     int y = point.y() / m_tileSize.height();
-    return { std::max(x, 0), std::max(y, 0) };
+    return CoordinatedBackingStoreProxyTile::Coordinate(std::max(x, 0), std::max(y, 0));
 }
 
-} // namespace WebCore
+}
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -1,132 +1,106 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
- * Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public License
- * along with this library; see the file COPYING.LIB.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301, USA.
+ Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+ 
+ You should have received a copy of the GNU Library General Public License
+ along with this library; see the file COPYING.LIB.  If not, write to
+ the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
  */
 
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
-#include "IntPointHash.h"
+
+#include "CoordinatedBackingStoreProxyTile.h"
+#include "FloatPoint.h"
+#include "IntPoint.h"
 #include "IntRect.h"
-#include <optional>
-#include <wtf/Function.h>
-#include <wtf/Noncopyable.h>
+#include <wtf/Assertions.h>
+#include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
-class CoordinatedGraphicsLayer;
-class CoordinatedTileBuffer;
+
+class GraphicsContext;
+class CoordinatedBackingStoreProxyClient;
 
 class CoordinatedBackingStoreProxy {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
     WTF_MAKE_NONCOPYABLE(CoordinatedBackingStoreProxy);
 public:
-    static std::unique_ptr<CoordinatedBackingStoreProxy> create(float contentsScale, std::optional<IntSize> tileSize = std::nullopt);
-    CoordinatedBackingStoreProxy(float contentsScale, const IntSize& tileSize);
-    ~CoordinatedBackingStoreProxy() = default;
+    CoordinatedBackingStoreProxy(CoordinatedBackingStoreProxyClient&, float contentsScale = 1.f);
+    ~CoordinatedBackingStoreProxy();
 
-    bool setContentsScale(float);
-    const IntRect& coverRect() const { return m_coverRect; }
-    bool hasPendingTileCreation() const { return m_pendingTileCreation; }
+    CoordinatedBackingStoreProxyClient& client() { return m_client; }
 
-    struct TileUpdate {
-        uint32_t tileID { 0 };
-        IntRect tileRect;
-        IntRect dirtyRect;
-        Ref<CoordinatedTileBuffer> buffer;
-    };
+    void setTrajectoryVector(const FloatPoint&);
+    void createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
 
-    class Update final : public ThreadSafeRefCounted<Update> {
-    public:
-        static RefPtr<Update> create(Vector<uint32_t>&& tilesToCreate, Vector<TileUpdate>&& tilesToUpdate, Vector<uint32_t>&& tilesToRemove)
-        {
-            if (tilesToCreate.isEmpty() && tilesToUpdate.isEmpty() && tilesToRemove.isEmpty())
-                return nullptr;
-            return adoptRef(new Update(WTFMove(tilesToCreate), WTFMove(tilesToUpdate), WTFMove(tilesToRemove)));
-        }
-        ~Update();
+    float contentsScale() const { return m_contentsScale; }
 
-        const Vector<uint32_t> tilesToCreate() const { return m_tilesToCreate; }
-        const Vector<TileUpdate>& tilesToUpdate() const { return m_tilesToUpdate; }
-        const Vector<uint32_t> tilesToRemove() const { return m_tilesToRemove; }
+    Vector<std::reference_wrapper<CoordinatedBackingStoreProxyTile>> dirtyTiles();
 
-        void appendUpdate(RefPtr<Update>&);
+    void invalidate(const IntRect& dirtyRect);
 
-    private:
-        Update(Vector<uint32_t>&&, Vector<TileUpdate>&&, Vector<uint32_t>&&);
+    WEBCORE_EXPORT IntRect mapToContents(const IntRect&) const;
+    IntRect mapFromContents(const IntRect&) const;
 
-        Vector<uint32_t> m_tilesToCreate;
-        Vector<TileUpdate> m_tilesToUpdate;
-        Vector<uint32_t> m_tilesToRemove;
-    };
+    IntRect tileRectForCoordinate(const CoordinatedBackingStoreProxyTile::Coordinate&) const;
+    CoordinatedBackingStoreProxyTile::Coordinate tileCoordinateForPoint(const IntPoint&) const;
+    double tileDistance(const IntRect& viewport, const CoordinatedBackingStoreProxyTile::Coordinate&) const;
 
-    RefPtr<Update> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, bool shouldCreateAndDestroyTiles, Vector<IntRect>&& dirtyRegion, CoordinatedGraphicsLayer&);
+    IntRect coverRect() const { return m_coverRect; }
+    bool visibleAreaIsCovered() const;
+    void removeAllNonVisibleTiles(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
 
 private:
-    struct Tile {
-        Tile() = default;
-        Tile(uint32_t id, const IntPoint& position, IntRect&& tileRect)
-            : id(id)
-            , position(position)
-            , rect(WTFMove(tileRect))
-            , dirtyRect(rect)
-        {
-        }
+    void createTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier);
+    void computeCoverAndKeepRect(const IntRect& visibleRect, IntRect& coverRect, IntRect& keepRect) const;
 
-        void resize(const IntSize& size)
-        {
-            rect.setSize(size);
-            dirtyRect = rect;
-        }
+    void resizeEdgeTiles();
+    void setCoverRect(const IntRect& rect) { m_coverRect = rect; }
+    void setKeepRect(const IntRect&);
 
-        void addDirtyRect(const IntRect& dirty)
-        {
-            auto tileDirtyRect = intersection(dirty, rect);
-            dirtyRect.unite(tileDirtyRect);
-        }
+    float coverageRatio(const IntRect&) const;
+    void adjustForContentsRect(IntRect&) const;
 
-        uint32_t id { 0 };
-        IntPoint position;
-        IntRect rect;
-        IntRect dirtyRect;
-    };
+    void paintCheckerPattern(GraphicsContext*, const IntRect&, const CoordinatedBackingStoreProxyTile::Coordinate&);
 
-    std::pair<IntRect, IntRect> computeCoverAndKeepRect() const;
-    void invalidateRegion(const Vector<IntRect>&);
+private:
+    CoordinatedBackingStoreProxyClient& m_client;
 
-    IntRect mapToContents(const IntRect&) const;
-    IntRect mapFromContents(const IntRect&) const;
-    IntRect tileRectForPosition(const IntPoint&) const;
-    IntPoint tilePositionForPoint(const IntPoint&) const;
+    typedef UncheckedKeyHashMap<CoordinatedBackingStoreProxyTile::Coordinate, std::unique_ptr<CoordinatedBackingStoreProxyTile>> TileMap;
+    TileMap m_tiles;
 
-    float m_contentsScale { 1 };
     IntSize m_tileSize;
-    float m_coverAreaMultiplier { 2 };
-    bool m_pendingTileCreation { false };
-    IntRect m_contentsRect;
+    float m_coverAreaMultiplier;
+
+    FloatPoint m_trajectoryVector;
+    FloatPoint m_pendingTrajectoryVector;
     IntRect m_visibleRect;
+
     IntRect m_coverRect;
     IntRect m_keepRect;
-    UncheckedKeyHashMap<IntPoint, Tile> m_tiles;
+    IntRect m_rect;
+    IntRect m_previousRect;
+
+    float m_contentsScale;
+
+    bool m_pendingTileCreation;
+
+    friend class CoordinatedBackingStoreProxyTile;
 };
 
-} // namespace WebCore
+}
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+ 
+ You should have received a copy of the GNU Library General Public License
+ along with this library; see the file COPYING.LIB.  If not, write to
+ the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+
+namespace WebCore {
+class CoordinatedTileBuffer;
+class GraphicsContext;
+class SurfaceUpdateInfo;
+
+class CoordinatedBackingStoreProxyClient {
+public:
+    virtual ~CoordinatedBackingStoreProxyClient() = default;
+    virtual void tiledBackingStoreHasPendingTileCreation() = 0;
+
+    virtual void createTile(uint32_t tileID, float) = 0;
+    virtual void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&) = 0;
+    virtual void removeTile(uint32_t tileID) = 0;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CoordinatedBackingStoreProxyTile.h"
+
+#if USE(COORDINATED_GRAPHICS)
+
+#include "CoordinatedBackingStoreProxy.h"
+#include "CoordinatedBackingStoreProxyClient.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Tile);
+
+static const uint32_t InvalidTileID = 0;
+
+CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy& tiledBackingStore, const Coordinate& tileCoordinate)
+    : m_tiledBackingStore(tiledBackingStore)
+    , m_ID(InvalidTileID)
+    , m_coordinate(tileCoordinate)
+    , m_rect(tiledBackingStore.tileRectForCoordinate(tileCoordinate))
+    , m_dirtyRect(m_rect)
+{
+}
+
+CoordinatedBackingStoreProxyTile::~CoordinatedBackingStoreProxyTile()
+{
+    if (m_ID != InvalidTileID)
+        m_tiledBackingStore.client().removeTile(m_ID);
+}
+
+void CoordinatedBackingStoreProxyTile::ensureTileID()
+{
+    static uint32_t id = 1;
+    if (m_ID == InvalidTileID) {
+        m_ID = id++;
+        // We may get an invalid ID due to wrap-around on overflow.
+        if (m_ID == InvalidTileID)
+            m_ID = id++;
+        m_tiledBackingStore.client().createTile(m_ID, m_tiledBackingStore.contentsScale());
+    }
+}
+
+bool CoordinatedBackingStoreProxyTile::isDirty() const
+{
+    return !m_dirtyRect.isEmpty();
+}
+
+bool CoordinatedBackingStoreProxyTile::isReadyToPaint() const
+{
+    return m_ID != InvalidTileID;
+}
+
+void CoordinatedBackingStoreProxyTile::invalidate(const IntRect& dirtyRect)
+{
+    IntRect tileDirtyRect = intersection(dirtyRect, m_rect);
+    if (!tileDirtyRect.isEmpty())
+        m_dirtyRect.unite(tileDirtyRect);
+}
+
+void CoordinatedBackingStoreProxyTile::markClean()
+{
+    m_dirtyRect = { };
+}
+
+void CoordinatedBackingStoreProxyTile::resize(const IntSize& newSize)
+{
+    m_rect = IntRect(m_rect.location(), newSize);
+    m_dirtyRect = m_rect;
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2010-2011 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+
+#include "IntPoint.h"
+#include "IntPointHash.h"
+#include "IntRect.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class CoordinatedBackingStoreProxy;
+
+class CoordinatedBackingStoreProxyTile {
+    WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxyTile);
+public:
+    typedef IntPoint Coordinate;
+
+    CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy&, const Coordinate&);
+    ~CoordinatedBackingStoreProxyTile();
+
+    uint32_t tileID() const { return m_ID; }
+    void ensureTileID();
+
+    const Coordinate& coordinate() const { return m_coordinate; }
+    const IntRect& rect() const { return m_rect; }
+    const IntRect& dirtyRect() const { return m_dirtyRect; }
+    bool isDirty() const;
+    bool isReadyToPaint() const;
+
+    void invalidate(const IntRect&);
+    void markClean();
+    void resize(const IntSize&);
+
+private:
+    CoordinatedBackingStoreProxy& m_tiledBackingStore;
+    uint32_t m_ID;
+    Coordinate m_coordinate;
+    IntRect m_rect;
+    IntRect m_dirtyRect;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS)
+

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -35,6 +35,7 @@
 #include "GraphicsLayerAsyncContentsDisplayDelegateTextureMapper.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsLayerFactory.h"
+#include "NicosiaBackingStore.h"
 #include "ScrollableArea.h"
 #include "TextureMapperPlatformLayerProxyProvider.h"
 #include "TransformOperation.h"
@@ -172,8 +173,9 @@ CoordinatedGraphicsLayer::~CoordinatedGraphicsLayer()
         m_coordinator->detachLayer(this);
     }
     ASSERT(!m_imageBacking.store);
-    ASSERT(!m_backingStore);
+    ASSERT(!m_nicosia.backingStore);
     ASSERT(!m_animatedBackingStoreClient);
+
     if (CoordinatedGraphicsLayer* parentLayer = downcast<CoordinatedGraphicsLayer>(parent()))
         parentLayer->didChangeChildren();
     willBeDestroyed();
@@ -813,17 +815,20 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
 
     // Determine the backing store presence. Content is painted later, in the updateContentBuffers() traversal.
     if (shouldHaveBackingStore()) {
-        if (!m_backingStore) {
-            m_backingStore = CoordinatedBackingStoreProxy::create(effectiveContentsScale());
-            m_pendingVisibleRectAdjustment = true;
+        if (!m_nicosia.backingStore) {
+            m_nicosia.backingStore = Nicosia::BackingStore::create();
+            m_nicosia.delta.backingStoreChanged = true;
         }
-        m_nicosia.delta.backingStoreChanged = true;
-    } else if (m_backingStore) {
-        m_backingStore = nullptr;
+    } else if (m_nicosia.backingStore) {
+        auto& layerState = m_nicosia.backingStore->layerState();
+        layerState.isPurging = true;
+        layerState.mainBackingStore = nullptr;
+
+        m_nicosia.backingStore = nullptr;
         m_nicosia.delta.backingStoreChanged = true;
     }
 
-    if (hasActiveTransformAnimation && m_backingStore) {
+    if (hasActiveTransformAnimation && m_nicosia.backingStore) {
         // The layer has a backingStore and a transformation animation. This means that we need to add an
         // AnimatedBackingStoreClient to check whether we need to update the backingStore due to the animation.
         // At this point we don't know the area covered by tiles available, so we just pass an empty rectangle
@@ -952,7 +957,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
                     state.debugBorder = m_nicosia.debugBorder;
 
                 if (localDelta.backingStoreChanged)
-                    state.backingStore.shouldHaveBackingStore = !!m_backingStore;
+                    state.backingStore = m_nicosia.backingStore;
                 if (localDelta.contentLayerChanged)
                     state.contentLayer = m_contentsLayer;
                 if (localDelta.imageBackingChanged) {
@@ -1065,60 +1070,112 @@ std::pair<bool, bool> CoordinatedGraphicsLayer::finalizeCompositingStateFlush()
 
 void CoordinatedGraphicsLayer::updateContentBuffers()
 {
-    if (!m_backingStore)
+    if (!m_nicosia.backingStore)
         return;
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     TraceScope traceScope(UpdateLayerContentBuffersStart, UpdateLayerContentBuffersEnd);
 #endif
 
+    // Prepare for painting on the impl-contained backing store. isFlushing is used there
+    // for internal sanity checks.
+    auto& layerState = m_nicosia.backingStore->layerState();
+    layerState.isFlushing = true;
+
+    // Helper lambda that finished the flush update and determines layer sync necessity.
+    auto finishUpdate =
+        [this, &layerState] {
+            auto& update = layerState.update;
+            m_nicosia.performLayerSync |= !update.tilesToCreate.isEmpty()
+                || !update.tilesToRemove.isEmpty() || !update.tilesToUpdate.isEmpty();
+            layerState.isFlushing = false;
+        };
+
     // Address the content scale adjustment.
     if (m_pendingContentsScaleAdjustment) {
-        if (m_backingStore->setContentsScale(effectiveContentsScale()))
-            m_pendingVisibleRectAdjustment = true;
+        if (layerState.mainBackingStore && layerState.mainBackingStore->contentsScale() != effectiveContentsScale()) {
+            // Discard the CoodinatedBackingStoreProxy object to reconstruct it with new content scale.
+            layerState.mainBackingStore = nullptr;
+        }
         m_pendingContentsScaleAdjustment = false;
     }
 
-    if (!m_pendingVisibleRectAdjustment && !m_needsDisplay.completeLayer && m_needsDisplay.rects.isEmpty())
-        return;
+    // Ensure the CoordinatedBackingStoreProxy object, and enforce a complete repaint if it's not been present yet.
+    if (!layerState.mainBackingStore) {
+        layerState.mainBackingStore = makeUnique<CoordinatedBackingStoreProxy>(*m_nicosia.backingStore, effectiveContentsScale());
+        m_pendingVisibleRectAdjustment = true;
+    }
 
-    IntRect contentsRect(IntPoint::zero(), IntSize(m_size));
-    Vector<IntRect> dirtyRegion;
+    // Bail if there's no painting recorded or enforced.
+    if (!m_pendingVisibleRectAdjustment && !m_needsDisplay.completeLayer && m_needsDisplay.rects.isEmpty()) {
+        finishUpdate();
+        return;
+    }
+
     if (!m_needsDisplay.completeLayer) {
-        dirtyRegion = m_needsDisplay.rects.map<Vector<IntRect>>([](const FloatRect& rect) {
-            return enclosingIntRect(rect);
-        });
+        for (auto& rect : m_needsDisplay.rects)
+            layerState.mainBackingStore->invalidate(enclosingIntRect(rect));
     } else
-        dirtyRegion = { contentsRect };
+        layerState.mainBackingStore->invalidate({ { }, IntSize { m_size } });
+
     m_needsDisplay.completeLayer = false;
     m_needsDisplay.rects.clear();
 
-    ASSERT(m_coordinator && m_coordinator->isFlushingLayerChanges());
-
-    auto update = m_backingStore->updateIfNeeded(transformedVisibleRectIncludingFuture(), contentsRect, m_pendingVisibleRectAdjustment, WTFMove(dirtyRegion), *this);
-    m_pendingVisibleRectAdjustment = false;
-
-    if (m_animatedBackingStoreClient)
-        m_animatedBackingStoreClient->setCoverRect(m_backingStore->coverRect());
-
-    if (update) {
-        m_nicosia.performLayerSync |= true;
-        if (!update->tilesToUpdate().isEmpty())
-            didUpdateTileBuffers();
+    if (m_pendingVisibleRectAdjustment) {
+        m_pendingVisibleRectAdjustment = false;
+        layerState.mainBackingStore->createTilesIfNeeded(transformedVisibleRectIncludingFuture(), IntRect(0, 0, m_size.width(), m_size.height()));
     }
 
-    m_nicosia.layer->accessPending([&](auto& state) {
-        state.backingStore.update = update;
-        state.backingStore.scale = effectiveContentsScale();
-        state.delta.backingStoreChanged = true;
-    });
+    if (m_animatedBackingStoreClient)
+        m_animatedBackingStoreClient->setCoverRect(layerState.mainBackingStore->coverRect());
+
+    ASSERT(m_coordinator && m_coordinator->isFlushingLayerChanges());
+
+    // With all the affected tiles created and/or invalidated, we can finally paint them.
+    auto dirtyTiles = layerState.mainBackingStore->dirtyTiles();
+    if (!dirtyTiles.isEmpty()) {
+        auto dirtyTilesCount = dirtyTiles.size();
+        bool didUpdateTiles = false;
+
+        WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %lu", dirtyTilesCount);
+
+        for (unsigned dirtyTileIndex = 0; dirtyTileIndex < dirtyTilesCount; ++dirtyTileIndex) {
+            auto& tile = dirtyTiles[dirtyTileIndex].get();
+            tile.ensureTileID();
+
+            WTFBeginSignpost(this, UpdateTile, "%u/%lu, id: %d", dirtyTileIndex + 1, dirtyTilesCount, tile.tileID());
+
+            auto& tileRect = tile.rect();
+            auto& dirtyRect = tile.dirtyRect();
+            auto buffer = paintTile(dirtyRect);
+
+            WTFBeginSignpost(this, UpdateTileBackingStore, "rect %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+
+            IntRect updateRect(dirtyRect);
+            updateRect.move(-tileRect.x(), -tileRect.y());
+            m_nicosia.backingStore->updateTile(tile.tileID(), updateRect, tileRect, WTFMove(buffer));
+
+            tile.markClean();
+            didUpdateTiles |= true;
+
+            WTFEndSignpost(this, UpdateTileBackingStore);
+            WTFEndSignpost(this, UpdateTile);
+        }
+
+        if (didUpdateTiles)
+            didUpdateTileBuffers();
+
+        WTFEndSignpost(this, UpdateTiles);
+    }
 
     // Request a new update immediately if some tiles are still pending creation. Do this on a timer
     // as we're in a layer flush and flush requests at this point would be discarded.
-    if (m_backingStore->hasPendingTileCreation()) {
+    if (layerState.hasPendingTileCreation) {
         setNeedsVisibleRectAdjustment();
         m_requestPendingTileCreationTimer.startOneShot(0_s);
     }
+
+    finishUpdate();
 }
 
 void CoordinatedGraphicsLayer::purgeBackingStores()
@@ -1127,7 +1184,13 @@ void CoordinatedGraphicsLayer::purgeBackingStores()
     SetForScope updateModeProtector(m_isPurging, true);
 #endif
 
-    m_backingStore = nullptr;
+    if (m_nicosia.backingStore) {
+        auto& layerState = m_nicosia.backingStore->layerState();
+        layerState.isPurging = true;
+        layerState.mainBackingStore = nullptr;
+
+        m_nicosia.backingStore = nullptr;
+    }
 
     if (m_animatedBackingStoreClient) {
         m_animatedBackingStoreClient->invalidate();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -164,7 +164,6 @@ public:
 
     Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const final;
 
-    Ref<CoordinatedTileBuffer> paintTile(const IntRect&);
 #if USE(SKIA)
     void paintIntoGraphicsContext(GraphicsContext&, const IntRect&) const;
 #endif
@@ -196,6 +195,8 @@ private:
 
     bool checkPendingStateChanges();
     bool checkContentLayerUpdated();
+
+    Ref<CoordinatedTileBuffer> paintTile(const IntRect& dirtyRect);
 
     void notifyFlushRequired();
 
@@ -250,9 +251,9 @@ private:
         Nicosia::CompositionLayer::LayerState::RepaintCounter repaintCounter;
         Nicosia::CompositionLayer::LayerState::DebugBorder debugBorder;
         bool performLayerSync { false };
+        RefPtr<Nicosia::BackingStore> backingStore;
     } m_nicosia;
 
-    std::unique_ptr<CoordinatedBackingStoreProxy> m_backingStore;
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
 
     RefPtr<NativeImage> m_pendingContentsImage;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -30,7 +30,6 @@
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TextureMapperPlatformLayerProxy.h>
 #include <wtf/Function.h>
-#include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
 #include <wtf/ThreadingPrimitives.h>
@@ -80,8 +79,6 @@ private:
 
     void onNewBufferAvailable() override;
 
-    void removeLayer(Nicosia::CompositionLayer&);
-
     struct {
         RefPtr<Nicosia::Scene> scene;
         Nicosia::Scene::State state;
@@ -99,8 +96,6 @@ private:
     std::unique_ptr<WebCore::TextureMapperLayer> m_rootLayer;
 
     Nicosia::PlatformLayer::LayerID m_rootLayerID { 0 };
-
-    UncheckedKeyHashMap<WebCore::TextureMapperLayer*, Ref<WebCore::CoordinatedBackingStore>> m_backingStores;
 
     WebCore::TextureMapperFPSCounter m_fpsCounter;
 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -228,8 +228,12 @@ void LayerTreeHost::flushLayers()
         WTFBeginSignpost(this, SyncFrame);
 
         m_nicosia.scene->accessState([this](Nicosia::Scene::State& state) {
-            for (auto& compositionLayer : m_nicosia.state.layers)
-                compositionLayer->flushState();
+            for (auto& compositionLayer : m_nicosia.state.layers) {
+                compositionLayer->flushState([] (const Nicosia::CompositionLayer::LayerState& state) {
+                    if (state.backingStore)
+                        state.backingStore->flushUpdate();
+                });
+            }
 
             ++state.id;
             state.layers = m_nicosia.state.layers;


### PR DESCRIPTION
#### d7943445840bfd47bfce6bc4d78ca6830415c944
<pre>
Unreviewed, reverting 285011@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281950">https://bugs.webkit.org/show_bug.cgi?id=281950</a>

Introduced a performance regression.

Reverted changeset:
&quot;[CoordinatedGraphics] Simplify tiled backing store handling&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=280606">https://bugs.webkit.org/show_bug.cgi?id=280606</a>
<a href="https://commits.webkit.org/285011@main">https://commits.webkit.org/285011@main</a>

Canonical link: <a href="https://commits.webkit.org/285591@main">https://commits.webkit.org/285591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4576cca374dc943e5f08c85a1b98127b432e7e1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73182 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/393 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15985 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62978 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79064 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/74 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65938 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-5.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-002i.html (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65220 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7219 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/461 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->