### PR TITLE
Work around -Wunsafe-buffer-usage warnings in mig-generated files by invoking mig manually and post-processing the results

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -913,6 +913,22 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
+		147572882CCD82170027BA8F /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			fileType = sourcecode.mig;
+			inputFiles = (
+				"$(INPUT_FILE_PATH)",
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(DERIVED_FILE_DIR)/$(CURRENT_ARCH)/$(INPUT_FILE_BASE).h",
+				"$(DERIVED_FILE_DIR)/$(CURRENT_ARCH)/$(INPUT_FILE_BASE)User.c",
+				"$(DERIVED_FILE_DIR)/$(CURRENT_ARCH)/$(INPUT_FILE_BASE)Server.h",
+				"$(DERIVED_FILE_DIR)/$(CURRENT_ARCH)/$(INPUT_FILE_BASE)Server.c",
+			);
+			script = "mig -arch ${CURRENT_ARCH} -header ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}.h -user ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}User.c -sheader ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}Server.h -server ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}Server.c -DMACH_EXC_SERVER_TASKIDTOKEN_STATE ${INPUT_FILE_PATH}\n\necho \"#pragma clang diagnostic ignored \\\"-Wunsafe-buffer-usage\\\"\\n$(cat ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}Server.c)\" > ${DERIVED_SOURCES_DIR}/${CURRENT_ARCH}/${INPUT_FILE_BASE}Server.c\n";
+		};
 		DD3C8E7627C84C9400322F62 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
@@ -3891,6 +3907,7 @@
 				DDA35E4929CA74D4006C1018 /* Generate TAPI filelist */,
 			);
 			buildRules = (
+				147572882CCD82170027BA8F /* PBXBuildRule */,
 				DDF307FB27C08869006A526F /* PBXBuildRule */,
 				DDF3080F27C091A9006A526F /* PBXBuildRule */,
 				DD3C8E7627C84C9400322F62 /* PBXBuildRule */,


### PR DESCRIPTION
#### d45649fa32a499702c30474e94bd6843c4c67849
<pre>
Work around -Wunsafe-buffer-usage warnings in mig-generated files by invoking mig manually and post-processing the results
<a href="https://bugs.webkit.org/show_bug.cgi?id=282138">https://bugs.webkit.org/show_bug.cgi?id=282138</a>
<a href="https://rdar.apple.com/138704307">rdar://138704307</a>

Reviewed by Keith Miller.

I considered passing extra compiler flags to Xcode&apos;s built-in Mig build step,
but that has no effect (<a href="https://rdar.apple.com/138572990">rdar://138572990</a>).

* Source/WTF/WTF.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285743@main">https://commits.webkit.org/285743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33acc11fa1dcc669961c88cae43624ef90d0806d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24888 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23221 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66787 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72907 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63383 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65556 "102 api tests failed or timed out") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7595 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94689 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11358 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/931 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20823 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->