### PR TITLE
[css-view-transitions-2] Traversal navigations to a cached entry should succeed even if the Document was created with a cross-origin redirect.

### DIFF
--- a/LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache-expected.txt
+++ b/LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VT object created on the old Document is skipped before persisting in BFCache
+

--- a/LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html
+++ b/LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html
@@ -1,0 +1,108 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<title>VT object created on the old Document is skipped before persisting in BFCache</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/html/browsers/browsing-the-web/back-forward-cache/resources/helper.sub.js"></script>
+<script>
+// runBfcacheTest opens a popup to pageA which navigates to pageB and then
+// back, ensuring pageA is stored in the BFCache.
+
+let originSameSiteCrossSiteRedirect = "http://127.0.0.1:8800/common/redirect.py?location=" + originSameOrigin;
+
+runBfcacheTest({
+  openFunc: url =>
+        window.open(
+          originSameSiteCrossSiteRedirect + url,
+          "_blank",
+          "noopener"
+  ),
+  funcBeforeNavigation: async () => {
+    // This function executes in pageA
+
+    function addTransitionOptIn() {
+      let css = '@view-transition { navigation: auto; }';
+      let style = document.createElement('style');
+      style.appendChild(document.createTextNode(css));
+      document.head.appendChild(style);
+    }
+    addTransitionOptIn();
+
+    // Wait for at least one frame to ensure there is a transition on the
+    // navigation.
+    function waitForAtLeastOneFrame() {
+      return new Promise(resolve => {
+        // Different web engines work slightly different on this area but waiting
+        // for two requestAnimationFrames() to happen, one after another, should be
+        // sufficient to ensure at least one frame has been generated anywhere.
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+    }
+    await waitForAtLeastOneFrame();
+
+    onpageswap = (e) => {
+      if (e.viewTransition == null)
+        return;
+
+      document.documentElement.classList.add('transition');
+      
+      e.viewTransition.ready.catch(() => { });
+    }
+    onpagereveal = (e) => {
+      if (e.viewTransition == null)
+        return;
+
+      document.documentElement.classList.add('transition-back');
+    }
+  },
+  funcBeforeBackNavigation: async () => {
+    // This function executes in pageB
+
+    function addTransitionOptIn() {
+      let css = '@view-transition { navigation: auto; }';
+      let style = document.createElement('style');
+      style.appendChild(document.createTextNode(css));
+      document.head.appendChild(style);
+    }
+    addTransitionOptIn();
+
+    // Wait for at least one frame to ensure there is a transition on the
+    // navigation.
+    function waitForAtLeastOneFrame() {
+      return new Promise(resolve => {
+        // Different web engines work slightly different on this area but waiting
+        // for two requestAnimationFrames() to happen, one after another, should be
+        // sufficient to ensure at least one frame has been generated anywhere.
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+    }
+    await waitForAtLeastOneFrame();
+  },
+  funcAfterAssertion: async (pageA, pageB, t) => {
+    assert_true(
+      await pageA.execute_script(() => {
+          return document.documentElement.classList.contains('transition');
+      }),
+      'navigation had viewTransition');
+    
+    assert_true(
+      await pageA.execute_script(() => {
+          return document.documentElement.classList.contains('transition-back');
+      }),
+      'back navigation had viewTransition');
+  },
+  targetOrigin: originSameOrigin,
+});
+</script>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2490,7 +2490,7 @@ ShouldOpenExternalURLsPolicy DocumentLoader::shouldOpenExternalURLsPolicyToPropa
 }
 
 // https://www.w3.org/TR/css-view-transitions-2/#navigation-can-trigger-a-cross-document-view-transition
-bool DocumentLoader::navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument)
+bool DocumentLoader::navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument, bool fromBackForwardCache)
 {
     // FIXME: Consider adding implementation-defined navigation experience step.
 
@@ -2504,7 +2504,7 @@ bool DocumentLoader::navigationCanTriggerCrossDocumentViewTransition(Document& o
     if (!newOrigin->isSameOriginAs(oldDocument.securityOrigin()))
         return false;
 
-    if (const auto* metrics = response().deprecatedNetworkLoadMetricsOrNull()) {
+    if (const auto* metrics = response().deprecatedNetworkLoadMetricsOrNull(); metrics && !fromBackForwardCache) {
         if (metrics->crossOriginRedirect())
             return false;
     }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -524,7 +524,7 @@ public:
 
     bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
 
-    bool navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument);
+    bool navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument, bool fromBackForwardCache);
     WEBCORE_EXPORT void whenDocumentIsCreated(Function<void(Document*)>&&);
 
 protected:

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2288,7 +2288,7 @@ void FrameLoader::commitProvisionalLoad()
         bool canTriggerCrossDocumentViewTransition = false;
         RefPtr<NavigationActivation> activation;
         if (pdl) {
-            canTriggerCrossDocumentViewTransition = pdl->navigationCanTriggerCrossDocumentViewTransition(*document);
+            canTriggerCrossDocumentViewTransition = pdl->navigationCanTriggerCrossDocumentViewTransition(*document, !!cachedPage);
 
             RefPtr domWindow = document->domWindow();
             auto navigationAPIType = pdl->triggeringAction().navigationAPIType();
@@ -2301,7 +2301,7 @@ void FrameLoader::commitProvisionalLoad()
                 if (RefPtr page = frame->page(); page && *navigationAPIType != NavigationNavigationType::Reload)
                     newItem = frame->checkedHistory()->createItemWithLoader(page->historyItemClient(), pdl.get());
 
-                activation = domWindow->protectedNavigation()->createForPageswapEvent(newItem.get(), pdl.get());
+                activation = domWindow->protectedNavigation()->createForPageswapEvent(newItem.get(), pdl.get(), !!cachedPage);
             }
         }
         document->dispatchPageswapEvent(canTriggerCrossDocumentViewTransition, WTFMove(activation));

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -208,7 +208,7 @@ void Navigation::updateForActivation(HistoryItem* previousItem, std::optional<Na
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#fire-the-pageswap-event
-RefPtr<NavigationActivation> Navigation::createForPageswapEvent(HistoryItem* newItem, DocumentLoader* documentLoader)
+RefPtr<NavigationActivation> Navigation::createForPageswapEvent(HistoryItem* newItem, DocumentLoader* documentLoader, bool fromBackForwardCache)
 {
     auto type = documentLoader->triggeringAction().navigationAPIType();
     if (!type || !frame())
@@ -216,7 +216,7 @@ RefPtr<NavigationActivation> Navigation::createForPageswapEvent(HistoryItem* new
 
     // Skip cross-origin requests, or if any cross-origin redirects have been made.
     bool isSameOrigin = SecurityOrigin::create(documentLoader->documentURL())->isSameOriginAs(window()->protectedDocument()->securityOrigin());
-    if (!isSameOrigin || !documentLoader->request().isSameSite())
+    if (!isSameOrigin || (!documentLoader->request().isSameSite() && !fromBackForwardCache))
         return nullptr;
 
     RefPtr<NavigationHistoryEntry> oldEntry;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -146,7 +146,7 @@ public:
     void updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems, HistoryItem& reactivatedItem);
     void updateForActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 
-    RefPtr<NavigationActivation> createForPageswapEvent(HistoryItem* newItem, DocumentLoader*);
+    RefPtr<NavigationActivation> createForPageswapEvent(HistoryItem* newItem, DocumentLoader*, bool fromBackForwardCache);
 
     void abortOngoingNavigationIfNeeded();
 


### PR DESCRIPTION
#### a26a5b4e9a657cfecaa4674cf3ef17f19cab2ee8
<pre>
[css-view-transitions-2] Traversal navigations to a cached entry should succeed even if the Document was created with a cross-origin redirect.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282012">https://bugs.webkit.org/show_bug.cgi?id=282012</a>
&lt;<a href="https://rdar.apple.com/138517027">rdar://138517027</a>&gt;

Reviewed by Charlie Wolfe.

As per
<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable">https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable</a>:latest-entry,
the cross-origin redirect check should only apply if not loading from BFCache.

I&apos;m also changing the view-transitions logic, which isn&apos;t currently in the spec,
but is drafted here: <a href="https://github.com/w3c/csswg-drafts/pull/11070.">https://github.com/w3c/csswg-drafts/pull/11070.</a>

Without this change, navigating to a site via a cross-origin redirect marks the
initial Document as having being created with a cross-origin redirect. If you
then navigate within the site, and then back to the initial, the view
transition is blocked due to this despite the redirect being unrelated to the
&apos;back&apos; traversal.

* LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache-expected.txt: Added.
* LayoutTests/http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::navigationCanTriggerCrossDocumentViewTransition):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::createForPageswapEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/285663@main">https://commits.webkit.org/285663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2feb2012a80084b61f51de19135795296e229715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22903 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/648 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/171 "Found 1 new test failure: http/tests/paymentrequest/ApplePayPaymentCompleteDetails-orderDetails.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7334 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3352 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->