### PR TITLE
[JSC] add support for `Map.prototype.getOrInsert` et al

### DIFF
--- a/JSTests/stress/map-getOrInsert.js
+++ b/JSTests/stress/map-getOrInsert.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useMapGetOrInsert=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let map = new Map;
+
+shouldBe(map.getOrInsert("a", 1), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+shouldBe(map.getOrInsert("a", 2), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+shouldBe(map.getOrInsert("a", 3), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+
+shouldBe(map.getOrInsert("b", 3), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);
+shouldBe(map.getOrInsert("b", 2), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);
+shouldBe(map.getOrInsert("b", 1), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);

--- a/JSTests/stress/map-getOrInsertComputed.js
+++ b/JSTests/stress/map-getOrInsertComputed.js
@@ -1,0 +1,54 @@
+//@ requireOptions("--useMapGetOrInsert=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let map = new Map;
+
+shouldBe(map.getOrInsertComputed("a", function(key) {
+    assert(key === "a", "should provide key");
+    return 1;
+}), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+shouldBe(map.getOrInsertComputed("a", function(key) {
+    assert(false, "not reached");
+    return 2;
+}), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+shouldBe(map.getOrInsertComputed("a", function(key) {
+    assert(false, "not reached");
+    return 3;
+}), 1);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1]]`);
+
+shouldBe(map.getOrInsertComputed("b", function(key) {
+    assert(key === "b", "should provide key");
+    return 3;
+}), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);
+shouldBe(map.getOrInsertComputed("b", function(key) {
+    assert(false, "not reached");
+    return 2;
+}), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);
+shouldBe(map.getOrInsertComputed("b", function(key) {
+    assert(false, "not reached");
+    return 1;
+}), 3);
+shouldBe(JSON.stringify(Array.from(map)), `[["a",1],["b",3]]`);
+
+for (let invalid of [null, undefined, true, "test", 42, [], {}]) {
+    try {
+        map.getOrInsertComputed(42, invalid);
+        assert(false, "should throw");
+    } catch (e) {
+        assert(e instanceof TypeError, "should throw");
+    }
+}

--- a/JSTests/stress/weakmap-getOrInsert.js
+++ b/JSTests/stress/weakmap-getOrInsert.js
@@ -1,0 +1,33 @@
+//@ requireOptions("--useMapGetOrInsert=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let object1 = {};
+let object2 = {};
+
+let weakmap = new WeakMap;
+
+shouldBe(weakmap.getOrInsert(object1, 1), 1);
+shouldBe(weakmap.getOrInsert(object1, 2), 1);
+shouldBe(weakmap.getOrInsert(object1, 3), 1);
+
+shouldBe(weakmap.getOrInsert(object2, 3), 3);
+shouldBe(weakmap.getOrInsert(object2, 2), 3);
+shouldBe(weakmap.getOrInsert(object2, 1), 3);
+
+for (let invalid of [null, undefined, true, "test", 42, Symbol.for("symbol")]) {
+    try {
+        weakmap.getOrInsert(invalid, 42);
+        assert(false, "should throw");
+    } catch (e) {
+        assert(e instanceof TypeError, "should throw");
+    }
+}

--- a/JSTests/stress/weakmap-getOrInsertComputed.js
+++ b/JSTests/stress/weakmap-getOrInsertComputed.js
@@ -1,0 +1,63 @@
+//@ requireOptions("--useMapGetOrInsert=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let object1 = {};
+let object2 = {};
+
+let weakmap = new WeakMap;
+
+shouldBe(weakmap.getOrInsertComputed(object1, function(key) {
+    assert(key === object1, "should provide key");
+    return 1;
+}), 1);
+shouldBe(weakmap.getOrInsertComputed(object1, function(key) {
+    assert(false, "not reached");
+    return 2;
+}), 1);
+shouldBe(weakmap.getOrInsertComputed(object1, function(key) {
+    assert(false, "not reached");
+    return 3;
+}), 1);
+
+shouldBe(weakmap.getOrInsertComputed(object2, function(key) {
+    assert(key === object2, "should provide key");
+    return 3;
+}), 3);
+shouldBe(weakmap.getOrInsertComputed(object2, function(key) {
+    assert(false, "not reached");
+    return 2;
+}), 3);
+shouldBe(weakmap.getOrInsertComputed(object2, function(key) {
+    assert(false, "not reached");
+    return 1;
+}), 3);
+
+for (let invalid of [null, undefined, true, "test", 42, Symbol.for("symbol")]) {
+    try {
+        weakmap.getOrInsertComputed(invalid, () => {
+            assert(false, "not reached");
+            return 42;
+        });
+        assert(false, "should throw");
+    } catch (e) {
+        assert(e instanceof TypeError, "should throw");
+    }
+}
+
+for (let invalid of [null, undefined, true, "test", 42, [], {}]) {
+    try {
+        weakmap.getOrInsertComputed({}, invalid);
+        assert(false, "should throw");
+    } catch (e) {
+        assert(e instanceof TypeError, "should throw");
+    }
+}

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -591,6 +591,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorHelpers, true, Normal, "Expose the Iterator Helpers."_s) \
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
+    v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
     v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -425,6 +425,17 @@ public:
             return;
         }
 
+        scope.release();
+        addImpl(globalObject, owner, base, key, value, result);
+    }
+    ALWAYS_INLINE static void addImpl(JSGlobalObject* globalObject, HashTable* owner, Storage& base, JSValue key, JSValue value, FindResult& result)
+    {
+        VM& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        ASSERT(!isObsolete(base));
+
+        ASSERT(!isValidTableIndex(result.entryKeyIndex));
+
         Storage* candidate = expandIfNeeded(globalObject, owner, base);
         RETURN_IF_EXCEPTION(scope, void());
 

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -72,6 +72,25 @@ ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue 
         rehash();
 }
 
+template <typename WeakMapBucket>
+ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::addBucket(VM& vm, JSCell* key, JSValue value, uint32_t hash, size_t index)
+{
+    UNUSED_PARAM(hash);
+    ASSERT(jsWeakMapHash(key) == hash);
+    ASSERT(!findBucket(key, hash));
+
+    WeakMapBucket* newEntry = buffer() + index;
+    ASSERT(newEntry);
+    ASSERT(newEntry->isEmpty());
+
+    newEntry->setKey(vm, this, key);
+    newEntry->setValue(vm, this, value);
+    ++m_keyCount;
+
+    if (shouldRehashAfterAdd())
+        rehash();
+}
+
 // Note that this function can be executed in parallel as long as the mutator stops.
 template<typename WeakMapBucket>
 void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm, CollectionScope)


### PR DESCRIPTION
#### 2b8f7267635745ac735406185b3f36348c5e82fc
<pre>
[JSC] add support for `Map.prototype.getOrInsert` et al
<a href="https://bugs.webkit.org/show_bug.cgi?id=282014">https://bugs.webkit.org/show_bug.cgi?id=282014</a>

Reviewed by Yusuke Suzuki.

It&apos;s an extremely common pattern to check for the existence of a key in a `Map` (or `WeakMap`) before adding a new entry.

```js
if (map.has(key))
    return map.get(key);
map.set(key, value);
return value;
```

The primary benefit of of `getOrInsert` is that it avoids having to re-hash the key.

The additional benefit of `getOrInsertComputed` beyond the above is that it doesn&apos;t have to compute the value unless the key is not present.

For both `Map` and `WeakMap` it was necesasry to create additional helper methods that returned the hash and/or existing entry.

Spec: &lt;<a href="https://tc39.es/proposal-upsert/">https://tc39.es/proposal-upsert/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-upsert">https://github.com/tc39/proposal-upsert</a>&gt;

* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::MapPrototype::finishCreation):
(JSC::mapProtoFuncGetOrInsert): Added.
(JSC::mapProtoFuncGetOrInsertComputed): Added.
* Source/JavaScriptCore/runtime/OrderedHashTable.h:
(JSC::OrderedHashMap::getOrInsert): Added.
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::addImpl):

* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::WeakMapPrototype::finishCreation):
(JSC::protoFuncWeakMapGetOrInsert): Added.
(JSC::protoFuncWeakMapGetOrInsertComputed): Added.
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
(JSC::WeakMapImpl::getBucket): Added.
(JSC::WeakMapImpl::findBucketIndex): Added.
(JSC::WeakMapImpl::findBucket):
(JSC::WeakMapImpl::findBucketIndexAlreadyHashed): Added.
(JSC::WeakMapImpl::findBucketAlreadyHashed): Deleted.
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::addBucket): Added.

* Source/JavaScriptCore/runtime/OptionsList.h:

* JSTests/stress/map-getOrInsert.js: Added.
* JSTests/stress/map-getOrInsertComputed.js: Added.
* JSTests/stress/weakmap-getOrInsert.js: Added.
* JSTests/stress/weakmap-getOrInsertComputed.js: Added.

Canonical link: <a href="https://commits.webkit.org/286377@main">https://commits.webkit.org/286377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/250aa61239c3fddc2e3fc73dbb1ed1d2c18dbf2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27087 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25414 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68998 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81782 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75097 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66993 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9058 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3140 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21284 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->