### PR TITLE
[css-view-transitions] https://simple-set-demos.glitch.me/5-heading-text/ glitches

### DIFF
--- a/LayoutTests/fast/css/view-transitions-hide-under-page-background-color-expected.html
+++ b/LayoutTests/fast/css/view-transitions-hide-under-page-background-color-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE HTML>
+<html>
+</html>

--- a/LayoutTests/fast/css/view-transitions-hide-under-page-background-color.html
+++ b/LayoutTests/fast/css/view-transitions-hide-under-page-background-color.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<script>
+    function finishTest() {
+        document.documentElement.classList.remove("reftest-wait");
+    }
+    async function startTest() {
+        document.startViewTransition(() => requestAnimationFrame(() => requestAnimationFrame(finishTest)));
+    }
+    onload = () => requestAnimationFrame(() => requestAnimationFrame(startTest));
+
+    if (window.internals)
+        internals.setUnderPageBackgroundColorOverride("red");
+</script>
+<style>
+    html::view-transition-group(root) { animation-duration: 300s; }
+    html::view-transition-new(root) { animation: unset; opacity: 0; }
+    html::view-transition-old(root) { animation: unset; opacity: 0; }
+</style>

--- a/Source/WebCore/css/color/CSSUnresolvedColorResolutionState.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColorResolutionState.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 enum class CSSUnresolvedLightDarkAppearance : bool;
 
-class CSSUnresolvedColorResolutionDelegate {
+class WEBCORE_EXPORT CSSUnresolvedColorResolutionDelegate {
 public:
     virtual ~CSSUnresolvedColorResolutionDelegate();
 

--- a/Source/WebCore/css/parser/CSSParserFastPaths.h
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.h
@@ -55,7 +55,7 @@ public:
     static bool isKeywordValidForStyleProperty(CSSPropertyID, CSSValueID, const CSSParserContext&);
 
     // Parses numeric and named colors.
-    static std::optional<SRGBA<uint8_t>> parseSimpleColor(StringView, bool strict = false);
+    static WEBCORE_EXPORT std::optional<SRGBA<uint8_t>> parseSimpleColor(StringView, bool strict = false);
     static std::optional<SRGBA<uint8_t>> parseHexColor(StringView); // Hex colors of length 3, 4, 6, or 8, without leading "#".
     static std::optional<SRGBA<uint8_t>> parseNamedColor(StringView);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -58,7 +58,7 @@ RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange&, const CSSParserCont
 Color consumeColorRaw(CSSParserTokenRange&, const CSSParserContext&, const CSSColorParsingOptions&, CSSUnresolvedColorResolutionState&);
 
 // MARK: <color> parsing (raw)
-Color parseColorRawSlow(const String&, const CSSParserContext&, const CSSColorParsingOptions&, CSSUnresolvedColorResolutionState&);
+WEBCORE_EXPORT Color parseColorRawSlow(const String&, const CSSParserContext&, const CSSColorParsingOptions&, CSSUnresolvedColorResolutionState&);
 
 template<typename F> Color parseColorRaw(const String& string, const CSSParserContext& context, F&& lazySlowPathOptionsFunctor)
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -686,7 +686,7 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const;
     CSSCounterStyleRegistry& counterStyleRegistry();
 
-    CSSParserContext cssParserContext() const;
+    WEBCORE_EXPORT CSSParserContext cssParserContext() const;
     void invalidateCachedCSSParserContext();
 
     bool gotoAnchorNeededAfterStylesheetsLoad() { return m_gotoAnchorNeededAfterStylesheetsLoad; }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4659,6 +4659,24 @@ void RenderLayerCompositor::rootOrBodyStyleChanged(RenderElement& renderer, cons
     }
 }
 
+void RenderLayerCompositor::setRootElementCapturedInViewTransition(bool captured)
+{
+    if (m_rootElementCapturedInViewTransition == captured)
+        return;
+    m_rootElementCapturedInViewTransition = captured;
+    updateRootContentsLayerBackgroundColor();
+}
+
+void RenderLayerCompositor::updateRootContentsLayerBackgroundColor()
+{
+    if (!m_rootContentsLayer)
+        return;
+    if (m_rootElementCapturedInViewTransition)
+        m_rootContentsLayer->setBackgroundColor(m_viewBackgroundColor);
+    else
+        m_rootContentsLayer->setBackgroundColor(Color());
+}
+
 void RenderLayerCompositor::rootBackgroundColorOrTransparencyChanged()
 {
     if (!usesCompositing())
@@ -4688,6 +4706,7 @@ void RenderLayerCompositor::rootBackgroundColorOrTransparencyChanged()
 #if HAVE(RUBBER_BANDING)
         updateLayerForOverhangAreasBackgroundColor();
 #endif
+        updateRootContentsLayerBackgroundColor();
     }
     
     rootLayerConfigurationChanged();
@@ -4825,6 +4844,7 @@ void RenderLayerCompositor::ensureRootLayer()
 
         // Need to clip to prevent transformed content showing outside this frame
         updateRootContentLayerClipping();
+        updateRootContentsLayerBackgroundColor();
     }
 
     if (requiresScrollLayer(expectedAttachment)) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -360,6 +360,8 @@ public:
     void updateSizeAndPositionForOverhangAreaLayer();
 #endif // HAVE(RUBBER_BANDING)
 
+    void updateRootContentsLayerBackgroundColor();
+
     // FIXME: make the coordinated/async terminology consistent.
     bool isViewportConstrainedFixedOrStickyLayer(const RenderLayer&) const;
     bool useCoordinatedScrollingForLayer(const RenderLayer&) const;
@@ -390,6 +392,8 @@ public:
     const Color& rootExtendedBackgroundColor() const { return m_rootExtendedBackgroundColor; }
 
     void updateRootContentLayerClipping();
+
+    void setRootElementCapturedInViewTransition(bool);
 
     void updateScrollSnapPropertiesWithFrameView(const LocalFrameView&) const;
 
@@ -619,6 +623,7 @@ private:
     bool m_flushingLayers { false };
     bool m_shouldFlushOnReattach { false };
     bool m_forceCompositingMode { false };
+    bool m_rootElementCapturedInViewTransition { false };
 
     bool m_isTrackingRepaints { false }; // Used for testing.
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1832,9 +1832,10 @@ void RenderObject::setCapturedInViewTransition(bool captured)
         m_stateBitfields.setFlag(StateFlag::CapturedInViewTransition, captured);
 
         CheckedPtr<RenderLayer> layerToInvalidate;
-        if (isDocumentElementRenderer())
+        if (isDocumentElementRenderer()) {
             layerToInvalidate = view().layer();
-        else if (hasLayer())
+            view().compositor().setRootElementCapturedInViewTransition(captured);
+        } else if (hasLayer())
             layerToInvalidate = downcast<RenderLayerModelObject>(*this).layer();
 
         if (layerToInvalidate) {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -377,6 +377,7 @@ public:
 
     ExceptionOr<String> viewBaseBackgroundColor();
     ExceptionOr<void> setViewBaseBackgroundColor(const String& colorValue);
+    ExceptionOr<void> setUnderPageBackgroundColorOverride(const String& colorValue);
 
     ExceptionOr<String> documentBackgroundColor();
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -590,6 +590,7 @@ enum RenderingMode {
 
     DOMString viewBaseBackgroundColor();
     undefined setViewBaseBackgroundColor(DOMString colorValue);
+    undefined setUnderPageBackgroundColorOverride(DOMString colorValue);
 
     DOMString documentBackgroundColor();
 


### PR DESCRIPTION
#### c3c287eed0e50afb009294c6fa02389e36858489
<pre>
[css-view-transitions] <a href="https://simple-set-demos.glitch.me/5-heading-text/">https://simple-set-demos.glitch.me/5-heading-text/</a> glitches
<a href="https://bugs.webkit.org/show_bug.cgi?id=279962">https://bugs.webkit.org/show_bug.cgi?id=279962</a>
&lt;<a href="https://rdar.apple.com/136324427">rdar://136324427</a>&gt;

Reviewed by Wenson Hsieh and Tim Nguyen.

When a view transition captures the root element, we reparent the RenderView&apos;s
layer into the new snapshot, which takes the view&apos;s background color with it.

Normally this color is also present on the overhang areas layer, but in some
cases it can be overwritten by the &apos;under page background color override&apos;. That
color should only be visible for overscrolling, and with view transitions it can
be visible across the whole page if the snapshots aren&apos;t visible for any reason.

Add the view&apos;s background color to the &apos;contents root&apos; layer too, so that it
always obscures the under page background color (in the page area). This should
be fine to do unconditionally, but I&apos;ve made it only happen during a view
transition (with the root element captured) to reduce any risk from this change.

There are still some corner cases where which colors should be in the
view-transition snapshots and which shouldn&apos;t is underdefined, for which I&apos;ve
filed <a href="https://github.com/w3c/csswg-drafts/issues/11083">https://github.com/w3c/csswg-drafts/issues/11083</a>

* LayoutTests/fast/css/view-transitions-hide-under-page-background-color-expected.html: Added.
* LayoutTests/fast/css/view-transitions-hide-under-page-background-color.html: Added.
* Source/WebCore/css/color/CSSUnresolvedColorResolutionState.h:
(WebCore::CSSUnresolvedColorResolutionDelegate::currentColor const): Deleted.
(WebCore::CSSUnresolvedColorResolutionDelegate::internalDocumentTextColor const): Deleted.
(WebCore::CSSUnresolvedColorResolutionDelegate::webkitLink const): Deleted.
(WebCore::CSSUnresolvedColorResolutionDelegate::webkitLinkVisited const): Deleted.
(WebCore::CSSUnresolvedColorResolutionDelegate::webkitActiveLink const): Deleted.
(WebCore::CSSUnresolvedColorResolutionDelegate::webkitFocusRingColor const): Deleted.
* Source/WebCore/css/parser/CSSParserFastPaths.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::setRootElementCapturedInViewTransition):
(WebCore::RenderLayerCompositor::updateRootContentsLayerBackgroundColor):
(WebCore::RenderLayerCompositor::rootBackgroundColorOrTransparencyChanged):
(WebCore::RenderLayerCompositor::ensureRootLayer):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setCapturedInViewTransition):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setUnderPageBackgroundColorOverride):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/285812@main">https://commits.webkit.org/285812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c1567eaf48614cbde11d905a4f52a884caa5072

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26732 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25159 "Failed to checkout and rebase branch from PR 35699") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1135 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/25159 "Failed to checkout and rebase branch from PR 35699") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1238 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/79811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1381 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/9612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1202 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->