### PR TITLE
UniqueRef<T>::operator-> shouldn't return a const T*

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -86,14 +86,12 @@ public:
     T* operator&() { ASSERT(m_ref); return m_ref.get(); }
     const T* operator&() const { ASSERT(m_ref); return m_ref.get(); }
 
-    T* operator->() { ASSERT(m_ref); return m_ref.get(); }
-    const T* operator->() const { ASSERT(m_ref); return m_ref.get(); }
-    
+    T* operator->() const { ASSERT(m_ref); return m_ref.get(); }
+
     operator T&() { ASSERT(m_ref); return *m_ref; }
     operator const T&() const { ASSERT(m_ref); return *m_ref; }
 
-    T& operator*() { ASSERT(m_ref); return *m_ref.get(); }
-    const T& operator*() const { ASSERT(m_ref); return *m_ref.get(); }
+    T& operator*() const { ASSERT(m_ref); return *m_ref.get(); }
 
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }
 

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -214,11 +214,6 @@ DOMWindow* WindowProxy::window() const
     return m_frame ? m_frame->window() : nullptr;
 }
 
-WindowProxy::ProxyMap::ValuesConstIteratorRange WindowProxy::jsWindowProxies() const
-{
-    return m_jsWindowProxies->values();
-}
-
 WindowProxy::ProxyMap WindowProxy::releaseJSWindowProxies()
 {
     return std::exchange(m_jsWindowProxies, makeUniqueRef<ProxyMap>());

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -57,7 +57,6 @@ public:
 
     void destroyJSWindowProxy(DOMWrapperWorld&);
 
-    ProxyMap::ValuesConstIteratorRange jsWindowProxies() const;
     Vector<JSC::Strong<JSWindowProxy>> jsWindowProxiesAsVector() const;
 
     WEBCORE_EXPORT ProxyMap releaseJSWindowProxies();

--- a/Tools/TestWebKitAPI/Tests/WTF/UniqueRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UniqueRef.cpp
@@ -81,6 +81,9 @@ TEST(WTF, UniqueRef)
     C h(makeUniqueRef<A>());
     C i(makeUniqueRef<D>());
     
+    const UniqueRef<B> k = makeUniqueRef<B>(1, 2, 3);
+    k->a = 4;
+
     UNUSED_PARAM(b);
     UNUSED_PARAM(c);
     UNUSED_PARAM(d);
@@ -90,6 +93,7 @@ TEST(WTF, UniqueRef)
     UNUSED_PARAM(h);
     UNUSED_PARAM(i);
     UNUSED_PARAM(j);
+    UNUSED_PARAM(k);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### c684d1a74a2b18b4b347830a3adc7304439d14e8
<pre>
UniqueRef&lt;T&gt;::operator-&gt; shouldn&apos;t return a const T*
<a href="https://bugs.webkit.org/show_bug.cgi?id=281835">https://bugs.webkit.org/show_bug.cgi?id=281835</a>
<a href="https://rdar.apple.com/138270047">rdar://138270047</a>

Reviewed by Chris Dumez.

Align UniqueRef with the behavior of Ref, RefPtr and std::unique_ptr by removing the const transitivity for the operator-&gt; and operator*.
This facilite the adoption of UniqueRef over std::unique_ptr, allowing the use of const UniqueRef members more easily.

Add API test verifying that things still compile.

* Source/WTF/wtf/UniqueRef.h:
(WTF::UniqueRef::operator-&gt; const):
(WTF::UniqueRef::operator* const):
(WTF::UniqueRef::operator-&gt;): Deleted.
(WTF::UniqueRef::operator*): Deleted.
* Source/WebCore/bindings/js/WindowProxy.h: Method relied on the constness of object being returned. However it was unused code, so remove it.
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::jsWindowProxies const): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/UniqueRef.cpp:
(TestWebKitAPI::TEST(WTF, UniqueRef)):

Canonical link: <a href="https://commits.webkit.org/285628@main">https://commits.webkit.org/285628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb6c640116429e34179047b23d5791149cc8514

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/413 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57536 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Skipped layout-tests; Running layout-tests; Running upload-test-results; Running layout-tests-repeat-failures; Compiled WebKit (warnings)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16002 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37955 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72710 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22769 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66337 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79084 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72459 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65956 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/72878 "Build is in progress. Recent messages:") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65239 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16143 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7241 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94238 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/481 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20723 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->