### PR TITLE
[GStreamer][WebCodecs] H.264 encoding fixes

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_baseline-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_baseline-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_high-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_high-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_main-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_main-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_baseline-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_baseline-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_high-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_high-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_main-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_main-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Test that encoding with a specific H264 profile actually produces that profile. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'description.length')"
-

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -75,10 +75,11 @@ std::pair<const char*, const char*> GStreamerCodecUtilities::parseH264ProfileAnd
 static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(const String& codecString)
 {
     auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
-    // FIXME: Set level on caps too?
-    auto [gstProfile, _] = GStreamerCodecUtilities::parseH264ProfileAndLevel(codecString);
+    auto [gstProfile, level] = GStreamerCodecUtilities::parseH264ProfileAndLevel(codecString);
     if (gstProfile)
         gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, gstProfile, nullptr);
+    if (level)
+        gst_caps_set_simple(outputCaps.get(), "level", G_TYPE_STRING, level, nullptr);
 
     StringBuilder formatBuilder;
     auto profile = StringView::fromLatin1(gstProfile);

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -712,7 +712,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
     gst_element_class_set_static_metadata(elementClass, "WebKit video encoder", "Codec/Encoder/Video", "Encodes video for streaming", "Igalia");
     gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&sinkTemplate));
 
-    Encoders::registerEncoder(OmxH264, "omxh264enc"_s, "h264parse"_s, "video/x-h264"_s, "video/x-h264,alignment=au,stream-format=byte-stream,profile=baseline"_s,
+    Encoders::registerEncoder(OmxH264, "omxh264enc"_s, "h264parse"_s, "video/x-h264"_s, "video/x-h264,alignment=au,stream-format=avc,profile=baseline"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
         }, "target-bitrate"_s, setBitrateBitPerSec, "interval-intraframes"_s, [](GstElement* encoder, BitrateMode mode) {
@@ -728,10 +728,21 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             notImplemented();
         });
     Encoders::registerEncoder(X264, "x264enc"_s, "h264parse"_s, "video/x-h264"_s,
-        "video/x-h264,alignment=au,stream-format=byte-stream"_s,
+        "video/x-h264,alignment=au,stream-format=avc"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->encoder.get(), "key-int-max", 15, "threads", NUMBER_OF_THREADS, "b-adapt", FALSE, "vbv-buf-capacity", 120, nullptr);
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
+
+            const auto& encodedCaps = self->priv->encodedCaps;
+            if (LIKELY(!gst_caps_is_any(encodedCaps.get()) && !gst_caps_is_empty(encodedCaps.get()))) {
+                auto structure = gst_caps_get_structure(encodedCaps.get(), 0);
+                auto profile = gstStructureGetString(structure, "profile"_s);
+
+                if (profile == "high"_s)
+                    gst_preset_load_preset(GST_PRESET(self->priv->encoder.get()), "Profile High");
+                else if (profile == "main"_s)
+                    gst_preset_load_preset(GST_PRESET(self->priv->encoder.get()), "Profile Main");
+            }
         }, "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, [](GstElement* encoder, BitrateMode mode) {
             switch (mode) {
             case CONSTANT_BITRATE_MODE:
@@ -755,7 +766,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             };
         });
     Encoders::registerEncoder(OpenH264, "openh264enc"_s, "h264parse"_s, "video/x-h264"_s,
-        "video/x-h264,alignment=au,stream-format=byte-stream"_s,
+        "video/x-h264,alignment=au,stream-format=avc"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
             g_object_set(self->priv->outputCapsFilter.get(), "caps", self->priv->encodedCaps.get(), nullptr);


### PR DESCRIPTION
#### 019a912ac61b2e8323294984123635caba20083a
<pre>
[GStreamer][WebCodecs] H.264 encoding fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281977">https://bugs.webkit.org/show_bug.cgi?id=281977</a>

Reviewed by Xabier Rodriguez-Calvar.

While debugging some mediarecorder test failure a caps negotiation issue was detected in our video
encoder. Encodebin2 was expecting an avc stream on the encoder output. Updating our encoder
accordingly made some WebCodec tests pass. In addition to that change, the X264 encoder is
explicitely configured according to the requested H.264 profile.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_baseline-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_high-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.worker_main-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_baseline-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_high-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any_main-expected.txt: Removed.
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):

Canonical link: <a href="https://commits.webkit.org/285691@main">https://commits.webkit.org/285691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f61968fb3f5bffc5e8120424b1478c1882089322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/61954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57657 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16114 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66078 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7375 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->