### PR TITLE
Undo test changes expecting SameSite=Lax cookies by default

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/testharness-helpers.js
+++ b/LayoutTests/http/tests/cookies/resources/testharness-helpers.js
@@ -5,9 +5,9 @@ var TEST_SUB  = "subdomain." + TEST_HOST;
 
 var STRICT_DOM = "strict_from_dom";
 var IMPLICIT_STRICT_DOM = "implicit_strict_from_dom";
-var IMPLICIT_LAX_DOM = "implicit_lax_from_dom";
+var IMPLICIT_NONE_DOM = "implicit_none_from_dom";
 var STRICT_BECAUSE_INVALID_SAMESITE_VALUE = "strict_because_invalid_SameSite_value";
-var LAX_BECAUSE_INVALID_SAMESITE_VALUE = "lax_because_invalid_SameSite_value";
+var NONE_BECAUSE_INVALID_SAMESITE_VALUE = "none_because_invalid_SameSite_value";
 var LAX_DOM = "lax_from_dom";
 var NORMAL_DOM = "normal_from_dom";
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt
@@ -10,14 +10,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Cookies sent with HTTP request:
 PASS Do not have cookie "strict".
-PASS Do not have cookie "implicit-lax".
-PASS Do not have cookie "lax-because-invalid-SameSite-value".
+PASS Has cookie "implicit-none" with value 6.
+PASS Has cookie "none-because-invalid-SameSite-value" with value 6.
 PASS Do not have cookie "lax".
 
 Cookies visible in DOM:
 PASS Do not have DOM cookie "strict".
-PASS Do not have DOM cookie "implicit-lax".
-PASS Do not have DOM cookie "lax-because-invalid-SameSite-value".
+PASS Has DOM cookie "implicit-none" with value 6.
+PASS Has DOM cookie "none-because-invalid-SameSite-value" with value 6.
 PASS Do not have DOM cookie "lax".
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html
@@ -8,8 +8,8 @@ async function runTest()
 {
     await resetCookies();
     await setCookie("strict", "6", {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
-    await setCookie("implicit-lax", "6", {"SameSite": null, "Max-Age": 100, "path": "/"});
-    await setCookie("lax-because-invalid-SameSite-value", "6", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-none", "6", {"SameSite": null, "Max-Age": 100, "path": "/"});
+    await setCookie("none-because-invalid-SameSite-value", "6", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
     await setCookie("lax", "6", {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
     window.location.href = "http://localhost:8000/resources/echo-iframe-src.py?src=http%3A//127.0.0.1%3A8000/cookies/same-site/resources/click-hyperlink.py%3Fhref%3Dfetch-after-navigating-iframe-in-cross-origin-page.py";
 }

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt
@@ -10,14 +10,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Cookies sent with HTTP request:
 PASS Do not have cookie "strict".
-PASS Do not have cookie "implicit-lax".
-PASS Do not have cookie "lax-because-invalid-SameSite-value".
+PASS Has cookie "implicit-none" with value 10.
+PASS Has cookie "none-because-invalid-SameSite-value" with value 10.
 PASS Do not have cookie "lax".
 
 Cookies visible in DOM:
 PASS Do not have DOM cookie "strict".
-PASS Do not have DOM cookie "implicit-lax".
-PASS Do not have DOM cookie "lax-because-invalid-SameSite-value".
+PASS Do not have DOM cookie "implicit-none".
+PASS Do not have DOM cookie "none-because-invalid-SameSite-value".
 PASS Do not have DOM cookie "lax".
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html
@@ -18,8 +18,8 @@ async function runTest()
     if (window.location.hostname === "127.0.0.1") {
         await resetCookies();
         await setCookie("strict", "10", {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
-        await setCookie("implicit-lax", "10", {"SameSite": null, "Max-Age": 100, "path": "/"});
-        await setCookie("lax-because-invalid-SameSite-value", "10", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
+        await setCookie("implicit-none", "10", {"SameSite": null, "Max-Age": 100, "path": "/"});
+        await setCookie("none-because-invalid-SameSite-value", "10", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
         await setCookie("lax", "10", {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
         window.location.hostname = "localhost";
     } else {

--- a/LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html
+++ b/LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html
@@ -7,8 +7,8 @@
 if (window.location.hostname == "127.0.0.1") {
     clearKnownCookies();
     document.cookie = STRICT_DOM + "=1; SameSite=Strict; Max-Age=100; path=/";
-    document.cookie = IMPLICIT_LAX_DOM + "=1; SameSite; Max-Age=100; path=/";
-    document.cookie = LAX_BECAUSE_INVALID_SAMESITE_VALUE + "=1; SameSite=invalid; Max-Age=100; path=/";
+    document.cookie = IMPLICIT_NONE_DOM + "=1; SameSite; Max-Age=100; path=/";
+    document.cookie = NONE_BECAUSE_INVALID_SAMESITE_VALUE + "=1; SameSite=invalid; Max-Age=100; path=/";
     document.cookie = LAX_DOM + "=1; SameSite=Lax; Max-Age=100; path=/";
     document.cookie = NORMAL_DOM + "=1; Max-Age=100; path=/";
     window.location.hostname = "localhost";
@@ -16,11 +16,11 @@ if (window.location.hostname == "127.0.0.1") {
     async_test(t => {
         window.addEventListener("message", t.step_func_done(e => {
             assert_equals(e.data.http[STRICT_DOM], undefined, "strict");
-            assert_equals(e.data.http[IMPLICIT_LAX_DOM], undefined, "implicit-lax");
-            assert_equals(e.data.http[LAX_BECAUSE_INVALID_SAMESITE_VALUE], undefined, "lax-because-invalid-SameSite-value");
+            assert_equals(e.data.http[IMPLICIT_NONE_DOM], "1", "implicit-none");
+            assert_equals(e.data.http[NONE_BECAUSE_INVALID_SAMESITE_VALUE], "1", "none-because-invalid-SameSite-value");
             assert_equals(e.data.http[LAX_DOM], undefined, "lax");
-            assert_equals(e.data.http[NORMAL_DOM], undefined, "normal");
-            assert_equals(normalizeCookie(e.data.document), normalizeCookie(IMPLICIT_LAX_DOM + "=1; " + LAX_DOM + "=1; " + NORMAL_DOM + "=1; " + LAX_BECAUSE_INVALID_SAMESITE_VALUE + "=1; " + STRICT_DOM + "=1"));
+            assert_equals(e.data.http[NORMAL_DOM], "1", "normal");
+            assert_equals(normalizeCookie(e.data.document), normalizeCookie(IMPLICIT_NONE_DOM + "=1; " + LAX_DOM + "=1; " + NORMAL_DOM + "=1; " + NONE_BECAUSE_INVALID_SAMESITE_VALUE + "=1; " + STRICT_DOM + "=1"));
             e.source.close();
         }));
 

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
@@ -31,14 +31,14 @@ async function checkResult()
 {{
     debug("Cookies sent with HTTP request:");
     await shouldNotHaveCookie("strict");
-    await shouldNotHaveCookie("implicit-lax", "6");
-    await shouldNotHaveCookie("lax-because-invalid-SameSite-value", "6");
+    await shouldHaveCookieWithValue("implicit-none", "6");
+    await shouldHaveCookieWithValue("none-because-invalid-SameSite-value", "6");
     await shouldNotHaveCookie("lax");
 
     debug("<br>Cookies visible in DOM:");
     shouldNotHaveDOMCookie("strict");
-    shouldNotHaveDOMCookie("implicit-lax", "6");
-    shouldNotHaveDOMCookie("lax-because-invalid-SameSite-value", "6");
+    shouldHaveDOMCookieWithValue("implicit-none", "6");
+    shouldHaveDOMCookieWithValue("none-because-invalid-SameSite-value", "6");
     shouldNotHaveDOMCookie("lax");
 
     await resetCookies();

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html
@@ -16,14 +16,14 @@ async function checkResult()
 
     debug("Cookies sent with HTTP request:");
     await shouldNotHaveCookie("strict");
-    await shouldNotHaveCookie("implicit-lax", "10"); // Behaves like a non-SameSite cookie
-    await shouldNotHaveCookie("lax-because-invalid-SameSite-value", "10"); // Behaves like a non-SameSite cookie
+    await shouldHaveCookieWithValue("implicit-none", "10"); // Behaves like a non-SameSite cookie
+    await shouldHaveCookieWithValue("none-because-invalid-SameSite-value", "10"); // Behaves like a non-SameSite cookie
     await shouldNotHaveCookie("lax");
 
     debug("<br>Cookies visible in DOM:");
     shouldNotHaveDOMCookie("strict");
-    shouldNotHaveDOMCookie("implicit-lax");
-    shouldNotHaveDOMCookie("lax-because-invalid-SameSite-value");
+    shouldNotHaveDOMCookie("implicit-none");
+    shouldNotHaveDOMCookie("none-because-invalid-SameSite-value");
     shouldNotHaveDOMCookie("lax");
 
     await resetCookies();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Setup
 FAIL Anonymous same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS Anonymous cross-origin iframe is loaded without credentials
+FAIL Anonymous cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
 FAIL same_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS same_origin anonymous iframe can't send cross_origin credentials
-PASS cross_origin anonymous iframe can't send cross_origin credentials
-PASS cross_origin anonymous iframe can't send same_origin credentials
+FAIL same_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
 FAIL same_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS same_origin anonymous iframe can't send cross_origin credentials on child iframe
-PASS cross_origin anonymous iframe can't send cross_origin credentials on child iframe
-PASS cross_origin anonymous iframe can't send same_origin credentials on child iframe
+FAIL same_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Setup
 FAIL Anonymous same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS Anonymous cross-origin iframe is loaded without credentials
+FAIL Anonymous cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
 FAIL same_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS same_origin anonymous iframe can't send cross_origin credentials
-PASS cross_origin anonymous iframe can't send cross_origin credentials
-PASS cross_origin anonymous iframe can't send same_origin credentials
+FAIL same_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
 FAIL same_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
-PASS same_origin anonymous iframe can't send cross_origin credentials on child iframe
-PASS cross_origin anonymous iframe can't send cross_origin credentials on child iframe
-PASS cross_origin anonymous iframe can't send same_origin credentials on child iframe
+FAIL same_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4261,10 +4261,6 @@ webkit.org/b/124566 fast/dom/SelectorAPI/resig-SelectorsAPI-test.xhtml [ Skip ] 
 # Failures related with compositing tests.
 webkit.org/b/169918 compositing/fixed-with-fixed-layout.html [ Crash Pass ]
 
-# Fails when cookies are not SameSite=Lax by default
-imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-
 # Touch events related layout tests failing
 webkit.org/b/278719 fast/events/touch/basic-multi-touch-events.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/basic-multi-touch-events-limited.html [ Failure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1945,3 +1945,7 @@ webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/touch-globaleve
 
 fast/text/simple-line-layout-hyphenation-constrains.html [ ImageOnlyFailure ]
 editing/spelling/spelling-marker-includes-hyphen.html [ ImageOnlyFailure ]
+
+http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
+http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
+http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]

--- a/LayoutTests/platform/ios-17/TestExpectations
+++ b/LayoutTests/platform/ios-17/TestExpectations
@@ -95,13 +95,6 @@ imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullw
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht [ Pass ]
 fast/text/text-underline-position-under.html [ Pass ]
 
-# Fails when cookies are not SameSite=Lax by default
-http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
-http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-
 # Fails with SameSite=None cookies by default
 http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Failure ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2959,9 +2959,6 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
 
-[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-[ Ventura Sonoma ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-
 webkit.org/b/276636 imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html [ Failure ]
 
 # webkit.org/b/278293 [MacOS WK1] imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub.html is a flakey failure

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1765,25 +1765,6 @@ webkit.org/b/275913 [ Debug ] imported/w3c/web-platform-tests/media-source/dedic
 
 webkit.org/b/275873 storage/indexeddb/database-transaction-cycle.html [ Pass Failure ]
 
-# rdar://135211047
-[ Sequoia+ ] http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.https.html [ Failure ]
-[ Sequoia+ ] http/tests/privateClickMeasurement/send-attribution-conversion-request.https.html [ Failure ]
-[ Sequoia+ ] http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
-[ Sequoia+ ] http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
-[ Sequoia+ ] http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html [ Failure ]
-[ Sequoia+ ] http/tests/storageAccess/request-and-grant-access-then-navigate-same-site-should-have-access.https.html [ Failure ]
-
-# rdar://125587489
-[ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
-[ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
-
-[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
-[ Ventura Sonoma ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-[ Ventura Sonoma ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-[ Ventura Sonoma ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-[ Ventura Sonoma ] http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Failure ]
-
 webkit.org/b/276389 media/video-transformed.html [ Pass Failure ] 
 
 # webkit.org/b/277841 [ macOS wk2 ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html is a flaky failure
@@ -1904,17 +1885,8 @@ imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopen
 # webkit.org/b/281840 [ Ventura wk2 ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html is a flaky failure.
 [ Ventura ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html [ Pass Failure ]
 
-# webkit.org/b/281923 [ Sequoia wk2 Debug arm64 ] 3 tests in http/tests/cookies/same-site are constant failure (failure in EWS)
-[ Sequoia+ Debug arm64 ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-[ Sequoia+ Debug arm64 ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
-[ Sequoia+ Debug arm64 ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-
 # webkit.org/b/281939 [Sequoia] svg/stroke/non-scaling-stroke-gradient-text.html is a constant image failure
 [ Sequoia ] svg/stroke/non-scaling-stroke-gradient-text.html [ ImageOnlyFailure ]
-
-# webkit.org/b/281984 [ SequoiaA wk2 Debug arm64 ] 2x imported/w3c/web-platform-tests/html/anonymous-iframe/* are constant failures. 
-[ Sequoia+ Debug arm64 ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-[ Sequoia+ Debug arm64 ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 
 # webkit.org/b/281999 REGRESSION (285061@main): [macOS Debug arm64 ] ASSERTION FAILED: m_lastEnqueuedRawVideoFrame <= sampleTime in http/wpt/mediarecorder/paus e-recording.html (EWS failure)
 [ Debug arm64 ] http/wpt/mediarecorder/pause-recording.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1684,3 +1684,7 @@ webkit.org/b/279179 imported/w3c/web-platform-tests/eventsource/eventsource-cons
 
 webkit.org/b/281053 fast/storage/serialized-script-value.html [ Pass Crash ]
 webkit.org/b/281053 imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https.html [ Pass Crash ]
+
+http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
+http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
+http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]


### PR DESCRIPTION
#### 9d5f18152a927cd0136adca280385f8e64ebb532
<pre>
Undo test changes expecting SameSite=Lax cookies by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=281984">https://bugs.webkit.org/show_bug.cgi?id=281984</a>
<a href="https://rdar.apple.com/138487628">rdar://138487628</a>

Reviewed by Matthew Finkel.

* LayoutTests/http/tests/cookies/resources/testharness-helpers.js:
* LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt:
* LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html:
* LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt:
* LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html:
* LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html:
* LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py:
* LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-17/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/285696@main">https://commits.webkit.org/285696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d4879cedbea2f78476d5aaa1bae00c282988ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24773 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/749 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16214 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63270 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23105 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79422 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/332 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65460 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7492 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11329 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/814 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->