### PR TITLE
REGRESSION(285507@main): [ macOS iOS Debug ] ASSERTION FAILED: showCount == hideCount in virtual WebCore::MockPaymentCoordinator result of crash in ApplePay

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1919,16 +1919,5 @@ imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopen
 # webkit.org/b/281999 REGRESSION (285061@main): [macOS Debug arm64 ] ASSERTION FAILED: m_lastEnqueuedRawVideoFrame <= sampleTime in http/wpt/mediarecorder/paus e-recording.html (EWS failure)
 [ Debug arm64 ] http/wpt/mediarecorder/pause-recording.html [ Skip ]
 
-# webkit.org/b/282003 REGRESSION(285507@main?): [ macOS iOS Debug ] ASSERTION FAILED: showCount == hideCount in virtual WebCore::MockPaymentCoordinator result of crash in ApplePay
-[ Debug ] http/tests/ssl/applepay/ApplePayRequestShippingContactV3.https.html [ Skip ]
-[ Debug ] http/tests/ssl/applepay/ApplePayShippingAddressChangeEventErrors.https.html [ Skip ]
-[ Debug ] http/tests/ssl/applepay/ApplePayRequestShippingContact.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/ApplePayModifier-multiTokenContexts.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/payment-response-complete-method.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/payment-response-payerEmail-attribute.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/ApplePayModifier-deferredPaymentRequest.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/payment-response-methodName-attribute.https.html [ Skip ]
-[ Debug ] http/tests/paymentrequest/updateWith-displayItems.https.html [ Skip ]
-
 # webkit.org/b/282046 REGRESSION(285592@main): [ macOS iOS wk2 ] http/tests/site-isolation/l oad-event.html are near constant failures.
 http/tests/site-isolation/load-event.html [ Pass Failure ]

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -150,6 +150,8 @@ private:
 
     WeakPtr<PaymentCoordinator> m_paymentCoordinator;
     WeakRef<Page> m_page;
+    uint64_t m_showCount { 0 };
+    uint64_t m_hideCount { 0 };
     bool m_canMakePayments { true };
     bool m_canMakePaymentsWithActiveCard { true };
     ApplePayPaymentContact m_shippingAddress;


### PR DESCRIPTION
#### 3376205b5d9b7ccf64b938731f37a9f086406b15
<pre>
REGRESSION(285507@main): [ macOS iOS Debug ] ASSERTION FAILED: showCount == hideCount in virtual WebCore::MockPaymentCoordinator result of crash in ApplePay
<a href="https://bugs.webkit.org/show_bug.cgi?id=282003">https://bugs.webkit.org/show_bug.cgi?id=282003</a>
<a href="https://rdar.apple.com/138506302">rdar://138506302</a>

Reviewed by Per Arne Vollan.

In 285507@main, MockPaymentCoordinator was made ref-counted, which means its
lifetime can now get extended. This means that when a MockPaymentCoordinator
get replaced with another, 2 MockPaymentCoordinator instance can be alive at
the same time, temporarily.

The assertion in the MockPaymentCoordinator destructor checks that the
coordinator has shown as many dialogs as it has hidden. However, this check
relies on global static variables. This used to work fine when only one
MockPaymentCoordinator could be alive at the same time. However, now that
this is no longer true, the assertion can be hit because a new MockPaymentCoordinator
instance may have shown a dialog before the previous MockPaymentCoordinator
got a chance to get destroyed.

To address the issue, I converted this global variables into data members.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::~MockPaymentCoordinator):
(WebCore::MockPaymentCoordinator::dispatchIfShowing):
(WebCore::MockPaymentCoordinator::showPaymentUI):
(WebCore::MockPaymentCoordinator::cancelPayment):
(WebCore::MockPaymentCoordinator::completePaymentSession):
(WebCore::MockPaymentCoordinator::abortPaymentSession):
(WebCore::MockPaymentCoordinator::cancelPaymentSession):
* Source/WebCore/testing/MockPaymentCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/285653@main">https://commits.webkit.org/285653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43e0c288b0c9e63cb70c0dd455baff7a3e359466

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26241 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75548 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/61991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/645 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/77690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/61991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/61991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/61991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79316 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11302 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->