### PR TITLE
Annotate various WTF functions with [[clang::noescape]]

### DIFF
--- a/Source/WTF/wtf/AggregateLogger.h
+++ b/Source/WTF/wtf/AggregateLogger.h
@@ -90,7 +90,11 @@ public:
 
     inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level) const
     {
-        return allOf(m_loggers, [channel, level] (auto& logger) { return logger->willLog(channel, level); });
+        for (auto& loggers : m_loggers) {
+            if (!loggers->willLog(channel, level))
+                return false;
+        }
+        return true;
     }
 
 private:

--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -28,18 +28,19 @@
 #include <cstring>
 #include <type_traits>
 #include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
 
 namespace WTF {
 
 template<typename ContainerType, typename ForEachFunction>
-void forEach(ContainerType&& container, ForEachFunction forEachFunction)
+void forEach(ContainerType&& container, NOESCAPE ForEachFunction&& forEachFunction)
 {
     for (auto& value : container)
         forEachFunction(value);
 }
 
 template<typename ContainerType, typename AnyOfFunction>
-bool anyOf(ContainerType&& container, AnyOfFunction anyOfFunction)
+bool anyOf(ContainerType&& container, NOESCAPE AnyOfFunction&& anyOfFunction)
 {
     for (auto& value : container) {
         if (anyOfFunction(value))
@@ -49,7 +50,7 @@ bool anyOf(ContainerType&& container, AnyOfFunction anyOfFunction)
 }
 
 template<typename ContainerType, typename AllOfFunction>
-bool allOf(ContainerType&& container, AllOfFunction allOfFunction)
+bool allOf(ContainerType&& container, NOESCAPE AllOfFunction&& allOfFunction)
 {
     for (auto& value : container) {
         if (!allOfFunction(value))

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -562,6 +562,18 @@
 #define IGNORE_NULL_CHECK_WARNINGS_BEGIN IGNORE_WARNINGS_BEGIN("nonnull")
 #define IGNORE_NULL_CHECK_WARNINGS_END IGNORE_WARNINGS_END
 
+/* NOESCAPE */
+/* This attribute promises that a function argumemnt will only be used for the duration of the function,
+   and not stored to the heap or in a global state for later use. The compiler does not verify this claim. */
+
+#if !defined(NOESCAPE) && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::noescape)
+#define NOESCAPE [[clang::noescape]]
+#else
+#define NOESCAPE
+#endif
+#endif
+
 /* NO_UNIQUE_ADDRESS */
 
 #if !defined(NO_UNIQUE_ADDRESS) && defined(__has_cpp_attribute)

--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -77,7 +77,7 @@ public:
     }
 
     template<std::invocable<size_t> Generator>
-    static std::unique_ptr<EmbeddedFixedVector> createWithSizeFromGenerator(unsigned size, Generator&& generator)
+    static std::unique_ptr<EmbeddedFixedVector> createWithSizeFromGenerator(unsigned size, NOESCAPE Generator&& generator)
     {
 
         auto result = std::unique_ptr<EmbeddedFixedVector> { new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::Failable { }, size, std::forward<Generator>(generator)) };

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -130,7 +130,7 @@ public:
     }
 
     template<std::invocable<size_t> Generator>
-    static FixedVector createWithSizeFromGenerator(size_t size, Generator&& generator)
+    static FixedVector createWithSizeFromGenerator(size_t size, NOESCAPE Generator&& generator)
     {
         return FixedVector<T> { Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)) };
     }

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -117,7 +117,7 @@ public:
     // function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
-    template<typename HashTranslator> AddResult ensure(auto&&, const Invocable<ValueType()> auto&);
+    template<typename HashTranslator> AddResult ensure(auto&&, NOESCAPE const Invocable<ValueType()> auto&);
 
     // Attempts to add a list of things to the set. Returns true if any of
     // them are new to the set. Returns false if the set is unchanged.
@@ -128,7 +128,7 @@ public:
 
     bool remove(const ValueType&);
     bool remove(iterator);
-    bool removeIf(const Invocable<bool(const ValueType&)> auto&);
+    bool removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto&);
     void clear();
 
     TakeType take(const ValueType&);
@@ -136,7 +136,7 @@ public:
     TakeType takeAny();
 
     template<size_t inlineCapacity = 0>
-    Vector<TakeType, inlineCapacity> takeIf(const Invocable<bool(const ValueType&)> auto& functor) { return m_impl.template takeIf<inlineCapacity>(functor); }
+    Vector<TakeType, inlineCapacity> takeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor) { return m_impl.template takeIf<inlineCapacity>(functor); }
 
     // Returns a new set with the elements of both this and the given
     // collection (a.k.a. OR).
@@ -207,7 +207,7 @@ template<typename ValueTraits, typename HashFunctions>
 struct HashSetTranslator {
     static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
     static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
-    static void translate(auto& location, auto&&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
+    static void translate(auto& location, auto&&, NOESCAPE const Invocable<typename ValueTraits::TraitType()> auto& functor)
     { 
         ValueTraits::assignToEmpty(location, functor());
     }
@@ -227,7 +227,7 @@ template<typename ValueTraits, typename Translator>
 struct HashSetEnsureTranslatorAdaptor {
     static unsigned hash(const auto& key) { return Translator::hash(key); }
     static bool equal(const auto& a, const auto& b) { return Translator::equal(a, b); }
-    static void translate(auto& location, auto&&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
+    static void translate(auto& location, auto&&, NOESCAPE const Invocable<typename ValueTraits::TraitType()> auto& functor)
     {
         ValueTraits::assignToEmpty(location, functor());
     }
@@ -303,7 +303,7 @@ inline bool HashSet<Value, HashFunctions, Traits, TableTraits>::contains(const T
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
 template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::ensure(T&& key, const Invocable<ValueType()> auto& functor) -> AddResult
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::ensure(T&& key, NOESCAPE const Invocable<ValueType()> auto& functor) -> AddResult
 {
     return m_impl.template add<HashSetEnsureTranslatorAdaptor<Traits, HashTranslator>>(std::forward<T>(key), functor);
 }
@@ -376,7 +376,7 @@ inline bool HashSet<T, U, V, W>::remove(const ValueType& value)
 }
 
 template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::removeIf(const Invocable<bool(const ValueType&)> auto& functor)
+inline bool HashSet<T, U, V, W>::removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
 }

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -300,7 +300,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     public:
         static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
         static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
-        static void translate(auto& location, const auto&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
+        static void translate(auto& location, const auto&, NOESCAPE const Invocable<typename ValueTraits::TraitType()> auto& functor)
         {
             ValueTraits::assignToEmpty(location, functor());
         }
@@ -484,8 +484,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         // A special version of add() that finds the object by hashing and comparing
         // with some other type, to avoid the cost of type conversion if the object is already
         // in the table.
-        template<typename HashTranslator> AddResult add(auto&& key, const std::invocable<> auto& functor);
-        template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, const std::invocable<> auto& functor);
+        template<typename HashTranslator> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor);
+        template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor);
 
         iterator find(const KeyType& key) { return find<IdentityTranslatorType>(key); }
         const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType>(key); }
@@ -500,11 +500,11 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         void removeWithoutEntryConsistencyCheck(iterator);
         void removeWithoutEntryConsistencyCheck(const_iterator);
         // FIXME: This feels like it should be Invocable<bool(const ValueType&)> but that breaks many HashMap users.
-        bool removeIf(const Invocable<bool(ValueType&)> auto&);
+        bool removeIf(NOESCAPE const Invocable<bool(ValueType&)> auto&);
         void clear();
 
         template<size_t inlineCapacity>
-        Vector<TakeType, inlineCapacity> takeIf(const Invocable<bool(const ValueType&)> auto&);
+        Vector<TakeType, inlineCapacity> takeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto&);
 
         static bool isEmptyBucket(const ValueType& value) { return isHashTraitsEmptyValue<KeyTraits>(Extractor::extract(value)); }
         static bool isReleasedWeakBucket(const ValueType& value) { return isHashTraitsReleasedWeakValue<KeyTraits>(Extractor::extract(value)); }
@@ -541,7 +541,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         template<typename HashTranslator, typename T> ValueType* lookupForReinsert(const T&);
         template<typename HashTranslator, typename T> FullLookupType fullLookupForWriting(const T&);
 
-        template<typename HashTranslator> void addUniqueForInitialization(auto&& key, const std::invocable<> auto& functor);
+        template<typename HashTranslator> void addUniqueForInitialization(auto&& key, NOESCAPE const std::invocable<> auto& functor);
 
         template<typename HashTranslator, typename T> void checkKey(const T&);
 
@@ -826,7 +826,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
     template<typename HashTranslator, typename T>
-    ALWAYS_INLINE void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::addUniqueForInitialization(T&& key, const std::invocable<> auto& functor)
+    ALWAYS_INLINE void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::addUniqueForInitialization(T&& key, NOESCAPE const std::invocable<> auto& functor)
     {
         ASSERT(m_table);
         checkKey<HashTranslator>(key);
@@ -867,7 +867,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
     template<typename HashTranslator, typename T>
-    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::add(T&& key, const std::invocable<> auto& functor) -> AddResult
+    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
     {
         checkKey<HashTranslator>(key);
         invalidateIterators(this);
@@ -950,7 +950,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
     template<typename HashTranslator, typename T>
-    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::addPassingHashCode(T&& key, const std::invocable<> auto& functor) -> AddResult
+    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
     {
         checkKey<HashTranslator>(key);
 
@@ -1113,7 +1113,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    inline bool HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::removeIf(const Invocable<bool(ValueType&)> auto& functor)
+    inline bool HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::removeIf(NOESCAPE const Invocable<bool(ValueType&)> auto& functor)
     {
         // We must use local copies in case "functor" or "deleteBucket"
         // make a function call, which prevents the compiler from keeping
@@ -1146,7 +1146,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
     template<size_t inlineCapacity>
-    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::takeIf(const Invocable<bool(const ValueType&)> auto& functor) -> Vector<TakeType, inlineCapacity>
+    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::takeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor) -> Vector<TakeType, inlineCapacity>
     {
         // We must use local copies in case "functor" or "deleteBucket"
         // make a function call, which prevents the compiler from keeping

--- a/Source/WTF/wtf/LocklessBag.h
+++ b/Source/WTF/wtf/LocklessBag.h
@@ -70,7 +70,7 @@ public:
     // CONSUMER FUNCTIONS: Everything below here is only safe to call from the consumer thread.
 
     // This function is actually safe to call from more than one thread, but ONLY if no thread can call consumeAll.
-    void iterate(const Invocable<void(const T&)> auto& func)
+    void iterate(NOESCAPE const Invocable<void(const T&)> auto& func)
     {
         Node* node = m_head.load();
         while (node) {
@@ -79,7 +79,7 @@ public:
         }
     }
 
-    void consumeAll(const Invocable<void(T&&)> auto& func)
+    void consumeAll(NOESCAPE const Invocable<void(T&&)> auto& func)
     {
         consumeAllWithNode([&] (T&& data, Node* node) {
             func(WTFMove(data));
@@ -87,7 +87,7 @@ public:
         });
     }
 
-    void consumeAllWithNode(const Invocable<void(T&&, Node*)> auto& func)
+    void consumeAllWithNode(NOESCAPE const Invocable<void(T&&, Node*)> auto& func)
     {
         Node* node = m_head.exchange(nullptr);
         while (node) {

--- a/Source/WTF/wtf/PriorityQueue.h
+++ b/Source/WTF/wtf/PriorityQueue.h
@@ -63,7 +63,7 @@ public:
         return result;
     }
 
-    void decreaseKey(const Invocable<bool(T&)> auto& desiredElement)
+    void decreaseKey(NOESCAPE const Invocable<bool(T&)> auto& desiredElement)
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
@@ -74,7 +74,7 @@ public:
         ASSERT(isValidHeap());
     }
 
-    void increaseKey(const Invocable<bool(T&)> auto& desiredElement)
+    void increaseKey(NOESCAPE const Invocable<bool(T&)> auto& desiredElement)
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -183,8 +183,8 @@ public:
     // A special version of add() that finds the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion if the object is already
     // in the table.
-    template<typename HashTranslator> AddResult add(auto&& key, const std::invocable<> auto& functor);
-    template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, const std::invocable<> auto& functor);
+    template<typename HashTranslator> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor);
+    template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor);
 
     iterator find(const KeyType& key) { return find<IdentityTranslatorType>(key); }
     const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType>(key); }
@@ -388,7 +388,7 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
 template<typename HashTranslator, typename T>
-ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::add(T&& key, const std::invocable<> auto& functor) -> AddResult
+ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 
@@ -478,7 +478,7 @@ ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
 template<typename HashTranslator, typename T>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::addPassingHashCode(T&& key, const std::invocable<> auto& functor) -> AddResult
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -70,8 +70,7 @@ public:
     }
 
     void dump(PrintStream&) const;
-    template<typename Functor> // void Functor(int frameNumber, void* stackFrame, const char* name)
-    void forEachFrame(Functor) const;
+    void forEachFrame(NOESCAPE const std::invocable<int, void*, const char*> auto&) const;
     WTF_EXPORT_PRIVATE String toString() const;
 
 private:
@@ -116,8 +115,7 @@ public:
 
     WTF_EXPORT_PRIVATE static std::optional<DemangleEntry> demangle(void*);
 
-    template<typename Functor>
-    void forEach(Functor functor) const
+    void forEach(NOESCAPE const std::invocable<int, void*, const char*> auto& functor) const
     {
 #if USE(LIBBACKTRACE)
         char** symbols = symbolize(m_stack.data(), m_stack.size());
@@ -188,8 +186,7 @@ inline void StackTrace::dump(PrintStream& out) const
     StackTracePrinter { *this }.dump(out);
 }
 
-template<typename Functor>
-void StackTrace::forEachFrame(Functor functor) const
+void StackTrace::forEachFrame(NOESCAPE const std::invocable<int, void*, const char*> auto& functor) const
 {
     StackTraceSymbolResolver { *this }.forEach(functor);
 }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -749,7 +749,7 @@ constexpr auto constructFixedSizeArrayWithArguments(Args&&... args) -> decltype(
     return constructFixedSizeArrayWithArgumentsImpl<ResultType>(tuple, std::forward<Args>(args)...);
 }
 
-template<typename OptionalType, class Callback> typename OptionalType::value_type valueOrCompute(OptionalType optional, Callback callback) 
+template<typename OptionalType> typename OptionalType::value_type valueOrCompute(OptionalType optional, NOESCAPE const std::invocable<> auto& callback)
 {
     return optional ? *optional : callback();
 }

--- a/Source/WTF/wtf/TinyPtrSet.h
+++ b/Source/WTF/wtf/TinyPtrSet.h
@@ -168,7 +168,7 @@ public:
         return mergeOtherOutOfLine(other);
     }
     
-    void forEach(const Invocable<void(const T&)> auto& functor) const
+    void forEach(NOESCAPE const Invocable<void(const T&)> auto& functor) const
     {
         if (isThin()) {
             if (!singleEntry())
@@ -182,7 +182,7 @@ public:
             functor(list->list()[i]);
     }
         
-    void genericFilter(const Invocable<bool(const T&)> auto& functor)
+    void genericFilter(NOESCAPE const Invocable<bool(const T&)> auto& functor)
     {
         if (isThin()) {
             if (!singleEntry())

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -94,7 +94,7 @@ protected:
     // should be used as appropriate.
     struct Failable { };
     template<std::invocable<size_t> Generator>
-    explicit TrailingArray(Failable, unsigned size, Generator&& generator)
+    explicit TrailingArray(Failable, unsigned size, NOESCAPE Generator&& generator)
         : m_size(size)
     {
         static_assert(std::is_final_v<Derived>);

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -714,7 +714,7 @@ public:
     }
 
     template<std::invocable<size_t> Functor>
-    Vector(size_t size, const Functor& valueGenerator)
+    Vector(size_t size, NOESCAPE const Functor& valueGenerator)
     {
         reserveInitialCapacity(size);
 
@@ -856,10 +856,10 @@ public:
     
     bool contains(const auto&) const;
     size_t find(const auto&) const;
-    size_t findIf(const Invocable<bool(const T&)> auto& matches) const;
+    size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const;
     size_t reverseFind(const auto&) const;
-    size_t reverseFindIf(const Invocable<bool(const T&)> auto& matches) const;
-    bool containsIf(const Invocable<bool(const T&)> auto& matches) const { return findIf(matches) != notFound; }
+    size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const;
+    bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const { return findIf(matches) != notFound; }
 
     bool appendIfNotContains(const auto&);
 
@@ -895,7 +895,7 @@ public:
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(const Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&);
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&&);
 
-    void appendUsingFunctor(size_t, const Invocable<T(size_t)> auto&);
+    void appendUsingFunctor(size_t, NOESCAPE const Invocable<T(size_t)> auto&);
 
     void insert(size_t position, value_type&& value) { insert<value_type>(position, std::forward<value_type>(value)); }
     void insertFill(size_t position, const T& value, size_t dataSize);
@@ -906,12 +906,12 @@ public:
     void remove(size_t position);
     void remove(size_t position, size_t length);
     bool removeFirst(const auto&);
-    bool removeFirstMatching(const Invocable<bool(T&)> auto&, size_t startIndex = 0);
+    bool removeFirstMatching(NOESCAPE const Invocable<bool(T&)> auto&, size_t startIndex = 0);
     bool removeLast(const auto&);
-    bool removeLastMatching(const Invocable<bool(T&)> auto&);
-    bool removeLastMatching(const Invocable<bool(T&)> auto&, size_t startIndex);
+    bool removeLastMatching(NOESCAPE const Invocable<bool(T&)> auto&);
+    bool removeLastMatching(NOESCAPE const Invocable<bool(T&)> auto&, size_t startIndex);
     unsigned removeAll(const auto&);
-    unsigned removeAllMatching(const Invocable<bool(T&)> auto&, size_t startIndex = 0);
+    unsigned removeAllMatching(NOESCAPE const Invocable<bool(T&)> auto&, size_t startIndex = 0);
 
     void removeLast()
     {
@@ -924,7 +924,7 @@ public:
     void fill(const T& val) { fill(val, size()); }
 
     template<typename Iterator> void appendRange(Iterator start, Iterator end);
-    template<typename ContainerType, typename MapFunction> void appendContainerWithMapping(ContainerType&&, const MapFunction&);
+    template<typename ContainerType, typename MapFunction> void appendContainerWithMapping(ContainerType&&, NOESCAPE const MapFunction&);
 
     MallocPtr<T, Malloc> releaseBuffer();
 
@@ -951,10 +951,10 @@ public:
     void checkConsistency();
 
     template<typename ResultVector>
-    ResultVector map(const std::invocable<const T&> auto& mapFunction) const;
+    ResultVector map(NOESCAPE const std::invocable<const T&> auto& mapFunction) const;
 
     template<std::invocable<const T&> MapFunction>
-    Vector<std::invoke_result_t<MapFunction, const T&>> map(const MapFunction&) const;
+    Vector<std::invoke_result_t<MapFunction, const T&>> map(NOESCAPE const MapFunction&) const;
 
     bool isHashTableDeletedValue() const { return m_size == std::numeric_limits<decltype(m_size)>::max(); }
 
@@ -1123,7 +1123,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(c
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(const Invocable<bool(const T&)> auto& matches) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))
@@ -1152,7 +1152,7 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseF
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFindIf(const Invocable<bool(const T&)> auto& matches) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 1; i <= size(); ++i) {
         const size_t index = size() - i;
@@ -1208,7 +1208,7 @@ void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendRang
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendUsingFunctor(size_t size, const Invocable<T(size_t)> auto& valueGenerator)
+void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendUsingFunctor(size_t size, NOESCAPE const Invocable<T(size_t)> auto& valueGenerator)
 {
     reserveCapacity(this->size() + size);
     for (size_t i = 0; i < size; ++i)
@@ -1696,7 +1696,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirstMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirstMatching(NOESCAPE const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     for (size_t i = startIndex; i < size(); ++i) {
         if (matches(at(i))) {
@@ -1716,13 +1716,13 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const Invocable<bool(T&)> auto& matches)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(NOESCAPE const Invocable<bool(T&)> auto& matches)
 {
     return removeLastMatching(matches, size());
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(NOESCAPE const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     for (size_t i = std::min(startIndex + 1, size()); i > 0; --i) {
         if (matches(at(i - 1))) {
@@ -1742,7 +1742,7 @@ inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAllMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
+inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAllMatching(NOESCAPE const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     iterator holeBegin = end();
     iterator holeEnd = end();
@@ -1776,7 +1776,7 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rev
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 template<typename ResultVector>
-inline ResultVector Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(const std::invocable<const T&> auto& mapFunction) const
+inline ResultVector Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(NOESCAPE const std::invocable<const T&> auto& mapFunction) const
 {
     ResultVector result;
     result.reserveInitialCapacity(size());
@@ -1790,14 +1790,14 @@ size_t containerSize(const ContainerType& container) { return std::size(containe
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 template<std::invocable<const T&> MapFunction>
-inline Vector<std::invoke_result_t<MapFunction, const T&>> Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(const MapFunction& mapFunction) const
+inline Vector<std::invoke_result_t<MapFunction, const T&>> Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(NOESCAPE const MapFunction& mapFunction) const
 {
     return map<Vector<typename std::invoke_result_t<MapFunction, const T&>>, MapFunction>(mapFunction);
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 template<typename ContainerType, typename MapFunction>
-void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendContainerWithMapping(ContainerType&& container, const MapFunction& mapFunction)
+void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendContainerWithMapping(ContainerType&& container, NOESCAPE const MapFunction& mapFunction)
 {
     reserveCapacity(size() + containerSize(container));
     for (auto&& item : container)
@@ -1903,7 +1903,7 @@ struct Mapper<MapFunction, DestinationVectorType, SourceType, typename std::enab
 };
 
 template<size_t inlineCapacity = 0, typename OverflowHandler = CrashOnOverflow, size_t minCapacity = 16, typename MapFunction, typename SourceType>
-Vector<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&&>::type, inlineCapacity, OverflowHandler, minCapacity> map(SourceType&& source, MapFunction&& mapFunction)
+Vector<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&&>::type, inlineCapacity, OverflowHandler, minCapacity> map(SourceType&& source, NOESCAPE MapFunction&& mapFunction)
 {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&&>::type;
@@ -1915,7 +1915,7 @@ Vector<typename std::invoke_result<MapFunction, typename CollectionInspector<Sou
 }
 
 template<size_t inlineCapacity = 0, typename OverflowHandler = CrashOnOverflow, size_t minCapacity = 16, typename MapFunction, typename SourceType>
-Vector<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>::type, inlineCapacity, OverflowHandler, minCapacity> map(SourceType& source, MapFunction&& mapFunction)
+Vector<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>::type, inlineCapacity, OverflowHandler, minCapacity> map(SourceType& source, NOESCAPE MapFunction&& mapFunction)
 {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
@@ -1959,7 +1959,7 @@ struct CompactMapper {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
 
-    static void compactMap(DestinationVectorType& result, const SourceType& source, const MapFunction& mapFunction)
+    static void compactMap(DestinationVectorType& result, const SourceType& source, NOESCAPE const MapFunction& mapFunction)
     {
         for (auto&& item : source) {
             auto itemResult = mapFunction(item);
@@ -1975,7 +1975,7 @@ struct CompactMapper<MapFunction, DestinationVectorType, SourceType, typename st
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&&>::type;
 
-    static void compactMap(DestinationVectorType& result, SourceType&& source, const MapFunction& mapFunction)
+    static void compactMap(DestinationVectorType& result, SourceType&& source, NOESCAPE const MapFunction& mapFunction)
     {
         for (auto&& item : source) {
             auto itemResult = mapFunction(WTFMove(item));
@@ -1987,7 +1987,7 @@ struct CompactMapper<MapFunction, DestinationVectorType, SourceType, typename st
 };
 
 template<size_t inlineCapacity = 0, typename OverflowHandler = CrashOnOverflow, size_t minCapacity = 16, typename MapFunction, typename SourceType>
-Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&&>::type>::ItemType, inlineCapacity, OverflowHandler, minCapacity> compactMap(SourceType&& source, MapFunction&& mapFunction)
+Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&&>::type>::ItemType, inlineCapacity, OverflowHandler, minCapacity> compactMap(SourceType&& source, NOESCAPE MapFunction&& mapFunction)
 {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&&>::type;
@@ -2001,7 +2001,7 @@ Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typena
 }
 
 template<size_t inlineCapacity = 0, typename OverflowHandler = CrashOnOverflow, size_t minCapacity = 16, typename MapFunction, typename SourceType>
-Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>::type>::ItemType, inlineCapacity, OverflowHandler, minCapacity> compactMap(SourceType& source, MapFunction&& mapFunction)
+Vector<typename CompactMapTraits<typename std::invoke_result<MapFunction, typename CollectionInspector<SourceType>::SourceItemType&>::type>::ItemType, inlineCapacity, OverflowHandler, minCapacity> compactMap(SourceType& source, NOESCAPE MapFunction&& mapFunction)
 {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
@@ -2045,7 +2045,7 @@ struct FlatMapper<MapFunction, SourceType> {
 };
 
 template<typename MapFunction, typename SourceType>
-Vector<typename FlatMapper<MapFunction, SourceType>::DestinationItemType> flatMap(SourceType&& source, MapFunction&& mapFunction)
+Vector<typename FlatMapper<MapFunction, SourceType>::DestinationItemType> flatMap(SourceType&& source, NOESCAPE MapFunction&& mapFunction)
 {
     return FlatMapper<MapFunction, SourceType>::flatMap(std::forward<SourceType>(source), std::forward<MapFunction>(mapFunction));
 }

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -195,7 +195,7 @@ public:
     const_iterator end() const { return WeakHashMapConstIterator(*this, m_map.end()); }
 
     template <typename Functor>
-    AddResult ensure(const KeyType& key, Functor&& functor)
+    AddResult ensure(const KeyType& key, NOESCAPE Functor&& functor)
     {
         amortizedCleanupIfNeeded();
         auto result = m_map.ensure(makeKeyImpl(key), functor);
@@ -279,7 +279,7 @@ public:
     }
 
     template<typename Functor>
-    bool removeIf(Functor&& functor)
+    bool removeIf(NOESCAPE Functor&& functor)
     {
         bool result = m_map.removeIf([&](auto& entry) {
             auto* key = static_cast<KeyType*>(entry.key->template get<KeyType>());

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -178,7 +178,7 @@ public:
         return m_set.size();
     }
 
-    void forEach(const Function<void(T&)>& callback)
+    void forEach(NOESCAPE const Function<void(T&)>& callback)
     {
         auto items = map(m_set, [](const Ref<WeakPtrImpl>& item) {
             auto* pointer = static_cast<T*>(item->template get<T>());

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -54,11 +54,11 @@ template<typename VectorElementType> Vector<VectorElementType> makeVector(NSArra
 // This overload of createNSArray takes a function to map each vector element to an Objective-C object.
 // The map function has the same interface as the makeNSArrayElement function above, but can be any
 // function including a lambda, a function-like object, or Function<>.
-template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableArray> createNSArray(CollectionType&&, MapFunctionType&&);
+template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableArray> createNSArray(CollectionType&&, NOESCAPE MapFunctionType&&);
 
 // This overload of makeVector takes a function to map each Objective-C object to a vector element.
 // Currently, the map function needs to return an Optional.
-template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> makeVector(NSArray *, MapFunctionType&&);
+template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> makeVector(NSArray *, NOESCAPE MapFunctionType&&);
 
 // Implementation details of the function templates above.
 
@@ -76,7 +76,7 @@ template<typename CollectionType> RetainPtr<NSMutableArray> createNSArray(Collec
     return array;
 }
 
-template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableArray> createNSArray(CollectionType&& collection, MapFunctionType&& function)
+template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableArray> createNSArray(CollectionType&& collection, NOESCAPE MapFunctionType&& function)
 {
     auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:std::size(collection)]);
     for (auto&& element : std::forward<CollectionType>(collection)) {
@@ -101,7 +101,7 @@ template<typename VectorElementType> Vector<VectorElementType> makeVector(NSArra
     return vector;
 }
 
-template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> makeVector(NSArray *array, MapFunctionType&& function)
+template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> makeVector(NSArray *array, NOESCAPE MapFunctionType&& function)
 {
     Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> vector;
     vector.reserveInitialCapacity(array.count);

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -92,7 +92,7 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 }
 
 template<typename Func>
-inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) const
+inline void SignalHandlers::forEachHandler(Signal signal, NOESCAPE const Func& func) const
 {
     size_t signalIndex = static_cast<size_t>(signal);
     size_t handlerIndex = numberOfHandlers[signalIndex];

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -90,7 +90,7 @@ struct SignalHandlers {
 
     void add(Signal, SignalHandler&&);
     template<typename Func>
-    void forEachHandler(Signal, const Func&) const;
+    void forEachHandler(Signal, NOESCAPE const Func&) const;
 
     // We intentionally disallow presigning the return PC on platforms that can't authenticate it so
     // we don't accidentally leave an unfrozen pointer in the heap somewhere.

--- a/Source/WTF/wtf/win/SignalsWin.cpp
+++ b/Source/WTF/wtf/win/SignalsWin.cpp
@@ -60,7 +60,7 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 }
 
 template<typename Func>
-inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) const
+inline void SignalHandlers::forEachHandler(Signal signal, NOESCAPE const Func& func) const
 {
     size_t signalIndex = static_cast<size_t>(signal);
     size_t handlerIndex = numberOfHandlers[signalIndex];

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.h
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.h
@@ -89,7 +89,7 @@ inline void propagateException(JSC::JSGlobalObject& lexicalGlobalObject, JSC::Th
         propagateException(lexicalGlobalObject, throwScope, value.releaseException());
 }
 
-template<typename Functor> void invokeFunctorPropagatingExceptionIfNecessary(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& throwScope, Functor&& functor)
+template<typename Functor> void invokeFunctorPropagatingExceptionIfNecessary(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& throwScope, NOESCAPE Functor&& functor)
 {
     using ReturnType = std::invoke_result_t<Functor>;
 


### PR DESCRIPTION
#### 81fbecbe3fd4cad0f1296627466b1efa63c4f806
<pre>
Annotate various WTF functions with [[clang::noescape]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=282149">https://bugs.webkit.org/show_bug.cgi?id=282149</a>

Reviewed by Geoffrey Garen.

In order to prepare WebKit for the deployment of lambda captures checker,
annotate various functions in WTF (and one function in WebCore) with
[[clang::noescape]], which is defined using NOESCAPE macro.

* Source/WTF/wtf/AggregateLogger.h:
(WTF::AggregateLogger::willLog const): Replace the use of allOf with a for
loop since clang doesn&apos;t like it.
* Source/WTF/wtf/Algorithms.h:
(WTF::forEach):
(WTF::anyOf):
(WTF::allOf):
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::createWithSizeFromGenerator):
* Source/WTF/wtf/HashMap.h:
(WTF::HashMapTranslator::translate):
(WTF::HashMapEnsureTranslator::translate):
(WTF::HashMapTranslatorAdapter::translate):
(WTF::HashMapEnsureTranslatorAdapter::translate):
(WTF::shouldValidateKey&gt;::inlineEnsure):
(WTF::shouldValidateKey&gt;::ensure):
(WTF::shouldValidateKey&gt;::removeIf):
* Source/WTF/wtf/HashSet.h:
(WTF::HashSetTranslator::translate):
(WTF::HashSetEnsureTranslatorAdaptor::translate):
(WTF::TableTraits&gt;::ensure):
(WTF::W&gt;::removeIf):
* Source/WTF/wtf/HashTable.h:
(WTF::IdentityHashTranslator::translate):
(WTF::shouldValidateKey&gt;::addUniqueForInitialization):
(WTF::shouldValidateKey&gt;::add):
(WTF::shouldValidateKey&gt;::addPassingHashCode):
(WTF::shouldValidateKey&gt;::removeIf):
(WTF::shouldValidateKey&gt;::takeIf):
* Source/WTF/wtf/LocklessBag.h:
* Source/WTF/wtf/PriorityQueue.h:
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::SizePolicy&gt;::add):
(WTF::SizePolicy&gt;::addPassingHashCode):
* Source/WTF/wtf/StackTrace.h:
(WTF::StackTraceSymbolResolver::forEach const):
(WTF::StackTrace::forEachFrame const):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::valueOrCompute):
* Source/WTF/wtf/TinyPtrSet.h:
(WTF::TinyPtrSet::forEach const):
(WTF::TinyPtrSet::genericFilter):
* Source/WTF/wtf/TrailingArray.h:
(WTF::TrailingArray::TrailingArray):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
(WTF::Vector::containsIf const):
(WTF::Malloc&gt;::findIf const):
(WTF::Malloc&gt;::reverseFindIf const):
(WTF::Malloc&gt;::appendUsingFunctor):
(WTF::Malloc&gt;::removeFirstMatching):
(WTF::Malloc&gt;::removeLastMatching):
(WTF::Malloc&gt;::removeAllMatching):
(WTF::Malloc&gt;::map const):
(WTF:: const const):
(WTF::Malloc&gt;::appendContainerWithMapping):
(WTF::map):
(WTF::CompactMapper::compactMap):
(WTF::compactMap):
(WTF::flatMap):
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::createNSArray):
(WTF::makeVector):
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::SignalHandlers::forEachHandler const):
* Source/WTF/wtf/threads/Signals.h:
* Source/WTF/wtf/win/SignalsWin.cpp:
(WTF::SignalHandlers::forEachHandler const):
* Source/WebCore/bindings/js/JSDOMExceptionHandling.h:
(WebCore::invokeFunctorPropagatingExceptionIfNecessary):

Canonical link: <a href="https://commits.webkit.org/285751@main">https://commits.webkit.org/285751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29df838144fd6885d1c4e4045edb8af20671ffb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73707 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/921 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16348 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23278 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79596 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72964 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/486 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7641 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94746 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11363 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3738 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20829 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->