### PR TITLE
[vision] Controls not always showing in spatial player

### DIFF
--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 
+#import "LinearMediaKitExtras.h"
 #import "LinearMediaKitSPI.h"
 #import "PlaybackSessionInterfaceLMK.h"
 #import "WKSLinearMediaPlayer.h"
@@ -99,6 +100,10 @@ void VideoPresentationInterfaceLMK::setSpatialImmersive(bool immersive)
 void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView* parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     linearMediaPlayer().contentDimensions = videoDimensions;
+    if (!linearMediaPlayer().enteredFromInline && playerViewController()) {
+        playableViewController().wks_automaticallyDockOnFullScreenPresentation = NO;
+        playableViewController().wks_dismissFullScreenOnExitingDocking = NO;
+    }
     VideoPresentationInterfaceIOS::setupFullscreen(videoView, initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -458,8 +458,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     LMPlayableViewController *playableViewController = videoPresentationInterface ? videoPresentationInterface->playableViewController() : nil;
     UIViewController *environmentPickerButtonViewController = playableViewController.wks_environmentPickerButtonViewController;
 
-    if (environmentPickerButtonViewController)
+    if (environmentPickerButtonViewController) {
         playableViewController.wks_automaticallyDockOnFullScreenPresentation = YES;
+        playableViewController.wks_dismissFullScreenOnExitingDocking = YES;
+    }
 
     if (_environmentPickerButtonViewController == environmentPickerButtonViewController) {
         ASSERT(!environmentPickerButtonViewController || [[_stackView arrangedSubviews] containsObject:environmentPickerButtonViewController.view]);
@@ -469,8 +471,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _removeEnvironmentPickerButtonView];
     if (!environmentPickerButtonViewController)
         return;
-
-    playableViewController.wks_dismissFullScreenOnExitingDocking = YES;
 
     [self addChildViewController:environmentPickerButtonViewController];
     [_stackView insertArrangedSubview:environmentPickerButtonViewController.view atIndex:1];
@@ -1001,14 +1001,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RefPtr page = [self._webView _page].get();
     if (!page)
         return;
-
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    RefPtr videoPresentationManager = page->videoPresentationManager();
-    RefPtr videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
-
-    LMPlayableViewController *playableViewController = videoPresentationInterface ? videoPresentationInterface->playableViewController() : nil;
-    playableViewController.wks_automaticallyDockOnFullScreenPresentation = NO;
-#endif
 
     page->enterFullscreen();
 }

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -127,6 +127,9 @@ enum LinearMediaPlayerErrors: Error {
 #endif
         }
     }
+    var enteredFromInline: Bool {
+        get { swiftOnlyData.enteredFromInline }
+    }
 
     // FIXME: These should be stored properties on WKSLinearMediaPlayer, but a bug prevents that from compiling (rdar://121877511).
     var startDate: Date? {

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -159,6 +159,7 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic, strong, nullable) NSDate *endDate;
 @property (nonatomic) BOOL spatialImmersive;
 @property (nonatomic, strong, nullable) WKSLinearMediaSpatialVideoMetadata *spatialVideoMetadata;
+@property (nonatomic, readonly) BOOL enteredFromInline;
 
 - (LMPlayableViewController *)makeViewController;
 - (void)enterFullscreenWithCompletionHandler:(void (^)(BOOL, NSError * _Nullable))completionHandler;


### PR DESCRIPTION
#### f5512c37f54de84db9d0b46efcdcf4ba2b3051d1
<pre>
[vision] Controls not always showing in spatial player
<a href="https://bugs.webkit.org/show_bug.cgi?id=282094">https://bugs.webkit.org/show_bug.cgi?id=282094</a>
<a href="https://rdar.apple.com/138595244">rdar://138595244</a>

Reviewed by Andy Estes.

In 285658@main, we fixed entering spatial portal from element fullscreen after selecting the &quot;view in spatial&quot; button.
But it was incomplete.

whenever we configure the docking menu, we also set two properties on the PlayableViewController. Unfortunately, those properties
break spatial and prevent the media controls from appearing. So we only want to have them set when entering video fullscreen from
the environment menu.
There&apos;s no proper way to distinguish in which fashion we entered video fullscreen, either from a call to HTML&apos;s enterFullScreen, via the
docking environment or through the dedicated spatial button.
We add a property on the LinearMediaPlayer :enteredFromInline which is set if we entered fullscreen from the environment menu.
Later, before configuring fullscreen, we check that property and it set we clear the two PlayableViewController properties.

Manually tested on a real device with the following steps.
1- element fullscreen
2 - spatial
3 - exit
4- [go back to step 2 a random number of times)
5- exit element fullscreen
6 - enter native fullscreen (spatial)
7 - exit
8- [go back to step 6 a random number of times)
9 - go into element fullscreen
10 - tap on environment button, select 1
11 - exit
12- go back to step 8 a random number of times.
13 - goto 1.

* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setupFullscreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController _enterVideoFullscreenAction:]):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.enteredFromInline):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:

Canonical link: <a href="https://commits.webkit.org/285715@main">https://commits.webkit.org/285715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6ea15988c506681da505f06bf07f199c6dd4f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57813 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44550 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79435 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65472 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7510 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->