### PR TITLE
Regression(279037@main) Safari stopped rendering shadow under emoji when color is set to transparent.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-shadow-property">
+<style>
+.test {
+    font-size: 100px;
+    text-shadow: 300px 300px 0 green;
+}
+.hide-text {
+    background-color: white;
+    position: absolute;
+    width: 300px;
+    height: 200px;
+    z-index: 1;
+    left: 0;
+}
+</style>
+</head>
+<body>
+    <span class="test">A&#x1F44D;B</span>
+    <span class="hide-text"></span>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-shadow-property">
+<style>
+.test {
+    font-size: 100px;
+    text-shadow: 300px 300px 0 green;
+}
+.hide-text {
+    background-color: white;
+    position: absolute;
+    width: 300px;
+    height: 200px;
+    z-index: 1;
+    left: 0;
+}
+</style>
+</head>
+<body>
+    <span class="test">A&#x1F44D;B</span>
+    <span class="hide-text"></span>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-shadow-property">
+<link rel="match" href="text-shadow-transparent-emoji-ref.html">
+<style>
+.test {
+    font-size: 100px;
+    text-shadow: 300px 300px 0 green;
+    color: transparent
+}
+</style>
+</head>
+<body>
+    <span class="test">A&#x1F44D;B</span>
+</body>

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -52,6 +52,7 @@ namespace WebCore {
 
 class GraphicsContext;
 class LayoutRect;
+class RenderStyle;
 class RenderText;
 class TextLayout;
 class TextRun;
@@ -205,6 +206,8 @@ public:
 
     static bool isCJKIdeograph(char32_t);
     static bool isCJKIdeographOrSymbol(char32_t);
+
+    static bool canUseGlyphDisplayList(const RenderStyle&);
 
     // Returns (the number of opportunities, whether the last expansion is a trailing expansion)
     // If there are no opportunities, the bool will be true iff we are forbidding leading expansions.

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -45,6 +45,11 @@ bool FontCascade::canExpandAroundIdeographsInComplexText()
     return false;
 }
 
+bool FontCascade::canUseGlyphDisplayList(const RenderStyle&)
+{
+    return true;
+}
+
 static bool characterSequenceIsEmoji(SurrogatePairAwareTextIterator& iterator, char32_t firstCharacter, unsigned firstClusterLength)
 {
     char32_t character = firstCharacter;

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -514,4 +514,10 @@ ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariant
     }
 }
 
+bool FontCascade::canUseGlyphDisplayList(const RenderStyle& style)
+{
+    // CoreText won't call the drawImage delegate for glyphs that are invisible, even if they have an associated shadow applied to its graphic context. This would result in a glyph display list without the invisible glyph which is drawn as image and we would not draw its associated shadow. Therefore, we won't use a display list for runs that are invisible and have an associated shadow.
+    return !(style.textShadow() && !style.color().isVisible());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -101,6 +101,11 @@ bool FontCascade::canExpandAroundIdeographsInComplexText()
     return false;
 }
 
+bool FontCascade::canUseGlyphDisplayList(const RenderStyle&)
+{
+    return true;
+}
+
 ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariantEmoji, char32_t character)
 {
     switch (fontVariantEmoji) {

--- a/Source/WebCore/platform/graphics/win/FontWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontWin.cpp
@@ -38,4 +38,9 @@ bool FontCascade::canExpandAroundIdeographsInComplexText()
     return false;
 }
 
+bool FontCascade::canUseGlyphDisplayList(const RenderStyle&)
+{
+    return true;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -531,9 +531,9 @@ void TextBoxPainter<TextBoxPath>::paintForeground(const StyledMarkedText& marked
     updateGraphicsContext(context, markedText.style.textStyles);
 
     if constexpr (std::is_same_v<TextBoxPath, InlineIterator::BoxLegacyPath>)
-        textPainter.setGlyphDisplayListIfNeeded(downcast<LegacyInlineTextBox>(*textBox().legacyInlineBox()), m_paintInfo, m_paintTextRun);
+        textPainter.setGlyphDisplayListIfNeeded(downcast<LegacyInlineTextBox>(*textBox().legacyInlineBox()), m_paintInfo, m_style, m_paintTextRun);
     else
-        textPainter.setGlyphDisplayListIfNeeded(textBox().box(), m_paintInfo, m_paintTextRun);
+        textPainter.setGlyphDisplayListIfNeeded(textBox().box(), m_paintInfo, m_style, m_paintTextRun);
 
     // TextPainter wants the box rectangle and text origin of the entire line box.
     textPainter.paintRange(m_paintTextRun, m_paintRect, textOriginFromPaintRect(m_paintRect), markedText.startOffset, markedText.endOffset);

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -27,12 +27,14 @@
 #include "DisplayListRecorderImpl.h"
 #include "DisplayListReplayer.h"
 #include "FilterOperations.h"
+#include "FontCascade.h"
 #include "GraphicsContext.h"
 #include "InlineIteratorTextBox.h"
 #include "LayoutIntegrationInlineContent.h"
 #include "LegacyInlineTextBox.h"
 #include "RenderCombineText.h"
 #include "RenderLayer.h"
+#include "RenderStyle.h"
 #include "ShadowData.h"
 #include <wtf/NeverDestroyed.h>
 
@@ -215,9 +217,9 @@ void TextPainter::paintRange(const TextRun& textRun, const FloatRect& boxRect, c
     paintTextAndEmphasisMarksIfNeeded(textRun, boxRect, textOrigin, start, end, m_style, m_shadow, m_shadowColorFilter);
 }
 
-bool TextPainter::shouldUseGlyphDisplayList(const PaintInfo& paintInfo)
+bool TextPainter::shouldUseGlyphDisplayList(const PaintInfo& paintInfo, const RenderStyle& style)
 {
-    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer();
+    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer() && FontCascade::canUseGlyphDisplayList(style);
 }
 
 void TextPainter::setForceUseGlyphDisplayListForTesting(bool enabled)

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -61,15 +61,15 @@ public:
     void paintRange(const TextRun&, const FloatRect& boxRect, const FloatPoint& textOrigin, unsigned start, unsigned end);
 
     template<typename LayoutRun>
-    void setGlyphDisplayListIfNeeded(const LayoutRun& run, const PaintInfo& paintInfo, const TextRun& textRun)
+    void setGlyphDisplayListIfNeeded(const LayoutRun& run, const PaintInfo& paintInfo, const RenderStyle& style, const TextRun& textRun)
     {
-        if (!TextPainter::shouldUseGlyphDisplayList(paintInfo))
+        if (!TextPainter::shouldUseGlyphDisplayList(paintInfo, style))
             const_cast<LayoutRun&>(run).removeFromGlyphDisplayListCache();
         else
             m_glyphDisplayList = GlyphDisplayListCache::singleton().get(run, m_font, m_context, textRun, paintInfo);
     }
 
-    static bool shouldUseGlyphDisplayList(const PaintInfo&);
+    static bool shouldUseGlyphDisplayList(const PaintInfo&, const RenderStyle&);
     WEBCORE_EXPORT static void setForceUseGlyphDisplayListForTesting(bool);
     WEBCORE_EXPORT static String cachedGlyphDisplayListsForTextNodeAsText(Text&, OptionSet<DisplayList::AsTextFlag>);
     WEBCORE_EXPORT static void clearGlyphDisplayListCacheForTesting();


### PR DESCRIPTION
#### 1db24f6817a9f935c5e5cc8ccf1f740e40c6f285
<pre>
Regression(279037@main) Safari stopped rendering shadow under emoji when color is set to transparent.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282068">https://bugs.webkit.org/show_bug.cgi?id=282068</a>
<a href="https://rdar.apple.com/136067858">rdar://136067858</a>

Reviewed by Simon Fraser.

The bug comes from the fact that invisible glyphs that are drawn
as an image won&apos;t be recorded into the glyph display list, even if
they have an associated shadow.  When that happens we still try to
replay the cached DisplayList instead of drawing the glyph with the
appropriate mutated GraphicsContext.

CoreText won&apos;t call the drawImage delegate for glyphs that are invisible,
even if they have an associated shadow applied to its graphic context.
This would result in a glyph display list without the invisible glyph which
is drawn as image and we would not draw its associated shadow.
Therefore, we won&apos;t use a display list for runs that are invisible and have
an associated shadow for CoreText platorm use case.

 * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-expected.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent-ref.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html: Added.
 * Source/WebCore/rendering/GlyphDisplayListCache.cpp:
 (WebCore::GlyphDisplayListCache::getDisplayList):

Canonical link: <a href="https://commits.webkit.org/285870@main">https://commits.webkit.org/285870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee1fa6365d748d559ee19a6f3fa02931cacbb477

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1280 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38629 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23637 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79958 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1383 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63729 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16309 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9731 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1347 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1376 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->