### PR TITLE
Large box shadow is not clipped by clip-path() when in scroll container

### DIFF
--- a/LayoutTests/compositing/masks/clip-path-on-tiled-toggle-expected.html
+++ b/LayoutTests/compositing/masks/clip-path-on-tiled-toggle-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .test {
+            margin: 20px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            box-shadow: yellow 0 0 0 200px;
+            clip-path: inset(0px -100px 0px 0px);
+        }
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+    <p>There should be a green square next to a yellow square</p>
+    <div class="composited test">&nbsp;</div>
+</body>
+</html>

--- a/LayoutTests/compositing/masks/clip-path-on-tiled-toggle.html
+++ b/LayoutTests/compositing/masks/clip-path-on-tiled-toggle.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .test {
+            margin: 20px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            box-shadow: yellow 0 0 0 200px;
+            clip-path: inset(0px -100px 0px 0px);
+        }
+
+        body.changed .test {
+            box-shadow: yellow 0 0 0 1500px;
+        }
+
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>    
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            
+            document.body.classList.add('changed');
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <p>There should be a green square next to a yellow square</p>
+    <div class="composited test">&nbsp;</div>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1660,6 +1660,9 @@ webkit.org/b/186601 fullscreen/full-screen-layer-dump.html [ Failure ]
 
 webkit.org/b/187994 compositing/backing/backing-store-attachment-fill-forwards-animation.html [ Failure ]
 
+# No support for compositing clip-path?
+webkit.org/b/282148 compositing/masks/clip-path-on-tiled-toggle.html [ Failure ]
+
 webkit.org/b/188218 fast/repaint/canvas-object-fit.html [ Failure ]
 
 webkit.org/b/188436 svg/custom/href-svg-namespace-static.svg [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1621,6 +1621,9 @@ imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-pa
 imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-mixed-descendants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
 
+# No support for compositing clip-path?
+webkit.org/b/282148 compositing/masks/clip-path-on-tiled-toggle.html [ Failure ]
+
 webkit.org/b/272224 imported/w3c/web-platform-tests/selection/textcontrols/selectionchange.html [ Failure ]
 
 webkit.org/b/272225 media/media-source/media-managedmse-resume-after-stall.html [ Failure ]

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -438,11 +438,11 @@ void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const
     ASSERT(maskNode);
     if (!maskNode)
         return;
-    CALayer *maskLayer = maskNode->layer();
-    ASSERT(!maskLayer.superlayer);
-    if (maskLayer.superlayer)
-        return;
-    maskOwnerLayer.mask = maskLayer;
+
+    RetainPtr maskLayer = maskNode->layer();
+    [maskLayer removeFromSuperlayer];
+
+    maskOwnerLayer.mask = maskLayer.get();
 }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 574da2d10dd6c9ecb15699207636bb2236efb071
<pre>
Large box shadow is not clipped by clip-path() when in scroll container
<a href="https://bugs.webkit.org/show_bug.cgi?id=282106">https://bugs.webkit.org/show_bug.cgi?id=282106</a>
<a href="https://rdar.apple.com/138599295">rdar://138599295</a>

Reviewed by Mike Wyrzykowski.

When a layer with a mask toggled between tiled and non-tiled, we correctly call `GraphicsLayerCA::updateMaskLayer()`
on the WebCore side, but on the WebKit side we hit a quirk of CoreAnimation, which is that assigning a CALayer&apos;s mask
layer sets the superlayer of the mask layer. If the superlayer was non-nil, we&apos;d assert and early return, rather than
assigning the mask layer to its new owner.

* LayoutTests/compositing/masks/clip-path-on-tiled-toggle-expected.html: Added.
* LayoutTests/compositing/masks/clip-path-on-tiled-toggle.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::updateMask):

Canonical link: <a href="https://commits.webkit.org/285742@main">https://commits.webkit.org/285742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/228f00478ef29cec0e7adc08b4935684e45323a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57948 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20885 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66300 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7620 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3713 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->