### PR TITLE
imported/w3c/web-platform-tests/css/css-view-transitions/[new|old]-content-intrinsic-aspect-ratio.html are flaky failures

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7552,7 +7552,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-no
 
 # Flakes
 imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]
-imported/w3c/web-platform-tests/css/css-view-transitions/old-content-intrinsic-aspect-ratio.html [ ImageOnlyFailure Pass ]
 # webkit.org/b/278352
 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html [ Pass ImageOnlyFailure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7428,9 +7428,6 @@ imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-block
 # webkit.org/b/278352 [ iOS MacOS ] imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html is a flaky image failure
 imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html [ Pass ImageOnlyFailure ]
 
-# webkit.org/b/277841 REGRESSION (281870@main): [ macOS iOS wk2 ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html is a flaky failure
-imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html [ Pass ImageOnlyFailure ]
-
 # webkit.org/b/278934 [ macOS iOS wk2 ] imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html is a flaky failure.
 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Failure Pass ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1758,9 +1758,6 @@ webkit.org/b/275873 storage/indexeddb/database-transaction-cycle.html [ Pass Fai
 
 webkit.org/b/276389 media/video-transformed.html [ Pass Failure ] 
 
-# webkit.org/b/277841 [ macOS wk2 ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html is a flaky failure
-imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html [ Pass ImageOnlyFailure ]
-
 # rdar://132528380 (REGRESSION (281042@main): [ macOS ] 2x tiled-drawing/scrolling/overflow/overflow-scrolled-* is flaky failing.
 tiled-drawing/scrolling/overflow/overflow-scrolled-down-tile-coverage.html [ Pass Failure ]
 tiled-drawing/scrolling/overflow/overflow-scrolled-up-tile-coverage.html [ Pass Failure ]

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -431,7 +431,7 @@ public:
     bool descendantDependentFlagsAreDirty() const
     {
         return m_visibleDescendantStatusDirty || m_visibleContentStatusDirty || m_hasSelfPaintingLayerDescendantDirty
-            || m_hasNotIsolatedBlendingDescendantsStatusDirty || m_hasIntrinsicallyCompositedDescendantsStatusDirty;
+            || m_hasNotIsolatedBlendingDescendantsStatusDirty || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty;
     }
 
     bool isPaintingSVGResourceLayer() const { return m_isPaintingSVGResourceLayer; }
@@ -1224,12 +1224,13 @@ private:
     void updateAncestorChainHasBlendingDescendants();
     void dirtyAncestorChainHasBlendingDescendants();
 
-    void updateAncestorChainHasIntrinsicallyCompositedDescendants();
-    void dirtyAncestorChainHasIntrinsicallyCompositedDescendants();
+    void updateAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
+    void dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
 
-    bool isIntrinsicallyComposited() const { return m_intrinsicallyComposited; }
-    bool hasIntrinsicallyCompositedDescendants() const { return m_hasIntrinsicallyCompositedDescendants; }
+    bool alwaysIncludedInZOrderLists() const { return m_alwaysIncludedInZOrderLists; }
+    bool hasAlwaysIncludedInZOrderListsDescendants() const { return m_hasAlwaysIncludedInZOrderListsDescendants; }
     void setIntrinsicallyComposited(bool);
+    void updateAlwaysIncludedInZOrderLists();
 
     Ref<ClipRects> parentClipRects(const ClipRectsContext&) const;
     ClipRect backgroundClipRect(const ClipRectsContext&) const;
@@ -1339,8 +1340,9 @@ private:
     bool m_repaintRectsValid : 1;
 
     bool m_intrinsicallyComposited : 1 { false };
-    bool m_hasIntrinsicallyCompositedDescendants : 1 { false };
-    bool m_hasIntrinsicallyCompositedDescendantsStatusDirty : 1 { true };
+    bool m_alwaysIncludedInZOrderLists : 1 { false };
+    bool m_hasAlwaysIncludedInZOrderListsDescendants : 1 { false };
+    bool m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty : 1 { true };
 
     bool m_wasOmittedFromZOrderTree : 1 { false };
 


### PR DESCRIPTION
#### 838ee16a73415cc4d7270bc9a56db6bd2dfa87a5
<pre>
imported/w3c/web-platform-tests/css/css-view-transitions/[new|old]-content-intrinsic-aspect-ratio.html are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=277841">https://bugs.webkit.org/show_bug.cgi?id=277841</a>
&lt;<a href="https://rdar.apple.com/133608035">rdar://133608035</a>&gt;

Reviewed by Simon Fraser.

Visibility:hidden element with a layer get omitted from the RenderLayer z-order
tree, since they don&apos;t render or hit test.  View transitions walks the
RenderLayer z-order tree in order to determine paint order, and still needs to
find visibility:hidden elements with a view-transition-name.

Repurpose and rename the existing intrically composited descendant flags to be a
&apos;must be in z-order lists&apos; override, and include having a view transition name
in that. Make sure we invalidate the z-order lists if we start/stop having a
name.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::collectLayers):
(WebCore::RenderLayer::setIntrinsicallyComposited):
(WebCore::RenderLayer::updateMustBeInZOrderLists):
(WebCore::RenderLayer::updateAncestorChainHasMustBeInZOrderListsDescendants):
(WebCore::RenderLayer::dirtyAncestorChainHasMustBeInZOrderListsDescendants):
(WebCore::RenderLayer::updateDescendantDependentFlags):
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::RenderLayer::updateAncestorChainHasIntrinsicallyCompositedDescendants): Deleted.
(WebCore::RenderLayer::dirtyAncestorChainHasIntrinsicallyCompositedDescendants): Deleted.
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/285988@main">https://commits.webkit.org/285988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/531eae10984223a03779ae22112415360a94307c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16769 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21455 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8110 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4426 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->