### PR TITLE
w

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="max-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: max-content;" src="../support/60x60-green.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="min-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: min-content;" src="../support/60x60-green.png">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -69,6 +69,7 @@
 #include "RenderFragmentContainer.h"
 #include "RenderGeometryMap.h"
 #include "RenderGrid.h"
+#include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderLayerCompositor.h"
@@ -3330,6 +3331,14 @@ std::optional<LayoutUnit> RenderBox::computeIntrinsicLogicalContentHeightUsing(L
     // FIXME: The CSS sizing spec is considering changing what min-content/max-content should resolve to.
     // If that happens, this code will have to change.
     if (logicalHeightLength.isMinContent() || logicalHeightLength.isMaxContent() || logicalHeightLength.isFitContent() || logicalHeightLength.isLegacyIntrinsic()) {
+        if (auto* renderImage = dynamicDowncast<RenderImage>(this)) {
+            auto computedLogicalWidth = style().logicalWidth();
+            if ((logicalHeightLength.isMinContent() || logicalHeightLength.isMaxContent()) && computedLogicalWidth.isFixed() && !style().hasAspectRatio()) {
+                auto intrinsicRatio = renderImage->intrinsicRatio();
+                return resolveHeightForRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), LayoutUnit(computedLogicalWidth.value()), intrinsicRatio.transposedSize().aspectRatio(), BoxSizing::ContentBox);
+            }
+        }
+
         if (intrinsicContentHeight)
             return adjustIntrinsicLogicalHeightForBoxSizing(intrinsicContentHeight.value());
         return { };

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -152,4 +152,11 @@ inline void RenderBox::setLogicalWidth(LayoutUnit size)
         setHeight(size);
 }
 
+inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth, LayoutUnit borderAndPaddingLogicalHeight, LayoutUnit logicalWidth, double aspectRatio, BoxSizing boxSizing)
+{
+    if (boxSizing == BoxSizing::BorderBox)
+        return LayoutUnit((logicalWidth + borderAndPaddingLogicalWidth) * aspectRatio) - borderAndPaddingLogicalHeight;
+    return LayoutUnit(logicalWidth * aspectRatio);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -570,7 +570,8 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
 void RenderObject::clearNeedsLayout(HadSkippedLayout hadSkippedLayout)
 {
     // FIXME: Consider not setting the "ever had layout" bit to true when "hadSkippedLayout"
-    setEverHadLayout();
+    if (!isRenderSVGText() || hadSkippedLayout == HadSkippedLayout::No)
+        setEverHadLayout();
     setHadSkippedLayout(hadSkippedLayout == HadSkippedLayout::Yes);
 
     if (auto* renderElement = dynamicDowncast<RenderElement>(*this)) {

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -670,13 +670,6 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
     return computeReplacedLogicalWidthRespectingMinMaxWidth(intrinsicLogicalWidth(), shouldComputePreferred);
 }
 
-static inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth, LayoutUnit borderAndPaddingLogicalHeight, LayoutUnit logicalWidth, double aspectRatio, BoxSizing boxSizing)
-{
-    if (boxSizing == BoxSizing::BorderBox)
-        return LayoutUnit((logicalWidth + borderAndPaddingLogicalWidth) * aspectRatio) - borderAndPaddingLogicalHeight;
-    return LayoutUnit(logicalWidth * aspectRatio);
-}
-
 LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
 {
     // 10.5 Content height: the 'height' property: http://www.w3.org/TR/CSS21/visudet.html#propdef-height
@@ -920,6 +913,14 @@ void RenderReplaced::layoutShadowContent(const LayoutSize& oldSize)
     }
 
     clearChildNeedsLayout();
+}
+
+FloatSize RenderReplaced::intrinsicRatio() const
+{
+    FloatSize intrinsicRatio;
+    FloatSize constrainedSize;
+    computeAspectRatioInformationForRenderBox(embeddedContentBox(), constrainedSize, intrinsicRatio);
+    return intrinsicRatio;
 }
 
 }

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -40,6 +40,7 @@ public:
     bool setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
 
     LayoutSize intrinsicSize() const final;
+    FloatSize intrinsicRatio() const;
     
     bool isContentLikelyVisibleInViewport();
     bool needsPreferredWidthsRecalculation() const override;


### PR DESCRIPTION
#### 4c303daf71e60760c0af2364ea783af5c5ea6c93
<pre>
REGRESSION(281090@main): Sluggish animations on some shopify stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=279492">https://bugs.webkit.org/show_bug.cgi?id=279492</a>
<a href="https://rdar.apple.com/135791322">rdar://135791322</a>

Reviewed by NOBODY (OOPS!).

In 281090@main, we added an extra bit of information for the grid to keep track of on its
grid items. In particular, we expanded the grid&apos;s capabilities to keep track of whether or
not any of its grid items needed to perform stretch alignment. This included some extra
invalidation inside of GridTrackSizingAlgorithm::logicalHeightForGridItem, as performing
layout on a grid item would clear its stretched size.

However, this seems to expose an issue in which we experience thrashing when rerunning the
grid layout. This can become an issue because of 2 main aspects of grid layout currently:

1.) We rerun the full grid track sizing algorithm each time (i.e. little partial layout)
2.) Grid track sizing may need to query the intrinsic sizes of an item. If an item was
previously stretched, we will clear that size, compute the intrinsic sizes for track
sizing, and then stretch the item again.

These 2 issues unfortunately get compounded in the presence of nested grid content.

This patch aims to address 2 by caching the intrinsic logical height of a grid item
to try to avoid the adverse effects of recomputing it. This cache will specifically be
used to cache the intrinsic logical heights of grid items that are computed during the
first pass of row sizing. That means the values that it contains are only valid for that
portion of the track sizing algorithm code, and the track sizing algorithm should only
populate it with sizes during that step.

Availability -
The cache will live on RenderGrid, which will determine whether or not
it will be available to use by the rest of the code. This availability is dependent on the
type of the current grid content. The cache is available to use if none
of the following are true:

1.) The grid is a subgrid

2.) Any of the items are a subgrid

3.) The grid is a masonry grid

4.) Any of the items are being baseline aligned (due to the  intrinsic size implications
of baseline-aligned grid items in the spec).

5.) The grid is contained in a fragmented flow.

Invalidation -
If we have an existing cache that is still valid to use during another
pass of layout (i.e. it is still available), then we may need to
invalidate the items.

1.) Before we run grid layout, we will check to see if any of the grid
item renderers have been dirtied. If so, we will then invalidate that
item if it is in the cache and recompute the intrinsic size during the
track sizing algorithm.

2.) If the grid experiences any sort of style mutation, we just
invalidate the entire cache.

3.) During track sizing, we may end up changing the inline constraints
that were used to compute the logical height in a previous pass. If this
is the case, then we need to invalidate the item in the cache as a
different set of constraints may result in a different logical height.

API -
This cache is exposed by RenderGrid via intrinsicLogicalHeightsForRowSizingFirstPass()
so that callers can either query, invalidate, or populate it. Callers should only expect
to be able to use the cache if it is made available by RenderGrid.

Inside logicalHeightForGridItem, we will check to see if this cache exists and if it
contains a value we previously computed for the item. If we do not have a value for this
item, we will just compute it and add it to the cache afterwards.

nested-grids-single-item-content-change.html was added as a performance
test to demonstrate the effectiveness of this change. On my M1 Pro MBP,
running this test went from ~950 runs/s to ~1900 runs/s.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentContributionForGridItem const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::isSubgrid const):
(WebCore::RenderGrid::updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability):
(WebCore::RenderGrid::intrinsicLogicalHeightsForRowSizingFirstPass const):
(WebCore::RenderGrid::canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache const):
(WebCore::GridItemSizeCache::setSizeForGridItem):
(WebCore::GridItemSizeCache::sizeForItem const):
(WebCore::GridItemSizeCache::invalidateSizeForItem):
* Source/WebCore/rendering/RenderGrid.h:
</pre>