### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/WebProcess

### DIFF
--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -47,7 +47,9 @@ public:
     static RefPtr<GenericTypedArrayView> tryCreateUninitialized(size_t length);
     
     typename Adaptor::Type* data() const { return static_cast<typename Adaptor::Type*>(baseAddress()); }
-    
+    typename std::span<const typename Adaptor::Type> span() const { return { data(), length() }; }
+    typename std::span<typename Adaptor::Type> mutableSpan() { return { data(), length() }; }
+
     bool set(GenericTypedArrayView<Adaptor>* array, size_t offset)
     {
         return setImpl(array, offset * sizeof(typename Adaptor::Type));

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -167,6 +167,11 @@ inline std::span<const uint8_t> span(CFDataRef data)
     return { static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
 }
 
+inline std::span<uint8_t> mutableSpan(CFMutableDataRef data)
+{
+    return { static_cast<uint8_t*>(CFDataGetMutableBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+}
+
 inline RetainPtr<CFDataRef> toCFData(std::span<const uint8_t> span)
 {
     return adoptCF(CFDataCreate(kCFAllocatorDefault, span.data(), span.size()));
@@ -195,6 +200,7 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::createCFArray;
 using WTF::makeVector;
+using WTF::mutableSpan;
 using WTF::span;
 using WTF::toCFData;
 

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -80,7 +80,7 @@ ExceptionOr<void> GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GP
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.data(), dynamicOffsetsData.length(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
@@ -99,7 +99,7 @@ ExceptionOr<void> GPURenderBundleEncoder::setBindGroup(GPUIndex32 index, const G
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.data(), dynamicOffsetsData.length(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -98,7 +98,7 @@ ExceptionOr<void> GPURenderPassEncoder::setBindGroup(GPUIndex32 index, const GPU
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.data(), dynamicOffsetsData.length(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
@@ -76,14 +76,12 @@ void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGr
 }
 
 void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
-    const uint32_t* dynamicOffsetsArrayBuffer,
-    size_t dynamicOffsetsArrayBufferLength,
+    std::span<const uint32_t> dynamicOffsetsArrayBuffer,
     Size64 dynamicOffsetsDataStart,
     Size32 dynamicOffsetsDataLength)
 {
-    UNUSED_PARAM(dynamicOffsetsArrayBufferLength);
     // FIXME: Use checked algebra.
-    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart);
+    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
 }
 
 void ComputePassEncoderImpl::pushDebugGroup(String&& groupLabel)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
@@ -68,8 +68,7 @@ private:
         std::optional<Vector<BufferDynamicOffset>>&&) final;
 
     void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
@@ -95,8 +95,7 @@ void RenderBundleEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindG
 }
 
 void RenderBundleEncoderImpl::setBindGroup(Index32, const BindGroup&,
-    const uint32_t*,
-    size_t,
+    std::span<const uint32_t>,
     Size64,
     Size32)
 {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
@@ -77,8 +77,7 @@ private:
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) final;
 
     void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
@@ -96,14 +96,12 @@ void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGro
 }
 
 void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
-    const uint32_t* dynamicOffsetsArrayBuffer,
-    size_t dynamicOffsetsArrayBufferLength,
+    std::span<const uint32_t> dynamicOffsetsArrayBuffer,
     Size64 dynamicOffsetsDataStart,
     Size32 dynamicOffsetsDataLength)
 {
-    UNUSED_PARAM(dynamicOffsetsArrayBufferLength);
     // FIXME: Use checked algebra.
-    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart);
+    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
 }
 
 void RenderPassEncoderImpl::pushDebugGroup(String&& groupLabel)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
@@ -77,8 +77,7 @@ private:
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) final;
 
     void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
@@ -63,8 +63,7 @@ public:
         std::optional<Vector<BufferDynamicOffset>>&&) = 0;
 
     virtual void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
@@ -74,8 +74,7 @@ public:
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) = 0;
 
     virtual void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
@@ -76,8 +76,7 @@ public:
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) = 0;
 
     virtual void setBindGroup(Index32, const BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) = 0;
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -57,7 +57,7 @@ public:
 
     WEBCORE_EXPORT size_t storageSize() const;
 
-    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createPixelBufferFromMemory(const uint8_t* data, CVPixelBufferPoolRef = nullptr);
+    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createPixelBufferFromMemory(std::span<const uint8_t> data, CVPixelBufferPoolRef = nullptr);
 
     WEBCORE_EXPORT bool isReadWriteSupported() const;
     WEBCORE_EXPORT RetainPtr<CVPixelBufferPoolRef> createCompatibleBufferPool() const;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -32,8 +32,6 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoderProxy);
@@ -89,14 +87,13 @@ void RemoteComputePassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index,
 }
 
 void RemoteComputePassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, const WebCore::WebGPU::BindGroup& bindGroup,
-    const uint32_t* dynamicOffsetsArrayBuffer,
-    size_t dynamicOffsetsArrayBufferLength,
+    std::span<const uint32_t> dynamicOffsetsArrayBuffer,
     WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
 
-    auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
+    auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart, dynamicOffsetsDataLength))));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -125,7 +122,5 @@ void RemoteComputePassEncoderProxy::setLabelInternal(const String& label)
 }
 
 } // namespace WebKit::WebGPU
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -77,8 +77,7 @@ private:
         std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&&) final;
 
     void setBindGroup(WebCore::WebGPU::Index32, const WebCore::WebGPU::BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
         WebCore::WebGPU::Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -33,8 +33,6 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundleEncoderProxy);
@@ -124,14 +122,13 @@ void RemoteRenderBundleEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index
 }
 
 void RemoteRenderBundleEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, const WebCore::WebGPU::BindGroup& bindGroup,
-    const uint32_t* dynamicOffsetsArrayBuffer,
-    size_t dynamicOffsetsArrayBufferLength,
+    std::span<const uint32_t> dynamicOffsetsArrayBuffer,
     WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = protectedConvertToBackingContext()->convertToBacking(bindGroup);
 
-    auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
+    auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart, dynamicOffsetsDataLength))));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -180,7 +177,5 @@ Ref<ConvertToBackingContext> RemoteRenderBundleEncoderProxy::protectedConvertToB
 }
 
 } // namespace WebKit::WebGPU
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -87,8 +87,7 @@ private:
         std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets) final;
 
     void setBindGroup(WebCore::WebGPU::Index32, const WebCore::WebGPU::BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
         WebCore::WebGPU::Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -32,8 +32,6 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoderProxy);
@@ -123,14 +121,13 @@ void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, 
 }
 
 void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, const WebCore::WebGPU::BindGroup& bindGroup,
-    const uint32_t* dynamicOffsetsArrayBuffer,
-    size_t dynamicOffsetsArrayBufferLength,
+    std::span<const uint32_t> dynamicOffsetsArrayBuffer,
     WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = protectedConvertToBackingContext()->convertToBacking(bindGroup);
 
-    auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
+    auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart, dynamicOffsetsDataLength))));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -224,7 +221,5 @@ Ref<ConvertToBackingContext> RemoteRenderPassEncoderProxy::protectedConvertToBac
 }
 
 } // namespace WebKit::WebGPU
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -87,8 +87,7 @@ private:
         std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets) final;
 
     void setBindGroup(WebCore::WebGPU::Index32, const WebCore::WebGPU::BindGroup&,
-        const uint32_t* dynamicOffsetsArrayBuffer,
-        size_t dynamicOffsetsArrayBufferLength,
+        std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
         WebCore::WebGPU::Size32 dynamicOffsetsDataLength) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -39,8 +39,6 @@
 #import <WebCore/PlatformCALayer.h>
 #import <WebCore/PlatformCALayerDelegatedContents.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 namespace {
@@ -152,7 +150,7 @@ private:
     void addNewFence(Ref<DisplayBufferFence> newFence);
     static constexpr size_t maxPendingFences = 3;
     size_t m_oldestFenceIndex { 0 };
-    RefPtr<DisplayBufferFence> m_frameCompletionFences[maxPendingFences];
+    std::array<RefPtr<DisplayBufferFence>, maxPendingFences> m_frameCompletionFences;
 
     Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
     friend class RemoteGraphicsContextGLProxy;
@@ -202,7 +200,5 @@ Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(c
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/AudioUtilities.h>
 #include <WebCore/SharedMemory.h>
 #include <algorithm>
+#include <wtf/StdLibExtras.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/AudioUtilitiesCocoa.h>
@@ -44,8 +45,6 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <mach/mach_time.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -82,7 +81,7 @@ RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callba
 uint32_t RemoteAudioDestinationProxy::totalFrameCount() const
 {
     RELEASE_ASSERT(m_frameCount->size() == sizeof(std::atomic<uint32_t>));
-    return WTF::atomicLoad(reinterpret_cast<uint32_t*>(m_frameCount->mutableSpan().data()));
+    return WTF::atomicLoad(&spanReinterpretCast<uint32_t>(m_frameCount->mutableSpan())[0]);
 }
 
 void RemoteAudioDestinationProxy::startRenderingThread()
@@ -242,8 +241,9 @@ void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
         frameCount -= numberOfFrames;
         auto* ioData = m_audioBufferList->list();
 
-        auto* buffers = ioData->mBuffers;
+
         auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
+        auto buffers = unsafeForgeSpan(ioData->mBuffers, numberOfBuffers);
 
         // Associate the destination data array with the output bus then fill the FIFO.
         for (UInt32 i = 0; i < numberOfBuffers; ++i) {
@@ -270,7 +270,5 @@ void RemoteAudioDestinationProxy::gpuProcessConnectionDidClose(GPUProcessConnect
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/VP9UtilitiesCocoa.h>
 #include <WebCore/VideoFrameCV.h>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 ALLOW_COMMA_BEGIN
@@ -56,8 +57,6 @@ ALLOW_COMMA_BEGIN
 ALLOW_COMMA_END
 
 #include <pal/cf/CoreMediaSoftLink.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 using namespace WebCore;
@@ -154,7 +153,7 @@ static int32_t releaseVideoDecoder(webrtc::WebKitVideoDecoder::Value decoder)
 
 static int32_t decodeVideoFrame(webrtc::WebKitVideoDecoder::Value decoder, uint32_t timeStamp, const uint8_t* data, size_t size, uint16_t width,  uint16_t height)
 {
-    return WebProcess::singleton().libWebRTCCodecs().decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, { data, size }, width, height);
+    return WebProcess::singleton().libWebRTCCodecs().decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, unsafeForgeSpan(data, size), width, height);
 }
 
 static int32_t registerDecodeCompleteCallback(webrtc::WebKitVideoDecoder::Value decoder, void* decodedImageCallback)
@@ -807,7 +806,7 @@ void LibWebRTCCodecs::completedEncoding(VideoEncoderIdentifier identifier, std::
 
     if (encoder->encoderCallback) {
         auto temporalIndex = info.temporalIndex >= 0 ? std::make_optional<unsigned>(info.temporalIndex) : std::nullopt;
-        encoder->encoderCallback({ data.data(), data.size() }, info.frameType == webrtc::VideoFrameType::kVideoFrameKey, info.timeStamp, info.duration, temporalIndex);
+        encoder->encoderCallback(data, info.frameType == webrtc::VideoFrameType::kVideoFrameKey, info.timeStamp, info.duration, temporalIndex);
         return;
     }
 
@@ -929,7 +928,5 @@ inline RefPtr<RemoteVideoFrameObjectHeapProxy> LibWebRTCCodecs::protectedVideoFr
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -39,8 +39,6 @@
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if USE(LIBWEBRTC)
 
 ALLOW_COMMA_BEGIN
@@ -239,7 +237,7 @@ RetainPtr<CVPixelBufferRef> SharedVideoFrameReader::readBufferFromSharedMemory()
         return { };
     }
 
-    auto result = info->createPixelBufferFromMemory(data.data() + SharedVideoFrameInfoEncodingLength, pixelBufferPool(*info));
+    auto result = info->createPixelBufferFromMemory(data.subspan(SharedVideoFrameInfoEncodingLength), pixelBufferPool(*info));
     if (result && m_resourceOwner && m_useIOSurfaceBufferPool == UseIOSurfaceBufferPool::Yes)
         setOwnershipIdentityForCVPixelBuffer(result.get(), m_resourceOwner);
     return result;
@@ -314,7 +312,5 @@ bool SharedVideoFrameReader::setSharedMemory(SharedMemory::Handle&& handle)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -38,9 +38,8 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -122,7 +121,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
     if (m_isSuspended)
         return size;
 
-    std::span data(static_cast<const uint8_t*>(value), size);
+    auto data = unsafeForgeSpan(static_cast<const uint8_t*>(value), size);
     connection->send(Messages::NetworkRTCProvider::SendToSocket { identifier(), data, RTCNetwork::SocketAddress { address }, RTCPacketOptions { options } }, 0);
 
     return size;
@@ -181,7 +180,5 @@ void LibWebRTCSocket::suspend()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -100,7 +100,7 @@ private:
     State m_state { STATE_BINDING };
 
     static const unsigned MAX_SOCKET_OPTION { rtc::Socket::OPT_RTP_SENDTIME_EXTN_ID + 1 };
-    std::optional<int> m_options[MAX_SOCKET_OPTION];
+    std::array<std::optional<int>, MAX_SOCKET_OPTION> m_options;
 
     bool m_isSuspended { false };
     WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -79,7 +79,7 @@ public:
 
     // Only public for the callbacks
     size_t dataProviderGetBytesAtPosition(std::span<uint8_t> buffer, off_t position);
-    void dataProviderGetByteRanges(CFMutableArrayRef buffers, const CFRange* ranges, size_t count);
+    void dataProviderGetByteRanges(CFMutableArrayRef buffers, std::span<const CFRange> ranges);
 
 private:
     PDFIncrementalLoader(PDFPluginBase&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -45,8 +45,6 @@
 
 #import "PDFKitSoftLink.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -576,13 +574,13 @@ void PDFIncrementalLoader::requestDidCompleteWithAccumulatedData(ByteRangeReques
 static void dataProviderGetByteRangesCallback(void* info, CFMutableArrayRef buffers, const CFRange* ranges, size_t count)
 {
     RefPtr loader = reinterpret_cast<PDFIncrementalLoader*>(info);
-    loader->dataProviderGetByteRanges(buffers, ranges, count);
+    loader->dataProviderGetByteRanges(buffers, unsafeForgeSpan(ranges, count));
 }
 
 static size_t dataProviderGetBytesAtPositionCallback(void* info, void* buffer, off_t position, size_t count)
 {
     RefPtr loader = reinterpret_cast<PDFIncrementalLoader*>(info);
-    return loader->dataProviderGetBytesAtPosition({ static_cast<uint8_t*>(buffer), count }, position);
+    return loader->dataProviderGetBytesAtPosition(unsafeForgeSpan(static_cast<uint8_t*>(buffer), count), position);
 }
 
 static void dataProviderReleaseInfoCallback(void* info)
@@ -674,7 +672,7 @@ auto PDFIncrementalLoader::createDataSemaphore() -> RefPtr<SemaphoreWrapper>
     return dataSemaphore;
 }
 
-void PDFIncrementalLoader::dataProviderGetByteRanges(CFMutableArrayRef buffers, const CFRange* ranges, size_t count)
+void PDFIncrementalLoader::dataProviderGetByteRanges(CFMutableArrayRef buffers, std::span<const CFRange> ranges)
 {
     ASSERT(!isMainRunLoop());
 
@@ -685,20 +683,20 @@ void PDFIncrementalLoader::dataProviderGetByteRanges(CFMutableArrayRef buffers, 
 #if !LOG_DISABLED
     incrementThreadsWaitingOnCallback();
     TextStream stream;
-    stream << "PDF data provider requesting " << count << " byte ranges (";
-    for (size_t i = 0; i < count; ++i) {
+    stream << "PDF data provider requesting " << ranges.size() << " byte ranges (";
+    for (size_t i = 0; i < ranges.size(); ++i) {
         stream << ranges[i].length << " at " << ranges[i].location;
-        if (i < count - 1)
+        if (i < ranges.size() - 1)
             stream << ", ";
     }
     stream << ")";
     incrementalLoaderLog(stream.release());
 #endif
 
-    if (plugin->getByteRanges(buffers, ranges, count)) {
+    if (plugin->getByteRanges(buffers, ranges)) {
 #if !LOG_DISABLED
         decrementThreadsWaitingOnCallback();
-        incrementalLoaderLog(makeString("Satisfied "_s, count, " get byte ranges synchronously"_s));
+        incrementalLoaderLog(makeString("Satisfied "_s, ranges.size(), " get byte ranges synchronously"_s));
 #endif
         return;
     }
@@ -707,16 +705,16 @@ void PDFIncrementalLoader::dataProviderGetByteRanges(CFMutableArrayRef buffers, 
     if (!dataSemaphore)
         return;
 
-    Vector<RetainPtr<CFDataRef>> dataResults(count);
+    Vector<RetainPtr<CFDataRef>> dataResults(ranges.size());
 
-    // FIXME: Once we support multi-range requests, make a single request for all ranges instead of <count> individual requests.
-    RunLoop::protectedMain()->dispatch([protectedLoader = Ref { *this }, &dataResults, ranges, count, dataSemaphore]() mutable {
+    // FIXME: Once we support multi-range requests, make a single request for all ranges instead of <ranges.size()> individual requests.
+    RunLoop::protectedMain()->dispatch([protectedLoader = Ref { *this }, &dataResults, ranges, dataSemaphore]() mutable {
         if (dataSemaphore->wasSignaled())
             return;
         Ref callbackAggregator = CallbackAggregator::create([dataSemaphore] {
             dataSemaphore->signal();
         });
-        for (size_t i = 0; i < count; ++i) {
+        for (size_t i = 0; i < ranges.size(); ++i) {
             protectedLoader->getResourceBytesAtPosition(ranges[i].length, ranges[i].location, [i, &dataResults, dataSemaphore, callbackAggregator](std::span<const uint8_t> bytes) {
                 if (dataSemaphore->wasSignaled())
                     return;
@@ -729,7 +727,7 @@ void PDFIncrementalLoader::dataProviderGetByteRanges(CFMutableArrayRef buffers, 
 
 #if !LOG_DISABLED
     decrementThreadsWaitingOnCallback();
-    incrementalLoaderLog(makeString("PDF data provider finished receiving the requested "_s, count, " byte ranges"_s));
+    incrementalLoaderLog(makeString("PDF data provider finished receiving the requested "_s, ranges.size(), " byte ranges"_s));
 #endif
 
     for (auto& result : dataResults) {
@@ -865,7 +863,5 @@ void PDFIncrementalLoader::logState(TextStream& ts)
 #endif
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN) && HAVE(INCREMENTAL_PDF_APIS)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -295,7 +295,7 @@ private:
     // FIXME: It would be nice to avoid having both the "copy into a buffer" and "return a pointer" ways of getting data.
     std::span<const uint8_t> dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges) const;
     // Returns true only if we can satisfy all of the requests.
-    bool getByteRanges(CFMutableArrayRef, const CFRange*, size_t count) const;
+    bool getByteRanges(CFMutableArrayRef, std::span<const CFRange>) const;
 
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
@@ -36,8 +36,6 @@
 #import <wtf/text/StringView.h>
 #import <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit::PDFScriptEvaluation {
 
 static bool isPrintScript(const String& script)
@@ -106,9 +104,9 @@ static bool pdfDocumentContainsPrintScript(RetainPtr<CGPDFDocumentRef> pdfDocume
         if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
             continue;
 
-        auto scriptFromBytes = [](const UInt8* bytes, CFIndex length) {
-            CFStringEncoding encoding = (length > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;
-            return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, bytes, length, encoding, true));
+        auto scriptFromBytes = [](std::span<const uint8_t> bytes) {
+            CFStringEncoding encoding = (bytes.size() > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;
+            return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, bytes.data(), bytes.size(), encoding, true));
         };
 
         auto scriptFromStream = [&] -> RetainPtr<CFStringRef> {
@@ -119,14 +117,14 @@ static bool pdfDocumentContainsPrintScript(RetainPtr<CGPDFDocumentRef> pdfDocume
             RetainPtr<CFDataRef> data = adoptCF(CGPDFStreamCopyData(stream, &format));
             if (!data)
                 return nullptr;
-            return scriptFromBytes(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
+            return scriptFromBytes(span(data.get()));
         };
 
         auto scriptFromString = [&] -> RetainPtr<CFStringRef> {
             CGPDFStringRef string = nullptr;
             if (!CGPDFDictionaryGetString(javaScriptAction, "JS", &string))
                 return nullptr;
-            return scriptFromBytes(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string));
+            return scriptFromBytes(unsafeForgeSpan(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string)));
         };
 
         if (RetainPtr<CFStringRef> script = scriptFromStream() ?: scriptFromString(); script && isPrintScript({ script.get() }))
@@ -143,7 +141,5 @@ void runScripts(CGPDFDocumentRef document, PrintingCallback&& callback)
 }
 
 } // namespace WebKit::PDFScriptEvaluation
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -68,8 +68,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit::IPCTestingAPI {
 
 class JSIPC;
@@ -495,9 +493,9 @@ struct SyncIPCMessageInfo {
 
 }
 
-static std::optional<SyncIPCMessageInfo> extractSyncIPCMessageInfo(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static std::optional<SyncIPCMessageInfo> extractSyncIPCMessageInfo(JSContextRef context, std::span<const JSValueRef> arguments, JSValueRef* exception)
 {
-    ASSERT(argumentCount >= 2);
+    ASSERT(arguments.size() >= 2);
     auto* globalObject = toJS(context);
     auto destinationID = destinationIDFromArgument(globalObject, arguments[0], exception);
     if (!destinationID)
@@ -847,14 +845,16 @@ JSValueRef JSIPCConnection::invalidate(JSContextRef context, JSObjectRef, JSObje
     return JSValueMakeUndefined(context);
 }
 
-JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -866,18 +866,20 @@ JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObj
     auto messageName = messageNameFromArgument(globalObject, arguments[1], exception);
     if (!messageName)
         return JSValueMakeUndefined(context);
-    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 2 ? arguments[2] : nullptr;
     return jsSend(jsIPC->m_testedConnection.get(), *destinationID, *messageName, context, messageArguments, exception);
 }
 
-JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 4) {
+    if (arguments.size() < 4) {
         *exception = createTypeError(context, "Must specify the destination ID, message ID, messageArguments, callback as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -906,55 +908,61 @@ JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef
     return jsSendWithAsyncReply(jsIPC->m_testedConnection.get(), *destinationID, *messageName, context, callback, arguments[2], exception);
 }
 
-JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
-    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 3 ? arguments[3] : nullptr;
     return jsSendSync(jsIPC->m_testedConnection.get(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
-JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
     return jsWaitForMessage(jsIPC->m_testedConnection.get(), destinationID, messageName, timeout, context, exception);
 }
 
-JSValueRef JSIPCConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 3) {
+    if (arguments.size() < 3) {
         *exception = createTypeError(context, "Must specify the message name, async reply ID and timeout as the first three arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
@@ -1063,8 +1071,10 @@ JSValueRef JSIPCStreamClientConnection::streamBuffer(JSContextRef context, JSObj
     return JSIPCStreamConnectionBuffer::create(*jsStreamConnection)->createJSWrapper(context);
 }
 
-JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
     RefPtr jsStreamConnection = toWrapped(context, thisObject);
@@ -1073,7 +1083,7 @@ JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSOb
         return JSValueMakeUndefined(context);
     }
 
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify an IPC semaphore as the first and second argument"_s);
         return JSValueMakeUndefined(context);
     }
@@ -1099,9 +1109,9 @@ struct IPCStreamMessageInfo {
     IPC::MessageName messageName;
 };
 
-static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContextRef context, std::span<const JSValueRef> arguments, JSValueRef* exception)
 {
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify destination ID, message ID as the first two arguments"_s);
         return std::nullopt;
     }
@@ -1129,36 +1139,40 @@ bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(uint64_t desti
     return true;
 }
 
-JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName] = *info;
     auto timeout = jsIPC->m_streamConnection->defaultTimeout();
     if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout))
         return JSValueMakeUndefined(context);
-    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 2 ? arguments[2] : nullptr;
     return jsSend(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, messageArguments, exception);
 }
 
-JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 4) {
+    if (arguments.size() < 4) {
         *exception = createTypeError(context, "Must specify destination ID, message ID, messageArguments, callback as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName] = *info;
@@ -1184,14 +1198,16 @@ JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context,
     return jsSendWithAsyncReply(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, callback, arguments[2], exception);
 }
 
-JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName] = *info;
@@ -1200,13 +1216,15 @@ JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JS
         *exception = createError(context, "IPC error: prepare failed"_s);
         return JSValueMakeUndefined(context);
     }
-    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 2 ? arguments[2] : nullptr;
     return jsSendSync(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
 // FIXME(http://webkit.org/b/237197): Cannot send arbitrary messages, so we hard-code this one to be able to send it.
-JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
 
@@ -1216,7 +1234,7 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
         return JSValueMakeUndefined(context);
     }
 
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify destination ID, value as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -1249,36 +1267,40 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
     return JSValueMakeNumber(context, resultValue);
 }
 
-JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName] = *info;
     return jsWaitForMessage(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, jsIPC->m_streamConnection->defaultTimeout(), context, exception);
 }
 
-JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 2) {
+    if (arguments.size() < 2) {
         *exception = createTypeError(context, "Must specify the message name, async reply ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName] = *info;
@@ -1515,8 +1537,10 @@ const JSStaticFunction* JSSharedMemory::staticFunctions()
     return functions;
 }
 
-JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsSharedMemory = toWrapped(context, thisObject);
     if (!jsSharedMemory) {
         *exception = createTypeError(context, "Wrong type"_s);
@@ -1529,7 +1553,7 @@ JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObject
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
-    if (argumentCount) {
+    if (!arguments.empty()) {
         auto offsetValue = convertToUint64(toJS(globalObject, arguments[0]));
         if (!offsetValue) {
             *exception = createTypeError(context, "The first argument must be a byte offset to read"_s);
@@ -1542,7 +1566,7 @@ JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObject
         length -= offset;
     }
 
-    if (argumentCount > 1) {
+    if (arguments.size() > 1) {
         auto lengthValue = convertToUint64(toJS(globalObject, arguments[1]));
         if (!lengthValue) {
             *exception = createTypeError(context, "The second argument must be the number of bytes to read"_s);
@@ -1585,18 +1609,20 @@ static std::span<const uint8_t> arrayBufferSpanFromValueRef(JSContextRef context
     else
         length = JSObjectGetTypedArrayByteLength(context, objectRef, exception);
 
-    return { static_cast<const uint8_t*>(buffer), length };
+    return unsafeForgeSpan(static_cast<const uint8_t*>(buffer), length);
 }
 
-JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsSharedMemory = toWrapped(context, thisObject);
     if (!jsSharedMemory) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
 
-    auto type = argumentCount ? JSValueGetTypedArrayType(context, arguments[0], exception) : kJSTypedArrayTypeNone;
+    auto type = arguments.size() > 0 ? JSValueGetTypedArrayType(context, arguments[0], exception) : kJSTypedArrayTypeNone;
     if (type == kJSTypedArrayTypeNone) {
         *exception = createTypeError(context, "The first argument must be an array buffer or a typed array"_s);
         return JSValueMakeUndefined(context);
@@ -1616,7 +1642,7 @@ JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjec
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
 
-    if (argumentCount > 1) {
+    if (arguments.size() > 1) {
         auto offsetValue = convertToUint64(toJS(globalObject, arguments[1]));
         if (!offsetValue) {
             *exception = createTypeError(context, "The second argument must be a byte offset to write"_s);
@@ -1629,7 +1655,7 @@ JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjec
         offset = *offsetValue;
     }
 
-    if (argumentCount > 2) {
+    if (arguments.size() > 2) {
         auto lengthValue = convertToUint64(toJS(globalObject, arguments[2]));
         if (!lengthValue) {
             *exception = createTypeError(context, "The third argument must be the number of bytes to write"_s);
@@ -1685,14 +1711,16 @@ JSValueRef JSIPCStreamConnectionBuffer::readDataBytes(JSContextRef context, JSOb
     return readBytes(context, nullptr, thisObject, argumentCount, arguments, exception, span);
 }
 
-JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception, std::span<uint8_t> span)
+JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception, std::span<uint8_t> span)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     size_t offset = 0;
     size_t length = span.size();
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
-    if (argumentCount) {
+    if (!arguments.empty()) {
         auto offsetValue = convertToUint64(toJS(globalObject, arguments[0]));
         if (!offsetValue) {
             *exception = createTypeError(context, "The first argument must be a byte offset to read"_s);
@@ -1705,7 +1733,7 @@ JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObject
         length -= offset;
     }
 
-    if (argumentCount > 1) {
+    if (arguments.size() > 1) {
         auto lengthValue = convertToUint64(toJS(globalObject, arguments[1]));
         if (!lengthValue) {
             *exception = createTypeError(context, "The second argument must be the number of bytes to read"_s);
@@ -1765,9 +1793,11 @@ JSValueRef JSIPCStreamConnectionBuffer::writeDataBytes(JSContextRef context, JSO
     return writeBytes(context, nullptr, thisObject, argumentCount, arguments, exception, span);
 }
 
-JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception, std::span<uint8_t> span)
+JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception, std::span<uint8_t> span)
 {
-    auto type = argumentCount ? JSValueGetTypedArrayType(context, arguments[0], exception) : kJSTypedArrayTypeNone;
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
+    auto type = arguments.size() > 0 ? JSValueGetTypedArrayType(context, arguments[0], exception) : kJSTypedArrayTypeNone;
     if (type == kJSTypedArrayTypeNone) {
         *exception = createTypeError(context, "The first argument must be an array buffer or a typed array"_s);
         return JSValueMakeUndefined(context);
@@ -1783,13 +1813,13 @@ JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjec
     size_t length = data.size();
 
     size_t sharedMemorySize = span.size();
-    uint8_t* destinationData = span.data();
+    auto destinationData = span;
 
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
 
-    if (argumentCount > 1) {
+    if (arguments.size() > 1) {
         auto offsetValue = convertToUint64(toJS(globalObject, arguments[1]));
         if (!offsetValue) {
             *exception = createTypeError(context, "The second argument must be a byte offset to write"_s);
@@ -1802,7 +1832,7 @@ JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjec
         offset = *offsetValue;
     }
 
-    if (argumentCount > 2) {
+    if (arguments.size() > 2) {
         auto lengthValue = convertToUint64(toJS(globalObject, arguments[2]));
         if (!lengthValue) {
             *exception = createTypeError(context, "The third argument must be the number of bytes to write"_s);
@@ -1815,7 +1845,7 @@ JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjec
         length = *lengthValue;
     }
 
-    memcpy(destinationData + offset, data.data(), length);
+    memcpySpan(destinationData.subspan(offset), data.first(length));
     return JSValueMakeUndefined(context);
 }
 
@@ -1928,14 +1958,16 @@ RefPtr<JSIPCConnection> JSIPC::processTargetFromArgument(JSC::JSGlobalObject* gl
     return nullptr;
 }
 
-void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef context, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef context, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return;
     }
-    if (argumentCount < 1) {
+    if (arguments.size() < 1) {
         *exception = createTypeError(context, "Must specify the target process as the first argument"_s);
         return;
     }
@@ -1946,7 +1978,7 @@ void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef contex
         return;
 
     RefPtr<JSMessageListener> listener;
-    if (argumentCount >= 2 && JSValueIsObject(context, arguments[1])) {
+    if (arguments.size() >= 2 && JSValueIsObject(context, arguments[1])) {
         auto listenerObjectRef = JSValueToObject(context, arguments[1], exception);
         if (JSObjectIsFunction(context, listenerObjectRef))
             listener = JSMessageListener::create(*jsIPC, type, globalObject, listenerObjectRef);
@@ -2489,14 +2521,16 @@ JSValueRef JSIPC::connectionForProcessTarget(JSContextRef context, JSObjectRef, 
     return connection->createJSWrapper(context);
 }
 
-JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 3) {
+    if (arguments.size() < 3) {
         *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID as the first three arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -2511,18 +2545,20 @@ JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thi
     auto messageName = messageNameFromArgument(globalObject, arguments[2], exception);
     if (!messageName)
         return JSValueMakeUndefined(context);
-    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 3 ? arguments[3] : nullptr;
     return jsSend(connection->connection().get(), *destinationID, *messageName, context, messageArguments, exception);
 }
 
-JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 4) {
+    if (arguments.size() < 4) {
         *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID, timeout as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -2531,21 +2567,23 @@ JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef 
     auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return JSValueMakeUndefined(context);
-    auto info = extractSyncIPCMessageInfo(context, argumentCount - 1, arguments + 1, exception);
+    auto info = extractSyncIPCMessageInfo(context, arguments.subspan(1), exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
     return jsWaitForMessage(connection->connection().get(), destinationID, messageName, timeout, context, exception);
 }
 
-JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 4) {
+    if (arguments.size() < 4) {
         *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID, timeout as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
@@ -2554,11 +2592,11 @@ JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef
     auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return JSValueMakeUndefined(context);
-    auto info = extractSyncIPCMessageInfo(context, argumentCount - 1, arguments + 1, exception);
+    auto info = extractSyncIPCMessageInfo(context, arguments.subspan(1), exception);
     if (!info)
         return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
-    JSValueRef messageArguments = argumentCount > 4 ? arguments[4] : nullptr;
+    JSValueRef messageArguments = arguments.size() > 4 ? arguments[4] : nullptr;
     return jsSendSync(connection->connection().get(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
@@ -2588,8 +2626,10 @@ JSValueRef JSIPC::createConnectionPair(JSContextRef context, JSObjectRef, JSObje
     return toRef(vm, connectionPairObject);
 }
 
-JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
+    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
     RefPtr jsIPC = toWrapped(context, thisObject);
@@ -2598,17 +2638,17 @@ JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef
         return JSValueMakeUndefined(context);
     }
 
-    if (argumentCount < 1) {
+    if (arguments.size() < 1) {
         *exception = createTypeError(context, "Must specify the buffer size as the first argument"_s);
         return JSValueMakeUndefined(context);
     }
 
-    auto bufferSizeLog2 = argumentCount ? convertToUint64(toJS(globalObject, arguments[0])) : std::optional<uint64_t> { };
+    auto bufferSizeLog2 = arguments.size() > 0 ? convertToUint64(toJS(globalObject, arguments[0])) : std::optional<uint64_t> { };
     if (!bufferSizeLog2) {
         *exception = createTypeError(context, "Must specify the size"_s);
         return JSValueMakeUndefined(context);
     }
-    auto defaultTimeoutDuration = argumentCount > 1 ? convertToDouble(toJS(globalObject, arguments[1])) : std::optional<double> { };
+    auto defaultTimeoutDuration = arguments.size() > 1 ? convertToDouble(toJS(globalObject, arguments[1])) : std::optional<double> { };
     if (!defaultTimeoutDuration) {
         *exception = createTypeError(context, "Must specify the defaultTimeoutDuration"_s);
         return JSValueMakeUndefined(context);
@@ -3158,5 +3198,3 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* glob
 } // namespace IPC
 
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -34,8 +34,6 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 static constexpr Seconds deltaHistoryMaximumAge = 500_ms;
@@ -468,8 +466,8 @@ void MomentumEventDispatcher::equalizeTailGaps()
         return;
 
     enum Axis { Horizontal, Vertical };
-    Vector<float> deltas[2];
-    unsigned firstZeroIndex[2] = { 0, 0 };
+    std::array<Vector<float>, 2> deltas;
+    std::array<unsigned, 2> firstZeroIndex = { 0, 0 };
     deltas[Horizontal].reserveInitialCapacity(initialTableSize);
     deltas[Vertical].reserveInitialCapacity(initialTableSize);
     for (unsigned i = 0; i < initialTableSize; i++) {
@@ -496,11 +494,11 @@ void MomentumEventDispatcher::equalizeTailGaps()
     sortDeltas(Vertical);
 
     // GapSize is a count of contiguous frames with zero deltas.
-    typedef unsigned GapSize[2];
+    using GapSize = std::array<unsigned, 2>;
     GapSize minimumGap = { 0, 0 };
     GapSize currentGap = { 0, 0 };
     GapSize remainingGapToGenerate = { 0, 0 };
-    unsigned originalTableIndex[2] = { 0, 0 };
+    std::array<unsigned, 2> originalTableIndex = { 0, 0 };
 
     auto takeNextDelta = [&] (uint8_t axis) -> float {
         if (originalTableIndex[axis] >= initialTableSize)
@@ -681,7 +679,5 @@ void MomentumEventDispatcher::flushLog()
 #endif
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -191,8 +191,6 @@
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #import <pal/cocoa/MediaToolboxSoftLink.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #define RELEASE_LOG_SESSION_ID (m_sessionID ? m_sessionID->toUInt64() : 0)
 #define WEBPROCESS_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
 #define WEBPROCESS_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
@@ -1534,5 +1532,3 @@ void WebProcess::postObserverNotification(const String& message)
 #undef RELEASE_LOG_SESSION_ID
 #undef WEBPROCESS_RELEASE_LOG
 #undef WEBPROCESS_RELEASE_LOG_ERROR
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 6694cfadc3d03260771eb5770239256d5f39f1c4
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=282119">https://bugs.webkit.org/show_bug.cgi?id=282119</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/runtime/GenericTypedArrayView.h:
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::mutableSpan):
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp:
(WebCore::GPUComputePassEncoder::setBindGroup):
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp:
(WebCore::GPURenderBundleEncoder::setBindGroup):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp:
(WebCore::WebGPU::ComputePassEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp:
(WebCore::WebGPU::RenderBundleEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp:
(WebCore::WebGPU::RenderPassEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::copyToCVPixelBufferPlane):
(WebCore::SharedVideoFrameInfo::createPixelBufferFromMemory):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::totalFrameCount const):
(WebKit::RemoteAudioDestinationProxy::renderAudio):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::decodeVideoFrame):
(WebKit::LibWebRTCCodecs::completedEncoding):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameReader::readBufferFromSharedMemory):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::SendTo):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::dataProviderGetByteRangesCallback):
(WebKit::dataProviderGetBytesAtPositionCallback):
(WebKit::PDFIncrementalLoader::dataProviderGetByteRanges):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::dataSpanForRange const):
(WebKit::PDFPluginBase::getByteRanges const):
(WebKit::PDFPluginBase::insertRangeRequestData):
(WebKit::PDFPluginBase::streamDidReceiveData):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm:
(WebKit::PDFScriptEvaluation::pdfDocumentContainsPrintScript):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::extractSyncIPCMessageInfo):
(WebKit::IPCTestingAPI::JSIPCConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::setSemaphores):
(WebKit::IPCTestingAPI::extractIPCStreamMessageInfo):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSSharedMemory::readBytes):
(WebKit::IPCTestingAPI::arrayBufferSpanFromValueRef):
(WebKit::IPCTestingAPI::JSSharedMemory::writeBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::writeBytes):
(WebKit::IPCTestingAPI::JSIPC::addMessageListener):
(WebKit::IPCTestingAPI::JSIPC::sendMessage):
(WebKit::IPCTestingAPI::JSIPC::waitForMessage):
(WebKit::IPCTestingAPI::JSIPC::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPC::createStreamClientConnection):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::equalizeTailGaps):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/285731@main">https://commits.webkit.org/285731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a3b0e3809011cb478a90d4fc58071d759c233c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20855 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23216 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66782 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79534 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72902 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/433 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66277 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65550 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7590 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94684 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3676 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20821 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->