### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -802,6 +802,12 @@ std::span<const uint8_t> asByteSpan(const T& input)
     return { reinterpret_cast<const uint8_t*>(&input), sizeof(input) };
 }
 
+template<typename T>
+std::span<uint8_t> asMutableByteSpan(T& input)
+{
+    return { reinterpret_cast<uint8_t*>(&input), sizeof(input) };
+}
+
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 {
@@ -1027,6 +1033,7 @@ using WTF::MB;
 using WTF::approximateBinarySearch;
 using WTF::asBytes;
 using WTF::asByteSpan;
+using WTF::asMutableByteSpan;
 using WTF::asWritableBytes;
 using WTF::binarySearch;
 using WTF::bitwise_cast;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -209,8 +209,26 @@ public:
 
     // Returns an uninitialized string. The characters needs to be written
     // into the buffer returned in data before the returned string is used.
-    static String createUninitialized(unsigned length, UChar*& data) { return StringImpl::createUninitialized(length, data); }
-    static String createUninitialized(unsigned length, LChar*& data) { return StringImpl::createUninitialized(length, data); }
+    static String createUninitialized(unsigned length, std::span<UChar>& data) { return StringImpl::createUninitialized(length, data); }
+    static String createUninitialized(unsigned length, std::span<LChar>& data) { return StringImpl::createUninitialized(length, data); }
+
+    // FIXME: Port call sites to the overload taking in a span and remove.
+    static String createUninitialized(unsigned length, UChar*& data)
+    {
+        std::span<UChar> span;
+        auto result = StringImpl::createUninitialized(length, span);
+        data = span.data();
+        return result;
+    }
+
+    // FIXME: Port call sites to the overload taking in a span and remove.
+    static String createUninitialized(unsigned length, LChar*& data)
+    {
+        std::span<LChar> span;
+        auto result = StringImpl::createUninitialized(length, span);
+        data = span.data();
+        return result;
+    }
 
     using SplitFunctor = WTF::Function<void(StringView)>;
 

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -101,12 +101,12 @@ bool FileHandle::open()
     return static_cast<bool>(*this);
 }
 
-int FileHandle::read(void* data, int length)
+int FileHandle::read(std::span<uint8_t> data)
 {
     if (!open())
         return -1;
 
-    return FileSystem::readFromFile(m_fileHandle, { static_cast<uint8_t*>(data), static_cast<size_t>(length) });
+    return FileSystem::readFromFile(m_fileHandle, data);
 }
 
 int FileHandle::write(std::span<const uint8_t> data)

--- a/Source/WebCore/platform/FileHandle.h
+++ b/Source/WebCore/platform/FileHandle.h
@@ -49,7 +49,7 @@ public:
 
     bool open(const String& path, FileSystem::FileOpenMode);
     bool open();
-    int read(void* data, int length); // FIXME: Should use a std::span.
+    int read(std::span<uint8_t> data);
     int write(std::span<const uint8_t> data);
     bool printf(const char* format, ...) WTF_ATTRIBUTE_PRINTF(2, 3);
     void close();

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -37,8 +37,6 @@
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/NeverDestroyed.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -81,8 +79,8 @@ void UIGamepadProvider::gamepadSyncTimerFired()
 bool UIGamepadProvider::isAnyGamepadConnected() const
 {
     bool anyGamepadConnected = false;
-    for (auto it = m_gamepads.begin(); it != m_gamepads.end(); ++it) {
-        if (*it) {
+    for (auto& gamepad : m_gamepads) {
+        if (gamepad) {
             anyGamepadConnected = true;
             break;
         }
@@ -250,7 +248,5 @@ void UIGamepadProvider::platformStartMonitoringInput()
 #endif // !PLATFORM(COCOA) && !(USE(MANETTE) && OS(LINUX))
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -40,8 +40,6 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/SecurityOriginData.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -178,9 +176,9 @@ void WebNotificationManagerProxy::clearNotifications(WebPageProxy* webPage, cons
         globalNotificationIDs.append(globalNotificationID);
     }
 
-    for (auto it = globalNotificationIDs.begin(), end = globalNotificationIDs.end(); it != end; ++it) {
-        auto pageNotification = m_globalNotificationMap.take(*it);
-        m_notifications.remove(pageNotification);
+    for (auto globalNotificationID : globalNotificationIDs) {
+        if (auto pageNotification = m_globalNotificationMap.takeOptional(globalNotificationID))
+            m_notifications.remove(*pageNotification);
     }
 
     m_provider->clearNotifications(globalNotificationIDs);
@@ -389,5 +387,3 @@ void WebNotificationManagerProxy::getNotifications(const URL& url, const String&
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -62,8 +62,6 @@
 #include <WebCore/ScreenCaptureKitCaptureSource.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -1161,7 +1159,7 @@ const Logger& UserMediaPermissionRequestManagerProxy::logger() const
 
 String convertEnumerationToString(UserMediaPermissionRequestManagerProxy::RequestAction enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values = {
         MAKE_STATIC_STRING_IMPL("Deny"),
         MAKE_STATIC_STRING_IMPL("Grant"),
         MAKE_STATIC_STRING_IMPL("Prompt"),
@@ -1169,10 +1167,7 @@ String convertEnumerationToString(UserMediaPermissionRequestManagerProxy::Reques
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Deny) == 0, "UserMediaPermissionRequestManagerProxy::RequestAction::Deny is not 0 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Grant) == 1, "UserMediaPermissionRequestManagerProxy::RequestAction::Grant is not 1 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Prompt) == 2, "UserMediaPermissionRequestManagerProxy::RequestAction::Prompt is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -29,8 +29,6 @@
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/text/StringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -153,7 +151,7 @@ Vector<String> UserMediaPermissionRequestProxy::audioDeviceUIDs() const
 
 String convertEnumerationToString(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 7> values = {
         MAKE_STATIC_STRING_IMPL("NoConstraints"),
         MAKE_STATIC_STRING_IMPL("UserMediaDisabled"),
         MAKE_STATIC_STRING_IMPL("NoCaptureDevices"),
@@ -169,7 +167,6 @@ String convertEnumerationToString(UserMediaPermissionRequestProxy::UserMediaAcce
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::HardwareError) == 4, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::HardwareError is not 4 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied) == 5, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied is not 5 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::OtherFailure) == 6, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::OtherFailure is not 6 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -237,5 +234,3 @@ bool UserMediaPermissionRequestProxy::canRequestDisplayCapturePermission()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -33,8 +33,6 @@
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace fido;
 
@@ -55,7 +53,7 @@ static void reportReceived(void* context, IOReturn status, void*, IOHIDReportTyp
     ASSERT(reportID == kHidReportId);
     ASSERT(reportLength == kHidMaxPacketSize);
 
-    connection->receiveReport(std::span { report, static_cast<size_t>(reportLength) });
+    connection->receiveReport(unsafeForgeSpan(report, reportLength));
 }
 #endif // HAVE(SECURITY_KEY_API)
 
@@ -164,7 +162,5 @@ void HidConnection::registerDataReceivedCallbackInternal()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -30,12 +30,11 @@
 
 #include <WebCore/FidoConstants.h>
 #include <wtf/RunLoop.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRandomNumber.h>
 #include <wtf/text/Base64.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 using namespace fido;
@@ -190,7 +189,7 @@ void CtapHidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback
     ASSERT(!(kHidInitNonceLength % sizeof(uint32_t)) && steps >= 1);
     for (size_t i = 0; i < steps; ++i) {
         uint32_t weakRandom = weakRandomNumber<uint32_t>();
-        memcpy(m_nonce.data() + i * sizeof(uint32_t), &weakRandom, sizeof(uint32_t));
+        memcpySpan(m_nonce.mutableSpan().subspan(i * sizeof(uint32_t)), asByteSpan(weakRandom));
     }
 
     auto initCommand = FidoHidMessage::create(m_channelId, FidoHidDeviceCommand::kInit, m_nonce);
@@ -279,7 +278,5 @@ void CtapHidDriver::cancel()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -485,9 +485,9 @@ public:
 
     NSTrackingRectTag addTrackingRect(CGRect, id owner, void* userData, bool assumeInside);
     NSTrackingRectTag addTrackingRectWithTrackingNum(CGRect, id owner, void* userData, bool assumeInside, int tag);
-    void addTrackingRectsWithTrackingNums(CGRect*, id owner, void** userDataList, bool assumeInside, NSTrackingRectTag *trackingNums, int count);
+    void addTrackingRectsWithTrackingNums(Vector<CGRect>, id owner, void** userDataList, bool assumeInside, NSTrackingRectTag *trackingNums);
     void removeTrackingRect(NSTrackingRectTag);
-    void removeTrackingRects(NSTrackingRectTag *, int count);
+    void removeTrackingRects(std::span<NSTrackingRectTag>);
     NSString *stringForToolTip(NSToolTipTag tag);
     void toolTipChanged(const String& oldToolTip, const String& newToolTip);
 


### PR DESCRIPTION
#### 9425f553d7fe447855ca7bac2865f11d4f08bf15
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=282146">https://bugs.webkit.org/show_bug.cgi?id=282146</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::asMutableByteSpan):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createUninitializedInternal):
(WTF::StringImpl::createUninitializedInternalNonEmpty):
(WTF::StringImpl::createUninitialized):
(WTF::StringImpl::createInternal):
(WTF::StringImpl::create8BitIfPossible):
(WTF::StringImpl::convertToLowercaseWithoutLocale):
(WTF::StringImpl::convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit):
(WTF::StringImpl::foldCase):
(WTF::StringImpl::convertASCIICase):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::createByReplacingInCharacters):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/platform/FileHandle.cpp:
(WebCore::FileHandle::read):
* Source/WebCore/platform/FileHandle.h:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
(WebKit::compileAndCacheSandboxProfile):
(WebKit::tryApplyCachedSandbox):
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
(WebKit::WebMemorySampler::sampleSystemMalloc const):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _addTrackingRects:owner:userDataList:assumeInsideList:trackingNums:count:]):
(-[WKWebView _removeTrackingRects:count:]):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::clearNotifications):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::convertEnumerationToString):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp:
(WebKit::convertEnumerationToString):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::reportReceived):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::filterResponses const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriver::transact):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::encodeArithmeticType):
(WebKit::HistoryEntryDataEncoder::encodeFixedLengthData):
(WebKit::HistoryEntryDataEncoder::grow):
(WebKit::HistoryEntryDataEncoder::mutableBuffer):
(WebKit::HistoryEntryDataEncoder::buffer const):
(WebKit::encodeLegacySessionState):
(WebKit::HistoryEntryDataDecoder::operator&gt;&gt;):
(WebKit::HistoryEntryDataDecoder::decodeArithmeticType):
(WebKit::HistoryEntryDataDecoder::alignedBufferIsLargeEnoughToContain const):
(WebKit::decodeLegacySessionState):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::commandNameForSelector):
(WebKit::WebViewImpl::addTrackingRectsWithTrackingNums):
(WebKit::WebViewImpl::removeTrackingRects):

Canonical link: <a href="https://commits.webkit.org/285765@main">https://commits.webkit.org/285765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aa5e9a91c88576216746b0f799ab58884377f62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23286 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66852 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72972 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66326 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65605 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7649 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94754 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11371 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3746 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20835 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->