### PR TITLE
[scroll-animations] Implement timeline-scope

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7394,12 +7394,15 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-base
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html [ ImageOnlyFailure ]
 
 # webkit.org/b/281482 [scroll-animations] some WPT reftests can't find their reference
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-update-reversed-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update-reversed-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-bounds-update.html [ Skip ]
+
+webkit.org/b/283149 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html [ Skip ]
 
 # CSS @scope with shadow DOM
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Animation.timeline returns attached timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animations[0].timeline')"
-FAIL Animation.timeline returns null for inactive deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
+PASS Animation.timeline returns attached timeline
+FAIL Animation.timeline returns null for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
 FAIL Animation.timeline returns null for inactive (overattached) deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -1,15 +1,15 @@
 
 PASS scroll-timeline-name is referenceable in animation-timeline on the declaring element itself
-FAIL scroll-timeline-name is referenceable in animation-timeline on that element's descendants assert_equals: expected "100px" but got "none"
+PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
 FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "none"
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
 FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: expected "75px" but got "none"
-FAIL Timeline lookup updates candidate when closer match available. assert_equals: expected "A" but got "target"
+FAIL Timeline lookup updates candidate when closer match available. assert_equals: Timeline not updated expected "B" but got "A"
 FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "50px" but got "none"
-FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "auto"
-FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "auto"
-FAIL scroll-timeline-axis is x assert_equals: expected "50" but got "auto"
-FAIL scroll-timeline-axis is y assert_equals: expected "50" but got "auto"
-FAIL scroll-timeline-axis is mutated assert_equals: expected "25" but got "auto"
+FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "0"
+FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "0"
+PASS scroll-timeline-axis is x
+FAIL scroll-timeline-axis is y assert_equals: expected "50" but got "0"
+FAIL scroll-timeline-axis is mutated assert_equals: expected "75" but got "25"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Timeline appearing via container queries assert_equals: expected "rgb(0, 0, 0)" but got "rgb(100, 100, 100)"
+PASS Timeline appearing via container queries
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
 
-FAIL Multiple style/layout passes occur when necessary assert_equals: expected "1px" but got "100px"
+FAIL Multiple style/layout passes occur when necessary assert_equals: expected 100 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can see scroll timeline defined by :host assert_equals: expected "y" but got "x"
-FAIL Outer animation can see scroll timeline defined by ::slotted assert_equals: expected "y" but got "x"
+PASS Outer animation can see scroll timeline defined by :host
+PASS Outer animation can see scroll timeline defined by ::slotted
 PASS Inner animation can see scroll timeline defined by ::part
 FAIL Slotted element can see scroll timeline within the shadow assert_equals: expected "y" but got "x"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL Descendant can attach to deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Descendant can attach to deferred timeline assert_equals: expected "100px" but got "0px"
 PASS Deferred timeline with no attachments
-FAIL Inner timeline does not interfere with outer timeline assert_equals: expected "100px" but got "0px"
+PASS Inner timeline does not interfere with outer timeline
 PASS Deferred timeline with two attachments
 FAIL Dynamically re-attaching assert_equals: expected "100px" but got "0px"
-FAIL Dynamically detaching assert_equals: expected "100px" but got "0px"
+FAIL Dynamically detaching assert_equals: expected "0px" but got "100px"
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "100px" but got "0px"
 FAIL Ancestor attached element becoming display:none/block assert_equals: expected "100px" but got "0px"
-FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
-FAIL Animations prefer non-deferred timelines assert_equals: expected "150px" but got "0px"
+FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "0px" but got "100px"
+PASS Animations prefer non-deferred timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Default view-timeline assert_equals: expected "-1" but got "0"
-FAIL Horizontal view-timeline assert_equals: expected "0" but got "-1"
+FAIL Horizontal view-timeline assert_equals: expected "-1" but got "0"
 FAIL Multiple view-timelines on the same element assert_equals: expected "0" but got "-1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "3"
-FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "-1"
-FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "-1"
-FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "-1"
+FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "100"
+FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "50"
+FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "50"
+FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "50"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
@@ -1,9 +1,9 @@
 
 PASS view-timeline on self
-FAIL timeline-scope on preceding sibling assert_equals: expected "75" but got "-1"
-FAIL view-timeline on ancestor assert_equals: expected "25" but got "auto"
-FAIL timeline-scope on ancestor sibling assert_equals: expected "75" but got "auto"
+PASS timeline-scope on preceding sibling
+PASS view-timeline on ancestor
+PASS timeline-scope on ancestor sibling
 PASS timeline-scope on ancestor sibling, conflict remains unresolved
 PASS timeline-scope on ancestor sibling, closer timeline wins
-FAIL view-timeline on ancestor sibling, scroll-timeline wins on same element assert_equals: expected "0" but got "-1"
+PASS view-timeline on ancestor sibling, scroll-timeline wins on same element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can see view timeline defined by :host assert_equals: expected "y" but got "x"
-FAIL Outer animation can see view timeline defined by ::slotted assert_equals: expected "y" but got "x"
+PASS Outer animation can see view timeline defined by :host
+PASS Outer animation can see view timeline defined by ::slotted
 PASS Inner animation can see view timeline defined by ::part
 FAIL Slotted element can see view timeline within the shadow assert_equals: expected "y" but got "x"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Use the last value from view-timeline-axis if omitted assert_equals: expected "35" but got "45"
-FAIL Use the last value from view-timeline-inset if omitted assert_equals: expected "0" but got "-1"
+FAIL Use the last value from view-timeline-inset if omitted assert_equals: expected "50" but got "100"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
@@ -1,8 +1,8 @@
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input1 expected -74 +/- 0.1 but got -56.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -56.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -56.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got -56.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got -56.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -30.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -4.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got 21.59375
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got 47.59375
 Reservation Details
 Name:
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -126,10 +126,8 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
             [&] (Animation::TimelineKeyword keyword) {
                 setTimeline(keyword == Animation::TimelineKeyword::None ? nullptr : RefPtr { document->existingTimeline() });
             }, [&] (const AtomString& name) {
-                // FIXME: we should account for timeline-scope here.
                 CheckedRef timelinesController = document->ensureTimelinesController();
-                if (RefPtr timeline = timelinesController->timelineForName(name, target))
-                    setTimeline(WTFMove(timeline));
+                timelinesController->setTimelineForName(name, target, *this);
             }, [&] (Ref<ScrollTimeline> anonymousTimeline) {
                 if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(anonymousTimeline))
                     viewTimeline->setSubject(target.ptr());

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -189,6 +189,11 @@ Element* ScrollTimeline::sourceElementForProgressCalculation() const
     return nullptr;
 }
 
+void ScrollTimeline::setTimelineScopeElement(const Element& element)
+{
+    m_timelineScopeElement = WeakPtr { &element };
+}
+
 ScrollableArea* ScrollTimeline::scrollableAreaForSourceRenderer(RenderElement* renderer, Ref<Document> document)
 {
     CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer);

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -26,9 +26,11 @@
 #pragma once
 
 #include "AnimationTimeline.h"
+#include "Element.h"
 #include "ScrollAxis.h"
 #include "ScrollTimelineOptions.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -67,6 +69,9 @@ public:
 
     std::optional<WebAnimationTime> currentTime(const TimelineRange&) override;
     TimelineRange defaultRange() const override;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> timelineScopeDeclaredElement() const { return m_timelineScopeElement; }
+    void setTimelineScopeElement(const Element&);
+    void clearTimelineScopeDeclaredElement() { m_timelineScopeElement = nullptr; }
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
@@ -93,6 +98,7 @@ private:
     ScrollAxis m_axis { ScrollAxis::Block };
     AtomString m_name;
     Scroller m_scroller { Scroller::Self };
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_timelineScopeElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -28,6 +28,7 @@
 
 #include "AXObjectCache.h"
 #include "AnchorPositionEvaluator.h"
+#include "AnimationTimelinesController.h"
 #include "CSSFontSelector.h"
 #include "ComposedTreeAncestorIterator.h"
 #include "ComposedTreeIterator.h"
@@ -675,6 +676,11 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         if ((oldStyle && oldStyle->viewTimelines().size()) || resolvedStyle.style->viewTimelines().size()
             || (oldStyle && oldStyle->viewTimelineNames().size()) || resolvedStyle.style->viewTimelineNames().size()) {
             styleable.updateCSSViewTimelines(oldStyle, *resolvedStyle.style);
+        }
+
+        if ((oldStyle && oldStyle->timelineScope().type != TimelineScope::Type::None) || resolvedStyle.style->timelineScope().type != TimelineScope::Type::None) {
+            CheckedRef timelinesController = element.protectedDocument()->ensureTimelinesController();
+            timelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), element);
         }
 
         // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style


### PR DESCRIPTION
#### 28e4fdec7bdd67ab22f5b205e0a57305150d88c0
<pre>
[scroll-animations] Implement timeline-scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=282072">https://bugs.webkit.org/show_bug.cgi?id=282072</a>
<a href="https://rdar.apple.com/138597234">rdar://138597234</a>

Reviewed by Antoine Quint.

Scope named timeline lookups to particular subtree of declared element&apos;s subtree and
implement the timeline-scope property.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-used-values-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::originatingElement):
(WebCore::originatingElementIncludingTimelineScope):
(WebCore::originatingElementExcludingTimelineScope):
(WebCore::AnimationTimelinesController::relatedTimelineScopeElements):
(WebCore::determineTreeOrder):
(WebCore::determineTimelineForElement):
(WebCore::AnimationTimelinesController::updateTimelineForTimelineScope):
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::attachPendingOperations):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedTimeline):
(WebCore::AnimationTimelinesController::setTimelineForName):
(WebCore::updateTimelinesForTimelineScope):
(WebCore::AnimationTimelinesController::updateNamedTimelineMapForTimelineScope):
(WebCore::AnimationTimelinesController::timelineForName const): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::setTimelineScopeElement):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::timelineScopeDeclaredElement const):
(WebCore::ScrollTimeline::clearTimelineScopeDeclaredElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/286771@main">https://commits.webkit.org/286771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcea93e86ff1968a3ec40cfecdd8d0b99a7c2b6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60343 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40654 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82982 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67866 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9932 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7141 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->