### PR TITLE
[CoordinatedGraphics] Simplify CoordinatedBackingStoreProxy

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -96,15 +96,10 @@ private:
     };
 
     void invalidateRegion(const Vector<IntRect, 1>&);
-    void createTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier);
-    void computeCoverAndKeepRect(const IntRect& visibleRect, IntRect& coverRect, IntRect& keepRect) const;
-
-    void resizeEdgeTiles();
-    void setCoverRect(const IntRect& rect) { m_coverRect = rect; }
-    void setKeepRect(const IntRect&);
+    void createOrDestroyTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier);
+    std::pair<IntRect, IntRect> computeCoverAndKeepRect() const;
 
     void adjustForContentsRect(IntRect&) const;
-    double tileDistance(const IntRect& viewport, const IntPoint&) const;
 
     IntRect mapToContents(const IntRect&) const;
     IntRect mapFromContents(const IntRect&) const;
@@ -121,7 +116,6 @@ private:
     IntRect m_visibleRect;
     IntRect m_coverRect;
     IntRect m_keepRect;
-    IntRect m_previousContentsRect;
     UncheckedKeyHashMap<IntPoint, Tile> m_tiles;
 };
 


### PR DESCRIPTION
#### 37928048f89d8d8cd14c6b322a9bc7fbdbd78e01
<pre>
[CoordinatedGraphics] Simplify CoordinatedBackingStoreProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=282035">https://bugs.webkit.org/show_bug.cgi?id=282035</a>

Reviewed by Miguel Gomez.

This patch includes several improvements:

 - Removes the m_previousContentsRect since we already check if the
   contents rect changed.
 - Rename createTiles as createOrDestroyTiles since it also destroys
   tiles.
 - Use HashMap::removeIf when destroying tiles to avoid iterating twice.
 - Remove setCoverRect() and just set the m_coverRect when needed.
 - Remove setKeepRect() and drop the tiles outsice the new keep rect
   after the value is changed.
 - Remove resizeEdgeTiles() and do the iteration to remove or resize the
   tiles when contents rect changes.
 - Change computeCoverAndKeepRect() to return a std::pair.
 - Remove tileDistance and use a lambda doing the visible center
   position calculation once.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::setContentsScale):
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
(WebCore::CoordinatedBackingStoreProxy::createOrDestroyTiles):
(WebCore::CoordinatedBackingStoreProxy::computeCoverAndKeepRect const):
(WebCore::CoordinatedBackingStoreProxy::tileDistance const): Deleted.
(WebCore::CoordinatedBackingStoreProxy::createTiles): Deleted.
(WebCore::CoordinatedBackingStoreProxy::resizeEdgeTiles): Deleted.
(WebCore::CoordinatedBackingStoreProxy::setKeepRect): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
(WebCore::CoordinatedBackingStoreProxy::setCoverRect): Deleted.

Canonical link: <a href="https://commits.webkit.org/285647@main">https://commits.webkit.org/285647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daf439cd1c5333bfb274e08c051e4a840821692a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75506 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/61384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/603 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76458 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/61384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38071 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/61384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20622 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22958 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/61384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79274 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/208 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7373 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11300 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/670 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->