### PR TITLE
IMDB.com video fullscreen playback has double media controls

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -38,6 +38,7 @@
 #include "ContextMenuController.h"
 #include "ContextMenuItem.h"
 #include "ContextMenuProvider.h"
+#include "DocumentInlines.h"
 #include "Event.h"
 #include "EventListener.h"
 #include "EventNames.h"
@@ -57,6 +58,7 @@
 #include "Node.h"
 #include "Page.h"
 #include "PageGroup.h"
+#include "Quirks.h"
 #include "RenderTheme.h"
 #include "ShadowRoot.h"
 #include "TextTrack.h"
@@ -325,6 +327,13 @@ bool MediaControlsHost::supportsRewind() const
     if (auto sourceType = this->sourceType())
         return *sourceType == SourceType::HLS || *sourceType == SourceType::File;
 #endif
+    return false;
+}
+
+bool MediaControlsHost::needsChromeMediaControlsPseudoElement() const
+{
+    if (m_mediaElement)
+        return m_mediaElement->document().quirks().needsChromeMediaControlsPseudoElement();
     return false;
 }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -93,6 +93,7 @@ public:
     bool supportsSeeking() const;
     bool inWindowFullscreen() const;
     bool supportsRewind() const;
+    bool needsChromeMediaControlsPseudoElement() const;
 
     enum class ForceUpdate : bool { No, Yes };
     void updateCaptionDisplaySizes(ForceUpdate = ForceUpdate::No);

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -64,6 +64,7 @@ enum DeviceType {
     readonly attribute boolean supportsSeeking;
     readonly attribute boolean inWindowFullscreen;
     readonly attribute boolean supportsRewind;
+    readonly attribute boolean needsChromeMediaControlsPseudoElement;
 
     readonly attribute DOMString externalDeviceDisplayName;
     readonly attribute DeviceType externalDeviceType;

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -422,6 +422,9 @@ class MediaController
         }
 
         this._updateControlsAvailability();
+
+        if (this.host?.needsChromeMediaControlsPseudoElement)
+            this.controls.element.setAttribute('useragentpart', '-webkit-media-controls');
     }
 
     _stopPropagationOnClickEvents()

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -357,6 +357,11 @@
             "status": "non-standard",
             "user-agent-part": true
         },
+        "-webkit-media-controls": {
+            "comment": "For needsChromeMediaControlsPseudoElement quirk",
+            "status": "non-standard",
+            "user-agent-part": true
+        },
         "-webkit-media-text-track-container": {
             "status": "non-standard",
             "user-agent-part": true

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -58,7 +58,7 @@ KNOWN_KEY_TYPES = {
 # - an `-apple-` prefix only exposed to certain Apple clients (there is a settings-flag requirement for using this prefix)
 WEBKIT_PREFIX_COUNTS_DO_NOT_INCREASE = {
     'pseudo-classes': 5,
-    'pseudo-elements': 59,
+    'pseudo-elements': 60,
 }
 
 class InputValidator:

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1920,4 +1920,15 @@ bool Quirks::needsZeroMaxTouchPointsQuirk() const
     return false;
 }
 
+bool Quirks::needsChromeMediaControlsPseudoElement() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_needsChromeMediaControlsPseudoElementQuirk)
+        m_needsChromeMediaControlsPseudoElementQuirk = isDomain("imdb.com"_s);
+
+    return *m_needsChromeMediaControlsPseudoElementQuirk;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -213,6 +213,7 @@ public:
     bool implicitMuteWhenVolumeSetToZero() const;
 
     bool needsZeroMaxTouchPointsQuirk() const;
+    bool needsChromeMediaControlsPseudoElement() const;
 
 private:
     bool needsQuirks() const;
@@ -290,6 +291,7 @@ private:
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
     mutable std::optional<bool> m_needsZeroMaxTouchPointsQuirk;
 #endif
+    mutable std::optional<bool> m_needsChromeMediaControlsPseudoElementQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };


### PR DESCRIPTION
#### e9e91f5cb33b1147a1a7ce34ddf3037ddcf7c25e
<pre>
IMDB.com video fullscreen playback has double media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=282107">https://bugs.webkit.org/show_bug.cgi?id=282107</a>
<a href="https://rdar.apple.com/137991466">rdar://137991466</a>

Reviewed by Eric Carlson.

IMDB.com will set `video.controls = true` upon entering element fullscreen mode,
while simultaneously hiding those media controls from visibility with:
`video::-webkit-media-controls { display: none; }`. This works on Chrome due to
their use of the `::-webkit-media-controls` pseudo-element inside their shadow dom,
but WebKit does not use a pseudo-element (precisely to prevent sites from messing)
with the internals of our media controls from the page.

Add a Quirk that re-introduces the `::-webkit-media-controls` pseduo element within
our Modern Media Controls just for IMDB.com.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::needsChromeMediaControlsPseudoElement const):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsChromeMediaControlsPseudoElement const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/285848@main">https://commits.webkit.org/285848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a565b3167aca43d506de7ecccda04f2d2ddb49e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38580 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23559 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1305 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63665 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9674 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1269 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->