### PR TITLE
AX: RenderSVGInlineText accessibility objects are created in the wrong AXObjectCache

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -716,7 +716,7 @@ accessibility/AccessibilityNodeObject.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityObject.h
 accessibility/AccessibilityRenderObject.cpp
-accessibility/AccessibilitySVGElement.cpp
+accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityScrollbar.cpp
 accessibility/AccessibilitySlider.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -518,7 +518,7 @@ accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityObject.h
 accessibility/AccessibilityProgressIndicator.cpp
 accessibility/AccessibilityRenderObject.cpp
-accessibility/AccessibilitySVGElement.cpp
+accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilitySVGRoot.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityScrollbar.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -568,7 +568,7 @@ accessibility/AccessibilityNodeObject.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityProgressIndicator.cpp
 accessibility/AccessibilityRenderObject.cpp
-accessibility/AccessibilitySVGElement.cpp
+accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilitySVGRoot.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityScrollbar.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -52,7 +52,7 @@
 #include "AccessibilityMenuListPopup.h"
 #include "AccessibilityProgressIndicator.h"
 #include "AccessibilityRenderObject.h"
-#include "AccessibilitySVGElement.h"
+#include "AccessibilitySVGObject.h"
 #include "AccessibilitySVGRoot.h"
 #include "AccessibilityScrollView.h"
 #include "AccessibilityScrollbar.h"
@@ -110,6 +110,7 @@
 #include "RenderMeter.h"
 #include "RenderObjectInlines.h"
 #include "RenderProgress.h"
+#include "RenderSVGInlineText.h"
 #include "RenderSlider.h"
 #include "RenderTable.h"
 #include "RenderTableCell.h"
@@ -729,8 +730,8 @@ Ref<AccessibilityObject> AXObjectCache::createObjectFromRenderer(RenderObject& r
     if (renderer.isRenderOrLegacyRenderSVGRoot())
         return AccessibilitySVGRoot::create(renderer, this);
 
-    if (is<SVGElement>(node))
-        return AccessibilitySVGElement::create(renderer, this);
+    if (is<SVGElement>(node) || is<RenderSVGInlineText>(renderer))
+        return AccessibilitySVGObject::create(renderer, this);
 
     if (auto* renderImage = toSimpleImage(renderer))
         return AXImage::create(*renderImage);

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -31,13 +31,13 @@
 
 namespace WebCore {
 
-class AccessibilitySVGElement : public AccessibilityRenderObject {
+class AccessibilitySVGObject : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilitySVGElement> create(RenderObject&, AXObjectCache*);
-    virtual ~AccessibilitySVGElement();
+    static Ref<AccessibilitySVGObject> create(RenderObject&, AXObjectCache*);
+    virtual ~AccessibilitySVGObject();
 
 protected:
-    explicit AccessibilitySVGElement(RenderObject&, AXObjectCache*);
+    explicit AccessibilitySVGObject(RenderObject&, AXObjectCache*);
     AXObjectCache* axObjectCache() const override { return m_axObjectCache.get(); }
     AccessibilityRole determineAriaRoleAttribute() const final;
 

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
@@ -40,7 +40,7 @@
 namespace WebCore {
 
 AccessibilitySVGRoot::AccessibilitySVGRoot(RenderObject& renderer, AXObjectCache* cache)
-    : AccessibilitySVGElement(renderer, cache)
+    : AccessibilitySVGObject(renderer, cache)
 {
 }
 
@@ -63,7 +63,7 @@ AccessibilityObject* AccessibilitySVGRoot::parentObject() const
     if (m_parent)
         return m_parent.get();
     
-    return AccessibilitySVGElement::parentObject();
+    return AccessibilitySVGObject::parentObject();
 }
 
 AccessibilityRole AccessibilitySVGRoot::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.h
@@ -28,12 +28,12 @@
 
 #pragma once
 
-#include "AccessibilitySVGElement.h"
+#include "AccessibilitySVGObject.h"
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class AccessibilitySVGRoot final : public AccessibilitySVGElement {
+class AccessibilitySVGRoot final : public AccessibilitySVGObject {
 public:
     static Ref<AccessibilitySVGRoot> create(RenderObject&, AXObjectCache*);
     virtual ~AccessibilitySVGRoot();


### PR DESCRIPTION
#### 6dbdd5c6af9bf00c4f131bd0616f6ec9ad10d6c8
<pre>
AX: RenderSVGInlineText accessibility objects are created in the wrong AXObjectCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=282028">https://bugs.webkit.org/show_bug.cgi?id=282028</a>
<a href="https://rdar.apple.com/138534253">rdar://138534253</a>

Reviewed by Chris Fleizach.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=247316">https://bugs.webkit.org/show_bug.cgi?id=247316</a>, we largely addressed the problem where SVG objects were created
in the `AXObjectCache` associated with their `Document`, rather than the `Document` that contains the canonical
`AXObjectCache`, which is the top document.

There was one case we missed, however. Prior to this commit, we only created `AccessibilitySVGElement`s in this condition:

```
if (is&lt;SVGElement&gt;(node))
    return AccessibilitySVGObject::create(renderer, this);
```

Critically, `RenderSVGInlineText`s are not `SVGElement` subclasses. Instead, they subclass `RenderText`. Fix this by
making `RenderSVGInlineText`s created as `AccessibilitySVGElement`s, ensuring they have the the right `::axObjectCache()`
override.

This fixes an ASSERT we&apos;ve been hitting in ITM for a long time in accessibility/add-children-pseudo-element.html:

<a href="https://github.com/WebKit/WebKit/blob/aeacdd2cd7d9d2d77cc232b524975ee2f0815191/Source/WebCore/accessibility/AccessibilityObject.cpp#L689">https://github.com/WebKit/WebKit/blob/aeacdd2cd7d9d2d77cc232b524975ee2f0815191/Source/WebCore/accessibility/AccessibilityObject.cpp#L689</a>

`ASSERT(isTableComponent(*child) || isTableComponent(*this) || child-&gt;parentObject() == this);`

This commit also renames `AccessibilitySVGElement` to `AccessibilitySVGObject`. `AccessibilitySVGElement` was confusing
before this patch (&quot;element&quot; overrides a &quot;renderer&quot; class (`AccessibilityRenderObject`), which overrides a &quot;node&quot; class (`AccessibilityNodeObject`)).
But it now would&apos;ve been especially confusing, since we now may have `AccessibilitySVGObject`s that don&apos;t have an element,
just a text node. `AccessibilitySVGObject` is more appropriate and matches the naming scheme for all our other objects.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp: Renamed from Source/WebCore/accessibility/AccessibilitySVGElement.cpp.
(WebCore::AccessibilitySVGObject::AccessibilitySVGObject):
(WebCore::AccessibilitySVGObject::create):
(WebCore::AccessibilitySVGObject::targetForUseElement const):
(WebCore::AccessibilitySVGObject::childElementWithMatchingLanguage const):
(WebCore::AccessibilitySVGObject::accessibilityText const):
(WebCore::AccessibilitySVGObject::description const):
(WebCore::AccessibilitySVGObject::helpText const):
(WebCore::AccessibilitySVGObject::hasTitleOrDescriptionChild const):
(WebCore::AccessibilitySVGObject::computeIsIgnored const):
(WebCore::AccessibilitySVGObject::inheritsPresentationalRole const):
(WebCore::AccessibilitySVGObject::determineAriaRoleAttribute const):
(WebCore::AccessibilitySVGObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilitySVGObject.h: Renamed from Source/WebCore/accessibility/AccessibilitySVGElement.h.
* Source/WebCore/accessibility/AccessibilitySVGRoot.cpp:
(WebCore::AccessibilitySVGRoot::AccessibilitySVGRoot):
(WebCore::AccessibilitySVGRoot::parentObject const):
* Source/WebCore/accessibility/AccessibilitySVGRoot.h:

Canonical link: <a href="https://commits.webkit.org/285730@main">https://commits.webkit.org/285730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a27e9fadf4686c5df4bb6b9ad7702fc2745cf41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23220 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66274 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9413 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7594 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/930 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3680 "Found 8 new failures in accessibility/AccessibilitySVGObject.cpp and found 1 fixed file: accessibility/AccessibilitySVGElement.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->