### PR TITLE
Ignore -Wunsafe-buffer-usage-in-libc-call warnings when -Wunsafe-buffer-usage is enabled

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -62,6 +62,30 @@ OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef -Wvla;
 WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING_CFLAGS);
 
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL = -Wno-unknown-warning-option -Wno-unsafe-buffer-usage-in-libc-call;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx13*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx14*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.0*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.1*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.2*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.3*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=iphone*18.0*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=iphone*18.1*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=iphone*18.2*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=iphone*18.3*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=appletv*18.0*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=appletv*18.1*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=appletv*18.2*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=appletv*18.3*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=watch*11.0*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=watch*11.1*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=watch*11.2*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=watch*11.3*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=xr*2.0*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=xr*2.1*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=xr*2.2*] = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=xr*2.3*] = ;
+
 CLANG_CXX_STANDARD_LIBRARY_HARDENING = extensive;
 
 // Setting CLANG_CXX_STANDARD_LIBRARY_HARDENING is sufficient in recent XCode versions but we want to keep

--- a/Source/WebGPU/Configurations/Base.xcconfig
+++ b/Source/WebGPU/Configurations/Base.xcconfig
@@ -93,7 +93,7 @@ GCC_WARN_UNINITIALIZED_AUTOS = YES;
 GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 PREBINDING = NO;
-WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-typedef-redefinition -Wunsafe-buffer-usage;
+WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-typedef-redefinition -Wunsafe-buffer-usage $(WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL);
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;

--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -85,7 +85,7 @@ GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 OTHER_MIGFLAGS = -F$(BUILT_PRODUCTS_DIR);
 PREBINDING = NO;
-WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wunsafe-buffer-usage -Wno-missing-field-initializers;
+WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wunsafe-buffer-usage $(WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL) -Wno-missing-field-initializers;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter;


### PR DESCRIPTION
#### 1a97633eac49ebe67f7891f0c00046bf42222f42
<pre>
Ignore -Wunsafe-buffer-usage-in-libc-call warnings when -Wunsafe-buffer-usage is enabled
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=282100">https://bugs.webkit.org/show_bug.cgi?id=282100</a>&gt;
&lt;<a href="https://rdar.apple.com/138642975">rdar://138642975</a>&gt;

Reviewed by Geoffrey Garen.

The -Wunsafe-buffer-usage warning also enables the
-Wunsafe-buffer-usage-in-libc-call warning, but those need a separate
pass to resolve, so turn them off for now.

* Configurations/CommonBase.xcconfig:
(WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL): Add.
- Define a build setting to disable the
  -Wunsafe-buffer-usage-in-libc-call warning.
* Source/WebGPU/Configurations/Base.xcconfig:
(WARNING_CFLAGS):
- Add $(WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL) since
  -Wunsafe-buffer-usage is enabled for this project.
* Source/WebKit/Configurations/Base.xcconfig:
(WARNING_CFLAGS):
- Ditto.

Canonical link: <a href="https://commits.webkit.org/285720@main">https://commits.webkit.org/285720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5999039f90d54cf2e8b853c3f0bde5a250e43bb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/788 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57842 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16251 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44574 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66214 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65494 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7521 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3602 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->