### PR TITLE
[WPE] Add WPE context menu support

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -259,6 +259,7 @@ UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
 UIProcess/wpe/ScreenManagerWPE.cpp
 UIProcess/wpe/WebPageProxyWPE.cpp
 UIProcess/wpe/WebPreferencesWPE.cpp
+UIProcess/wpe/WebContextMenuProxyWPE.cpp
 
 WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
@@ -86,6 +86,9 @@ webkit_context_menu_item_get_action                       (WebKitContextMenuItem
 WEBKIT_API GAction *
 webkit_context_menu_item_get_gaction                      (WebKitContextMenuItem  *item);
 
+WEBKIT_API const gchar *
+webkit_context_menu_item_get_title                        (WebKitContextMenuItem  *item);
+
 WEBKIT_API WebKitContextMenuAction
 webkit_context_menu_item_get_stock_action                 (WebKitContextMenuItem  *item);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2251,21 +2251,7 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
 
     signals[CONTEXT_MENU] = createContextMenuSignal(webViewClass);
 
-    /**
-     * WebKitWebView::context-menu-dismissed:
-     * @web_view: the #WebKitWebView on which the signal is emitted
-     *
-     * Emitted after #WebKitWebView::context-menu signal, if the context menu is shown,
-     * to notify that the context menu is dismissed.
-     */
-    signals[CONTEXT_MENU_DISMISSED] =
-        g_signal_new("context-menu-dismissed",
-                     G_TYPE_FROM_CLASS(webViewClass),
-                     G_SIGNAL_RUN_LAST,
-                     G_STRUCT_OFFSET(WebKitWebViewClass, context_menu_dismissed),
-                     0, 0,
-                     g_cclosure_marshal_VOID__VOID,
-                     G_TYPE_NONE, 0);
+    signals[CONTEXT_MENU_DISMISSED] = createContextMenuDismissedSignal(webViewClass);
 
     /**
      * WebKitWebView::submit-form:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -126,6 +126,7 @@ void webkitWebViewSetIsWebProcessResponsive(WebKitWebView*, bool);
 
 guint createShowOptionMenuSignal(WebKitWebViewClass*);
 guint createContextMenuSignal(WebKitWebViewClass*);
+guint createContextMenuDismissedSignal(WebKitWebViewClass*);
 
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 WebKit::RendererBufferFormat webkitWebViewGetRendererBufferFormat(WebKitWebView*);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -129,7 +129,9 @@ gboolean webkitWebViewRunFileChooser(WebKitWebView* webView, WebKitFileChooserRe
 struct WindowStateEvent {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    enum class Type { Maximize, Minimize, Restore };
+    enum class Type { Maximize,
+        Minimize,
+        Restore };
 
     WindowStateEvent(Type type, CompletionHandler<void()>&& completionHandler)
         : type(type)
@@ -463,4 +465,25 @@ void webkit_web_view_get_background_color(WebKitWebView* webView, GdkRGBA* rgba)
 
     auto& page = *webkitWebViewBaseGetPage(reinterpret_cast<WebKitWebViewBase*>(webView));
     *rgba = page.backgroundColor().value_or(WebCore::Color::white);
+}
+
+guint createContextMenuDismissedSignal(WebKitWebViewClass* webViewClass)
+{
+    /**
+     * WebKitWebView::context-menu-dismissed:
+     * @web_view: the #WebKitWebView on which the signal is emitted
+     *
+     * Emitted after #WebKitWebView::context-menu signal, if the context menu is shown,
+     * to notify that the context menu is dismissed.
+     *
+     * Deprecated: 2.48, WPE WebKit does not emit this signal.
+     */
+    return g_signal_new(
+        "context-menu-dismissed",
+        G_TYPE_FROM_CLASS(webViewClass),
+        static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DEPRECATED),
+        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu_dismissed),
+        0, 0,
+        g_cclosure_marshal_VOID__VOID,
+        G_TYPE_NONE, 0);
 }

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -326,3 +326,24 @@ void webkit_web_view_toggle_inspector(WebKitWebView* webView)
         inspector->show();
 }
 #endif
+
+guint createContextMenuDismissedSignal(WebKitWebViewClass* webViewClass)
+{
+    /**
+     * WebKitWebView::context-menu-dismissed:
+     * @web_view: the #WebKitWebView on which the signal is emitted
+     *
+     * Emitted after #WebKitWebView::context-menu signal, if the context menu is shown,
+     * to notify that the context menu is dismissed.
+     *
+     * Deprecated: 2.48, WPE WebKit does not emit this signal.
+     */
+    return g_signal_new(
+        "context-menu-dismissed",
+        G_TYPE_FROM_CLASS(webViewClass),
+        static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DEPRECATED),
+        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu_dismissed),
+        0, 0,
+        g_cclosure_marshal_VOID__VOID,
+        G_TYPE_NONE, 0);
+}

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Christian Duerr
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -10,7 +10,7 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
@@ -23,27 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WebContextMenuProxyWPE.h"
 
 #if ENABLE(CONTEXT_MENUS)
 
-#include "WebContextMenuProxy.h"
-
 namespace WebKit {
+using namespace WebCore;
 
-class WebContextMenuProxyWPE final : public WebContextMenuProxy {
-public:
-    static auto create(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
-    {
-        return adoptRef(*new WebContextMenuProxyWPE(page, WTFMove(context), userData));
-    }
+WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+    : WebContextMenuProxy(page, WTFMove(context), userData)
+{
+}
 
-private:
-    WebContextMenuProxyWPE(WebPageProxy&, ContextMenuContextData&&, const UserData&);
-    void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
-    void show() override;
-};
+void WebContextMenuProxyWPE::show()
+{
+    WebContextMenuProxy::show();
+}
+
+void WebContextMenuProxyWPE::showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&& items)
+{
+    notImplemented();
+}
 
 } // namespace WebKit
-
 #endif // ENABLE(CONTEXT_MENUS)


### PR DESCRIPTION
<pre>
Add WPE context menu support
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=272354</a>

Reviewed by NOBODY (OOPS!).

This replaces the existing context menu stub implementation with a minimal version which emits the WebView's context menu signal.

This also resolves a bug where all mouse input would break after right-clicking, since the stub implementation was waiting for the context menu to be opened before processing new mouse events.

The `context-menu-dismissed` signal is removed from the WPE backend in a breaking change, since dismissal is handled by the consumer of the API.

* Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp: (webkit_context_menu_item_get_title):
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp: (webkit_web_view_class_init):
* Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp: Copied from Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h. (WebKit::WebContextMenuProxyWPE::WebContextMenuProxyWPE): (WebKit::WebContextMenuProxyWPE::show):
(WebKit::WebContextMenuProxyWPE::showContextMenuWithItems):
* Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h:

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcde3dc0734583304c5a65a972b7dde90e539b75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64019 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44300 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1174 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-001.html imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-break-001.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31645 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9393 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6702 "Found 2 new test failures: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html pdf/pdf-plugin-printing.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71623 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14661 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14875 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->