### PR TITLE
Default AbortSignal's reason to AbortError

### DIFF
--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -27,8 +27,6 @@
 #include "AbortController.h"
 
 #include "AbortSignal.h"
-#include "DOMException.h"
-#include "JSDOMException.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -52,12 +50,8 @@ AbortSignal& AbortController::signal()
     return m_signal.get();
 }
 
-void AbortController::abort(JSDOMGlobalObject& globalObject, JSC::JSValue reason)
+void AbortController::abort(JSC::JSValue reason)
 {
-    ASSERT(reason);
-    if (reason.isUndefined())
-        reason = toJS(&globalObject, &globalObject, DOMException::create(ExceptionCode::AbortError));
-
     protectedSignal()->signalAbort(reason);
 }
 

--- a/Source/WebCore/dom/AbortController.h
+++ b/Source/WebCore/dom/AbortController.h
@@ -37,7 +37,6 @@ class JSValue;
 namespace WebCore {
 
 class AbortSignal;
-class JSDOMGlobalObject;
 class ScriptExecutionContext;
 
 class AbortController final : public ScriptWrappable, public RefCounted<AbortController> {
@@ -48,7 +47,7 @@ public:
 
     AbortSignal& signal();
     Ref<AbortSignal> protectedSignal() const;
-    void abort(JSDOMGlobalObject&, JSC::JSValue reason);
+    void abort(JSC::JSValue reason);
 
     WebCoreOpaqueRoot opaqueRoot();
 

--- a/Source/WebCore/dom/AbortController.idl
+++ b/Source/WebCore/dom/AbortController.idl
@@ -31,5 +31,5 @@
 
     [SameObject] readonly attribute AbortSignal signal;
 
-    [CallWith=CurrentGlobalObject] undefined abort(optional any reason);
+    undefined abort(optional any reason);
 };

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -129,7 +129,16 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     if (m_aborted)
         return;
 
-    // 2. Set signal’s aborted flag.
+    // 2. ... if the reason is not given, set it to a new "AbortError" DOMException.
+    ASSERT(reason);
+    if (reason.isUndefined()) {
+        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(protectedScriptExecutionContext()->globalObject());
+        if (!globalObject)
+            return;
+        reason = toJS(globalObject, globalObject, DOMException::create(ExceptionCode::AbortError));
+    }
+
+    // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
     markAborted(reason);
 
     Vector<Ref<AbortSignal>> dependentSignalsToAbort;

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -53,11 +53,8 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
-        ASSERT(globalObject);
-
         Ref { m_promise }->resolve<IDLAny>(value);
-        Ref { m_controller }->abort(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), JSC::jsUndefined());
+        Ref { m_controller }->abort(JSC::jsUndefined());
     }
 
     void error(JSC::JSValue value) final

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -117,7 +117,7 @@ void Subscriber::close(JSC::JSValue reason)
 
     m_active = false;
 
-    m_abortController->abort(*JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()), reason);
+    m_abortController->abort(reason);
 
     {
         Locker locker { m_teardownsLock };


### PR DESCRIPTION
#### 7d575e9f5b200225c8feb627db492ee92ad1e5b6
<pre>
Default AbortSignal&apos;s reason to AbortError
<a href="https://bugs.webkit.org/show_bug.cgi?id=281961">https://bugs.webkit.org/show_bug.cgi?id=281961</a>

Reviewed by Chris Dumez.

The DOM specification for AbortSignal states that if no reason is provided,
to default or fallback to a DOMException AbortError. This pull request moves this
logic from the AbortController&apos;s abort method to AbortSignal&apos;s signalAbort method,
where it rightly belongs.

As specified in the AbortSignal spec, <a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a>, step 2:

&gt; Set signal&apos;s abort reason to reason if it is provided; otherwise, to a new &quot;AbortError&quot; DOMException.

In contrast, the AbortController spec, <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a> which simply states:

&gt; The abort(reason) method steps are to signal abort on this with reason if it is provided.

It does not mention the default behavior. Essentially, we&apos;re shifting this logic from
AbortController:abort to its encapsulated AbortSignal:signalAbort method.

* Source/WebCore/dom/AbortController.cpp:
(WebCore::AbortController::abort):
  Removes default reason, to simply forward it to the
  encapsulated AbortSignal:signalAbort.
* Source/WebCore/dom/AbortController.h:
* Source/WebCore/dom/AbortController.idl:
  We should not &quot;[CallWith=CurrentGlobalObject]&quot; for the abort method,
  instead use the GlobalObject the controller was constructed with.
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::signalAbort):
  Logic implemented as description reads.
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::close):
  AbortController::abort no longer accepts a globalObject, so removed
  the callsite reference.
* Source/WebCore/dom/InternalObserverFirst.cpp:
  AbortController::abort no longer accepts a globalObject, so removed
  the callsite reference.

Canonical link: <a href="https://commits.webkit.org/285686@main">https://commits.webkit.org/285686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1667ecec11b2cf8476b10113ce9784a3222c646

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79372 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66142 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65419 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7452 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/766 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->