### PR TITLE
Update W3C URLPattern API Test Results based on URLPatternInit changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.serviceworker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.sharedworker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.worker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.serviceworker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.sharedworker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.worker-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Loading data...
-FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} Can't find variable: URLPattern
-FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} Can't find variable: URLPattern
-FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Can't find variable: URLPattern
-FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} Can't find variable: URLPattern
-FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} Can't find variable: URLPattern
-FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} Can't find variable: URLPattern
-FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} Can't find variable: URLPattern
-FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} Can't find variable: URLPattern
-FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} Can't find variable: URLPattern
-FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} Can't find variable: URLPattern
+FAIL Component: pathname Left: {"pathname":"/foo/a"} Right: {"pathname":"/foo/b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/b"} Right: {"pathname":"/foo/bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/bar"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/"} Right: {"pathname":"/foo/:bar"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:bar"} Right: {"pathname":"/foo/*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/(bar)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}"} Right: {"pathname":"/foo/{bar}+"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}+"} Right: {"pathname":"/foo/{bar}?"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}?"} Right: {"pathname":"/foo/{bar}*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/(123)"} Right: {"pathname":"/foo/(12)"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"/foo/:b"} Right: {"pathname":"/foo/:a"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"*/foo"} Right: {"pathname":"*"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: port Left: {"port":"9"} Right: {"port":"100"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo/{:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"fo{o/:bar}?/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: {"pathname":"foo/:bar?/baz"} Right: {"pathname":"foo{/:bar/}?baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: pathname Left: "https://a.example.com/b?a" Right: "https://b.example.com/a?b" Not implemented.
+FAIL Component: pathname Left: {"pathname":"/foo/{bar}/baz"} Right: {"pathname":"/foo/bar/baz"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: protocol Left: {"protocol":"a"} Right: {"protocol":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: username Left: {"username":"a"} Right: {"username":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: password Left: {"password":"a"} Right: {"password":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hostname Left: {"hostname":"a"} Right: {"hostname":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: search Left: {"search":"a"} Right: {"search":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
+FAIL Component: hash Left: {"hash":"a"} Right: {"hash":"b"} URLPattern.compareComponent is not a function. (In 'URLPattern.compareComponent(entry.component, left, right)', 'URLPattern.compareComponent' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups Can't find variable: URLPattern
+FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups Can't find variable: URLPattern
+FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups Can't find variable: URLPattern
+FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL urlpattern-hasregexpgroups Can't find variable: URLPattern
+FAIL urlpattern-hasregexpgroups assert_true: named regexp group in protocol expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -1,433 +1,367 @@
 
 PASS Loading data...
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://other.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar","baseURL":"http://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
+FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] The operation is not supported.
+FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
+FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
+FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
+FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
+FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
+FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
+FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
+FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Not implemented.
+FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Not implemented.
+FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Not implemented.
+FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":℘"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:℘"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":℘"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":℘"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":㐀"}] Inputs: [{"protocol":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":":㐀"}] Inputs: [{"username":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":":㐀"}] Inputs: [{"password":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Not implemented.
+FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Not implemented.
+FAIL Pattern: ["data:"] Inputs: ["data:"] Not implemented.
+FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Not implemented.
+FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Not implemented.
+FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] The operation is not supported.
+FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
+FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
+FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] The operation is not supported.
+FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] The operation is not supported.
+FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Not implemented.
+FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Not implemented.
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
+FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
+FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
+FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
+FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
+FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
+PASS Pattern: ["/foo",""] Inputs: undefined
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] Can't find variable: URLPattern
-FAIL Pattern: ["data:"] Inputs: ["data:"] Can't find variable: URLPattern
-FAIL Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"] Can't find variable: URLPattern
-FAIL Pattern: ["(café)://foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Can't find variable: URLPattern
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] Can't find variable: URLPattern
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Can't find variable: URLPattern
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: ["/foo",""] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: ["https://example.com/"] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [{}] Can't find variable: URLPattern
-FAIL Pattern: [] Inputs: [] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] Can't find variable: URLPattern
-FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Can't find variable: URLPattern
-FAIL Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "ReferenceError: Can't find variable: URLPattern" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Can't find variable: URLPattern
-FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Can't find variable: URLPattern
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] Can't find variable: URLPattern
-FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] Can't find variable: URLPattern
+FAIL Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+FAIL Pattern: [{}] Inputs: ["https://example.com/"] The operation is not supported.
+FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
+FAIL Pattern: [] Inputs: [{}] Not implemented.
+FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo.."}] Inputs: [{"pathname":"/bar.."}] The operation is not supported.
+FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
+FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.
+FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
+FAIL Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] The operation is not supported.
+FAIL Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] The operation is not supported.
+FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/3"}] The operation is not supported.
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7487,7 +7487,7 @@ UAVisualTransitionDetectionEnabled:
 URLPatternAPIEnabled:
   type: bool
   category: dom
-  status: unstable
+  status: testable
   humanReadableName: "URL Pattern API"
   humanReadableDescription: "Enable URL Pattern API"
   defaultValue:

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternCanonical.h"
 
+#include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -192,10 +193,7 @@ ExceptionOr<String> canonicalizePath(const String& pathnameValue, StringView pro
     if (pathnameValueType == BaseURLStringType::Pattern)
         return String { pathnameValue };
 
-    if (protocolValue == "ftp"_s || protocolValue == "file"_s
-        || protocolValue == "http"_s || protocolValue == "https"_s
-        || protocolValue == "ws"_s || protocolValue == "wss"_s) {
-
+    if (WTF::URLParser::isSpecialScheme(protocolValue)) {
         bool hasLeadingSlash = pathnameValue[0] == '/';
         auto maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue : makeString("/-"_s, pathnameValue);
 


### PR DESCRIPTION
#### 0d6e1aa69f56ab2f6ef2ec8df65bf11de374e7f4
<pre>
Update W3C URLPattern API Test Results based on URLPatternInit changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=282085">https://bugs.webkit.org/show_bug.cgi?id=282085</a>
<a href="https://rdar.apple.com/138617566">rdar://138617566</a>

Reviewed by Sihui Liu.

These are the updated w3c test results for the URLPatternInit changes implemented in another bugzilla ticket, see <a href="https://bugs.webkit.org/show_bug.cgi?id=281711.">https://bugs.webkit.org/show_bug.cgi?id=281711.</a>

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizePath):

Canonical link: <a href="https://commits.webkit.org/285756@main">https://commits.webkit.org/285756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87faa0c338b834cc995c4eb5263d5be028828e10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57866 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16275 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20822 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23179 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66745 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79496 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72865 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7557 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94647 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/889 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3639 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->