### PR TITLE
Finish off smart pointer coverage in WebGPU

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
@@ -37,7 +37,7 @@ struct GPUPipelineLayoutDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            bindGroupLayouts.map([](const auto& bindGroupLayout) -> std::reference_wrapper<WebGPU::BindGroupLayout> {
+            bindGroupLayouts.map([](const auto& bindGroupLayout) -> Ref<WebGPU::BindGroupLayout> {
                 return bindGroupLayout->backing();
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -62,7 +62,7 @@ void GPUQueue::setLabel(String&& label)
 
 void GPUQueue::submit(Vector<Ref<GPUCommandBuffer>>&& commandBuffers)
 {
-    auto result = WTF::map(commandBuffers, [](auto& commandBuffer) -> std::reference_wrapper<WebGPU::CommandBuffer> {
+    auto result = WTF::map(commandBuffers, [](auto& commandBuffer) -> Ref<WebGPU::CommandBuffer> {
         return commandBuffer->backing();
     });
     m_backing->submit(WTFMove(result));

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -152,7 +152,7 @@ void GPURenderPassEncoder::endOcclusionQuery()
 
 void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles)
 {
-    auto result = WTF::map(bundles, [](auto& bundle) -> std::reference_wrapper<WebGPU::RenderBundle> {
+    auto result = WTF::map(bundles, [](auto& bundle) -> Ref<WebGPU::RenderBundle> {
         return bundle->backing();
     });
     m_backing->executeBundles(WTFMove(result));

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -48,7 +48,7 @@ QueueImpl::QueueImpl(WebGPUPtr<WGPUQueue>&& queue, ConvertToBackingContext& conv
 
 QueueImpl::~QueueImpl() = default;
 
-void QueueImpl::submit(Vector<std::reference_wrapper<CommandBuffer>>&& commandBuffers)
+void QueueImpl::submit(Vector<Ref<WebGPU::CommandBuffer>>&& commandBuffers)
 {
     auto backingCommandBuffers = commandBuffers.map([&convertToBackingContext = m_convertToBackingContext.get()](auto commandBuffer) {
         return convertToBackingContext.convertToBacking(commandBuffer);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -59,7 +59,7 @@ private:
 
     WGPUQueue backing() const { return m_backing.get(); }
 
-    void submit(Vector<std::reference_wrapper<CommandBuffer>>&&) final;
+    void submit(Vector<Ref<WebGPU::CommandBuffer>>&&) final;
 
     void onSubmittedWorkDone(CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
@@ -154,7 +154,7 @@ void RenderPassEncoderImpl::endOcclusionQuery()
     wgpuRenderPassEncoderEndOcclusionQuery(m_backing.get());
 }
 
-void RenderPassEncoderImpl::executeBundles(Vector<std::reference_wrapper<RenderBundle>>&& renderBundles)
+void RenderPassEncoderImpl::executeBundles(Vector<Ref<RenderBundle>>&& renderBundles)
 {
     auto backingBundles = renderBundles.map([&convertToBackingContext = m_convertToBackingContext.get()](auto renderBundle) {
         return convertToBackingContext.convertToBacking(renderBundle.get());

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
@@ -98,7 +98,7 @@ private:
     void beginOcclusionQuery(Size32 queryIndex) final;
     void endOcclusionQuery() final;
 
-    void executeBundles(Vector<std::reference_wrapper<RenderBundle>>&&) final;
+    void executeBundles(Vector<Ref<RenderBundle>>&&) final;
     void end() final;
 
     void setLabelInternal(const String&) final;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayoutDescriptor.h
@@ -34,7 +34,7 @@ namespace WebCore::WebGPU {
 class BindGroupLayout;
 
 struct PipelineLayoutDescriptor : public ObjectDescriptorBase {
-    std::optional<Vector<std::reference_wrapper<BindGroupLayout>>> bindGroupLayouts;
+    std::optional<Vector<Ref<BindGroupLayout>>> bindGroupLayouts;
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -58,7 +58,7 @@ public:
         setLabelInternal(m_label);
     }
 
-    virtual void submit(Vector<std::reference_wrapper<CommandBuffer>>&&) = 0;
+    virtual void submit(Vector<Ref<WebGPU::CommandBuffer>>&&) = 0;
 
     virtual void onSubmittedWorkDone(CompletionHandler<void()>&&) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
@@ -97,7 +97,7 @@ public:
     virtual void beginOcclusionQuery(Size32 queryIndex) = 0;
     virtual void endOcclusionQuery() = 0;
 
-    virtual void executeBundles(Vector<std::reference_wrapper<RenderBundle>>&&) = 0;
+    virtual void executeBundles(Vector<Ref<RenderBundle>>&&) = 0;
     virtual void end() = 0;
 
 protected:

--- a/Source/WebGPU/WebGPU/Adapter.h
+++ b/Source/WebGPU/WebGPU/Adapter.h
@@ -68,7 +68,6 @@ public:
 
     RefPtr<Instance> instance() const { return m_instance.get(); }
 
-
 private:
     Adapter(id<MTLDevice>, Instance&, bool xrCompatible, HardwareCapabilities&&);
     Adapter(Instance&);

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -95,7 +95,8 @@ public:
     static NSString* usageName(const OptionSet<BindGroupEntryUsage>&);
     static uint64_t makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect);
 
-    const BindGroupLayout* bindGroupLayout() const;
+    const BindGroupLayout* bindGroupLayout() const { return m_bindGroupLayout.get(); }
+
     const BufferAndType* dynamicBuffer(uint32_t) const;
     uint32_t dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*) const;
     void rebindSamplersIfNeeded() const;

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1229,11 +1229,6 @@ bool BindGroup::isValid() const
     return !!bindGroupLayout();
 }
 
-const BindGroupLayout* BindGroup::bindGroupLayout() const
-{
-    return m_bindGroupLayout.get();
-}
-
 BindGroup::BindGroup(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, Vector<BindableResources>&& resources, const BindGroupLayout& bindGroupLayout, DynamicBuffersContainer&& dynamicBuffers, SamplersContainer&& samplers, ShaderStageArray<ExternalTextureIndices>&& externalTextureIndices, Device& device)
     : m_vertexArgumentBuffer(vertexArgumentBuffer)
     , m_fragmentArgumentBuffer(fragmentArgumentBuffer)
@@ -1336,7 +1331,7 @@ void BindGroup::rebindSamplersIfNeeded() const
         return;
 
     for (auto& [samplerRefPtr, shaderStageArray] : m_samplers) {
-        auto* sampler = samplerRefPtr.get();
+        auto sampler = samplerRefPtr;
         ASSERT(sampler);
         if (!sampler || sampler->cachedSampler())
             continue;

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -87,7 +87,8 @@ public:
 
     id<MTLBuffer> buffer() const { return m_buffer; }
     id<MTLBuffer> indirectBuffer() const;
-    id<MTLBuffer> indirectIndexedBuffer() const;
+    id<MTLBuffer> indirectIndexedBuffer() const { return m_indirectIndexedBuffer; }
+
     uint64_t initialSize() const;
     uint64_t currentSize() const;
     WGPUBufferUsageFlags usage() const { return m_usage; }
@@ -95,7 +96,8 @@ public:
 
     Device& device() const { return m_device; }
     Ref<Device> protectedDevice() const { return m_device; }
-    bool isDestroyed() const;
+    bool isDestroyed() const { return state() == State::Destroyed; }
+
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     std::span<uint8_t> getBufferContents();
     bool indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType, uint32_t firstInstance) const;

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -178,14 +178,14 @@ Buffer::~Buffer() = default;
 
 void Buffer::incrementBufferMapCount()
 {
-    for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.incrementBufferMapCount();
+    for (Ref commandEncoder : m_commandEncoders)
+        commandEncoder->incrementBufferMapCount();
 }
 
 void Buffer::decrementBufferMapCount()
 {
-    for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.decrementBufferMapCount();
+    for (Ref commandEncoder : m_commandEncoders)
+        commandEncoder->decrementBufferMapCount();
 }
 
 void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuffer) const
@@ -209,8 +209,8 @@ void Buffer::destroy()
     }
 
     setState(State::Destroyed);
-    for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.makeSubmitInvalid();
+    for (Ref commandEncoder : m_commandEncoders)
+        commandEncoder->makeSubmitInvalid();
 
     m_commandEncoders.clear();
     m_buffer = protectedDevice()->placeholderBuffer();
@@ -418,19 +418,9 @@ bool Buffer::isValid() const
     return isDestroyed() || m_buffer;
 }
 
-bool Buffer::isDestroyed() const
-{
-    return state() == State::Destroyed;
-}
-
 id<MTLBuffer> Buffer::indirectBuffer() const
 {
     return m_indirectBuffer;
-}
-
-id<MTLBuffer> Buffer::indirectIndexedBuffer() const
-{
-    return m_indirectIndexedBuffer;
 }
 
 bool Buffer::indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType indexType, uint32_t firstInstance) const

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -253,7 +253,7 @@ void CommandEncoder::discardCommandBuffer()
         return;
     }
 
-    id<MTLCommandEncoder> existingEncoder = m_device->getQueue().encoderForBuffer(m_commandBuffer);
+    id<MTLCommandEncoder> existingEncoder = m_device->protectedQueue()->encoderForBuffer(m_commandBuffer);
     auto queue = m_device->protectedQueue();
     queue->endEncoding(existingEncoder, m_commandBuffer);
     queue->removeMTLCommandBuffer(m_commandBuffer);
@@ -945,7 +945,7 @@ void CommandEncoder::copyBufferToTexture(const WGPUImageCopyBuffer& source, cons
         return;
     }
 
-    auto logicalSize = fromAPI(destination.texture).logicalMiplevelSpecificTextureExtent(destination.mipLevel);
+    auto logicalSize = protectedFromAPI(destination.texture)->logicalMiplevelSpecificTextureExtent(destination.mipLevel);
     auto widthForMetal = logicalSize.width < destination.origin.x ? 0 : std::min(copySize.width, logicalSize.width - destination.origin.x);
     auto heightForMetal = logicalSize.height < destination.origin.y ? 0 : std::min(copySize.height, logicalSize.height - destination.origin.y);
     auto depthForMetal = logicalSize.depthOrArrayLayers < destination.origin.z ? 0 : std::min(copySize.depthOrArrayLayers, logicalSize.depthOrArrayLayers - destination.origin.z);

--- a/Source/WebGPU/WebGPU/CommandsMixin.mm
+++ b/Source/WebGPU/WebGPU/CommandsMixin.mm
@@ -28,6 +28,7 @@
 
 #import "Buffer.h"
 #import "Device.h"
+#import "PipelineLayout.h"
 #import "RenderPipeline.h"
 
 namespace WebGPU {

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -81,18 +81,18 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
     if (descriptor.nextInChain || descriptor.compute.nextInChain)
         return returnInvalidComputePipeline(*this, isAsync);
 
-    ShaderModule& shaderModule = WebGPU::protectedFromAPI(descriptor.compute.module);
-    if (!shaderModule.isValid() || &shaderModule.device() != this || !descriptor.layout)
+    auto shaderModule = WebGPU::protectedFromAPI(descriptor.compute.module);
+    if (!shaderModule->isValid() || &shaderModule->device() != this || !descriptor.layout)
         return returnInvalidComputePipeline(*this, isAsync);
 
-    PipelineLayout& pipelineLayout = WebGPU::protectedFromAPI(descriptor.layout);
+    Ref pipelineLayout = WebGPU::protectedFromAPI(descriptor.layout);
     auto& deviceLimits = limits();
     auto label = fromAPI(descriptor.label);
-    auto entryPointName = descriptor.compute.entryPoint ? fromAPI(descriptor.compute.entryPoint) : shaderModule.defaultComputeEntryPoint();
+    auto entryPointName = descriptor.compute.entryPoint ? fromAPI(descriptor.compute.entryPoint) : shaderModule->defaultComputeEntryPoint();
     NSError *error;
     BufferBindingSizesForPipeline minimumBufferSizes;
-    auto libraryCreationResult = createLibrary(m_device, shaderModule, &pipelineLayout, entryPointName, label, descriptor.compute.constantsSpan(), minimumBufferSizes, &error);
-    if (!libraryCreationResult || &pipelineLayout.device() != this)
+    auto libraryCreationResult = createLibrary(m_device, shaderModule.get(), &pipelineLayout.get(), entryPointName, label, descriptor.compute.constantsSpan(), minimumBufferSizes, &error);
+    if (!libraryCreationResult || &pipelineLayout->device() != this)
         return returnInvalidComputePipeline(*this, isAsync, error.localizedDescription ?: @"Compute library failed creation");
 
     auto library = libraryCreationResult->library;
@@ -117,7 +117,7 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
     if (!size.width || size.width > deviceLimits.maxComputeWorkgroupSizeX || !size.height || size.height > deviceLimits.maxComputeWorkgroupSizeY || !size.depth || size.depth > deviceLimits.maxComputeWorkgroupSizeZ || size.width * size.height * size.depth > deviceLimits.maxComputeInvocationsPerWorkgroup)
         return returnInvalidComputePipeline(*this, isAsync);
 
-    if (pipelineLayout.isAutoLayout() && entryPointInformation.defaultLayout) {
+    if (pipelineLayout->isAutoLayout() && entryPointInformation.defaultLayout) {
         Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
         if (NSString* error = addPipelineLayouts(bindGroupEntries, entryPointInformation.defaultLayout))
             return returnInvalidComputePipeline(*this, isAsync, error);
@@ -130,7 +130,7 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
     }
 
     auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label);
-    return std::make_pair(ComputePipeline::create(computePipelineState, pipelineLayout, size, WTFMove(minimumBufferSizes), *this), nil);
+    return std::make_pair(ComputePipeline::create(computePipelineState, WTFMove(pipelineLayout), size, WTFMove(minimumBufferSizes), *this), nil);
 }
 
 void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<ComputePipeline>&&, String&& message)>&& callback)
@@ -167,19 +167,22 @@ ComputePipeline::~ComputePipeline() = default;
 
 Ref<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
+    Ref device = m_device;
+    Ref pipelineLayout = m_pipelineLayout;
+
     if (!isValid()) {
-        m_device->generateAValidationError("getBindGroupLayout: ComputePipeline is invalid"_s);
-        m_pipelineLayout->makeInvalid();
-        return BindGroupLayout::createInvalid(m_device);
+        device->generateAValidationError("getBindGroupLayout: ComputePipeline is invalid"_s);
+        pipelineLayout->makeInvalid();
+        return BindGroupLayout::createInvalid(device);
     }
 
-    if (groupIndex >= m_pipelineLayout->numberOfBindGroupLayouts()) {
-        m_device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
-        m_pipelineLayout->makeInvalid();
-        return BindGroupLayout::createInvalid(m_device);
+    if (groupIndex >= pipelineLayout->numberOfBindGroupLayouts()) {
+        device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
+        pipelineLayout->makeInvalid();
+        return BindGroupLayout::createInvalid(device);
     }
 
-    return m_pipelineLayout->bindGroupLayout(groupIndex);
+    return pipelineLayout->bindGroupLayout(groupIndex);
 }
 
 void ComputePipeline::setLabel(String&&)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -241,14 +241,14 @@ Device::~Device()
 
 RefPtr<XRSubImage> Device::getXRViewSubImage(XRProjectionLayer& projectionLayer)
 {
-    m_xrSubImage->update(projectionLayer.colorTexture(), projectionLayer.depthTexture(), projectionLayer.reusableTextureIndex(), projectionLayer.completionEvent());
+    RefPtr { m_xrSubImage }->update(projectionLayer.colorTexture(), projectionLayer.depthTexture(), projectionLayer.reusableTextureIndex(), projectionLayer.completionEvent());
     return m_xrSubImage;
 }
 
 void Device::makeInvalid()
 {
     m_device = nil;
-    m_defaultQueue->makeInvalid();
+    protectedQueue()->makeInvalid();
 }
 
 void Device::loseTheDevice(WGPUDeviceLostReason reason)
@@ -262,7 +262,7 @@ void Device::loseTheDevice(WGPUDeviceLostReason reason)
         m_deviceLostCallback = nullptr;
     }
 
-    m_defaultQueue->makeInvalid();
+    protectedQueue()->makeInvalid();
     m_isLost = true;
 }
 
@@ -311,11 +311,6 @@ bool Device::getLimits(WGPUSupportedLimits& limits)
 
     limits.limits = m_capabilities.limits;
     return true;
-}
-
-id<MTLBuffer> Device::placeholderBuffer() const
-{
-    return m_placeholderBuffer;
 }
 
 id<MTLTexture> Device::placeholderTexture(WGPUTextureFormat format) const
@@ -394,23 +389,6 @@ void Device::generateAnInternalError(String&& message)
         m_uncapturedErrorCallback(WGPUErrorType_Internal, WTFMove(message));
         m_uncapturedErrorCallback = nullptr;
     }
-}
-
-uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
-{
-    ASSERT(m_capabilities.limits.maxBindGroupsPlusVertexBuffers > 0);
-    return m_capabilities.limits.maxBindGroupsPlusVertexBuffers;
-}
-
-uint32_t Device::maxBuffersForFragmentStage() const
-{
-    return m_capabilities.limits.maxBindGroups;
-}
-
-uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
-{
-    ASSERT(maxBuffersPlusVertexBuffersForVertexStage() > 0);
-    return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxBuffersPlusVertexBuffersForVertexStage() - 1);
 }
 
 id<MTLBuffer> Device::newBufferWithBytes(const void* pointer, size_t length, MTLResourceOptions options) const

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -70,8 +70,8 @@ void ExternalTexture::destroy()
 {
     m_pixelBuffer = nil;
     m_destroyed = true;
-    for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.makeSubmitInvalid();
+    for (Ref commandEncoder : m_commandEncoders)
+        commandEncoder->makeSubmitInvalid();
 
     m_commandEncoders.clear();
 }

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -38,7 +38,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
         return std::nullopt;
 
     if (shaderModule.library() && pipelineLayout) {
-        if (const auto* pipelineLayoutHint = shaderModule.pipelineLayoutHint(entryPoint)) {
+        if (const RefPtr pipelineLayoutHint = shaderModule.pipelineLayoutHint(entryPoint)) {
             if (*pipelineLayoutHint == *pipelineLayout) {
                 if (const auto* entryPointInformation = shaderModule.entryPointInformation(entryPoint))
                     return { { shaderModule.library(), *entryPointInformation,  wgslConstantValues } };
@@ -171,7 +171,7 @@ id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::E
 
 NSString* errorValidatingBindGroup(const BindGroup& bindGroup, const BufferBindingSizesForBindGroup* mininumBufferSizes, const Vector<uint32_t>* dynamicOffsets)
 {
-    auto bindGroupLayout = bindGroup.bindGroupLayout();
+    RefPtr bindGroupLayout = bindGroup.bindGroupLayout();
     if (!bindGroupLayout)
         return nil;
 

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -296,7 +296,7 @@ NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLa
         if (it == bindGroups.end() || !it->value.get())
             return [NSString stringWithFormat:@"can not find bind group in pipeline for bindGroup index %zu", bindGroupIndex];
 
-        auto* setBindGroupLayout = it->value->bindGroupLayout();
+        RefPtr setBindGroupLayout = it->value->bindGroupLayout();
         if (!setBindGroupLayout)
             return [NSString stringWithFormat:@"can not find bind group in set bind groups for bindGroup index %zu", bindGroupIndex];
 

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -103,8 +103,8 @@ void QuerySet::destroy()
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
     m_visibilityBuffer = nil;
     m_timestampBuffer = nil;
-    for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.makeSubmitInvalid();
+    for (Ref commandEncoder : m_commandEncoders)
+        commandEncoder->makeSubmitInvalid();
 
     m_commandEncoders.clear();
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -65,7 +65,7 @@ public:
     ~Queue();
 
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
-    void submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands);
+    void submit(Vector<Ref<WebGPU::CommandBuffer>>&& commands);
     void writeBuffer(Buffer&, uint64_t bufferOffset, std::span<uint8_t> data);
     void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data);
     void writeTexture(const WGPUImageCopyTexture& destination, std::span<uint8_t> data, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize, bool skipValidation = false);
@@ -95,7 +95,7 @@ private:
     Queue(id<MTLCommandQueue>, Device&);
     Queue(Device&);
 
-    NSString* errorValidatingSubmit(const Vector<std::reference_wrapper<CommandBuffer>>&) const;
+    NSString* errorValidatingSubmit(const Vector<Ref<WebGPU::CommandBuffer>>&) const;
     bool validateWriteBuffer(const Buffer&, uint64_t bufferOffset, size_t) const;
 
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -77,7 +77,7 @@ public:
     void drawIndirect(Buffer& indirectBuffer, uint64_t indirectOffset);
     void endOcclusionQuery();
     void endPass();
-    void executeBundles(Vector<std::reference_wrapper<RenderBundle>>&& bundles);
+    void executeBundles(Vector<Ref<RenderBundle>>&& bundles);
     void insertDebugMarker(String&& markerLabel);
     void popDebugGroup();
     void pushDebugGroup(String&& groupLabel);
@@ -97,7 +97,8 @@ public:
     bool colorDepthStencilTargetsMatch(const RenderPipeline&) const;
     id<MTLRenderCommandEncoder> renderCommandEncoder() const;
     void makeInvalid(NSString* = nil);
-    CommandEncoder& parentEncoder();
+    CommandEncoder& parentEncoder() { return m_parentEncoder; }
+
     bool setCommandEncoder(const BindGroupEntryUsageData::Resource&);
     void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, id<MTLResource>, OptionSet<BindGroupEntryUsage>);
     static double quantizedDepthValue(double, WGPUTextureFormat);

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -86,15 +86,18 @@ public:
     uint32_t sampleMask() const { return m_sampleMask; }
 
     Device& device() const { return m_device; }
-    PipelineLayout& pipelineLayout() const;
+    PipelineLayout& pipelineLayout() const { return m_pipelineLayout; }
+    Ref<PipelineLayout> protectedPipelineLayout() const { return m_pipelineLayout; }
     bool colorDepthStencilTargetsMatch(const WGPURenderPassDescriptor&, const Vector<RefPtr<TextureView>>&, const RefPtr<TextureView>&) const;
     bool validateRenderBundle(const WGPURenderBundleEncoderDescriptor&) const;
     bool writesDepth() const;
     bool writesStencil() const;
 
     const RequiredBufferIndicesContainer& requiredBufferIndices() const { return m_requiredBufferIndices; }
-    WGPUPrimitiveTopology primitiveTopology() const;
-    MTLIndexType stripIndexFormat() const;
+    WGPUPrimitiveTopology primitiveTopology() const { return m_descriptor.primitive.topology; }
+
+    MTLIndexType stripIndexFormat() const { return m_descriptor.primitive.stripIndexFormat == WGPUIndexFormat_Uint16 ? MTLIndexTypeUInt16 : MTLIndexTypeUInt32; }
+
     const BufferBindingSizesForBindGroup* minimumBufferSizes(uint32_t) const;
 
 private:

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -977,10 +977,10 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
 
     uint32_t maxVertexOffset = 0, maxFragmentOffset = 0, maxComputeOffset = 0;
     for (size_t i = 0; i < pipelineLayout.numberOfBindGroupLayouts(); ++i) {
-        auto& bindGroupLayout = pipelineLayout.bindGroupLayout(i);
+        Ref bindGroupLayout = pipelineLayout.bindGroupLayout(i);
         WGSL::BindGroupLayout wgslBindGroupLayout;
         auto vertexOffset = maxVertexOffset, fragmentOffset = maxFragmentOffset, computeOffset = maxComputeOffset;
-        for (auto& entry : bindGroupLayout.entries()) {
+        for (auto& entry : bindGroupLayout->entries()) {
             WGSL::BindGroupLayoutEntry wgslEntry;
             wgslEntry.binding = entry.value.binding;
             wgslEntry.visibility = wgslEntry.visibility.fromRaw(entry.value.visibility);

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -114,7 +114,8 @@ public:
 
     bool previouslyCleared(uint32_t mipLevel, uint32_t slice) const;
     void setPreviouslyCleared(uint32_t mipLevel, uint32_t slice, bool = true);
-    bool isDestroyed() const;
+    bool isDestroyed() const { return m_destroyed; }
+
     static bool hasStorageBindingCapability(WGPUTextureFormat, const Device&, WGPUStorageTextureAccess = WGPUStorageTextureAccess_Undefined);
     static bool supportsMultisampling(WGPUTextureFormat, const Device&);
     static bool supportsResolve(WGPUTextureFormat, const Device&);
@@ -123,7 +124,8 @@ public:
     void makeCanvasBacking();
     void setCommandEncoder(CommandEncoder&) const;
     static ASCIILiteral formatToString(WGPUTextureFormat);
-    bool isCanvasBacking() const;
+    bool isCanvasBacking() const { return m_canvasBacking; }
+
     bool waitForCommandBufferCompletion();
     void updateCompletionEvent(const std::pair<id<MTLSharedEvent>, uint64_t>&);
     id<MTLSharedEvent> sharedEvent() const;

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -64,12 +64,12 @@ id<MTLTexture> TextureView::parentTexture() const
 
 bool TextureView::previouslyCleared() const
 {
-    return m_parentTexture->previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
+    return Ref { m_parentTexture }->previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
 }
 
 void TextureView::setPreviouslyCleared(uint32_t mipLevel, uint32_t slice)
 {
-    m_parentTexture->setPreviouslyCleared(m_texture.parentRelativeLevel + mipLevel, m_texture.parentRelativeSlice + slice);
+    Ref { m_parentTexture }->setPreviouslyCleared(m_texture.parentRelativeLevel + mipLevel, m_texture.parentRelativeSlice + slice);
 }
 
 uint32_t TextureView::parentRelativeMipLevel() const
@@ -85,17 +85,17 @@ uint32_t TextureView::parentRelativeSlice() const
 
 uint32_t TextureView::width() const
 {
-    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
+    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
 }
 
 uint32_t TextureView::height() const
 {
-    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
+    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
 }
 
 uint32_t TextureView::depthOrArrayLayers() const
 {
-    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
+    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
 }
 
 WGPUTextureUsageFlags TextureView::usage() const
@@ -170,10 +170,10 @@ bool TextureView::isValid() const
 
 void TextureView::destroy()
 {
-    m_texture = m_device->placeholderTexture(format());
+    m_texture = Ref { m_device }->placeholderTexture(format());
     if (!m_parentTexture->isCanvasBacking()) {
-        for (auto& commandEncoder : m_commandEncoders)
-            commandEncoder.makeSubmitInvalid();
+        for (Ref commandEncoder : m_commandEncoders)
+            commandEncoder->makeSubmitInvalid();
     }
 
     m_commandEncoders.clear();

--- a/Source/WebGPU/WebGPU/XRBinding.h
+++ b/Source/WebGPU/WebGPU/XRBinding.h
@@ -62,7 +62,9 @@ public:
     bool isValid() const;
     Ref<XRProjectionLayer> createXRProjectionLayer(WGPUTextureFormat, WGPUTextureFormat*, WGPUTextureUsageFlags, double);
     RefPtr<XRSubImage> getViewSubImage(XRProjectionLayer&);
-    Device& device();
+    Device& device() { return m_device; }
+    Ref<Device> protectedDevice() { return m_device; }
+
 
 private:
     XRBinding(bool, Device&);

--- a/Source/WebGPU/WebGPU/XRBinding.mm
+++ b/Source/WebGPU/WebGPU/XRBinding.mm
@@ -62,11 +62,6 @@ bool XRBinding::isValid() const
     return true;
 }
 
-Device& XRBinding::device()
-{
-    return m_device;
-}
-
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.mm
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.mm
@@ -117,7 +117,7 @@ Ref<XRProjectionLayer> XRBinding::createXRProjectionLayer(WGPUTextureFormat colo
     UNUSED_PARAM(flags);
     UNUSED_PARAM(scale);
 
-    return XRProjectionLayer::create(device());
+    return XRProjectionLayer::create(protectedDevice().get());
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRSubImage.mm
+++ b/Source/WebGPU/WebGPU/XRSubImage.mm
@@ -71,7 +71,7 @@ void XRSubImage::update(id<MTLTexture> colorTexture, id<MTLTexture> depthTexture
         return;
 
     m_currentTextureIndex = currentTextureIndex;
-    auto* texture = this->colorTexture();
+    RefPtr texture = this->colorTexture();
     if (!texture || texture->texture() != colorTexture) {
         auto colorFormat = WGPUTextureFormat_BGRA8UnormSrgb;
         WGPUTextureDescriptor colorTextureDescriptor = {
@@ -134,7 +134,7 @@ Texture* XRSubImage::depthTexture()
 
 RefPtr<XRSubImage> XRBinding::getViewSubImage(XRProjectionLayer& projectionLayer)
 {
-    return device().getXRViewSubImage(projectionLayer);
+    return protectedDevice()->getXRViewSubImage(projectionLayer);
 }
 
 } // namespace WebGPU

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -64,7 +64,7 @@ void RemoteQueue::stopListeningForIPC()
 
 void RemoteQueue::submit(Vector<WebGPUIdentifier>&& commandBuffers)
 {
-    Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>> convertedCommandBuffers;
+    Vector<Ref<WebCore::WebGPU::CommandBuffer>> convertedCommandBuffers;
     convertedCommandBuffers.reserveInitialCapacity(commandBuffers.size());
     for (WebGPUIdentifier identifier : commandBuffers) {
         auto convertedCommandBuffer = protectedObjectHeap()->convertCommandBufferFromBacking(identifier);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -199,7 +199,7 @@ void RemoteRenderPassEncoder::endOcclusionQuery()
 
 void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBundles)
 {
-    Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>> convertedBundles;
+    Vector<Ref<WebCore::WebGPU::RenderBundle>> convertedBundles;
     convertedBundles.reserveInitialCapacity(renderBundles.size());
     for (WebGPUIdentifier identifier : renderBundles) {
         auto convertedBundle = protectedObjectHeap()->convertRenderBundleFromBacking(identifier);

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -139,7 +139,6 @@ Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
 Shared/WebGPU/WebGPUImageCopyBuffer.cpp
 Shared/WebGPU/WebGPUImageCopyTexture.cpp
 Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
-Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
 Shared/WebGPU/WebGPUProgrammableStage.cpp
 Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
 Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
@@ -60,8 +60,8 @@ std::optional<WebCore::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingConte
     if (!base)
         return std::nullopt;
 
-    std::optional<Vector<std::reference_wrapper<WebCore::WebGPU::BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
-    Vector<std::reference_wrapper<WebCore::WebGPU::BindGroupLayout>> bindGroupLayouts;
+    std::optional<Vector<Ref<WebCore::WebGPU::BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
+    Vector<Ref<WebCore::WebGPU::BindGroupLayout>> bindGroupLayouts;
     if (pipelineLayoutDescriptor.bindGroupLayouts) {
         bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts->size());
         for (const auto& backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts) {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -49,7 +49,7 @@ RemoteQueueProxy::~RemoteQueueProxy()
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteQueueProxy::submit(Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>>&& commandBuffers)
+void RemoteQueueProxy::submit(Vector<Ref<WebCore::WebGPU::CommandBuffer>>&& commandBuffers)
 {
     auto convertedCommandBuffers = WTF::compactMap(commandBuffers, [&](auto& commandBuffer) -> std::optional<WebGPUIdentifier> {
         auto convertedCommandBuffer = protectedConvertToBackingContext()->convertToBacking(commandBuffer);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -74,7 +74,7 @@ private:
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
 
-    void submit(Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>>&&) final;
+    void submit(Vector<Ref<WebCore::WebGPU::CommandBuffer>>&&) final;
 
     void onSubmittedWorkDone(CompletionHandler<void()>&&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -193,7 +193,7 @@ void RemoteRenderPassEncoderProxy::endOcclusionQuery()
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderPassEncoderProxy::executeBundles(Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>>&& renderBundles)
+void RemoteRenderPassEncoderProxy::executeBundles(Vector<Ref<WebCore::WebGPU::RenderBundle>>&& renderBundles)
 {
     auto convertedRenderBundles = WTF::compactMap(renderBundles, [&](auto& renderBundle) -> std::optional<WebGPUIdentifier> {
         return protectedConvertToBackingContext()->convertToBacking(renderBundle);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -108,7 +108,7 @@ private:
     void beginOcclusionQuery(WebCore::WebGPU::Size32 queryIndex) final;
     void endOcclusionQuery() final;
 
-    void executeBundles(Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>>&&) final;
+    void executeBundles(Vector<Ref<WebCore::WebGPU::RenderBundle>>&&) final;
     void end() final;
 
     void setLabelInternal(const String&) final;


### PR DESCRIPTION
#### ee90c1745f1a38eb48656cbf01916274168c7984
<pre>
Finish off smart pointer coverage in WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=282145">https://bugs.webkit.org/show_bug.cgi?id=282145</a>
<a href="https://rdar.apple.com/138712492">rdar://138712492</a>

Reviewed by Mike Wyrzykowski.

Fixed the remaining static analyzer complaints.

I skipped false positives to do with the implementations of RefCounted,
ThreadSafeRefCounted, String, and Thread.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::submit):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp:
(WebCore::WebGPU::RenderPassEncoderImpl::executeBundles):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h:
* Source/WebGPU/WebGPU/Adapter.h:
* Source/WebGPU/WebGPU/BindGroup.h:
(WebGPU::BindGroup::bindGroupLayout const):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::BindGroup::rebindSamplersIfNeeded const):
(WebGPU::BindGroup::bindGroupLayout const): Deleted.
* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::indirectIndexedBuffer const):
(WebGPU::Buffer::isDestroyed const):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::incrementBufferMapCount):
(WebGPU::Buffer::decrementBufferMapCount):
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::isDestroyed const): Deleted.
(WebGPU::Buffer::indirectIndexedBuffer const): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::discardCommandBuffer):
(WebGPU::CommandEncoder::copyBufferToTexture):
* Source/WebGPU/WebGPU/CommandsMixin.mm:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::instance const):
(WebGPU::Device::maxBuffersPlusVertexBuffersForVertexStage const):
(WebGPU::Device::maxBuffersForFragmentStage const):
(WebGPU::Device::vertexBufferIndexForBindGroup const):
(WebGPU::Device::placeholderBuffer const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::getXRViewSubImage):
(WebGPU::Device::makeInvalid):
(WebGPU::Device::loseTheDevice):
(WebGPU::Device::placeholderBuffer const): Deleted.
(WebGPU::Device::maxBuffersPlusVertexBuffersForVertexStage const): Deleted.
(WebGPU::Device::maxBuffersForFragmentStage const): Deleted.
(WebGPU::Device::vertexBufferIndexForBindGroup const): Deleted.
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::destroy):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
(WebGPU::errorValidatingBindGroup):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::errorValidatingBindGroupCompatibility const):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::onSubmittedWorkScheduled):
(WebGPU::PresentationContextIOSurface::getTextureAsNativeImage):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::QuerySet::destroy):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::errorValidatingSubmit const):
(WebGPU::invalidateCommandBuffers):
(WebGPU::Queue::submit):
(WebGPU::Queue::clearTextureViewIfNeeded):
(wgpuQueueSubmit):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::replayCommands const):
(WebGPU::RenderBundle::updateMinMaxDepths):
(WebGPU::RenderBundle::validateRenderPass const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::returnIfEncodingIsFinished):
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setPipeline):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::parentEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::m_maxDrawCount):
(WebGPU::RenderPassEncoder::~RenderPassEncoder):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::splitRenderPass):
(WebGPU::RenderPassEncoder::endPass):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::makeInvalid):
(WebGPU::RenderPassEncoder::setBindGroup):
(WebGPU::RenderPassEncoder::errorValidatingPipeline const):
(WebGPU::RenderPassEncoder::setPipeline):
(wgpuRenderPassEncoderExecuteBundles):
(WebGPU::RenderPassEncoder::parentEncoder): Deleted.
* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::pipelineLayout const):
(WebGPU::RenderPipeline::protectedPipelineLayout const):
(WebGPU::RenderPipeline::primitiveTopology const):
(WebGPU::RenderPipeline::stripIndexFormat const):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
(WebGPU::RenderPipeline::colorDepthStencilTargetsMatch const):
(WebGPU::RenderPipeline::pipelineLayout const): Deleted.
(WebGPU::RenderPipeline::primitiveTopology const): Deleted.
(WebGPU::RenderPipeline::stripIndexFormat const): Deleted.
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::convertPipelineLayout):
* Source/WebGPU/WebGPU/Texture.h:
(WebGPU::Texture::isDestroyed const):
(WebGPU::Texture::isCanvasBacking const):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::createView):
(WebGPU::Texture::waitForCommandBufferCompletion):
(WebGPU::Texture::destroy):
(WebGPU::Texture::isCanvasBacking const): Deleted.
(WebGPU::Texture::isDestroyed const): Deleted.
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::previouslyCleared const):
(WebGPU::TextureView::setPreviouslyCleared):
(WebGPU::TextureView::width const):
(WebGPU::TextureView::height const):
(WebGPU::TextureView::depthOrArrayLayers const):
(WebGPU::TextureView::destroy):
* Source/WebGPU/WebGPU/XRBinding.h:
(WebGPU::XRBinding::device):
(WebGPU::XRBinding::protectedDevice):
* Source/WebGPU/WebGPU/XRBinding.mm:
(WebGPU::XRBinding::device): Deleted.
* Source/WebGPU/WebGPU/XRProjectionLayer.mm:
(WebGPU::XRBinding::createXRProjectionLayer):
* Source/WebGPU/WebGPU/XRSubImage.mm:
(WebGPU::XRSubImage::update):
(WebGPU::XRBinding::getViewSubImage):

Canonical link: <a href="https://commits.webkit.org/285748@main">https://commits.webkit.org/285748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffe017634d73bc499d27bc547eec8bbfc2f270ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26517 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24944 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/920 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76773 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/44837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/20904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23277 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1023 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/79595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1165 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/79595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/9458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11361 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->