### PR TITLE
Web Inspector: Elements tab DOM tree view reduces deeply-nested nodes to one character wide

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -25,7 +25,8 @@
 
 .tree-outline.dom {
     position: relative;
-
+    /* Ensure this containing block for the absolutely-positioned descendant .selection-area spans the full width of the scroll container so .selection-area spans from edge-to-edge of the scoll area. */
+    width: fit-content;
     min-width: 100%;
     margin: 0;
     padding: 0;
@@ -39,6 +40,7 @@
     color: var(--text-color);
 
     --item-pseudo-class-indicator-start: 2px;
+    --item-minimum-width: 200px;
 
     --sublist-margin-start: 4px;
     --sublist-padding-start: 1px;
@@ -129,6 +131,7 @@ body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemph
     padding: 0;
     word-wrap: break-word;
     outline: none;
+    min-width: var(--item-minimum-width);
 
     --item-padding-start: 17px;
     --item-padding-end: 6px;


### PR DESCRIPTION
#### c0cef41981cc6b72b407b35d20183df01caeebf5
<pre>
Web Inspector: Elements tab DOM tree view reduces deeply-nested nodes to one character wide
<a href="https://bugs.webkit.org/show_bug.cgi?id=234376">https://bugs.webkit.org/show_bug.cgi?id=234376</a>
<a href="https://rdar.apple.com/86833831">rdar://86833831</a>

Reviewed by BJ Burg.

Set a minimum width for DOM tree outline items to prevent wrapping to unusable widths.

Ensure the containing block for the absolutely-positioned selection area
(the blue/gray highlight for selected tree items) spans the full width of the scroll container.

Without this change, the absolutely-positioned element spans only the width of the scroll port,
and appears cut-off when scrolling horizontally.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css:
(.content-view.dom-tree &gt; .tree-outline-wrapper):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.tree-outline.dom):
(.tree-outline.dom li):
* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype.treeElementFromEvent):

Canonical link: <a href="https://commits.webkit.org/286163@main">https://commits.webkit.org/286163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec7967ec08702545aa5c8ec65bcf494734a1598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58318 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16659 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80078 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9831 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7988 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1466 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->