### PR TITLE
[visionOS 2] Build failure - missing PreviewSession members

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/QuickLook_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/visionos/QuickLook_SPI.swiftinterface
@@ -23,6 +23,7 @@ final public class PreviewApplication {
 }
 
 @available(visionOS 2.0, *)
-public struct PreviewSession : Swift.Sendable {
+extension QuickLook.PreviewSession {
+@_silgen_name("$s9QuickLook14PreviewSessionV6update5items12selectedItemySayAA0cH0VG_AHSgtYaKFTu")
   public func update(items: [QuickLook.PreviewItem], selectedItem: QuickLook.PreviewItem? = nil) async throws
 }


### PR DESCRIPTION
#### bfcacf9493e70442c7c8ec453cefeaccb0dbae10
<pre>
[visionOS 2] Build failure - missing PreviewSession members
<a href="https://bugs.webkit.org/show_bug.cgi?id=281996">https://bugs.webkit.org/show_bug.cgi?id=281996</a>
<a href="https://rdar.apple.com/138494366">rdar://138494366</a>

Reviewed by NOBODY (OOPS!).

Update the forward declaration of `PreviewSession.update` to reflect
that we&apos;re extending an existing API `PreviewSession` and not
creating an entirely new class.

* Source/WebKit/Platform/spi/visionos/QuickLook_SPI.swiftinterface:
Change `PreviewSession` to an extension of the
`QuickLook.PreviewSession` API instead of a new declaration.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfcacf9493e70442c7c8ec453cefeaccb0dbae10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24542 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57590 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16065 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44260 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22871 "Failed to checkout and rebase branch from PR 35639") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79186 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/607 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/151 "Found 1 new test failure: http/tests/ssl/applepay/ApplePaySessionFinalState.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66024 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/761 "Failed to checkout and rebase branch from PR 35639") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65300 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7310 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/583 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3320 "Failed to checkout and rebase branch from PR 35639") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->