### PR TITLE
RenderViewTransitionCapture unconditionally allocates a backing store.

### DIFF
--- a/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
@@ -1,0 +1,36 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (backgroundColor #FFFFFF)
+  (children 1
+    (GraphicsLayer
+      (preserves3D 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (children 2
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (opacity 0.00)
+                )
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 800.00 600.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo.html
+++ b/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<script>
+    function finishTest() {
+        if (window.internals)
+            document.getElementById("results").textContent = internals.layerTreeAsText(document);
+        document.documentElement.classList.remove("reftest-wait");
+    }
+    async function startTest() {
+        document.startViewTransition(() => requestAnimationFrame(() => requestAnimationFrame(finishTest)));
+    }
+    onload = () => requestAnimationFrame(() => requestAnimationFrame(startTest));
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<style>
+    html::view-transition-group(root) { animation-duration: 300s; }
+    html::view-transition-new(root) { animation: unset; opacity: 1; }
+    html::view-transition-old(root) { animation: unset; opacity: 0; }
+</style>
+<body>
+<pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
@@ -1,0 +1,30 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (preserves3D 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 800.00 600.00)
+          (children 2
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (opacity 0.00)
+            )
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4391,3 +4391,5 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/background-image.html [ Im
 imported/w3c/web-platform-tests/css/css-viewport/zoom/image-intrinsic-size.html [ ImageOnlyFailure Pass ]
 
 http/tests/login-status/login-status-api-getter-setter-functions.html [ Failure ]
+
+fast/css/view-transitions-no-content-for-new-pseudo.html [ Failure ]

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -489,4 +489,9 @@ CursorDirective RenderEmbeddedObject::getCursor(const LayoutPoint& point, Cursor
     return RenderWidget::getCursor(point, cursor);
 }
 
+bool RenderEmbeddedObject::paintsContent() const
+{
+    return !requiresAcceleratedCompositing();
+}
+
 }

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -68,6 +68,8 @@ public:
     void willAttachScrollingNode();
     void didAttachScrollingNode();
 
+    bool paintsContent() const final;
+
 private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
     void paint(PaintInfo&, const LayoutPoint&) final;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2958,12 +2958,6 @@ bool RenderLayerBacking::paintsContent(RenderLayer::PaintedContentRequest& reque
     return paintsContent;
 }
 
-static bool isCompositedPlugin(RenderObject& renderer)
-{
-    auto* embeddedObject = dynamicDowncast<RenderEmbeddedObject>(renderer);
-    return embeddedObject && embeddedObject->requiresAcceleratedCompositing();
-}
-
 // A "simple container layer" is a RenderLayer which has no visible content to render.
 // It may have no children, or all its children may be themselves composited.
 // This is a useful optimization, because it allows us to avoid allocating backing store.
@@ -2975,8 +2969,10 @@ bool RenderLayerBacking::isSimpleContainerCompositingLayer(PaintedContentsInfo& 
     if (hasBackingSharingLayers())
         return false;
 
-    if (renderer().isRenderReplaced() && !isCompositedPlugin(renderer()))
-        return false;
+    if (auto* replaced = dynamicDowncast<RenderReplaced>(renderer())) {
+        if (replaced->paintsContent())
+            return false;
+    }
 
     if (renderer().isRenderTextControl())
         return false;

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -48,6 +48,8 @@ public:
 
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
 
+    virtual bool paintsContent() const { return true; }
+
 protected:
     RenderReplaced(Type, Element&, RenderStyle&&, OptionSet<ReplacedFlag> = { });
     RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<ReplacedFlag> = { });

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -119,6 +119,13 @@ Node* RenderViewTransitionCapture::nodeForHitTest() const
     return document().documentElement();
 }
 
+bool RenderViewTransitionCapture::paintsContent() const
+{
+    if (style().pseudoElementType() == PseudoId::ViewTransitionOld)
+        return true;
+    return !canUseExistingLayers();
+}
+
 String RenderViewTransitionCapture::debugDescription() const
 {
     StringBuilder builder;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -54,6 +54,8 @@ public:
 
     bool canUseExistingLayers() const { return !hasNonVisibleOverflow(); }
 
+    bool paintsContent() const final;
+
 private:
     ASCIILiteral renderName() const override { return "RenderViewTransitionCapture"_s; }
     String debugDescription() const override;


### PR DESCRIPTION
#### 2c059ec5441d7d1553910f1224059f9a28b28ec3
<pre>
RenderViewTransitionCapture unconditionally allocates a backing store.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282077">https://bugs.webkit.org/show_bug.cgi?id=282077</a>
&lt;<a href="https://rdar.apple.com/138601957">rdar://138601957</a>&gt;

Reviewed by Tim Nguyen.

The RenderLayerBacking for RenderViewTransitionCapture always allocates a
backing store, since isSimpleContainerCompositingLayer always returns false for
RenderReplaced subclasses.

When being used for a ::view-transition-new() pseudo element, this layer just
exists to attach other composited layers to, and doesn&apos;t draw anything itself
(unless it has box decorations etc).

* LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt: Added.
* LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo.html: Added.
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::paintsContent const):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isSimpleContainerCompositingLayer const):
(WebCore::isCompositedPlugin): Deleted.
* Source/WebCore/rendering/RenderReplaced.h:
(WebCore::RenderReplaced::paintsContent const):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::paintsContent const):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/285978@main">https://commits.webkit.org/285978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa5ec2638951616f06fecfb91253ec1f4b6c6f3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16764 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21453 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80252 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/964 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66730 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63976 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16396 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8108 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1635 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->