### PR TITLE
[UnifiedPDF] mail.proton.me: Encrypted <object> PDF does not show "document is password protected" UI

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -398,7 +398,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&);
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable);
 
-    ShadowRoot* userAgentShadowRoot() const;
+    WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;
     RefPtr<ShadowRoot> protectedUserAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();
     WEBCORE_EXPORT ShadowRoot& createUserAgentShadowRoot();

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -287,6 +287,11 @@ void HTMLObjectElement::renderFallbackContent()
     scheduleUpdateForAfterStyleResolution();
     invalidateStyleAndRenderersForSubtree();
 
+    // Presence of a UA shadow root indicates render invalidation during embedded PDF plugin bringup, and not a failed render.
+    // It's safe to special case here because UA shadow root cannot be attached to <object>/<embed> programmatically.
+    if (userAgentShadowRoot())
+        return;
+
     // Before we give up and use fallback content, check to see if this is a MIME type issue.
     auto* loader = imageLoader();
     if (loader && loader->image() && loader->image()->status() != CachedResource::LoadError) {

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -57,7 +57,7 @@ private:
     void element() const = delete;
     ASCIILiteral renderName() const override { return "RenderAttachment"_s; }
     LayoutSize layoutWideLayoutAttachmentOnly();
-    void layoutShadowContent(const LayoutSize&);
+    void layoutShadowContent(const LayoutSize&) override;
 
     bool shouldDrawSelectionTint() const override { return isWideLayout(); }
     void paintReplaced(PaintInfo&, const LayoutPoint& offset) final;

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -376,7 +376,8 @@ void RenderEmbeddedObject::layout()
     updateLogicalWidth();
     updateLogicalHeight();
 
-    RenderWidget::layout();
+    LayoutSize oldSize = contentBoxRect().size();
+    RenderReplaced::layout();
 
     clearOverflow();
     addVisualEffectOverflow();
@@ -387,6 +388,9 @@ void RenderEmbeddedObject::layout()
         view().frameView().addEmbeddedObjectToUpdate(*this);
 
     clearNeedsLayout();
+
+    if (m_hasShadowContent)
+        layoutShadowContent(oldSize);
 }
 
 bool RenderEmbeddedObject::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -26,6 +26,7 @@
 
 namespace WebCore {
 
+class LayoutSize;
 class MouseEvent;
 class TextRun;
 
@@ -70,6 +71,8 @@ public:
 
     bool paintsContent() const final;
 
+    void setHasShadowContent() { m_hasShadowContent = true; }
+
 private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
     void paint(PaintInfo&, const LayoutPoint&) final;
@@ -94,6 +97,8 @@ private:
     void getReplacementTextGeometry(const LayoutPoint& accumulatedOffset, FloatRect& contentRect, FloatRect& indicatorRect, FloatRect& replacementTextRect, FloatRect& arrowRect, FontCascade&, TextRun&, float& textWidth) const;
     LayoutRect getReplacementTextGeometry(const LayoutPoint& accumulatedOffset) const;
 
+    bool canHaveChildren() const override { return m_hasShadowContent; }
+
     bool m_isPluginUnavailable;
     enum class UnavailablePluginIndicatorState { Uninitialized, Hidden, Visible };
     UnavailablePluginIndicatorState m_isUnavailablePluginIndicatorState { UnavailablePluginIndicatorState::Uninitialized };
@@ -102,6 +107,7 @@ private:
     bool m_unavailablePluginIndicatorIsPressed;
     bool m_mouseDownWasInUnavailablePluginIndicator;
     String m_unavailabilityDescription;
+    bool m_hasShadowContent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -136,8 +136,6 @@ private:
     void updateInnerContentRect();
 
     void paintAreaElementFocusRing(PaintInfo&, const LayoutPoint& paintOffset);
-    
-    void layoutShadowContent(const LayoutSize& oldSize);
 
     bool hasShadowContent() const { return m_hasShadowControls || m_hasImageOverlay; }
 

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -75,6 +75,8 @@ protected:
 
     void willBeDestroyed() override;
 
+    virtual void layoutShadowContent(const LayoutSize&);
+
 private:
     LayoutUnit computeConstrainedLogicalWidth(ShouldComputePreferred) const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -547,7 +547,7 @@ PDFPlugin::PDFPlugin(HTMLPlugInElement& element)
         m_annotationContainer->setAttributeWithoutSynchronization(idAttr, "annotationContainer"_s);
 
         auto annotationStyleElement = document->createElement(styleTag, false);
-        annotationStyleElement->setTextContent(annotationStyle);
+        annotationStyleElement->setTextContent(annotationStyle());
 
         m_annotationContainer->appendChild(annotationStyleElement);
         RefPtr { document->bodyOrFrameset() }->appendChild(*m_annotationContainer);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -304,7 +304,7 @@ protected:
 
     virtual void teardown();
 
-    bool supportsForms();
+    bool supportsForms() const;
 
     void createPDFDocument();
     virtual void installPDFDocument() = 0;
@@ -380,6 +380,8 @@ protected:
 
     virtual void teardownPasswordEntryForm() = 0;
 
+    String annotationStyle() const;
+
     SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
     WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> m_element;
@@ -432,66 +434,6 @@ protected:
     CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)> m_pendingSaveCompletionHandler;
     CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)> m_pendingOpenCompletionHandler;
 #endif
-
-    // Set overflow: hidden on the annotation container so <input> elements scrolled out of view don't show
-    // scrollbars on the body. We can't add annotations directly to the body, because overflow: hidden on the body
-    // will break rubber-banding.
-    static constexpr auto annotationStyle =
-    "#annotationContainer {"
-    "    overflow: hidden;"
-    "    position: absolute;"
-    "    pointer-events: none;"
-    "    top: 0;"
-    "    left: 0;"
-    "    right: 0;"
-    "    bottom: 0;"
-    "    display: flex;"
-    "    flex-direction: column;"
-    "    justify-content: center;"
-    "    align-items: center;"
-    "}"
-    ""
-    ".annotation {"
-    "    position: absolute;"
-    "    pointer-events: auto;"
-    "}"
-    ""
-    "textarea.annotation { "
-    "    resize: none;"
-    "}"
-    ""
-    "input.annotation[type='password'] {"
-    "    position: static;"
-    "    width: 238px;"
-    "    margin-top: 110px;"
-    "    font-size: 15px;"
-    "}"
-    ""
-    ".lock-icon {"
-    "    width: 64px;"
-    "    height: 64px;"
-    "    margin-bottom: 12px;"
-    "}"
-    ""
-    ".password-form {"
-    "    position: static;"
-    "    display: block;"
-    "    text-align: center;"
-    "    font-family: system-ui;"
-    "    font-size: 15px;"
-    "}"
-    ""
-    ".password-form p {"
-    "    margin: 4pt;"
-    "}"
-    ""
-    ".password-form .subtitle {"
-    "    font-size: 12px;"
-    "}"
-    ""
-    ".password-form + input.annotation[type='password'] {"
-    "    margin-top: 16px;"
-    "}"_s;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1105,7 +1105,7 @@ void PDFPluginBase::notifyCursorChanged(WebCore::PlatformCursorType cursorType)
     m_frame->protectedPage()->send(Messages::WebPageProxy::SetCursor(WebCore::Cursor::fromType(cursorType)));
 }
 
-bool PDFPluginBase::supportsForms()
+bool PDFPluginBase::supportsForms() const
 {
     // FIXME: We support forms for full-main-frame and <iframe> PDFs, but not <embed> or <object>, because those cases do not have their own Document into which to inject form elements.
     return isFullFramePlugin();
@@ -1244,6 +1244,106 @@ void PDFPluginBase::registerPDFTest(RefPtr<WebCore::VoidCallback>&& callback)
 std::optional<FrameIdentifier> PDFPluginBase::rootFrameID() const
 {
     return m_view->frame()->rootFrame().frameID();
+}
+
+// FIXME: Share more of the style sheet between the embed/non-embed case.
+String PDFPluginBase::annotationStyle() const
+{
+    if (!supportsForms()) {
+        return
+        "#annotationContainer {"
+        "    overflow: hidden;"
+        "    position: relative;"
+        "    pointer-events: none;"
+        "    display: flex;"
+        "    place-content: center;"
+        "    place-items: center;"
+        "}"
+        ""
+        ".annotation {"
+        "    position: absolute;"
+        "    pointer-events: auto;"
+        "}"
+        ""
+        ".lock-icon {"
+        "    width: 64px;"
+        "    height: 64px;"
+        "    margin-bottom: 12px;"
+        "}"
+        ""
+        ".password-form {"
+        "    position: static;"
+        "    display: block;"
+        "    text-align: center;"
+        "    font-family: system-ui;"
+        "    font-size: 15px;"
+        "}"
+        ""
+        ".password-form p {"
+        "    margin: 4pt;"
+        "}"
+        ""
+        ".password-form .subtitle {"
+        "    font-size: 12px;"
+        "}"_s;
+    }
+
+    return
+    "#annotationContainer {"
+    "    overflow: hidden;"
+    "    position: absolute;"
+    "    pointer-events: none;"
+    "    top: 0;"
+    "    left: 0;"
+    "    right: 0;"
+    "    bottom: 0;"
+    "    display: flex;"
+    "    flex-direction: column;"
+    "    justify-content: center;"
+    "    align-items: center;"
+    "}"
+    ""
+    ".annotation {"
+    "    position: absolute;"
+    "    pointer-events: auto;"
+    "}"
+    ""
+    "textarea.annotation { "
+    "    resize: none;"
+    "}"
+    ""
+    "input.annotation[type='password'] {"
+    "    position: static;"
+    "    width: 238px;"
+    "    margin-top: 110px;"
+    "    font-size: 15px;"
+    "}"
+    ""
+    ".lock-icon {"
+    "    width: 64px;"
+    "    height: 64px;"
+    "    margin-bottom: 12px;"
+    "}"
+    ""
+    ".password-form {"
+    "    position: static;"
+    "    display: block;"
+    "    text-align: center;"
+    "    font-family: system-ui;"
+    "    font-size: 15px;"
+    "}"
+    ""
+    ".password-form p {"
+    "    margin: 4pt;"
+    "}"
+    ""
+    ".password-form .subtitle {"
+    "    font-size: 12px;"
+    "}"
+    ""
+    ".password-form + input.annotation[type='password'] {"
+    "    margin-top: 16px;"
+    "}"_s;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -51,6 +51,7 @@ namespace WebCore {
 class FrameView;
 class PageOverlay;
 class PlatformWheelEvent;
+class ShadowRoot;
 
 enum class DelegatedScrollingMode : uint8_t;
 
@@ -514,6 +515,9 @@ private:
     void resetZoom();
 #endif
 
+    bool supportsPasswordForm() const;
+    void installAnnotationContainer();
+
     std::optional<PDFDocumentLayout::PageIndex> pageIndexForAnnotation(PDFAnnotation *) const;
     std::optional<PDFDocumentLayout::PageIndex> pageIndexWithHoveredAnnotation() const;
     void paintHoveredAnnotationOnPage(PDFDocumentLayout::PageIndex, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
@@ -627,6 +631,8 @@ private:
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
     std::unique_ptr<PDFDataDetectorOverlayController> m_dataDetectorOverlayController;
 #endif
+
+    RefPtr<WebCore::ShadowRoot> m_shadowRoot;
 
     // FIXME: We should rationalize these with the values in ViewGestureController.
     // For now, we'll leave them differing as they do in PDFPlugin.


### PR DESCRIPTION
#### 2528cea2fd90d74921dd1fee91edaccef6103ced
<pre>
[UnifiedPDF] mail.proton.me: Encrypted &lt;object&gt; PDF does not show &quot;document is password protected&quot; UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=282113">https://bugs.webkit.org/show_bug.cgi?id=282113</a>
<a href="https://rdar.apple.com/138051102">rdar://138051102</a>

Reviewed by Ryosuke Niwa.

In PDFLayerController, we got a password prompt for free because PDFKit
would paint one into a sublayer of the root document layer. In the
Unified PDF plugin, we implement this password prompt as a &lt;div&gt; element
on the annotation container.

This works great for main frame and &lt;iframe&gt; PDF plugins, since these
plugin types support annotation forms. However, for &lt;embed&gt;/&lt;object&gt;
plugins, since we don&apos;t support annotation forms, we are unable to
present the password prompt &lt;div&gt; and are left with an empty grey view.

To address this missing functionality, we implement the subset of
forms support required to present the password &lt;prompt&gt; div in embedded
plugins. We achieve this by attaching a shadow root under an embedded
plugin, which we then use as the host element to attach the annotation
container/password prompt elements to. More Details about this
implementation provided inline.

* Source/WebCore/dom/Element.h:
  WEBCORE_EXPORT userAgentShadowRoot() so we can call into it from
  WebKit::UnifiedPDFPlugin.

* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::renderFallbackContent):
  Special case the &lt;embed&gt;/&lt;object&gt; PDF case by not defaulting to
  fallback content on what we think may be a failed plugin creation
  attempt. We gate this behavior between presence of a UA shadow root on
  the embedded object, which would indicate we&apos;ve simply invalidated
  renderers and not actually failed to create the requested plugin
  object.

* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::layout):
  Teach RenderEmbeddedObject to also kick off layout for any shadow
  content, if needed.
* Source/WebCore/rendering/RenderEmbeddedObject.h:

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::layoutShadowContent): Deleted.
  Move this up from RenderImage to RenderReplaced so that
  RenderEmbeddedObject can reuse this shadow content layout logic too.
* Source/WebCore/rendering/RenderImage.h:

* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
(WebCore::RenderReplaced::layoutShadowContent):
  Special case the fragemented flow and new/old size comparison logic
  for RenderImage, so we don&apos;t introduce any unexpected behavior change
  during shadow content layout. However, skip this logic elsewhere since
  this seems mostly unnecessary.
* Source/WebCore/rendering/RenderReplaced.h:

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::supportsForms const):
(WebKit::PDFPluginBase::annotationStyle const):
  Make this a method, rather than a compile-time constant, so we can
  differentiate between the annotation stylesheet for plugins that have
  full support for forms versus those that do not (embedded plugins).
(WebKit::PDFPluginBase::supportsForms): Deleted.
  Make this a const method so it can be called from annotationStyle().

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installAnnotationContainer):
  Introduce a utility method that manages annotation container
  &quot;installation&quot; for the plugin. This method makes sure to instantiate a
  UA shadow root for the requisite plugin types and then appends the
  annotation container div to the appropriate parent element.
(WebKit::UnifiedPDFPlugin::createPasswordEntryForm):
  Enrich the password entry form creation logic by making it aware of
  the UA shadow root we create for certain plugin types. We still gate
  password entry field installation behind full forms support.
(WebKit::UnifiedPDFPlugin::supportsPasswordForm const):

Canonical link: <a href="https://commits.webkit.org/286001@main">https://commits.webkit.org/286001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ac10ee1dad0b08cf49edfaf702e45de4f30ac96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1689 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64038 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45723 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80382 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64056 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10027 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8182 "Failed to checkout and rebase branch from PR 35735") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1756 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->