### PR TITLE
[JSC] Remove outdated FIXME in JSDOMConvertDate.h

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertDate.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertDate.h
@@ -54,7 +54,6 @@ template<> struct JSConverter<IDLDate> {
     static constexpr bool needsState = true;
     static constexpr bool needsGlobalObject = false;
 
-    // FIXME: This should be taking a JSDOMGlobalObject and passing it to jsDate.
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, WallTime value)
     {
         return jsDate(lexicalGlobalObject, value);


### PR DESCRIPTION
#### 45b4d89d301b0bb5acb5a48c368625b4cd6245ce
<pre>
[JSC] Remove outdated FIXME in JSDOMConvertDate.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=282067">https://bugs.webkit.org/show_bug.cgi?id=282067</a>

Reviewed by Geoffrey Garen.

In JSDOMConvertDate there&apos;s a fixme that the convert function should be
taking a JSDOMGlobalObject and passing it to jsDate.

This is confusing because it&apos;s already taking a JSC::JSGlobalObject&amp;,
and it&apos;s unclear why a JSDOMGlobalObject would be better.

The reason for the FIXME appears to be that this function used to accept
a JSC::ExecState&amp; state - but in bug 202392 / commit
<a href="https://commits.webkit.org/216662@main">https://commits.webkit.org/216662@main</a> we switched away from ExecState.
So it looks like we just forgot to remove the FIXME when we made the
relevant change.

* Source/WebCore/bindings/js/JSDOMConvertDate.h:

Canonical link: <a href="https://commits.webkit.org/285746@main">https://commits.webkit.org/285746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30eb3afa4cf1005390e7e345f8066be06a75eb72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57747 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79374 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65425 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7454 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3511 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/798 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->