### PR TITLE
[Cocoa] Modern media controls should have accessibility identifiers

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -83,6 +83,7 @@ class Button extends LayoutItem
 
         this._loadImage(iconName);
         this.element.setAttribute("aria-label", iconName.label);
+        this.element.setAttribute("id", iconName.name);
     }
 
     get on()

--- a/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css
@@ -24,19 +24,19 @@
  */
 
 .media-controls.fullscreen.tvos > .metadata-container {
-    .title-label, .artist-label {
+    #title-label, #artist-label {
         mix-blend-mode: plus-lighter;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
-    .title-label {
+    #title-label {
         color: var(--primary-glyph-color);
         font-size: larger;
     }
 
-    .artist-label {
+    #artist-label {
         color: var(--secondary-glyph-color);
     }
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
@@ -32,8 +32,8 @@ class MetadataContainer extends LayoutNode
         this._title = "";
         this._artist = "";
         
-        this._titleNode = new LayoutNode(`<div class="title-label"></div>`);
-        this._artistNode = new LayoutNode(`<div class="artist-label"></div>`);
+        this._titleNode = new LayoutNode(`<div id="title-label"></div>`);
+        this._artistNode = new LayoutNode(`<div id="artist-label"></div>`);
         this.children = [this._titleNode, this._artistNode];
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
@@ -46,6 +46,20 @@ class TimeLabel extends LayoutNode
 
         this._type = type;
         this.setValueWithNumberOfDigits(0, 4);
+        
+        switch (this._type) {
+        case TimeLabel.Type.Elapsed:
+            this.element.setAttribute("id", "time-label-elapsed");
+            break;
+
+        case TimeLabel.Type.Remaining:
+            this.element.setAttribute("id", "time-label-remaining");
+            break;
+
+        case TimeLabel.Type.Duration:
+            this.element.setAttribute("id", "time-label-duration");
+            break;
+        }
     }
 
     // Public


### PR DESCRIPTION
#### a603828ce3a8b7c808f74e152061a1e7e59d3eac
<pre>
[Cocoa] Modern media controls should have accessibility identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=282022">https://bugs.webkit.org/show_bug.cgi?id=282022</a>
<a href="https://rdar.apple.com/138526033">rdar://138526033</a>

Reviewed by Antoine Quint.

Assigned id attributes to buttons and labels in modern media controls that also have aria-labels.
In a future change, WebKit will use these attributes to assign accessibility identifiers to these
elements.

* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype.set iconName):
* Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css:
(.media-controls.fullscreen.tvos &gt; .metadata-container):
(#title-label):
(#artist-label):
(.title-label): Deleted.
(.artist-label): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js:
* Source/WebCore/Modules/modern-media-controls/controls/time-label.js:
(TimeLabel.prototype.switch):

Canonical link: <a href="https://commits.webkit.org/285677@main">https://commits.webkit.org/285677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f89818229f055a4e1fb13dbc49f8b4403668124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57725 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23030 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/271 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66123 "Found 2 new test failures: compositing/animation/keyframe-order.html compositing/animation/repaint-after-clearing-shared-backing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7429 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/740 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->