### PR TITLE
Web Inspector: Network: allow the method of Request Local Overrides to passthrough

### DIFF
--- a/LayoutTests/http/tests/inspector/network/intercept-request-properties.html
+++ b/LayoutTests/http/tests/inspector/network/intercept-request-properties.html
@@ -179,7 +179,6 @@ function test()
         description: "Tests request headers passthrough with a new header",
         expression: "postData('resources/intercept-echo.py')",
         override: {
-            requestMethod: "POST",
             requestData: "value=overridden",
             requestHeaders: { "X-Expected": "PASS" },
             isPassthrough: true,
@@ -191,7 +190,6 @@ function test()
         description: "Tests request headers passthrough with an overridden header",
         expression: "postData('resources/intercept-echo.py', {'X-Expected': 'FAIL'})",
         override: {
-            requestMethod: "POST",
             requestData: "value=overridden",
             requestHeaders: { "X-Expected": "PASS" },
             isPassthrough: true,

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -101,6 +101,7 @@ localizedStrings["(local override)"] = "(local override)";
 localizedStrings["(many)"] = "(many)";
 localizedStrings["(memory)"] = "(memory)";
 localizedStrings["(multiple)"] = "(multiple)";
+localizedStrings["(passthrough)"] = "(passthrough)";
 localizedStrings["(program)"] = "(program)";
 localizedStrings["(service worker)"] = "(service worker)";
 localizedStrings["(uninitialized)"] = "(uninitialized)";

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -833,7 +833,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             type: cachedResourcePayload.type,
             loaderIdentifier,
             requestIdentifier,
-            requestMethod: "GET",
+            requestMethod: WI.HTTPUtilities.RequestMethod.GET,
             requestSentTimestamp: elapsedTime,
             initiatorStackTrace: this._initiatorStackTraceFromPayload(initiator),
             initiatorSourceCodeLocation: this._initiatorSourceCodeLocationFromPayload(initiator),
@@ -992,19 +992,20 @@ WI.NetworkManager = class NetworkManager extends WI.Object
                 return;
 
             case WI.LocalResourceOverride.InterceptType.Request: {
+                let method = localResource.requestMethod ?? (isPassthrough ? request.method : "");
                 target.NetworkAgent.interceptWithRequest.invoke({
                     requestId,
                     url: localResourceOverride.generateRequestRedirectURL(request.url) ?? undefined,
-                    method: localResource.requestMethod ?? (isPassthrough ? request.method : ""),
+                    method,
                     headers: {...originalHeaders, ...localResource.requestHeaders},
                     postData: (function() {
-                        if (!WI.HTTPUtilities.RequestMethodsWithBody.has(localResource.requestMethod))
-                            return undefined;
-                        if (localResource.requestData ?? false)
-                            return btoa(localResource.requestData);
-                        if (isPassthrough)
-                            return request.data;
-                        return "";
+                        if (method && WI.HTTPUtilities.RequestMethodsWithBody.has(method)) {
+                            if (localResource.requestData ?? false)
+                                return btoa(localResource.requestData);
+                            if (isPassthrough)
+                                return request.data;
+                        }
+                        return undefined;
                     })(),
                 });
                 return;

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -1235,7 +1235,7 @@ WI.Resource = class Resource extends WI.SourceCode
         for (let key in this.requestHeaders)
             command.push("-H " + escapeStringPosix(`${key}: ${this.requestHeaders[key]}`));
 
-        if (this.requestDataContentType && this.requestMethod !== "GET" && this.requestData) {
+        if (this.requestDataContentType && this.requestMethod !== WI.HTTPUtilities.RequestMethod.GET && this.requestData) {
             if (this.requestDataContentType.match(/^application\/x-www-form-urlencoded\s*(;.*)?$/i))
                 command.push("--data " + escapeStringPosix(this.requestData));
             else

--- a/Source/WebInspectorUI/UserInterface/Models/WebSocketResource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/WebSocketResource.js
@@ -31,7 +31,7 @@ WI.WebSocketResource = class WebSocketResource extends WI.Resource
             type: WI.Resource.Type.WebSocket,
             loaderIdentifier,
             requestIdentifier,
-            requestMethod: "GET",
+            requestMethod: WI.HTTPUtilities.RequestMethod.GET,
             requestHeaders,
             requestSentTimestamp,
         });

--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideRequestContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideRequestContentView.js
@@ -99,7 +99,7 @@ WI.LocalResourceOverrideRequestContentView = class LocalResourceOverrideRequestC
 
         case WI.LocalResourceOverride.InterceptType.Request: {
             let requestMethod = this.representedObject.localResource.requestMethod;
-            if (!WI.HTTPUtilities.RequestMethodsWithBody.has(requestMethod))
+            if (requestMethod && !WI.HTTPUtilities.RequestMethodsWithBody.has(requestMethod))
                 message = WI.UIString("%s requests do not have a body").format(requestMethod);
             break;
         }


### PR DESCRIPTION
#### 8b9a751017aa0d969a219404b0d59def58c92acb
<pre>
Web Inspector: Network: allow the method of Request Local Overrides to passthrough
<a href="https://bugs.webkit.org/show_bug.cgi?id=282076">https://bugs.webkit.org/show_bug.cgi?id=282076</a>

Reviewed by Anne van Kesteren.

This allows developers to use a Request Local Override to add headers to all requests matching the given URL without modifying any of the other data.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.resourceRequestWasServedFromMemoryCache):
(WI.NetworkManager.prototype.requestIntercepted):

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js:
(WI.LocalResourceOverridePopover.prototype.get serializedData):
(WI.LocalResourceOverridePopover.prototype.show):
Add a passthrough option to the method select when passthrough is enabled.

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideRequestContentView.js:
(WI.LocalResourceOverrideRequestContentView.prototype.initialLayout):
Only show the message about the request not having a body if the request method exists and is one of those.

* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource):
* Source/WebInspectorUI/UserInterface/Models/WebSocketResource.js:
(WI.WebSocketResource):
Drive-by: use `WI.HTTPUtilities.RequestMethod.GET` instead of `&quot;GET&quot;`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/http/tests/inspector/network/intercept-request-properties.html:

Canonical link: <a href="https://commits.webkit.org/286679@main">https://commits.webkit.org/286679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a860aa2604a8672b3c5c8a3eee2a81d4b9e56c3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24752 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16196 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7476 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->