### PR TITLE
Use NSURLSession instead of sendSynchronousRequest

### DIFF
--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -520,7 +520,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (BOOL)loadHistoryGutsFromURL:(NSURL *)URL savedItemsCount:(int *)numberOfItemsLoaded collectDiscardedItemsInto:(NSMutableArray *)discardedItems error:(NSError **)error
 {
     *numberOfItemsLoaded = 0;
-    NSDictionary *dictionary = nil;
+    __block NSDictionary *dictionary = nil;
 
     // Optimize loading from local file, which is faster than using the general URL loading mechanism
     if ([URL isFileURL]) {
@@ -534,17 +534,38 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return NO;
         }
     } else {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSData *data = [NSURLConnection sendSynchronousRequest:[NSURLRequest requestWithURL:URL] returningResponse:nil error:error];
-ALLOW_DEPRECATED_DECLARATIONS_END
-        if (data.length)
-            dictionary = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:nullptr error:nullptr];
-    }
 
-    // We used to support NSArrays here, but that was before Safari 1.0 shipped. We will no longer support
-    // that ancient format, so anything that isn't an NSDictionary is bogus.
-    if (![dictionary isKindOfClass:[NSDictionary class]])
-        return NO;
+        NSURLSession *session = [NSURLSession sharedSession];
+        __block NSError *outerError = nil;
+        [[session dataTaskWithURL:URL
+                completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                    if (error) {
+                        outerError = error;
+                        return;
+                    }
+
+                    if (data.length) {
+                        NSError *plistError = nil;
+                        id innerDictionary = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:NULL error:&plistError];
+                        if (plistError) {
+                            outerError = plistError;
+                            return;
+                        }
+                        if ([innerDictionary isKindOfClass:[NSDictionary class]])
+                            dictionary = innerDictionary;
+                    }
+                }] resume];
+
+        if (outerError) {
+            *error = outerError;
+            return NO;
+        }
+
+        // We used to support NSArrays here, but that was before Safari 1.0 shipped. We will no longer support
+        // that ancient format, so anything that isn't an NSDictionary is bogus.
+        if (!dictionary)
+            return NO;
+    }
 
     NSNumber *fileVersionObject = [dictionary objectForKey:FileVersionKey];
     int fileVersion;


### PR DESCRIPTION
<pre>Use NSURLSession instead of sendSynchronousRequest
https://bugs.webkit.org/show_bug.cgi?id=282048

Reviewed by NOBODY (OOPS!).

sendSynchronousRequest can have problems, so use NSURLSession instead.
See: https://developer.apple.com/documentation/foundation/nsurlconnection/1411393-sendsynchronousrequest?language=objc

* Source/WebKitLegacy/mac/History/WebHistory.mm:
  (-[WebHistoryPrivate loadHistoryGutsFromURL:savedItemsCount:collectDiscardedItemsInto:error:]):
  Migrate to NSURLSession.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f564c7683e83d538bd30e5a0cb41ce816997b627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83929 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23115 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73729 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72947 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15921 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2529 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16618 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->