### PR TITLE
[Observable] Use AbortSignal directly

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1102,7 +1102,6 @@ dom/StaticNodeList.cpp
 dom/StaticRange.cpp
 dom/StyledElement.cpp
 dom/Subscriber.cpp
-dom/Subscriber.h
 dom/TextDecoderStreamDecoder.h
 dom/Traversal.cpp
 dom/TreeScope.cpp

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -50,7 +50,9 @@ public:
     void addTeardown(Ref<VoidCallback>);
 
     bool active() { return m_active; }
-    AbortSignal& signal() { return m_abortController->signal(); }
+    AbortSignal& signal() { return m_signal.get(); }
+
+    Ref<AbortSignal> protectedSignal() const { return m_signal; }
 
     static Ref<Subscriber> create(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);
 
@@ -85,7 +87,7 @@ private:
 
     bool m_active = true;
     Lock m_teardownsLock;
-    Ref<AbortController> m_abortController;
+    Ref<AbortSignal> m_signal;
     Ref<InternalObserver> m_observer;
     SubscribeOptions m_options;
     Vector<Ref<VoidCallback>> m_teardowns WTF_GUARDED_BY_LOCK(m_teardownsLock);


### PR DESCRIPTION
#### 39636bf8cda7370d8b98b48ce85bd37263852748
<pre>
[Observable] Use AbortSignal directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=282069">https://bugs.webkit.org/show_bug.cgi?id=282069</a>

Reviewed by Chris Dumez.

As AbortController wraps an AbortSignal, there is no need for our
internal code to go through it as well. We save allocations, and still
entirely spec complaint. Seeing as the spec reads &quot;to signal abort&quot; in various
parts, which is only a concept on abort signals anyway.

* Source/WebCore/dom/InternalObserverFirst.cpp:
(WebCore::createInternalObserverOperatorFirst):
  The visitor signal should just be an AbortSignal, than through the
  AbortController bindings.
  Drive-by: Repeated Ref { m_promise } -&gt; protectedPromise
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::Subscriber):
  Construct a new AbortSignal, than AbortController
(WebCore::Subscriber::close):
  We need to signalAbort the AbortSignal, than abort the AbortController
* Source/WebCore/dom/Subscriber.h:

Canonical link: <a href="https://commits.webkit.org/285723@main">https://commits.webkit.org/285723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad62a5a593de4f8545531656f694616658739c0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/824 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48030 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63334 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23181 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79498 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/402 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7561 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/891 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->