### PR TITLE
requestIdleCallback can continuously schedule WindowEventLoop's timer

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS idleDeadline.timeRemaining() <= preferredRenderingUpdateInterval is true
-PASS didRunIdleCallback is true
+PASS didRunIdleCallback became true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html
@@ -22,10 +22,7 @@ onload = () => {
         if (idleDeadline.timeRemaining() > preferredRenderingUpdateInterval)
             console.log(idleDeadline.timeRemaining() + ' >'  + preferredRenderingUpdateInterval);
     });
-    setTimeout(() => {
-        shouldBeTrue('didRunIdleCallback');
-        finishJSTest();
-    }, 200);
+    shouldBecomeEqual("didRunIdleCallback", "true", finishJSTest);
 }
 
 </script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8470,6 +8470,13 @@ void Document::cancelIdleCallback(int id)
     m_idleCallbackController->removeIdleCallback(id);
 }
 
+bool Document::hasPendingIdleCallback() const
+{
+    if (activeDOMObjectsAreSuspended() || activeDOMObjectsAreStopped())
+        return false;
+    return m_idleCallbackController && !m_idleCallbackController->isEmpty();
+}
+
 HttpEquivPolicy Document::httpEquivPolicy() const
 {
     if (shouldEnforceContentDispositionAttachmentSandbox())

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1458,7 +1458,8 @@ public:
 
     int requestIdleCallback(Ref<IdleRequestCallback>&&, Seconds timeout);
     void cancelIdleCallback(int id);
-    IdleCallbackController* idleCallbackController() { return m_idleCallbackController.get(); }
+    bool hasPendingIdleCallback() const;
+    IdleCallbackController* idleCallbackController() const { return m_idleCallbackController.get(); }
 
     EventTarget* errorEventTarget() final;
     void logExceptionToConsole(const String& errorMessage, const String& sourceURL, int lineNumber, int columnNumber, RefPtr<Inspector::ScriptCallStack>&&) final;

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -64,8 +64,10 @@ int IdleCallbackController::queueIdleCallback(Ref<IdleRequestCallback>&& callbac
                 weakThis->invokeIdleCallbackTimeout(handle);
             });
         });
-    } else if (RefPtr page = m_document ? m_document->page() : nullptr)
-        m_document->protectedWindowEventLoop()->scheduleIdlePeriod(*page);
+    }
+
+    if (RefPtr document = m_document.get())
+        document->protectedWindowEventLoop()->scheduleIdlePeriod();
 
     return handle;
 }

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -92,6 +92,7 @@ inline Ref<WindowEventLoop> WindowEventLoop::create(const String& agentClusterKe
 inline WindowEventLoop::WindowEventLoop(const String& agentClusterKey)
     : m_agentClusterKey(agentClusterKey)
     , m_timer(*this, &WindowEventLoop::didReachTimeToRun)
+    , m_idleTimer(*this, &WindowEventLoop::didFireIdleTimer)
     , m_perpetualTaskGroupForSimilarOriginWindowAgents(*this)
 {
 }
@@ -121,28 +122,42 @@ MicrotaskQueue& WindowEventLoop::microtaskQueue()
     return *m_microtaskQueue;
 }
 
-void WindowEventLoop::scheduleIdlePeriod(Page& page)
+void WindowEventLoop::scheduleIdlePeriod()
 {
-    if (m_pagesWithRenderingOpportunity.contains(page) && page.opportunisticTaskScheduler().isScheduled())
-        page.opportunisticTaskScheduler().willQueueIdleCallback();
-    scheduleToRunIfNeeded();
+    m_idleTimer.startOneShot(0_s);
 }
 
-void WindowEventLoop::didScheduleRenderingUpdate(Page& page, MonotonicTime nextRenderingUpdate)
+void WindowEventLoop::opportunisticallyRunIdleCallbacks(std::optional<MonotonicTime> deadline)
 {
-    m_pagesWithRenderingOpportunity.set(page, nextRenderingUpdate);
-}
+    if (shouldEndIdlePeriod())
+        return; // No need to schedule m_idleTimer since there is a task. didReachTimeToRun() will call this function.
 
-void WindowEventLoop::didStartRenderingUpdate(Page& page)
-{
-    m_pagesWithRenderingOpportunity.remove(page);
-}
+    auto hasPendingIdleCallbacks = findMatchingAssociatedContext([&](ScriptExecutionContext& context) {
+        if (RefPtr document = dynamicDowncast<Document>(context))
+            return document->hasPendingIdleCallback();
+        return false;
+    });
 
-void WindowEventLoop::opportunisticallyRunIdleCallbacks()
-{
+    if (!hasPendingIdleCallbacks)
+        return;
+
     auto now = MonotonicTime::now();
-    if (shouldEndIdlePeriod(now)) {
+    if (auto scheduledWork = nextScheduledWorkTime()) {
+        if (*scheduledWork < now + m_expectedIdleCallbackDuration) {
+            // No pending tasks. Schedule m_idleTimer after all DOM timers and rAF.
+            auto timeToScheduledWork = *scheduledWork - now;
+            if (timeToScheduledWork < 0_s) // Timer may have been scheduled to fire in the past.
+                timeToScheduledWork = 0_s;
+            decayIdleCallbackDuration();
+            m_idleTimer.startOneShot(timeToScheduledWork + 1_ms);
+            return;
+        }
+    }
+
+    if (deadline && *deadline < now + m_expectedIdleCallbackDuration) {
+        // No pending tasks. Schedule m_idleTimer immediately.
         decayIdleCallbackDuration();
+        m_idleTimer.startOneShot(0_s);
         return;
     }
 
@@ -150,7 +165,7 @@ void WindowEventLoop::opportunisticallyRunIdleCallbacks()
 
     forEachAssociatedContext([&](ScriptExecutionContext& context) {
         RefPtr document = dynamicDowncast<Document>(context);
-        if (!document)
+        if (!document || !document->hasPendingIdleCallback())
             return;
         auto* idleCallbackController = document->idleCallbackController();
         if (!idleCallbackController)
@@ -162,45 +177,54 @@ void WindowEventLoop::opportunisticallyRunIdleCallbacks()
     m_expectedIdleCallbackDuration = (m_expectedIdleCallbackDuration + duration) / 2;
 }
 
-bool WindowEventLoop::shouldEndIdlePeriod(MonotonicTime now)
+bool WindowEventLoop::shouldEndIdlePeriod()
 {
     if (hasTasksForFullyActiveDocument())
         return true;
     if (microtaskQueue().hasMicrotasksForFullyActiveDocument())
-        return true;
-    auto expectedFinishTime = now + m_expectedIdleCallbackDuration;
-    auto renderingTime = nextRenderingTime();
-    if (renderingTime && *renderingTime < expectedFinishTime)
-        return true;
-    auto timerTime = nextTimerFireTime();
-    if (timerTime && *timerTime < expectedFinishTime)
         return true;
     return false;
 }
 
 MonotonicTime WindowEventLoop::computeIdleDeadline()
 {
-    auto minTime = m_lastIdlePeriodStartTime + 50_ms;
+    auto idleDeadline = m_lastIdlePeriodStartTime + 50_ms;
 
+    auto workTime = nextScheduledWorkTime();
+    if (workTime && *workTime < idleDeadline)
+        idleDeadline = *workTime;
+
+    return idleDeadline;
+}
+
+std::optional<MonotonicTime> WindowEventLoop::nextScheduledWorkTime() const
+{
     auto timerTime = nextTimerFireTime();
-    if (timerTime && *timerTime < minTime)
-        minTime = *timerTime;
-
     auto renderingTime = nextRenderingTime();
-    if (renderingTime && *renderingTime < minTime)
-        minTime = *renderingTime;
-
-    return minTime;
+    if (!timerTime)
+        return renderingTime;
+    if (!renderingTime)
+        return timerTime;
+    return *timerTime < *renderingTime ? *timerTime : *renderingTime;
 }
 
 std::optional<MonotonicTime> WindowEventLoop::nextRenderingTime() const
 {
-    std::optional<MonotonicTime> result;
-    for (auto it : m_pagesWithRenderingOpportunity) {
-        if (!result || it.value < *result)
-            result = it.value;
-    }
-    return result;
+    std::optional<MonotonicTime> nextRenderingTime;
+    const_cast<WindowEventLoop*>(this)->forEachAssociatedContext([&](ScriptExecutionContext& context) {
+        RefPtr document = dynamicDowncast<Document>(context);
+        if (!document)
+            return;
+        RefPtr page = document->page();
+        if (!page)
+            return;
+        auto renderingUpdateTimeForPage = page->nextRenderingUpdateTimestamp();
+        if (!renderingUpdateTimeForPage)
+            return;
+        if (!nextRenderingTime || *renderingUpdateTimeForPage < *nextRenderingTime)
+            nextRenderingTime = *renderingUpdateTimeForPage;
+    });
+    return nextRenderingTime;
 }
 
 void WindowEventLoop::didReachTimeToRun()
@@ -208,25 +232,12 @@ void WindowEventLoop::didReachTimeToRun()
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
     auto deadline = ApproximateTime::now() + ThreadTimers::maxDurationOfFiringTimers;
     run(deadline);
+    opportunisticallyRunIdleCallbacks(deadline.approximateMonotonicTime());
+}
 
-    auto hasIdleCallbacks = findMatchingAssociatedContext([&](ScriptExecutionContext& context) {
-        RefPtr document = dynamicDowncast<Document>(context);
-        if (!document || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
-            return false;
-        auto* idleCallbackController = document->idleCallbackController();
-        if (!idleCallbackController)
-            return false;
-        return !idleCallbackController->isEmpty();
-    });
-    if (!hasIdleCallbacks)
-        return;
-
-    if (shouldEndIdlePeriod(MonotonicTime::now())) {
-        decayIdleCallbackDuration();
-        scheduleToRunIfNeeded();
-        return;
-    }
-
+void WindowEventLoop::didFireIdleTimer()
+{
+    Ref protectedThis { *this }; // Executing idle tasks may remove the last reference to this WindowEventLoop.
     opportunisticallyRunIdleCallbacks();
 }
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -28,6 +28,7 @@
 
 #include "CommonVM.h"
 #include "GCController.h"
+#include "IdleCallbackController.h"
 #include "Page.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -53,7 +54,10 @@ void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
     if (page->isWaitingForLoadToFinish() || !page->isVisibleAndActive())
         return;
 
-    if (!m_mayHavePendingIdleCallbacks && !page->settings().opportunisticSweepingAndGarbageCollectionEnabled())
+    auto hasIdleCallbacks = page->findMatchingLocalDocument([](const Document& document) {
+        return document.hasPendingIdleCallback();
+    });
+    if (!hasIdleCallbacks && !page->settings().opportunisticSweepingAndGarbageCollectionEnabled())
         return;
 
     m_runloopCountAfterBeingScheduled = 0;
@@ -127,14 +131,7 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     };
 
     auto deadline = std::exchange(m_currentDeadline, MonotonicTime { });
-    if (std::exchange(m_mayHavePendingIdleCallbacks, false)) {
-        auto weakPage = m_page;
-        page->opportunisticallyRunIdleCallbacks();
-        if (UNLIKELY(!weakPage)) {
-            dataLogLnIf(verbose, "[OPPORTUNISTIC TASK] GaveUp: page gets destroyed", " signpost:(", JSC::activeJSGlobalObjectSignpostIntervalCount.load(), ")");
-            return;
-        }
-    }
+    page->opportunisticallyRunIdleCallbacks(deadline);
 
     if (!page->settings().opportunisticSweepingAndGarbageCollectionEnabled()) {
         dataLogLnIf(verbose, "[OPPORTUNISTIC TASK] GaveUp: opportunistic sweep and GC is not enabled", " signpost:(", JSC::activeJSGlobalObjectSignpostIntervalCount.load(), ")");

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -63,8 +63,6 @@ public:
 
     ~OpportunisticTaskScheduler();
 
-    void willQueueIdleCallback() { m_mayHavePendingIdleCallbacks = true; }
-
     bool isScheduled() const { return m_runLoopObserver->isScheduled(); }
     void rescheduleIfNeeded(MonotonicTime deadline);
     bool hasImminentlyScheduledWork() const { return m_imminentlyScheduledWorkCount; }
@@ -126,7 +124,6 @@ private:
     uint64_t m_runloopCountAfterBeingScheduled { 0 };
     MonotonicTime m_currentDeadline;
     std::unique_ptr<RunLoopObserver> m_runLoopObserver;
-    bool m_mayHavePendingIdleCallbacks { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1065,6 +1065,7 @@ public:
 #endif
 
     WEBCORE_EXPORT void forEachDocument(const Function<void(Document&)>&) const;
+    bool findMatchingLocalDocument(const Function<bool(Document&)>&) const;
     void forEachRenderableDocument(const Function<void(Document&)>&) const;
     void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);
     static void forEachDocumentFromMainFrame(const Frame&, const Function<void(Document&)>&);
@@ -1085,6 +1086,7 @@ public:
     WEBCORE_EXPORT void notifyToInjectUserScripts();
 
     MonotonicTime lastRenderingUpdateTimestamp() const { return m_lastRenderingUpdateTimestamp; }
+    std::optional<MonotonicTime> nextRenderingUpdateTimestamp() const;
 
     bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
 
@@ -1143,7 +1145,7 @@ public:
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
-    void opportunisticallyRunIdleCallbacks();
+    void opportunisticallyRunIdleCallbacks(MonotonicTime deadline);
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
     String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&);
     WEBCORE_EXPORT void setMediaKeysStorageDirectory(const String&);
@@ -1579,6 +1581,7 @@ private:
     bool m_isServiceWorkerPage { false };
 
     MonotonicTime m_lastRenderingUpdateTimestamp;
+    bool m_renderingUpdateIsScheduled { false };
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     MonotonicTime m_lastAccessibilityObjectRegionsUpdate;
 #endif


### PR DESCRIPTION
#### cb3478b28c691980974f822d1e662be89a504cf0
<pre>
requestIdleCallback can continuously schedule WindowEventLoop&apos;s timer
<a href="https://bugs.webkit.org/show_bug.cgi?id=282133">https://bugs.webkit.org/show_bug.cgi?id=282133</a>

Reviewed by Wenson Hsieh.

The bug was most likely caused by WindowEventLoop::didReachTimeToRun scheduling itself when exiting early
for shouldEndIdlePeriod returning true. While I have not been able to reproduce the issue, this PR
refactors the code in such a way that a bug like this could never happen.

Prior to this PR, WindowEventLoop::didReachTimeToRun() was responsible for re-scheduling itself. The idea
was that WindowEventLoop will utilize the WindowEventLoop&apos;s main timer to drive the idle callbacks when
there is an idle period. In practice, this led to a fragile design where shouldEndIdlePeriod returning
true can end up in a busy loop between WindowEventLoop::didReachTimeToRun() and Timer.

This PR refactors this code so that there is a dedicated m_idleTimer timer for scheduling idle callback,
and WindowEventLoop::opportunisticallyRunIdleCallbacks and scheduleIdlePeriod are responsible for
scheduling this timer. opportunisticallyRunIdleCallbacks specifically schedules the timer at 1ms after
the next rendering update or next timer which ever is sooner if either is scheduled. Neither is scheduled,
it would schedule immediately trigger a 0s timer.

This PR also removes the knowledge of rendering update time in WindowEventLoop. Instead, WindowEventLoop
will dynamically consults each Document&apos;s Page object for the next rendering update time. It also removes
the flag in OpportunisticTaskScheduler indicating there is an idle callback or not. Instead,
OpportunisticTaskScheduler will dynamically calls document&apos;s hasPendingIdleCallback.

* LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html:

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasPendingIdleCallback const): Added.

* Source/WebCore/dom/Document.h:
(WebCore::Document::idleCallbackController const):

* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback): Always schedule idle period when requestIdleCallback
is called.

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::WindowEventLoop):
(WebCore::WindowEventLoop::scheduleIdlePeriod): Schedule m_idleTimer in 0ms. This is okay because
WindowEventLoop::opportunisticallyRunIdleCallbacks exits early when there are other (higher priority)
tasks and microtasks scheduled in the event loop.
(WebCore::WindowEventLoop::didScheduleRenderingUpdate): Deleted.
(WebCore::WindowEventLoop::didStartRenderingUpdate): Deleted.
(WebCore::WindowEventLoop::opportunisticallyRunIdleCallbacks):
(WebCore::WindowEventLoop::shouldEndIdlePeriod): Now returns true when there are (higher priority) tasks
and microtasks scheduled in the event loop.
(WebCore::WindowEventLoop::computeIdleDeadline):
(WebCore::WindowEventLoop::nextScheduledWorkTime const): Extracted from
(WebCore::WindowEventLoop::nextRenderingTime const): Now polls rendering update time from each Page.
(WebCore::WindowEventLoop::didReachTimeToRun): Removed the much of logic for idle callback.
(WebCore::WindowEventLoop::didFireIdleTimer): Added.

* Source/WebCore/dom/WindowEventLoop.h:

* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::rescheduleIfNeeded):
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

* Source/WebCore/page/OpportunisticTaskScheduler.h:

* Source/WebCore/page/Page.cpp:
(WebCore::Page::scheduleRenderingUpdateInternal):
(WebCore::Page::nextRenderingUpdateTimestamp const): Added.
(WebCore::Page::updateRendering):
(WebCore::Page::findMatchingLocalDocument const): Added.
(WebCore::Page::opportunisticallyRunIdleCallbacks):

* Source/WebCore/page/Page.h:
(WebCore::Page::nextRenderingUpdateTimestamp const):

Canonical link: <a href="https://commits.webkit.org/285933@main">https://commits.webkit.org/285933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b89abac0f8d107a78391ebb09fab27cdb743349

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58348 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16684 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66647 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63866 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8015 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1509 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->