### PR TITLE
[UnifiedPDF] PrintWithJSExecutionOptionTests should also work with the feature enabled

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2403,6 +2403,7 @@
 		333B9CE11277F23100FEFCE3 /* PreventEmptyUserAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PreventEmptyUserAgent.cpp; sourceTree = "<group>"; };
 		3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIWebNavigation.mm; sourceTree = "<group>"; };
 		33976D8224DC479B00812304 /* IndexSparseSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IndexSparseSet.cpp; sourceTree = "<group>"; };
+		33B6F9E32CCB29EA009AD8FE /* WKPrinting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPrinting.h; sourceTree = "<group>"; };
 		33B767672CC066E400E4314F /* notEncrypted.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = notEncrypted.pdf; sourceTree = "<group>"; };
 		33BE5AF4137B5A6C00705813 /* MouseMoveAfterCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MouseMoveAfterCrash.cpp; sourceTree = "<group>"; };
 		33BE5AF8137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MouseMoveAfterCrash_Bundle.cpp; sourceTree = "<group>"; };
@@ -4490,6 +4491,7 @@
 				5102ED872950538D0053243E /* WKPageHasMediaStreamingActivity.mm */,
 				2D00065D1C1F58940088E6A7 /* WKPDFView.mm */,
 				3AEA55B22CB0897200A9ECAA /* WKPreferences.mm */,
+				33B6F9E32CCB29EA009AD8FE /* WKPrinting.h */,
 				1CC4C74A288909F600A3B23D /* WKPrinting.mm */,
 				3781746C2198AE2400062C26 /* WKProcessPoolConfiguration.mm */,
 				44817A2E1F0486BF00003810 /* WKRequestActivatedElementInfo.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -34,6 +34,7 @@
 #import "TestWKWebView.h"
 #import "UISideCompositingScope.h"
 #import "UnifiedPDFTestHelpers.h"
+#import "WKPrinting.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebCore/ColorSerialization.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
@@ -142,6 +143,14 @@ UNIFIED_PDF_TEST(CopyEditingCommandOnEmptySelectionShouldNotCrash)
     [webView sendClickAtPoint:NSMakePoint(200, 200)];
     [webView objectByEvaluatingJavaScript:@"internals.sendEditingCommandToPDFForTesting(document.querySelector('embed'), 'copy')"];
 }
+
+TEST_P(PrintWithJSExecutionOptionTests, PDFWithWindowPrintEmbeddedJS)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
+    runTest(webView.get());
+}
+
+INSTANTIATE_TEST_SUITE_P(UnifiedPDF, PrintWithJSExecutionOptionTests, testing::Bool(), &PrintWithJSExecutionOptionTests::testNameGenerator);
 
 #endif // PLATFORM(MAC)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebKit/WKUIDelegatePrivate.h>
+
+@class NSURLRequest;
+@class WKWebView;
+
+@interface TestPDFPrintDelegate : NSObject <WKUIDelegatePrivate>
+- (void)waitForPrintFrameCall;
+@end
+
+namespace TestWebKitAPI {
+
+class PrintWithJSExecutionOptionTests : public ::testing::TestWithParam<bool> {
+public:
+    bool allowsContentJavascript() const { return GetParam(); }
+    static NSURLRequest *pdfRequest();
+    static std::string testNameGenerator(testing::TestParamInfo<bool>);
+    void runTest(WKWebView *);
+};
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
@@ -24,13 +24,14 @@
  */
 
 #import "config.h"
+#import "WKPrinting.h"
 
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"
-#import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKUIDelegate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferences.h>
 #import <WebKit/_WKFrameHandle.h>
@@ -150,10 +151,6 @@ TEST(Printing, PrintPageBorders)
     [webView _waitUntilPageBorderDrawn];
 }
 
-@interface TestPDFPrintDelegate : NSObject <WKUIDelegatePrivate>
-- (void)waitForPrintFrameCall;
-@end
-
 @implementation TestPDFPrintDelegate {
     bool _printFrameCalled;
 }
@@ -172,19 +169,20 @@ TEST(Printing, PrintPageBorders)
 
 @end
 
-class PrintWithJSExecutionOptionTests : public ::testing::TestWithParam<bool> {
-public:
-    bool allowsContentJavascript() const { return GetParam(); }
+using namespace TestWebKitAPI;
 
-    static NSURLRequest *pdfRequest()
-    {
-        return [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test_print" withExtension:@"pdf"]];
-    }
-};
-
-TEST_P(PrintWithJSExecutionOptionTests, PDFWithWindowPrintEmbeddedJS)
+NSURLRequest *PrintWithJSExecutionOptionTests::pdfRequest()
 {
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    return [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test_print" withExtension:@"pdf"]];
+}
+
+std::string PrintWithJSExecutionOptionTests::testNameGenerator(testing::TestParamInfo<bool> info)
+{
+    return std::string { "allowsContentJavascript_is_" } + (info.param ? "true" : "false");
+}
+
+void PrintWithJSExecutionOptionTests::runTest(WKWebView *webView)
+{
     RetainPtr delegate = adoptNS([TestPDFPrintDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
@@ -196,9 +194,11 @@ TEST_P(PrintWithJSExecutionOptionTests, PDFWithWindowPrintEmbeddedJS)
     [delegate waitForPrintFrameCall];
 }
 
-INSTANTIATE_TEST_SUITE_P(Printing,
-    PrintWithJSExecutionOptionTests,
-    testing::Bool(),
-    [](testing::TestParamInfo<bool> info) { return std::string { "allowsContentJavascript_is_" } + (info.param ? "true" : "false"); }
-);
-#endif
+TEST_P(PrintWithJSExecutionOptionTests, PDFWithWindowPrintEmbeddedJS)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    runTest(webView.get());
+}
+
+INSTANTIATE_TEST_SUITE_P(Printing, PrintWithJSExecutionOptionTests, testing::Bool(), &TestWebKitAPI::PrintWithJSExecutionOptionTests::testNameGenerator);
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### b3e744b6e0fedd1aacd4aa29b0e1e7611e7c71be
<pre>
[UnifiedPDF] PrintWithJSExecutionOptionTests should also work with the feature enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=282088">https://bugs.webkit.org/show_bug.cgi?id=282088</a>
<a href="https://rdar.apple.com/138622168">rdar://138622168</a>

Reviewed by Sammy Gill.

This patch makes it so that PrintWithJSExecutionOptionTests also run
in environments where the Unified PDF feature is enabled. To achieve
this, we split out the PrintWithJSExecutionOptionTests fixture class and
TestPDFPrintDelegate observer into a separate WKPrinting.h header.

We also introduce a `runTest()` method on the fixture class, which runs
the test with a supplied web view. This allows us the flexibility to
spin up a test suite where web views have the Unified PDF feature
enabled.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.h: Added.
(TestWebKitAPI::PrintWithJSExecutionOptionTests::allowsContentJavascript const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm:
(PrintWithJSExecutionOptionTests::pdfRequest):
(PrintWithJSExecutionOptionTests::testNameGenerator):
(PrintWithJSExecutionOptionTests::runTest):
(TEST_P):
(PrintWithJSExecutionOptionTests::allowsContentJavascript const): Deleted.
(INSTANTIATE_TEST_SUITE_P): Deleted.

Canonical link: <a href="https://commits.webkit.org/285738@main">https://commits.webkit.org/285738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eb613eaad35feab134b9aa3d8f3327694ad4fc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65555 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7596 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11355 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/932 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/961 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->