### PR TITLE
[CoordinatedGraphics] Cleanup CoordinatedBackingStoreProxy

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -1,26 +1,25 @@
 /*
- Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
- 
- This library is free software; you can redistribute it and/or
- modify it under the terms of the GNU Library General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later version.
- 
- This library is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Library General Public License for more details.
- 
- You should have received a copy of the GNU Library General Public License
- along with this library; see the file COPYING.LIB.  If not, write to
- the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- Boston, MA 02110-1301, USA.
+ * Copyright (C) 2010-2012 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
  */
 
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
-
 #include "CoordinatedBackingStoreProxyTile.h"
 #include "FloatPoint.h"
 #include "IntPoint.h"
@@ -38,12 +37,11 @@ class CoordinatedBackingStoreProxy {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
     WTF_MAKE_NONCOPYABLE(CoordinatedBackingStoreProxy);
 public:
-    CoordinatedBackingStoreProxy(CoordinatedBackingStoreProxyClient&, float contentsScale = 1.f);
+    explicit CoordinatedBackingStoreProxy(CoordinatedBackingStoreProxyClient&, float contentsScale = 1.f);
     ~CoordinatedBackingStoreProxy();
 
     CoordinatedBackingStoreProxyClient& client() { return m_client; }
 
-    void setTrajectoryVector(const FloatPoint&);
     void createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
 
     float contentsScale() const { return m_contentsScale; }
@@ -52,16 +50,7 @@ public:
 
     void invalidate(const IntRect& dirtyRect);
 
-    WEBCORE_EXPORT IntRect mapToContents(const IntRect&) const;
-    IntRect mapFromContents(const IntRect&) const;
-
-    IntRect tileRectForCoordinate(const CoordinatedBackingStoreProxyTile::Coordinate&) const;
-    CoordinatedBackingStoreProxyTile::Coordinate tileCoordinateForPoint(const IntPoint&) const;
-    double tileDistance(const IntRect& viewport, const CoordinatedBackingStoreProxyTile::Coordinate&) const;
-
-    IntRect coverRect() const { return m_coverRect; }
-    bool visibleAreaIsCovered() const;
-    void removeAllNonVisibleTiles(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
+    const IntRect& coverRect() const { return m_coverRect; }
 
 private:
     void createTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier);
@@ -71,36 +60,31 @@ private:
     void setCoverRect(const IntRect& rect) { m_coverRect = rect; }
     void setKeepRect(const IntRect&);
 
-    float coverageRatio(const IntRect&) const;
     void adjustForContentsRect(IntRect&) const;
+    double tileDistance(const IntRect& viewport, const IntPoint&) const;
 
-    void paintCheckerPattern(GraphicsContext*, const IntRect&, const CoordinatedBackingStoreProxyTile::Coordinate&);
+    IntRect mapToContents(const IntRect&) const;
+    IntRect mapFromContents(const IntRect&) const;
+    IntRect tileRectForPosition(const IntPoint&) const;
+    IntPoint tilePositionForPoint(const IntPoint&) const;
 
-private:
     CoordinatedBackingStoreProxyClient& m_client;
 
-    typedef UncheckedKeyHashMap<CoordinatedBackingStoreProxyTile::Coordinate, std::unique_ptr<CoordinatedBackingStoreProxyTile>> TileMap;
-    TileMap m_tiles;
+    UncheckedKeyHashMap<IntPoint, std::unique_ptr<CoordinatedBackingStoreProxyTile>> m_tiles;
 
+    float m_contentsScale { 1 };
     IntSize m_tileSize;
-    float m_coverAreaMultiplier;
-
-    FloatPoint m_trajectoryVector;
-    FloatPoint m_pendingTrajectoryVector;
+    float m_coverAreaMultiplier { 2 };
+    bool m_pendingTileCreation { false };
+    IntRect m_contentsRect;
     IntRect m_visibleRect;
-
     IntRect m_coverRect;
     IntRect m_keepRect;
-    IntRect m_rect;
-    IntRect m_previousRect;
-
-    float m_contentsScale;
-
-    bool m_pendingTileCreation;
+    IntRect m_previousContentsRect;
 
     friend class CoordinatedBackingStoreProxyTile;
 };
 
-}
+} // namespace WebCore
 
-#endif
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
@@ -38,11 +38,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Tile);
 
 static const uint32_t InvalidTileID = 0;
 
-CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy& tiledBackingStore, const Coordinate& tileCoordinate)
+CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy& tiledBackingStore, const IntPoint& position, const IntRect& rect)
     : m_tiledBackingStore(tiledBackingStore)
     , m_ID(InvalidTileID)
-    , m_coordinate(tileCoordinate)
-    , m_rect(tiledBackingStore.tileRectForCoordinate(tileCoordinate))
+    , m_position(position)
+    , m_rect(rect)
     , m_dirtyRect(m_rect)
 {
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
@@ -39,15 +39,13 @@ class CoordinatedBackingStoreProxy;
 class CoordinatedBackingStoreProxyTile {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxyTile);
 public:
-    typedef IntPoint Coordinate;
-
-    CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy&, const Coordinate&);
+    CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy&, const IntPoint&, const IntRect&);
     ~CoordinatedBackingStoreProxyTile();
 
     uint32_t tileID() const { return m_ID; }
     void ensureTileID();
 
-    const Coordinate& coordinate() const { return m_coordinate; }
+    const IntPoint& position() const { return m_position; }
     const IntRect& rect() const { return m_rect; }
     const IntRect& dirtyRect() const { return m_dirtyRect; }
     bool isDirty() const;
@@ -60,7 +58,7 @@ public:
 private:
     CoordinatedBackingStoreProxy& m_tiledBackingStore;
     uint32_t m_ID;
-    Coordinate m_coordinate;
+    IntPoint m_position;
     IntRect m_rect;
     IntRect m_dirtyRect;
 };


### PR DESCRIPTION
#### 0f9826116cf3784ca9bcb14903af76f7a9aa3901
<pre>
[CoordinatedGraphics] Cleanup CoordinatedBackingStoreProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281957">https://bugs.webkit.org/show_bug.cgi?id=281957</a>

Reviewed by Miguel Gomez.

Removed unused code and other small cleanups.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::CoordinatedBackingStoreProxy):
(WebCore::CoordinatedBackingStoreProxy::createTilesIfNeeded):
(WebCore::CoordinatedBackingStoreProxy::invalidate):
(WebCore::CoordinatedBackingStoreProxy::tileDistance const):
(WebCore::CoordinatedBackingStoreProxy::createTiles):
(WebCore::CoordinatedBackingStoreProxy::adjustForContentsRect const):
(WebCore::CoordinatedBackingStoreProxy::computeCoverAndKeepRect const):
(WebCore::CoordinatedBackingStoreProxy::resizeEdgeTiles):
(WebCore::CoordinatedBackingStoreProxy::setKeepRect):
(WebCore::CoordinatedBackingStoreProxy::tileRectForPosition const):
(WebCore::CoordinatedBackingStoreProxy::tilePositionForPoint const):
(WebCore::CoordinatedBackingStoreProxy::setTrajectoryVector): Deleted.
(WebCore::CoordinatedBackingStoreProxy::coverageRatio const): Deleted.
(WebCore::CoordinatedBackingStoreProxy::visibleAreaIsCovered const): Deleted.
(WebCore::CoordinatedBackingStoreProxy::removeAllNonVisibleTiles): Deleted.
(WebCore::CoordinatedBackingStoreProxy::tileRectForCoordinate const): Deleted.
(WebCore::CoordinatedBackingStoreProxy::tileCoordinateForPoint const): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
(WebCore::CoordinatedBackingStoreProxy::coverRect const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp:
(WebCore::CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h:
(WebCore::CoordinatedBackingStoreProxyTile::position const):
(WebCore::CoordinatedBackingStoreProxyTile::coordinate const): Deleted.

Canonical link: <a href="https://commits.webkit.org/285594@main">https://commits.webkit.org/285594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9546b2d40b0a6a2aa5d4ef66b2c46ff1daa41422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62994 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44187 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22767 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66041 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79082 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65237 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7235 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11272 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/479 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->