### PR TITLE
AX: AccessibilityTable should use m_role like every other AccessibilityObject subclass

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -431,8 +431,7 @@ public:
     // Only if isColorWell()
     SRGBA<uint8_t> colorValue() const override;
 
-    // FIXME: This should be made final after AccessibilityTable is fixed to use m_role rather than computing its own roleValue().
-    AccessibilityRole roleValue() const override { return m_role; }
+    AccessibilityRole roleValue() const final { return m_role; }
     virtual AccessibilityRole determineAccessibilityRole() = 0;
     String rolePlatformString() const override;
     String roleDescription() const override;
@@ -524,7 +523,7 @@ public:
     void decrement() override { }
     virtual bool toggleDetailsAncestor() { return false; }
 
-    virtual void updateRole();
+    void updateRole();
     bool childrenInitialized() const { return m_childrenInitialized; }
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) override;
     virtual void addChildren() { }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -196,7 +196,7 @@ private:
 #endif
     String expandedTextValue() const override;
     bool supportsExpandedTextValue() const override;
-    virtual void updateRoleAfterChildrenCreation();
+    void updateRoleAfterChildrenCreation();
 
     bool inheritsPresentationalRole() const override;
 

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -44,11 +44,6 @@ public:
 
     void init() final;
 
-    // FIXME: Override roleValue(), updateRole(), and updateRoleAfterChildrenCreation() because this class does not use m_role. We should fix this so behavior is unified with other AccessibilityObject subclasses.
-    AccessibilityRole roleValue() const final;
-    void updateRole() final { }
-    void updateRoleAfterChildrenCreation() final { }
-
     virtual bool isAriaTable() const { return false; }
     bool hasGridAriaRole() const;
 
@@ -109,7 +104,8 @@ protected:
     void addRow(AccessibilityTableRow&, unsigned, unsigned& maxColumnCount);
 
 private:
-    virtual bool computeIsTableExposableThroughAccessibility() const;
+    AccessibilityRole determineAccessibilityRole() final;
+    virtual bool computeIsTableExposableThroughAccessibility() const { return isDataTable(); }
     void labelText(Vector<AccessibilityText>&) const final;
     HTMLTableElement* tableElement() const;
 


### PR DESCRIPTION
#### 1907a445147bf44d8a54bd25067bc62ecc06b63f
<pre>
AX: AccessibilityTable should use m_role like every other AccessibilityObject subclass
<a href="https://bugs.webkit.org/show_bug.cgi?id=282136">https://bugs.webkit.org/show_bug.cgi?id=282136</a>
<a href="https://rdar.apple.com/138698416">rdar://138698416</a>

Reviewed by Chris Fleizach.

Prior to this commit, every object besides AccessibilityTable initializes AccessibilityObject::m_role in
AccessibilityObject::init(), and has an implementation of roleValue() that simply returns this m_role. It&apos;s both
confusing and inefficient (for some reasons listed in the next paragraph) for AccessibilityTable to be the exception,
so this commit fixes that.

Fixing this is advantageous for performance in several ways:

  1. AccessibilityTable&apos;s override of `roleValue()` is now removed. This means that any time the compiler has a type of
     AccessibilityObject (rather than AXCoreObject), it can de-virtualize the `roleValue()` call. This is very important
     because roleValue() is called all over the place.

  2. AccessibilityTable::roleValue() is now cheaper, since it just reads from a member variable. Again, roleValue() is
     called all the time, so it&apos;s important that it&apos;s as cheap as possible.

  3. updateRoleAfterChildrenCreation() and updateRole() are now non-virtual, further improving the compiliers ability
     to perform optimizations.

This commit also includes a drive-by change to remove a redundant hasNonTableARIARole() check in computeIsTableExposableThroughAccessibility().
isDataTable() already checks this.

* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::init):
(WebCore::AccessibilityTable::recomputeIsExposable):
(WebCore::AccessibilityTable::determineAccessibilityRole):
(WebCore::AccessibilityTable::computeIsTableExposableThroughAccessibility const): Deleted.
(WebCore::AccessibilityTable::roleValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityTable.h:
(WebCore::AccessibilityTable::computeIsTableExposableThroughAccessibility const):

Canonical link: <a href="https://commits.webkit.org/285749@main">https://commits.webkit.org/285749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285cd75a73af3eafc80ab796eb5c3005bbcbd30d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66282 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7600 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3690 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->