### PR TITLE
Inputs with overflowing content cannot be scrolled within an iFrame.

### DIFF
--- a/LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe-expected.txt
+++ b/LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe-expected.txt
@@ -1,0 +1,12 @@
+
+Verifies that you can autoscroll inside of a text field in a subframe. To manually run the test, focus the text field and move the caret to the right edge; the text field should scroll to the end (after the word 'dog')
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS loadedSubframe became true
+PASS Autoscrolled to end of text field
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+iframe {
+    width: 100%;
+    height: 200px;
+}
+</style>
+<script>
+loadedSubframe = false;
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that you can autoscroll inside of a text field in a subframe. To manually run the test, focus the text field and move the caret to the right edge; the text field should scroll to the end (after the word 'dog')");
+
+    let subframe = document.querySelector("iframe");
+    subframe.addEventListener("load", () => { loadedSubframe = true; });
+    subframe.srcdoc = `
+        <style>
+        body {
+            margin: 0;
+        }
+
+        input {
+            font-size: 24px;
+            width: 150px;
+            height: 44px;
+            padding: 0.8em;
+            border: 1px solid black;
+            border-radius: 4px;
+            outline: none;
+        }
+        </style>
+        <input value="The quick brown fox jumped over the lazy dog." />
+    `;
+
+    await shouldBecomeEqual("loadedSubframe", "true");
+
+    const input = subframe.contentDocument.querySelector("input");
+    const inputRect = input.getBoundingClientRect();
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    async function autoscrollWithFloatingCaret() {
+        let caretLocation = { x: 0, y: 0 };
+        while (!caretLocation.x || !caretLocation.y) {
+            await UIHelper.ensurePresentationUpdate();
+            caretLocation = UIHelper.midPointOfRect(await UIHelper.getUICaretViewRect());
+        }
+
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(caretLocation.x, caretLocation.y)
+            .wait(0.5)
+            .move(inputRect.left + inputRect.width - 5, caretLocation.y, 0.5)
+            .wait(2)
+            .end()
+            .takeResult());
+    }
+
+    while (input.selectionStart != input.value.length)
+        await autoscrollWithFloatingCaret();
+
+    testPassed("Autoscrolled to end of text field");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <iframe frameborder="0"></iframe>
+    <p id="description"></p>
+    <p id="console"></p>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -730,8 +730,9 @@ private:
 #if PLATFORM(IOS_FAMILY)
     bool m_shouldAllowMouseDownToStartDrag { false };
     bool m_isAutoscrolling { false };
-    IntPoint m_targetAutoscrollPositionInUnscrolledRootViewCoordinates;
-    std::optional<IntPoint> m_initialTargetAutoscrollPositionInUnscrolledRootViewCoordinates;
+    IntPoint m_targetAutoscrollPositionInRootView;
+    IntPoint m_targetAutoscrollPositionInUnscrolledRootView;
+    std::optional<IntPoint> m_initialAutoscrollPositionInUnscrolledRootView;
 #endif
 };
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -470,6 +470,11 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
         } while (frame);
     }
 
+#if PLATFORM(IOS_FAMILY)
+    if (oldFrame)
+        oldFrame->eventHandler().cancelSelectionAutoscroll();
+#endif
+
     if (newFrame && newFrame->view() && isFocused()) {
         newFrame->selection().setFocused(true);
         newFrame->document()->dispatchWindowEvent(Event::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No));

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2130,35 +2130,34 @@ void WebPage::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& 
     
 void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return;
-
-    if (m_focusedElement && m_focusedElement->renderer()) {
-        localMainFrame->eventHandler().startSelectionAutoscroll(m_focusedElement->renderer(), positionInWindow);
-        return;
-    }
-    
     RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
         return;
+
+    if (m_focusedElement && m_focusedElement->renderer()) {
+        frame->eventHandler().startSelectionAutoscroll(m_focusedElement->renderer(), positionInWindow);
+        return;
+    }
+
     auto& selection = frame->selection().selection();
     if (!selection.isRange())
         return;
+
     auto range = selection.toNormalizedRange();
     if (!range)
         return;
+
     auto* renderer = range->start.container->renderer();
     if (!renderer)
         return;
 
-    Ref(*localMainFrame)->eventHandler().startSelectionAutoscroll(renderer, positionInWindow);
+    frame->eventHandler().startSelectionAutoscroll(renderer, positionInWindow);
 }
     
 void WebPage::cancelAutoscroll()
 {
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        localMainFrame->eventHandler().cancelSelectionAutoscroll();
+    if (RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame())
+        frame->eventHandler().cancelSelectionAutoscroll();
 }
 
 void WebPage::requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<FloatRect>&)>&& reply)


### PR DESCRIPTION
#### aeacdd2cd7d9d2d77cc232b524975ee2f0815191
<pre>
Inputs with overflowing content cannot be scrolled within an iFrame.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277666">https://bugs.webkit.org/show_bug.cgi?id=277666</a>
<a href="https://rdar.apple.com/133320357">rdar://133320357</a>

Reviewed by Abrar Rahman Protyasha.

Add support on iOS for selection autoscrolling, for content inside subframes. See below for more
details.

* LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe-expected.txt: Added.
* LayoutTests/editing/selection/ios/autoscroll-text-field-in-subframe.html: Added.

Add a layout test to exercise this fix. Note that the test will attempt to autoscroll against the
right edge of the focused input until it reaches the last selection offset, such that it will be
robust even if the maximum autoscrolling speed is lowered in the future.

* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):

Stop autoscrolling when a frame is no longer focused; this is necessary because it&apos;s no longer
guaranteed that `WebPage::cancelAutoscroll` will cancel autoscrolling in the correct frame, in the
case where the frame was blurred in the middle of autoscrolling.

* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::startSelectionAutoscroll):
(WebCore::EventHandler::cancelSelectionAutoscroll):
(WebCore::EventHandler::targetPositionInWindowForSelectionAutoscroll const):

Avoid adjusting the target autoscroll position for subframes, since the edges of the unobscured
content rect aren&apos;t flush with the edges of the layout viewport.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::startAutoscrollAtPosition):

Implement the main fix here — instead of always using the local main frame, tell the focused or main
frame to autoscroll.

(WebKit::WebPage::cancelAutoscroll):

Canonical link: <a href="https://commits.webkit.org/285635@main">https://commits.webkit.org/285635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a6edcdecf1c068543feec81644e32af4ed9e2d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26153 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/557 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/77580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63108 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20589 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63119 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16147 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7340 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/624 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->