### PR TITLE
[CoordinatedGraphics] Rename NicosiaPaintingEngine as CairoPaintingEngine

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -86,7 +86,17 @@ if (USE_COORDINATED_GRAPHICS)
     endif ()
 
     if (USE_CAIRO)
+        list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+            platform/graphics/cairo/CairoPaintingEngine.h
+        )
+
         list(APPEND WebCore_SOURCES
+            platform/graphics/cairo/CairoOperationRecorder.cpp
+            platform/graphics/cairo/CairoPaintingContext.cpp
+            platform/graphics/cairo/CairoPaintingEngine.cpp
+            platform/graphics/cairo/CairoPaintingEngineBasic.cpp
+            platform/graphics/cairo/CairoPaintingEngineThreaded.cpp
+
             platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
         )
     elseif (USE_SKIA)
@@ -126,26 +136,6 @@ if (USE_NICOSIA)
         platform/graphics/nicosia/NicosiaScene.h
         platform/graphics/nicosia/NicosiaSceneIntegration.h
     )
-
-    if (USE_CAIRO)
-        list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
-            "${WEBCORE_DIR}/platform/graphics/nicosia/cairo"
-        )
-        list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
-            platform/graphics/nicosia/NicosiaPaintingEngine.h
-        )
-
-        # Currently NicosiaPaintingContext.cpp will cause a compilation error
-        # when building without USE_CAIRO so these are not in unified sources
-        list(APPEND WebCore_SOURCES
-            platform/graphics/nicosia/NicosiaPaintingContext.cpp
-            platform/graphics/nicosia/NicosiaPaintingEngine.cpp
-            platform/graphics/nicosia/NicosiaPaintingEngineBasic.cpp
-            platform/graphics/nicosia/NicosiaPaintingEngineThreaded.cpp
-
-            platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
-        )
-    endif ()
 endif ()
 
 if (USE_GRAPHICS_LAYER_WC)

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -30,14 +30,15 @@
 #pragma once
 
 #if USE(CAIRO)
+#include "CairoPaintingOperation.h"
 #include "GraphicsContext.h"
-#include "NicosiaPaintingOperation.h"
 
-namespace Nicosia {
+namespace WebCore {
+namespace Cairo {
 
-class CairoOperationRecorder final : public WebCore::GraphicsContext {
+class OperationRecorder final : public WebCore::GraphicsContext {
 public:
-    CairoOperationRecorder(PaintingOperations&);
+    OperationRecorder(PaintingOperations&);
 
 private:
     bool hasPlatformContext() const override { return false; }
@@ -120,6 +121,7 @@ private:
     Vector<State, 32> m_stateStack;
 };
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingContext.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingContext.cpp
@@ -27,18 +27,19 @@
  */
 
 #include "config.h"
-#include "NicosiaPaintingContext.h"
+#include "CairoPaintingContext.h"
 
 #if USE(CAIRO)
+#include "CairoOperationRecorder.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsContextCairo.h"
-#include "NicosiaCairoOperationRecorder.h"
 #include <cairo.h>
 #include <utility>
 #include <wtf/TZoneMallocInlines.h>
 
-namespace Nicosia {
+namespace WebCore {
+namespace Cairo {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PaintingContext);
 
@@ -83,7 +84,7 @@ PaintingContext::PaintingContext(WebCore::CoordinatedTileBuffer& baseBuffer)
 }
 
 PaintingContext::PaintingContext(PaintingOperations& paintingOperations)
-    : m_graphicsContext(makeUnique<CairoOperationRecorder>(paintingOperations))
+    : m_graphicsContext(makeUnique<OperationRecorder>(paintingOperations))
 {
 }
 
@@ -112,6 +113,7 @@ void PaintingContext::replay(const PaintingOperations& paintingOperations)
         operation->execute(context);
 }
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingContext.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingContext.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #if USE(CAIRO)
-#include "NicosiaPaintingOperation.h"
+#include "CairoPaintingOperation.h"
 #include "RefPtrCairo.h"
 #include <memory>
 #include <wtf/TZoneMalloc.h>
@@ -39,9 +39,8 @@ typedef struct _cairo_surface cairo_surface_t;
 namespace WebCore {
 class CoordinatedTileBuffer;
 class GraphicsContext;
-}
 
-namespace Nicosia {
+namespace Cairo {
 
 class PaintingContext {
     WTF_MAKE_TZONE_ALLOCATED(PaintingContext);
@@ -86,6 +85,7 @@ private:
 #endif
 };
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.h
@@ -28,17 +28,29 @@
 
 #pragma once
 
-#include "NicosiaPaintingEngine.h"
+#if USE(CAIRO)
+#include <memory>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 
-namespace Nicosia {
+namespace WebCore {
+class CoordinatedTileBuffer;
+class GraphicsLayer;
+class IntRect;
 
-class PaintingEngineBasic final : public PaintingEngine {
+namespace Cairo {
+
+class PaintingEngine {
+    WTF_MAKE_TZONE_ALLOCATED(PaintingEngine);
 public:
-    PaintingEngineBasic();
-    virtual ~PaintingEngineBasic();
+    WEBCORE_EXPORT static std::unique_ptr<PaintingEngine> create();
 
-private:
-    void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
+    virtual ~PaintingEngine() = default;
+
+    virtual void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) = 0;
 };
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
+
+#endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.cpp
@@ -27,16 +27,16 @@
  */
 
 #include "config.h"
-#include "NicosiaPaintingEngineBasic.h"
+#include "CairoPaintingEngineBasic.h"
 
+#if USE(CAIRO)
+#include "CairoPaintingContext.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
-#include "NicosiaPaintingContext.h"
 
-namespace Nicosia {
-
-using namespace WebCore;
+namespace WebCore {
+namespace Cairo {
 
 PaintingEngineBasic::PaintingEngineBasic() = default;
 PaintingEngineBasic::~PaintingEngineBasic() = default;
@@ -71,4 +71,7 @@ void PaintingEngineBasic::paint(GraphicsLayer& layer, CoordinatedTileBuffer& buf
     buffer.completePainting();
 }
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
+
+#endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Metrological Group B.V.
- * Copyright (C) 2018 Igalia S.L.
+ * Copyright (C) 2017 Metrological Group B.V.
+ * Copyright (C) 2017 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,28 +29,21 @@
 #pragma once
 
 #if USE(CAIRO)
-#include <memory>
-#include <wtf/Vector.h>
+#include "CairoPaintingEngine.h"
 
 namespace WebCore {
-class GraphicsContextCairo;
-}
+namespace Cairo {
 
-namespace WTF {
-class TextStream;
-}
+class PaintingEngineBasic final : public PaintingEngine {
+public:
+    PaintingEngineBasic();
+    virtual ~PaintingEngineBasic();
 
-namespace Nicosia {
-
-struct PaintingOperation {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    virtual ~PaintingOperation() = default;
-    virtual void execute(WebCore::GraphicsContextCairo&) = 0;
-    virtual void dump(WTF::TextStream&) = 0;
+private:
+    void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
 };
 
-using PaintingOperations = Vector<std::unique_ptr<PaintingOperation>>;
-
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp
@@ -27,17 +27,16 @@
  */
 
 #include "config.h"
-#include "NicosiaPaintingEngineThreaded.h"
+#include "CairoPaintingEngineThreaded.h"
 
-#if USE(COORDINATED_GRAPHICS)
-
+#if USE(CAIRO) && USE(COORDINATED_GRAPHICS)
+#include "CairoPaintingContext.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
-#include "NicosiaPaintingContext.h"
 
-namespace Nicosia {
-using namespace WebCore;
+namespace WebCore {
+namespace Cairo {
 
 static void paintLayer(GraphicsContext& context, GraphicsLayer& layer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale, bool supportsAlpha)
 {
@@ -73,11 +72,9 @@ void PaintingEngineThreaded::paint(GraphicsLayer& layer, CoordinatedTileBuffer& 
     buffer.beginPainting();
 
     PaintingOperations paintingOperations;
-    PaintingContext::record(paintingOperations,
-        [&](GraphicsContext& context)
-        {
-            paintLayer(context, layer, sourceRect, mappedSourceRect, targetRect, contentsScale, buffer.supportsAlpha());
-        });
+    PaintingContext::record(paintingOperations, [&](GraphicsContext& context) {
+        paintLayer(context, layer, sourceRect, mappedSourceRect, targetRect, contentsScale, buffer.supportsAlpha());
+    });
 
     m_workerPool->postTask([paintingOperations = WTFMove(paintingOperations), buffer = Ref { buffer }] {
         PaintingContext::replay(buffer.get(), paintingOperations);
@@ -85,6 +82,7 @@ void PaintingEngineThreaded::paint(GraphicsLayer& layer, CoordinatedTileBuffer& 
     });
 }
 
-} // namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif // USE(CAIRO) && USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.h
@@ -28,26 +28,25 @@
 
 #pragma once
 
-#include <memory>
-#include <wtf/Ref.h>
-#include <wtf/TZoneMalloc.h>
+#if USE(CAIRO) && USE(COORDINATED_GRAPHICS)
+#include "CairoPaintingEngine.h"
+#include <wtf/WorkerPool.h>
 
 namespace WebCore {
-class CoordinatedTileBuffer;
-class GraphicsLayer;
-class IntRect;
-}
+namespace Cairo {
 
-namespace Nicosia {
-
-class PaintingEngine {
-    WTF_MAKE_TZONE_ALLOCATED(PaintingEngine);
+class PaintingEngineThreaded final : public PaintingEngine {
 public:
-    WEBCORE_EXPORT static std::unique_ptr<PaintingEngine> create();
+    explicit PaintingEngineThreaded(unsigned);
+    virtual ~PaintingEngineThreaded();
 
-    virtual ~PaintingEngine() = default;
+private:
+    void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
 
-    virtual void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) = 0;
+    Ref<WorkerPool> m_workerPool;
 };
 
-} /// namespace Nicosia
+} // namespace Cairo
+} // namespace WebCore
+
+#endif // USE(CAIRO) && USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -44,10 +44,6 @@ class SkiaThreadedPaintingPool;
 }
 #endif
 
-namespace Nicosia {
-class PaintingEngine;
-}
-
 namespace WebCore {
 class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedBackingStoreProxy;
@@ -55,6 +51,11 @@ class CoordinatedGraphicsLayer;
 class CoordinatedImageBackingStore;
 class CoordinatedTileBuffer;
 class TextureMapperPlatformLayerProxy;
+#if USE(CAIRO)
+namespace Cairo {
+class PaintingEngine;
+}
+#endif
 
 class CoordinatedGraphicsLayerClient {
 public:
@@ -63,7 +64,7 @@ public:
     virtual void detachLayer(CoordinatedGraphicsLayer*) = 0;
     virtual void attachLayer(CoordinatedGraphicsLayer*) = 0;
 #if USE(CAIRO)
-    virtual Nicosia::PaintingEngine& paintingEngine() = 0;
+    virtual Cairo::PaintingEngine& paintingEngine() = 0;
 #elif USE(SKIA)
     virtual BitmapTexturePool* skiaAcceleratedBitmapTexturePool() const = 0;
     virtual SkiaThreadedPaintingPool* skiaThreadedPaintingPool() const = 0;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
@@ -21,11 +21,11 @@
 #include "CoordinatedGraphicsLayer.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(CAIRO)
+#include "CairoPaintingContext.h"
+#include "CairoPaintingEngine.h"
 #include "CoordinatedTileBuffer.h"
 #include "FloatRect.h"
 #include "GraphicsContext.h"
-#include "NicosiaPaintingContext.h"
-#include "NicosiaPaintingEngine.h"
 
 namespace WebCore {
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -50,7 +50,7 @@
 #include <wtf/TZoneMallocInlines.h>
 
 #if USE(CAIRO)
-#include <WebCore/NicosiaPaintingEngine.h>
+#include <WebCore/CairoPaintingEngine.h>
 #elif USE(SKIA)
 #include <WebCore/ProcessCapabilities.h>
 #include <WebCore/SkiaThreadedPaintingPool.h>
@@ -77,7 +77,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
     , m_displayID(displayID)
 #endif
 #if USE(CAIRO)
-    , m_paintingEngine(Nicosia::PaintingEngine::create())
+    , m_paintingEngine(Cairo::PaintingEngine::create())
 #endif
 {
 #if USE(SKIA)
@@ -480,7 +480,7 @@ void LayerTreeHost::attachLayer(CoordinatedGraphicsLayer* layer)
 }
 
 #if USE(CAIRO)
-Nicosia::PaintingEngine& LayerTreeHost::paintingEngine()
+Cairo::PaintingEngine& LayerTreeHost::paintingEngine()
 {
     return *m_paintingEngine;
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -51,7 +51,6 @@
 #endif
 
 namespace Nicosia {
-class PaintingEngine;
 class SceneIntegration;
 }
 
@@ -65,6 +64,11 @@ class GraphicsLayerFactory;
 class NativeImage;
 class SkiaThreadedPaintingPool;
 struct ViewportAttributes;
+#if USE(CAIRO)
+namespace Cairo {
+class PaintingEngine;
+}
+#endif
 }
 
 namespace WebKit {
@@ -144,7 +148,7 @@ private:
     void detachLayer(WebCore::CoordinatedGraphicsLayer*) override;
     void attachLayer(WebCore::CoordinatedGraphicsLayer*) override;
 #if USE(CAIRO)
-    Nicosia::PaintingEngine& paintingEngine() override;
+    WebCore::Cairo::PaintingEngine& paintingEngine() override;
 #elif USE(SKIA)
     WebCore::BitmapTexturePool* skiaAcceleratedBitmapTexturePool() const override { return m_skiaAcceleratedBitmapTexturePool.get(); }
     WebCore::SkiaThreadedPaintingPool* skiaThreadedPaintingPool() const override { return m_skiaThreadedPaintingPool.get(); }
@@ -199,7 +203,7 @@ private:
     WebCore::PlatformDisplayID m_displayID;
 #endif
 #if USE(CAIRO)
-    std::unique_ptr<Nicosia::PaintingEngine> m_paintingEngine;
+    std::unique_ptr<WebCore::Cairo::PaintingEngine> m_paintingEngine;
 #elif USE(SKIA)
     std::unique_ptr<WebCore::BitmapTexturePool> m_skiaAcceleratedBitmapTexturePool;
     std::unique_ptr<WebCore::SkiaThreadedPaintingPool> m_skiaThreadedPaintingPool;


### PR DESCRIPTION
#### fafa539ea794cb27621c00a4a60d9d863d7d326a
<pre>
[CoordinatedGraphics] Rename NicosiaPaintingEngine as CairoPaintingEngine
<a href="https://bugs.webkit.org/show_bug.cgi?id=282090">https://bugs.webkit.org/show_bug.cgi?id=282090</a>

Reviewed by Adrian Perez de Castro.

It&apos;s actually the Cairo painting engine used by coordinated graphics to render tiles.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp.
(WebCore::Cairo::OperationData::arg const const):
(WebCore::Cairo::createCommand):
(WebCore::Cairo::OperationRecorder::OperationRecorder):
(WebCore::Cairo::OperationRecorder::didUpdateState):
(WebCore::Cairo::OperationRecorder::setLineCap):
(WebCore::Cairo::OperationRecorder::setLineDash):
(WebCore::Cairo::OperationRecorder::setLineJoin):
(WebCore::Cairo::OperationRecorder::setMiterLimit):
(WebCore::Cairo::OperationRecorder::fillRect):
(WebCore::Cairo::OperationRecorder::fillRoundedRect):
(WebCore::Cairo::OperationRecorder::fillRectWithRoundedHole):
(WebCore::Cairo::OperationRecorder::fillPath):
(WebCore::Cairo::OperationRecorder::fillEllipse):
(WebCore::Cairo::OperationRecorder::strokeRect):
(WebCore::Cairo::OperationRecorder::strokePath):
(WebCore::Cairo::OperationRecorder::strokeEllipse):
(WebCore::Cairo::OperationRecorder::clearRect):
(WebCore::Cairo::OperationRecorder::drawGlyphs):
(WebCore::Cairo::OperationRecorder::drawDecomposedGlyphs):
(WebCore::Cairo::OperationRecorder::drawImageBuffer):
(WebCore::Cairo::OperationRecorder::drawFilteredImageBuffer):
(WebCore::Cairo::OperationRecorder::drawNativeImageInternal):
(WebCore::Cairo::OperationRecorder::drawPattern):
(WebCore::Cairo::OperationRecorder::drawRect):
(WebCore::Cairo::OperationRecorder::drawLine):
(WebCore::Cairo::OperationRecorder::drawLinesForText):
(WebCore::Cairo::OperationRecorder::drawDotsForDocumentMarker):
(WebCore::Cairo::OperationRecorder::drawEllipse):
(WebCore::Cairo::OperationRecorder::drawFocusRing):
(WebCore::Cairo::OperationRecorder::save):
(WebCore::Cairo::OperationRecorder::restore):
(WebCore::Cairo::OperationRecorder::translate):
(WebCore::Cairo::OperationRecorder::rotate):
(WebCore::Cairo::OperationRecorder::scale):
(WebCore::Cairo::OperationRecorder::concatCTM):
(WebCore::Cairo::OperationRecorder::setCTM):
(WebCore::Cairo::OperationRecorder::getCTM const):
(WebCore::Cairo::OperationRecorder::beginTransparencyLayer):
(WebCore::Cairo::OperationRecorder::endTransparencyLayer):
(WebCore::Cairo::OperationRecorder::resetClip):
(WebCore::Cairo::OperationRecorder::clip):
(WebCore::Cairo::OperationRecorder::clipOut):
(WebCore::Cairo::OperationRecorder::clipPath):
(WebCore::Cairo::OperationRecorder::clipBounds const):
(WebCore::Cairo::OperationRecorder::clipToImageBuffer):
(WebCore::Cairo::OperationRecorder::applyDeviceScaleFactor):
(WebCore::Cairo::OperationRecorder::append):
(WebCore::Cairo::OperationRecorder::drawVideoFrame):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h: Renamed from Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h.
* Source/WebCore/platform/graphics/cairo/CairoPaintingContext.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.cpp.
(WebCore::Cairo::PaintingContext::createForPainting):
(WebCore::Cairo::PaintingContext::createForRecording):
(WebCore::Cairo::PaintingContext::PaintingContext):
(WebCore::Cairo::PaintingContext::~PaintingContext):
(WebCore::Cairo::PaintingContext::replay):
* Source/WebCore/platform/graphics/cairo/CairoPaintingContext.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.h.
(WebCore::Cairo::PaintingContext::paint):
(WebCore::Cairo::PaintingContext::record):
(WebCore::Cairo::PaintingContext::replay):
(WebCore::Cairo::PaintingContext::graphicsContext):
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp.
(WebCore::Cairo::PaintingEngine::create):
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.h.
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.cpp.
(WebCore::Cairo::PaintingEngineBasic::paint):
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngineBasic.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.h.
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.cpp.
(WebCore::Cairo::paintLayer):
(WebCore::Cairo::PaintingEngineThreaded::PaintingEngineThreaded):
(WebCore::Cairo::PaintingEngineThreaded::~PaintingEngineThreaded):
(WebCore::Cairo::PaintingEngineThreaded::paint):
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngineThreaded.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.h.
* Source/WebCore/platform/graphics/cairo/CairoPaintingOperation.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaPaintingOperation.h.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::paintingEngine):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/285759@main">https://commits.webkit.org/285759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b698691b1d0d549427ab3c75ed1ae3f62b4aa500

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57807 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66188 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65468 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7502 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3572 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->