### PR TITLE
resolvePseudoElement early exit Pseudo before/after

### DIFF
--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -390,6 +390,10 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
         return { };
     if (pseudoElementIdentifier.pseudoId == PseudoId::WebKitScrollbar && elementUpdate.style->overflowX() != Overflow::Scroll && elementUpdate.style->overflowY() != Overflow::Scroll)
         return { };
+    if (pseudoElementIdentifier.pseudoId == PseudoId::Before && !element.beforePseudoElement())
+        return { };
+    if (pseudoElementIdentifier.pseudoId == PseudoId::After && !element.afterPseudoElement())
+        return { };
     auto isViewTransitionPseudoElement = pseudoElementIdentifier.pseudoId == PseudoId::ViewTransition
         || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionGroup
         || pseudoElementIdentifier.pseudoId == PseudoId::ViewTransitionImagePair


### PR DESCRIPTION
#### 24d152feea36d319578dcbdff9f86c443bb4b329
<pre>
resolvePseudoElement early exit Pseudo before/after
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolvePseudoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d152feea36d319578dcbdff9f86c443bb4b329

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/577 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57631 "Failure limit exceed. At least found 439 new test failures: accessibility/add-children-pseudo-element.html accessibility/css-content-attribute.html accessibility/generated-content-with-display-table-crash.html accessibility/label-with-pseudo-elements.html accessibility/list-detection2.html accessibility/render-counter-text.html animations/many-pseudo-animations.html compositing/contents-opaque/negative-z-before-html.html compositing/generated-content.html css2.1/20110323/eof-001.htm ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16095 "Exiting early after 60 failures. 8299 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76432 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49273 "Found 60 new test failures: animations/many-pseudo-animations.html compositing/contents-format/deep-color-backing-store.html compositing/contents-opaque/negative-z-before-html.html compositing/generated-content.html css2.1/t040103-escapes-00-b.html css2.1/t1202-counter-00-b.html css2.1/t1202-counter-02-b.html css2.1/t1202-counter-03-b.html css2.1/t1202-counter-04-b.html css2.1/t1202-counter-05-b.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63123 "Found 1 new API test failure: TestWebKitAPI.ElementTargeting.AdjustVisibilityFromPseudoSelectors (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38047 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46669 "Found 60 new test failures: imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html imported/w3c/web-platform-tests/css/css-align/abspos/table-align-self-stretch.html imported/w3c/web-platform-tests/css/css-align/abspos/table-justify-self-stretch.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-003.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-pseudo-element.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20605 "Found 60 new test failures: accessibility/css-content-attribute.html accessibility/generated-content-with-display-table-crash.html accessibility/label-with-pseudo-elements.html accessibility/list-detection2.html accessibility/mac/alt-for-css-content.html compositing/contents-opaque/negative-z-before-html.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/generated-content.html css2.1/t1202-counter-00-b.html css2.1/t1202-counter-02-b.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22932 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67686 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20958 "Found 60 new test failures: accessibility/css-content-attribute.html accessibility/generated-content-with-display-table-crash.html accessibility/label-with-pseudo-elements.html accessibility/list-detection2.html accessibility/mac/alt-for-css-content.html accessibility/mac/pseudo-element-text-markers.html accessibility/render-counter-text.html compositing/contents-opaque/negative-z-before-html.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/generated-content.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79247 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/678 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/192 "Found 60 new test failures: accessibility/css-content-attribute.html accessibility/generated-content-with-display-table-crash.html accessibility/mac/alt-for-css-content.html accessibility/mac/pseudo-element-text-markers.html animations/many-pseudo-animations.html compositing/contents-opaque/negative-z-before-html.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/generated-content.html css2.1/t1202-counter-00-b.html css2.1/t1202-counter-02-b.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/79247 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63135 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/79247 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9173 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7356 "Found 60 new test failures: accessibility/css-content-attribute.html accessibility/generated-content-with-display-table-crash.html accessibility/label-with-pseudo-elements.html accessibility/list-detection2.html accessibility/mac/alt-for-css-content.html accessibility/mac/pseudo-element-text-markers.html compositing/contents-opaque/negative-z-before-html.html compositing/fixed-positioned-pseudo-content-no-compositing.html compositing/generated-content.html css2.1/20110323/eof-001.htm ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3381 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->