### PR TITLE
[CoordinatedGraphics] Move dirty tiles rendering to CoordinatedBackingStoreProxy

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
@@ -31,11 +31,6 @@
 
 namespace Nicosia {
 
-void BackingStore::tiledBackingStoreHasPendingTileCreation()
-{
-    m_layerState.hasPendingTileCreation = true;
-}
-
 void BackingStore::createTile(uint32_t tileID, float scale)
 {
     ASSERT(m_layerState.isFlushing);
@@ -84,7 +79,6 @@ void BackingStore::removeTile(uint32_t tileID)
 void BackingStore::flushUpdate()
 {
     ASSERT(!m_layerState.isFlushing);
-    m_layerState.hasPendingTileCreation = false;
 
     // Incrementally store updates as they are being flushed from the layer-side.
     {

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -86,7 +86,6 @@ public:
         TileUpdate update;
         bool isFlushing { false };
         bool isPurging { false };
-        bool hasPendingTileCreation { false };
     };
     LayerState& layerState() { return m_layerState; }
 
@@ -109,7 +108,6 @@ public:
 
     // CoordinatedBackingStoreProxyClient
     // FIXME: Move these to private once updateTile() is not called from CoordinatedGrahpicsLayer.
-    void tiledBackingStoreHasPendingTileCreation() override;
     void createTile(uint32_t, float) override;
     void updateTile(uint32_t, const WebCore::IntRect&, const WebCore::IntRect&, Ref<WebCore::CoordinatedTileBuffer>&&) override;
     void removeTile(uint32_t) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -29,9 +29,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class GraphicsContext;
 class CoordinatedBackingStoreProxyClient;
+class CoordinatedGraphicsLayer;
 
 class CoordinatedBackingStoreProxy {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
@@ -42,15 +41,17 @@ public:
 
     CoordinatedBackingStoreProxyClient& client() { return m_client; }
 
-    void createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
-
     float contentsScale() const { return m_contentsScale; }
-
-    Vector<std::reference_wrapper<CoordinatedBackingStoreProxyTile>> dirtyTiles();
 
     void invalidate(const IntRect& dirtyRect);
 
     const IntRect& coverRect() const { return m_coverRect; }
+
+    enum class UpdateResult : uint8_t {
+        BuffersChanged = 1 << 0,
+        TilesPending =  1 << 1
+    };
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, bool shouldCreateAndDestroyTiles, CoordinatedGraphicsLayer&);
 
 private:
     void createTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
@@ -29,7 +29,6 @@ class SurfaceUpdateInfo;
 class CoordinatedBackingStoreProxyClient {
 public:
     virtual ~CoordinatedBackingStoreProxyClient() = default;
-    virtual void tiledBackingStoreHasPendingTileCreation() = 0;
 
     virtual void createTile(uint32_t tileID, float) = 0;
     virtual void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&) = 0;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -172,6 +172,8 @@ public:
 
     static void clampToContentsRectIfRectIsInfinite(FloatRect&, const FloatSize&);
 
+    Ref<CoordinatedTileBuffer> paintTile(const IntRect& dirtyRect);
+
 private:
     enum class FlushNotification {
         Required,
@@ -195,8 +197,6 @@ private:
 
     bool checkPendingStateChanges();
     bool checkContentLayerUpdated();
-
-    Ref<CoordinatedTileBuffer> paintTile(const IntRect& dirtyRect);
 
     void notifyFlushRequired();
 


### PR DESCRIPTION
#### 372e098c66e08f1cef03a44274ebd902736821ab
<pre>
[CoordinatedGraphics] Move dirty tiles rendering to CoordinatedBackingStoreProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=281962">https://bugs.webkit.org/show_bug.cgi?id=281962</a>

Reviewed by Miguel Gomez.

Instead of doing the update in two steps, first create/destroy tiles if
needed and then get the dirty tiles to update them, add
CoordinatedBackingStoreProxy::updateIfNeeded() to perform the whole
update including tiles created, destroyed and updated.

* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp:
(Nicosia::BackingStore::flushUpdate):
(Nicosia::BackingStore::tiledBackingStoreHasPendingTileCreation): Deleted.
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
(WebCore::CoordinatedBackingStoreProxy::createTiles):
(WebCore::CoordinatedBackingStoreProxy::createTilesIfNeeded): Deleted.
(WebCore::CoordinatedBackingStoreProxy::dirtyTiles): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::updateContentBuffers):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/285595@main">https://commits.webkit.org/285595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6777dd4a1febed472e7789980dcef5ecc887b17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57529 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37948 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/72713 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79087 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65957 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65240 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7238 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11273 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/484 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/513 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->