### PR TITLE
Fix `testRunner.clearBackForwardList` for site isolation and remove `WKBundleClearHistoryForTesting`

### DIFF
--- a/LayoutTests/fast/dom/location-hash.html
+++ b/LayoutTests/fast/dom/location-hash.html
@@ -90,11 +90,11 @@
         setTimeout(step, 0);
     }
         
-    function runTests() {
+    async function runTests() {
         if (window.testRunner) {
-            testRunner.clearBackForwardList();
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
+            await testRunner.clearBackForwardList();
         }
         
         state = 0;

--- a/LayoutTests/fast/events/backspace-navigates-back.html
+++ b/LayoutTests/fast/events/backspace-navigates-back.html
@@ -83,7 +83,7 @@ function doStep(step, location) {
     }
 }
 
-window.onpageshow = function() {
+window.onpageshow = async function() {
     if (!window.testRunner || !window.eventSender || !window.internals) {
         log.innerText =
             'This test requires eventSender, testRunner and window.internals. ' +
@@ -93,8 +93,8 @@ window.onpageshow = function() {
     if (!location.search) {
         sessionStorage.step = 0;
         testRunner.dumpAsText();
-        testRunner.clearBackForwardList();
         testRunner.waitUntilDone();
+        await testRunner.clearBackForwardList();
     }
 
     setTimeout(function() {

--- a/LayoutTests/fast/history/history-length.html
+++ b/LayoutTests/fast/history/history-length.html
@@ -1,11 +1,11 @@
 <script>
-onload = function() {
+onload = async function() {
   if (location.search.substring(1).length == 0) {
     sessionStorage.testStage = 0;
     if (window.testRunner) {
       testRunner.dumpAsText();
-      testRunner.clearBackForwardList();
       testRunner.waitUntilDone();
+      await testRunner.clearBackForwardList();
     }
   }
 

--- a/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-with-fragment-scroll.html
+++ b/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-with-fragment-scroll.html
@@ -1,14 +1,6 @@
 <html>
 <head>
 <script>
-
-if (window.testRunner) {
-    if (!sessionStorage.stage)
-        testRunner.clearBackForwardList();
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
-
 function lastPathComponent(url)
 {
     return url.split('/').pop();
@@ -37,8 +29,13 @@ function runThirdStageOfTest()
     alert("Final stage of test loaded");
 }
 
-function runTest()
+async function runTest()
 {
+    testRunner?.dumpAsText();
+    testRunner?.waitUntilDone();
+    if (!sessionStorage.stage)
+        await testRunner?.clearBackForwardList();
+
     alert("LOADED");
     if (!sessionStorage.stage)
         runFirstStageOfTest();

--- a/LayoutTests/fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange.html
+++ b/LayoutTests/fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange.html
@@ -2,12 +2,10 @@
 <head>
 <script src="../../../resources/js-test.js"></script>
 <script>
-
-if (window.testRunner)
-    testRunner.clearBackForwardList();
-
-function runTest()
+async function runTest()
 {
+    testRunner?.waitUntilDone();
+    await testRunner?.clearBackForwardList();
     try {
         history.pushState(null, null, 'some-other.html');
         testFailed("history.pushState(null, null, 'some-other.html') didn't throw");

--- a/LayoutTests/fast/loader/stateobjects/replacestate-then-pushstate.html
+++ b/LayoutTests/fast/loader/stateobjects/replacestate-then-pushstate.html
@@ -1,20 +1,18 @@
 <html>
 <head>
 <script>
-
-if (window.testRunner) {
-    testRunner.clearBackForwardList();
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
-
 function log(txt)
 {
     document.getElementById("logger").innerText += txt + "\n";
 }
     
-function runTest()
+async function runTest()
 {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+        await testRunner.clearBackForwardList();
+    }
     history.replaceState("OriginalHistoryItem", "Replaced title");
     log("History length is " + history.length);
     history.pushState("NewHistoryItem", "Pushed title");

--- a/LayoutTests/http/tests/loading/state-object-security-exception.html
+++ b/LayoutTests/http/tests/loading/state-object-security-exception.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script>
-
-if (window.testRunner) {
-    testRunner.clearBackForwardList();
-    testRunner.dumpAsText();
-}
-
 function log(txt)
 {
     document.getElementById("logger").innerText += txt + "\n";
@@ -40,10 +34,14 @@ var URLsToTry = new Array(
 "file://anyfile.html/"
 );
 
-function runTest()
+async function runTest()
 {
+    testRunner?.dumpAsText();
+    testRunner?.waitUntilDone();
+    await testRunner?.clearBackForwardList();
     for (n in URLsToTry)
         tryURL(URLsToTry[n]);
+    testRunner?.notifyDone();
 }
 
 </script>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3346,3 +3346,14 @@ void WKPageSetPageScaleFactorForTesting(WKPageRef pageRef, float scaleFactor, WK
         completionHandler(context);
     });
 }
+
+void WKPageClearBackForwardListForTesting(WKPageRef pageRef, void* context, WKPageClearBackForwardListForTestingFunction completionHandler)
+{
+    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler(context);
+
+    pageForTesting->clearBackForwardList([context, completionHandler] {
+        completionHandler(context);
+    });
+}

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -229,6 +229,8 @@ typedef void (*WKPageSetTopContentInsetForTestingFunction)(void* functionContext
 WK_EXPORT void WKPageSetTopContentInsetForTesting(WKPageRef page, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback);
 typedef void (*WKPageSetPageScaleFactorForTestingFunction)(void* functionContext);
 WK_EXPORT void WKPageSetPageScaleFactorForTesting(WKPageRef page, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler);
+typedef void (*WKPageClearBackForwardListForTestingFunction)(void* functionContext);
+WK_EXPORT void WKPageClearBackForwardListForTesting(WKPageRef page, void* context, WKPageClearBackForwardListForTestingFunction completionHandler);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11402,11 +11402,6 @@ void WebPageProxy::updateAcceleratedCompositingMode(const LayerTreeContext& laye
         pageClient->updateAcceleratedCompositingMode(layerTreeContext);
 }
 
-void WebPageProxy::backForwardClear()
-{
-    protectedBackForwardList()->clear();
-}
-
 #if ENABLE(GAMEPAD)
 
 void WebPageProxy::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2813,7 +2813,6 @@ private:
     void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
     void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
-    void backForwardClear();
     void backForwardGoToProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardClearProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -206,7 +206,6 @@ messages -> WebPageProxy {
     BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (RefPtr<WebKit::FrameState> frameState) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardClear()
     WillGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache)
     BackForwardGoToProvisionalItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClearProvisionalItem(WebCore::BackForwardItemIdentifier itemID)

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -30,6 +30,7 @@
 #include "MessageSenderInlines.h"
 #include "NetworkProcessMessages.h"
 #include "NetworkProcessProxy.h"
+#include "WebBackForwardList.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
@@ -219,6 +220,17 @@ void WebPageProxyTesting::resetStateBetweenTests()
 
     protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPageTesting::ResetStateBetweenTests(), pageID);
+    });
+}
+
+void WebPageProxyTesting::clearBackForwardList(CompletionHandler<void()>&& completionHandler)
+{
+    Ref page = m_page.get();
+    page->protectedBackForwardList()->clear();
+
+    Ref callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPageTesting::ClearCachedBackForwardListCounts(), [callbackAggregator] { }, pageID);
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -78,6 +78,9 @@ public:
 #endif
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
+
+    void clearBackForwardList(CompletionHandler<void()>&&);
+
 private:
     explicit WebPageProxyTesting(WebPageProxy&);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -362,11 +362,6 @@ WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef 
     return WebKit::toCopiedAPI(WebKit::toImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
 }
 
-void WKBundleClearHistoryForTesting(WKBundlePageRef page)
-{
-    WebKit::toImpl(page)->clearHistory();
-}
-
 WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRef)
 {
     return nullptr;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -71,7 +71,6 @@ WK_EXPORT WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef);
 
 WK_EXPORT WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef page) WK_C_API_DEPRECATED;
 WK_EXPORT WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef directory);
-WK_EXPORT void WKBundleClearHistoryForTesting(WKBundlePageRef page);
 
 WK_EXPORT void WKBundlePageInstallPageOverlay(WKBundlePageRef page, WKBundlePageOverlayRef pageOverlay);
 WK_EXPORT void WKBundlePageUninstallPageOverlay(WKBundlePageRef page, WKBundlePageOverlayRef pageOverlay);

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -66,7 +66,7 @@ void WebBackForwardListProxy::addItem(FrameIdentifier targetFrameID, Ref<History
         return;
 
     LOG(BackForward, "(Back/Forward) WebProcess pid %i setting item %p for id %s with url %s", getCurrentProcessID(), item.ptr(), item->identifier().toString().utf8().data(), item->urlString().utf8().data());
-    clearCachedListCounts();
+    m_cachedBackForwardListCounts = std::nullopt;
     page->send(Messages::WebPageProxy::BackForwardAddItem(targetFrameID, toFrameState(item.get())));
 }
 
@@ -152,7 +152,7 @@ const WebBackForwardListCounts& WebBackForwardListProxy::cacheListCountsIfNecess
 
 void WebBackForwardListProxy::clearCachedListCounts()
 {
-    m_cachedBackForwardListCounts = std::nullopt;
+    m_cachedBackForwardListCounts = WebBackForwardListCounts { };
 }
 
 void WebBackForwardListProxy::close()
@@ -160,12 +160,6 @@ void WebBackForwardListProxy::close()
     ASSERT(m_page);
     m_page = nullptr;
     m_cachedBackForwardListCounts = WebBackForwardListCounts { };
-}
-
-void WebBackForwardListProxy::clear()
-{
-    m_cachedBackForwardListCounts = WebBackForwardListCounts { }; // Clearing the back/forward list will cause the counts to become 0.
-    m_page->send(Messages::WebPageProxy::BackForwardClear());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -41,7 +41,7 @@ public:
 
     static void removeItem(const WebCore::BackForwardItemIdentifier&);
 
-    void clear();
+    void clearCachedListCounts();
 
 private:
     WebBackForwardListProxy(WebPage&);
@@ -58,7 +58,6 @@ private:
     unsigned forwardListCount() const override;
     bool containsItem(const WebCore::HistoryItem&) const final;
     const WebBackForwardListCounts& cacheListCountsIfNecessary() const;
-    void clearCachedListCounts();
 
     void close() override;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2571,14 +2571,6 @@ String WebPage::frameTextForTestingIncludingSubframes(bool includeSubframes)
     return m_mainFrame->frameTextForTesting(includeSubframes);
 }
 
-void WebPage::clearHistory()
-{
-    if (!m_page)
-        return;
-
-    static_cast<WebBackForwardListProxy&>(m_page->backForward().client()).clear();
-}
-
 void WebPage::windowScreenDidChange(PlatformDisplayID displayID, std::optional<unsigned> nominalFramesPerSecond)
 {
     m_page->chrome().windowScreenDidChange(displayID, nominalFramesPerSecond);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -708,7 +708,6 @@ public:
     void didSetPageZoomFactor(double);
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
     String dumpHistoryForTesting(const String& directory);
-    void clearHistory();
 
     void accessibilitySettingsDidChange();
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -32,6 +32,7 @@
 #include "WebPage.h"
 #include "WebPageTestingMessages.h"
 #include "WebProcess.h"
+#include <WebCore/BackForwardController.h>
 #include <WebCore/Editor.h>
 #include <WebCore/FocusController.h>
 #include <WebCore/IntPoint.h>
@@ -132,6 +133,17 @@ void WebPageTesting::resetStateBetweenTests()
         // Force consistent "responsive" behavior for WebPage::eventThrottlingDelay() for testing. Tests can override via internals.
         corePage->setEventThrottlingBehaviorOverride(WebCore::EventThrottlingBehavior::Responsive);
     }
+}
+
+void WebPageTesting::clearCachedBackForwardListCounts(CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr page = m_page->corePage();
+    if (!page)
+        return completionHandler();
+
+    Ref backForwardListProxy = static_cast<WebBackForwardListProxy&>(page->backForward().client());
+    backForwardListProxy->clearCachedListCounts();
+    completionHandler();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -54,6 +54,7 @@ private:
     void setPermissionLevel(const String& origin, bool allowed);
     void isEditingCommandEnabled(const String& commandName, CompletionHandler<void(bool)>&&);
     void resetStateBetweenTests();
+    void clearCachedBackForwardListCounts(CompletionHandler<void()>&&);
 
 #if ENABLE(NOTIFICATIONS)
     void clearNotificationPermissionState();

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -33,4 +33,5 @@ messages -> WebPageTesting NotRefCounted {
     ClearWheelEventTestMonitor()
     ResetStateBetweenTests()
     SetTopContentInset(float contentInset) -> ()
+    ClearCachedBackForwardListCounts() -> ()
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -107,7 +107,7 @@ interface TestRunner {
     undefined stopLoading();
 
     // Special DOM functions.
-    undefined clearBackForwardList();
+    Promise<undefined> clearBackForwardList();
     undefined execCommand(DOMString name, DOMString showUI, DOMString value);
     boolean isCommandEnabled(DOMString name);
     unsigned long windowCount();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -350,8 +350,6 @@ InjectedBundlePage::~InjectedBundlePage()
 
 void InjectedBundlePage::prepare()
 {
-    WKBundleClearHistoryForTesting(m_page);
-
     WKBundlePageSetTracksRepaints(m_page, false);
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -484,9 +484,9 @@ unsigned TestRunner::windowCount()
     return InjectedBundle::singleton().pageCount();
 }
 
-void TestRunner::clearBackForwardList()
+void TestRunner::clearBackForwardList(JSContextRef context, JSValueRef callback)
 {
-    WKBundleClearHistoryForTesting(page());
+    postMessageWithAsyncReply(context, "ClearBackForwardList", callback);
 }
 
 void TestRunner::makeWindowObject(JSContextRef context)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -146,7 +146,7 @@ public:
     void setCustomUserAgent(JSStringRef);
 
     // Special DOM functions.
-    void clearBackForwardList();
+    void clearBackForwardList(JSContextRef, JSValueRef callback);
     void execCommand(JSStringRef name, JSStringRef showUI, JSStringRef value);
     bool isCommandEnabled(JSStringRef name);
     unsigned windowCount();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1298,7 +1298,9 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
             return false;
         }
     }
-    
+
+    WKPageClearBackForwardListForTesting(TestController::singleton().mainWebView()->page(), nullptr, [](void*) { });
+
     if (resetStage == ResetStage::AfterTest) {
         updateLiveDocumentsAfterTest();
 #if PLATFORM(COCOA)
@@ -2190,6 +2192,9 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetTopContentInset"))
         return WKPageSetTopContentInsetForTesting(TestController::singleton().mainWebView()->page(), static_cast<float>(doubleValue(messageBody)), completionHandler.leak(), adoptAndCallCompletionHandler);
+
+    if (WKStringIsEqualToUTF8CString(messageName, "ClearBackForwardList"))
+        return WKPageClearBackForwardListForTesting(TestController::singleton().mainWebView()->page(), completionHandler.leak(), adoptAndCallCompletionHandler);
 
     ASSERT_NOT_REACHED();
 }


### PR DESCRIPTION
#### f8031df73cb06c7f541f58b6e353483360d275da
<pre>
Fix `testRunner.clearBackForwardList` for site isolation and remove `WKBundleClearHistoryForTesting`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282143">https://bugs.webkit.org/show_bug.cgi?id=282143</a>
<a href="https://rdar.apple.com/138709373">rdar://138709373</a>

Reviewed by Alex Christensen.

Cached back forward list counts need to be updated for all web processes.

* LayoutTests/fast/dom/location-hash.html:
* LayoutTests/fast/events/backspace-navigates-back.html:
* LayoutTests/fast/history/history-length.html:
* LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-with-fragment-scroll.html:
* LayoutTests/fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange.html:
* LayoutTests/fast/loader/stateobjects/replacestate-then-pushstate.html:
* LayoutTests/http/tests/loading/state-object-security-exception.html:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageClearBackForwardListForTesting):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardClear): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::clearBackForwardList):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundleClearHistoryForTesting): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::addItem):
(WebKit::WebBackForwardListProxy::clearCachedListCounts):
(WebKit::WebBackForwardListProxy::clear): Deleted.
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::clearHistory): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::clearCachedBackForwardListCounts):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::prepare):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::clearBackForwardList):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/285775@main">https://commits.webkit.org/285775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/417e668bdf1c5e66d87055ac3b4ace7082f29180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66291 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65570 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7611 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11376 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->