### PR TITLE
Deploy more smart pointers in ApplyStyleCommand

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -739,7 +739,6 @@ dom/TreeScope.cpp
 dom/TrustedType.cpp
 dom/TypedElementDescendantIteratorInlines.h
 domjit/JSDocumentDOMJIT.cpp
-editing/ApplyStyleCommand.cpp
 editing/ChangeListTypeCommand.cpp
 editing/Editing.cpp
 editing/EditingStyle.cpp

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -67,7 +67,7 @@ static String& styleSpanClassString()
 
 bool isLegacyAppleStyleSpan(const Node* node)
 {
-    auto* spanElement = dynamicDowncast<HTMLSpanElement>(node);
+    RefPtr spanElement = dynamicDowncast<HTMLSpanElement>(node);
     return spanElement && spanElement->attributeWithoutSynchronization(classAttr) == styleSpanClassString();
 }
 
@@ -89,19 +89,19 @@ static bool hasNoAttributeOrOnlyStyleAttribute(const StyledElement& element, Sho
 
 bool isStyleSpanOrSpanWithOnlyStyleAttribute(const Element& element)
 {
-    auto* spanElement = dynamicDowncast<HTMLSpanElement>(element);
+    RefPtr spanElement = dynamicDowncast<HTMLSpanElement>(element);
     return spanElement && hasNoAttributeOrOnlyStyleAttribute(*spanElement, AllowNonEmptyStyleAttribute);
 }
 
 static inline bool isSpanWithoutAttributesOrUnstyledStyleSpan(const Element& element)
 {
-    auto* spanElement = dynamicDowncast<HTMLSpanElement>(element);
+    RefPtr spanElement = dynamicDowncast<HTMLSpanElement>(element);
     return spanElement && hasNoAttributeOrOnlyStyleAttribute(*spanElement, StyleAttributeShouldBeEmpty);
 }
 
 bool isEmptyFontTag(const Element* element, ShouldStyleAttributeBeEmpty shouldStyleAttributeBeEmpty)
 {
-    auto* fontElement = dynamicDowncast<HTMLFontElement>(element);
+    RefPtr fontElement = dynamicDowncast<HTMLFontElement>(element);
     return fontElement && hasNoAttributeOrOnlyStyleAttribute(*fontElement, shouldStyleAttributeBeEmpty);
 }
 
@@ -255,7 +255,7 @@ void ApplyStyleCommand::applyBlockStyle(EditingStyle& style)
                     block = newBlock;
             }
             ASSERT(!block || is<Element>(*block));
-            if (auto* htmlBlock = dynamicDowncast<HTMLElement>(block.get())) {
+            if (RefPtr htmlBlock = dynamicDowncast<HTMLElement>(block.get())) {
                 removeCSSStyle(style, *htmlBlock);
                 if (!m_removeOnly)
                     addBlockStyle(styleChange, *htmlBlock);
@@ -432,7 +432,7 @@ static ContainerNode* dummySpanAncestorForNode(Node* node)
 {
     RefPtr<Node> currentNode = node;
     while (currentNode) {
-        auto* element = dynamicDowncast<Element>(*currentNode);
+        RefPtr element = dynamicDowncast<Element>(*currentNode);
         if (element && isStyleSpanOrSpanWithOnlyStyleAttribute(*element))
             break;
         currentNode = currentNode->parentNode();
@@ -451,12 +451,12 @@ void ApplyStyleCommand::cleanupUnstyledAppleStyleSpans(ContainerNode* dummySpanA
     // all the children of the dummy's parent
 
     Vector<Ref<Element>> toRemove;
-    for (auto& child : childrenOfType<Element>(*dummySpanAncestor)) {
+    for (Ref child : childrenOfType<Element>(*dummySpanAncestor)) {
         if (isSpanWithoutAttributesOrUnstyledStyleSpan(child))
             toRemove.append(child);
     }
 
-    for (auto& element : toRemove)
+    for (Ref element : toRemove)
         removeNodePreservingChildren(element.get());
 }
 
@@ -518,11 +518,11 @@ void ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock(Node* node, Node* unsp
 
     for (RefPtr<Node> ancestor = node->parentNode(), parent; ancestor != block && ancestor != unsplitAncestor; ancestor = parent) {
         parent = ancestor->parentNode();
-        auto* element = dynamicDowncast<StyledElement>(*ancestor);
+        RefPtr element = dynamicDowncast<StyledElement>(*ancestor);
         if (!element)
             continue;
 
-        int unicodeBidi = valueID(ComputedStyleExtractor(element).propertyValue(CSSPropertyUnicodeBidi).get());
+        int unicodeBidi = valueID(ComputedStyleExtractor(element.get()).propertyValue(CSSPropertyUnicodeBidi).get());
         if (!unicodeBidi || unicodeBidi == CSSValueNormal)
             continue;
 
@@ -563,7 +563,7 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
     // update document layout once before removing styles
     // so that we avoid the expense of updating before each and every call
     // to check a computed style
-    auto document = protectedDocument();
+    Ref document = protectedDocument();
     document->updateLayoutIgnorePendingStylesheets();
 
     // adjust to the positions we want to use for applying style
@@ -770,7 +770,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
     if (m_removeOnly)
         return;
 
-    auto document = protectedDocument();
+    Ref document = protectedDocument();
     document->updateLayoutIgnorePendingStylesheets();
 
     Vector<InlineRunToApplyStyle> runs;


### PR DESCRIPTION
#### b273704639f88802ca8666873466daf47b24fbcf
<pre>
Deploy more smart pointers in ApplyStyleCommand
<a href="https://bugs.webkit.org/show_bug.cgi?id=282029">https://bugs.webkit.org/show_bug.cgi?id=282029</a>

Reviewed by Chris Dumez.

Deploy more smart pointers in ApplyStyleCommand

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::isLegacyAppleStyleSpan):
(WebCore::isStyleSpanOrSpanWithOnlyStyleAttribute):
(WebCore::isSpanWithoutAttributesOrUnstyledStyleSpan):
(WebCore::isEmptyFontTag):
(WebCore::ApplyStyleCommand::applyBlockStyle):
(WebCore::dummySpanAncestorForNode):
(WebCore::ApplyStyleCommand::cleanupUnstyledAppleStyleSpans):
(WebCore::ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock):
(WebCore::ApplyStyleCommand::applyInlineStyle):
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):

Canonical link: <a href="https://commits.webkit.org/286141@main">https://commits.webkit.org/286141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5e1142ad39d1f9a282caca297f00b95224b2c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47668 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63122 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79246 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66059 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65338 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7355 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11566 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->