### PR TITLE
Web Inspector: Remove obsolete platform version-specific styles for Web Inspector UI

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -2648,16 +2648,8 @@ WI.undockedTitleAreaHeight = function()
         return 0;
 
     if (WI.Platform.name === "mac") {
-        switch (WI.Platform.version.name) {
-        case "monterey":
-        case "big-sur":
-            /* Keep in sync with `--undocked-title-area-height` CSS variable. */
-            return 27 / WI.getZoomFactor();
-
-        case "catalina":
-            /* Keep in sync with `--undocked-title-area-height` CSS variable. */
-            return 22 / WI.getZoomFactor();
-        }
+        /* Keep in sync with `--undocked-title-area-height` CSS variable. */
+        return 27 / WI.getZoomFactor();
     }
 
     return 0;

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -115,11 +115,11 @@ body.docked.left #docked-resizer {
     background: var(--undocked-title-area-background);
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area {
+body.mac-platform #undocked-title-area {
     --undocked-title-area-background: white;
 }
 
-body:not(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area {
+body:not(.mac-platform) #undocked-title-area {
     --undocked-title-area-background: linear-gradient(to bottom, hsl(0, 0%, 92%), hsl(0, 0%, 87%));
     box-shadow: inset hsla(0, 0%, 100%, 0.5) 0 1px 1px;
 }
@@ -553,19 +553,19 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
         box-shadow: none;
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area {
+    body.mac-platform #undocked-title-area {
         --undocked-title-area-background: var(--background-color-content);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area {
+    body:not(.mac-platform) #undocked-title-area {
         --undocked-title-area-background: linear-gradient(to bottom, hsl(0, 0%, 26%), hsl(0, 0%, 23%));
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area {
+    body.mac-platform.window-inactive #undocked-title-area {
         --undocked-title-area-background: hsl(0, 0%, 11%);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area {
+    body:not(.mac-platform).window-inactive #undocked-title-area {
         --undocked-title-area-background: hsl(0, 0%, 19%);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -41,7 +41,7 @@
     --tab-bar-border-z-index: 10;
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
+body.mac-platform .tab-bar {
     --tab-bar-background: hsl(0, 0%, 90%);
 
     --tab-item-light-border-color: hsl(0, 0%, 85%);
@@ -49,13 +49,12 @@ body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
     --tab-item-dark-border-color: hsl(0, 0%, 75%);
 }
 
-body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
+body:not(.mac-platform) .tab-bar {
     background-size: 100% 200%;
     --tab-bar-background: linear-gradient(to bottom, hsl(0, 0%, 78%), hsl(0, 0%, 72%));
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar,
-body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar {
+body.window-inactive .tab-bar {
     --tab-bar-background: hsl(0, 0%, 92%);
 }
 
@@ -145,13 +144,12 @@ body.window-inactive .tab-bar > .navigation-bar > .item.divider {
     --tab-bar-item-height: 100%;
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item {
+body.mac-platform .tab-bar > .tabs > .item {
     --tab-item-background: var(--tab-bar-background);
 }
 
-body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item {
+body:not(.mac-platform) .tab-bar > .tabs > .item {
     background-size: 100% 200%;
-
     --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 78%), hsl(0, 0%, 72%));
 }
 
@@ -180,24 +178,24 @@ body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item
     padding: 0;
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item:not(.disabled).selected {
+body.mac-platform .tab-bar > .tabs > .item:not(.disabled).selected {
     --tab-item-background: white;
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) .tab-bar > .tabs > .item:not(.disabled).selected {
+body.mac-platform:not(.docked) .tab-bar > .tabs > .item:not(.disabled).selected {
     border-top-color: var(--tab-item-background);
 }
 
-body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item:not(.disabled).selected {
+body:not(.mac-platform) .tab-bar > .tabs > .item:not(.disabled).selected {
     --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 87%), hsl(0, 0%, 82%));
     background-size: 100% 100%;
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
+body.mac-platform .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
     --tab-item-background: hsl(0, 0%, 84%);
 }
 
-body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
+body:not(.mac-platform) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
     --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 67%), hsl(0, 0%, 64%));
 }
 
@@ -210,8 +208,7 @@ body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs:not(.an
     border-inline-end-color: var(--tab-item-dark-border-color);
 }
 
-body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item,
-body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item {
+body.window-inactive .tab-bar > .tabs > .item {
     border-top-color: var(--tab-item-light-border-color);
     border-bottom-color: var(--tab-item-light-border-color);
     border-right-color: var(--tab-item-light-border-color) !important;
@@ -350,40 +347,36 @@ body.window-inactive .tab-bar > .tabs.animating.closing-tab > .item:not(.disable
 }
 
 @media (prefers-color-scheme: dark) {
-    body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar,
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
+    body.mac-platform .tab-bar {
         /* FIXME: <https://webkit.org/b/189769> Dark Mode: use semantic color names */
         --tab-item-dark-border-color: var(--tab-item-border-color);
         --tab-item-medium-border-color: var(--tab-item-border-color);
         --tab-item-light-border-color: var(--tab-item-border-color);
         --tab-item-border-color: hsl(0, 0%, 36%);
-    }
-
-    body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
         --tab-bar-background: hsl(0, 0%, 8%);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
+    body:not(.mac-platform) .tab-bar {
         background-image: linear-gradient(to bottom, hsl(0, 0%, 12%), hsl(0, 0%, 10%));
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item {
+    body:not(.mac-platform) .tab-bar > .tabs > .item {
         --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 12%), hsl(0, 0%, 10%));
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item:not(.disabled).selected {
+    body.mac-platform .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: var(--background-color-content);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs > .item:not(.disabled).selected {
+    body:not(.mac-platform) .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 23%), hsl(0, 0%, 21%));
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
+    body.mac-platform .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
         --tab-item-background: hsl(0, 0%, 7%);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
+    body:not(.mac-platform) .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover {
         --tab-item-background: linear-gradient(to bottom, hsl(0, 0%, 11%), hsl(0, 0%, 9%));
     }
 
@@ -395,25 +388,24 @@ body.window-inactive .tab-bar > .tabs.animating.closing-tab > .item:not(.disable
         opacity: 0.6;
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar,
-    body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar {
+    body.window-inactive .tab-bar {
         --tab-bar-background: hsl(0, 0%, 7%);
         --tab-item-border-color: hsl(0, 0%, 34%);
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item {
+    body.mac-platform.window-inactive .tab-bar > .tabs > .item {
         --tab-item-background: hsl(0, 0%, 7%);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item {
+    body:not(.mac-platform).window-inactive .tab-bar > .tabs > .item {
         --tab-item-background: hsl(0, 0%, 13%);
     }
 
-    body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
+    body.mac-platform.window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: hsl(0, 0%, 11%);
     }
 
-    body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
+    body:not(.mac-platform).window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: hsl(0, 0%, 19%);
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -193,10 +193,6 @@ body[dir=rtl] .timeline-overview.frames > .timeline-ruler:not(.both-handles-clam
     left: 0;
 }
 
-body.mac-platform.legacy .timeline-overview > .graphs-container {
-    top: 22px;
-}
-
 .timeline-overview > .graphs-container > .timeline-overview-graph {
     height: 36px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -386,7 +386,7 @@ body {
         }
     }
 
-    &:is(.mac-platform.monterey, .mac-platform.big-sur) {
+    &.mac-platform {
         --text-color: hsl(0, 0%, 15%);
         --text-color-transparent: hsla(0, 0%, 15%, 0.4);
 
@@ -401,6 +401,16 @@ body {
         --border-color-secondary: hsl(0, 0%, 91%);
 
         --sorted-header-font-weight: 700;
+
+        --selected-foreground-color: -apple-system-alternate-selected-text;
+        --selected-background-color: -apple-system-selected-content-background;
+        --selected-text-background-color: -apple-system-selected-text-background;
+
+        --breakpoint-color: -apple-system-control-accent;
+        --breakpoint-color-disabled: -apple-system-selected-text-background;
+
+        --glyph-color-active: -apple-system-control-accent;
+        --glyph-color-active-pressed: -apple-system-control-accent;
 
         @media (prefers-color-scheme: dark) {
             --text-color: hsl(0, 0%, 85%);
@@ -424,23 +434,7 @@ body {
         }
     }
 
-    &:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
+    &:not(.docked) {
         --undocked-title-area-height: calc(27px / var(--zoom-factor));
-    }
-
-    &:is(.mac-platform.catalina):not(.docked) {
-        --undocked-title-area-height: calc(22px / var(--zoom-factor));
-    }
-
-    &.mac-platform {
-        --selected-foreground-color: -apple-system-alternate-selected-text;
-        --selected-background-color: -apple-system-selected-content-background;
-        --selected-text-background-color: -apple-system-selected-text-background;
-
-        --breakpoint-color: -apple-system-control-accent;
-        --breakpoint-color-disabled: -apple-system-selected-text-background;
-
-        --glyph-color-active: -apple-system-control-accent;
-        --glyph-color-active-pressed: -apple-system-control-accent;
     }
 }


### PR DESCRIPTION
#### 380f61c9af891cf77a4f28ef0668d0b2b9ef3330
<pre>
Web Inspector: Remove obsolete platform version-specific styles for Web Inspector UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=281910">https://bugs.webkit.org/show_bug.cgi?id=281910</a>
<a href="https://rdar.apple.com/138406941">rdar://138406941</a>

Reviewed by BJ Burg and Devin Rousso.

Remove style guards for macOS Big Sur and Monterey.
Make Monterey styles the default macOS platform styles.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(body.mac-platform #undocked-title-area):
(body:not(.mac-platform) #undocked-title-area):
(@media (prefers-color-scheme: dark) body.mac-platform #undocked-title-area):
(@media (prefers-color-scheme: dark) body:not(.mac-platform) #undocked-title-area):
(@media (prefers-color-scheme: dark) body.mac-platform.window-inactive #undocked-title-area):
(@media (prefers-color-scheme: dark) body:not(.mac-platform).window-inactive #undocked-title-area):
(body:is(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(body:not(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(body.mac-platform .tab-bar):
(body:not(.mac-platform) .tab-bar):
(body.window-inactive .tab-bar):
(body.mac-platform .tab-bar &gt; .tabs &gt; .item):
(body:not(.mac-platform) .tab-bar &gt; .tabs &gt; .item):
(body.mac-platform .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(body.mac-platform:not(.docked) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(body:not(.mac-platform) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(body.mac-platform .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover):
(body:not(.mac-platform) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover):
(body.window-inactive .tab-bar &gt; .tabs &gt; .item):
(@media (prefers-color-scheme: dark) body.mac-platform .tab-bar):
(@media (prefers-color-scheme: dark) body:not(.mac-platform) .tab-bar):
(@media (prefers-color-scheme: dark) body:not(.mac-platform) .tab-bar &gt; .tabs &gt; .item):
(@media (prefers-color-scheme: dark) body.mac-platform .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(@media (prefers-color-scheme: dark) body:not(.mac-platform) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(@media (prefers-color-scheme: dark) body.mac-platform .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover):
(@media (prefers-color-scheme: dark) body:not(.mac-platform) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover):
(@media (prefers-color-scheme: dark) body.window-inactive .tab-bar):
(@media (prefers-color-scheme: dark) body.mac-platform.window-inactive .tab-bar &gt; .tabs &gt; .item):
(@media (prefers-color-scheme: dark) body:not(.mac-platform).window-inactive .tab-bar &gt; .tabs &gt; .item):
(@media (prefers-color-scheme: dark) body.mac-platform.window-inactive .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(@media (prefers-color-scheme: dark) body:not(.mac-platform).window-inactive .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected):
(body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar): Deleted.
(body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar,): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item): Deleted.
(body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover): Deleted.
(body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover): Deleted.
(body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar &gt; .tabs &gt; .item,): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar,): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar &gt; .tabs:not(.animating) &gt; .item:not(.selected, .disabled):hover): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar,): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar &gt; .tabs &gt; .item): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar &gt; .tabs &gt; .item): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(body.mac-platform.legacy .timeline-overview &gt; .graphs-container): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(&amp;.mac-platform):
(&amp;:not(.docked)):
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur)): Deleted.
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked)): Deleted.
(&amp;:is(.mac-platform.catalina):not(.docked)): Deleted.

Canonical link: <a href="https://commits.webkit.org/285754@main">https://commits.webkit.org/285754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7c682f8c3daf2fc93ab979b67ea355843a79f49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24955 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/931 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76784 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63428 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/44869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66477 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1034 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/496 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66324 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1176 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63438 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65603 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9468 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1027 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->