### PR TITLE
Seeking troubles on large WebM files in Safari on mac and iOS

### DIFF
--- a/LayoutTests/http/tests/media/video-webm-stall-seek-expected.txt
+++ b/LayoutTests/http/tests/media/video-webm-stall-seek-expected.txt
@@ -1,0 +1,8 @@
+
+RUN(video.src = 'http://127.0.0.1:8000/media/resources/serve_video.py.webm?type=video/webm&name=../media-source/webm/test.webm&stallDuration=1&stallOffset=56386')
+RUN(video.currentTime = 5.976)
+EVENT(seeking)
+EXPECTED (video.readyState == '1') OK
+EVENT(seeked)
+END OF TEST
+

--- a/LayoutTests/http/tests/media/video-webm-stall-seek.html
+++ b/LayoutTests/http/tests/media/video-webm-stall-seek.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+    <script src=../../media-resources/video-test.js></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async event => {
+            findMediaElement();
+
+            if (video.canPlayType('video/webm; codecs="vp8"') == "") {
+                failTest('"video/webm" not supported');
+                return;
+            }
+
+            waitFor(video, 'error').then(event => { failTest('') });
+
+            let stallOffset = 56386; // offset of time = 1
+            run(`video.src = 'http://127.0.0.1:8000/media/resources/serve_video.py.webm?type=video/webm&name=../media-source/webm/test.webm&stallDuration=1&stallOffset=${stallOffset}'`);
+            run('video.currentTime = 5.976');
+            await waitFor(video, 'seeking');
+            testExpected("video.readyState", 1); // We can't have any data at the seek point yet.
+            await waitFor(video, 'seeked');
+
+            endTest();
+        });
+
+    </script>
+</head>
+<body>
+<video id="video" playsinline muted></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3548,6 +3548,7 @@ webkit.org/b/198830 media/video-size-intrinsic-scale.html [ Failure ]
 http/tests/media/video-preload.html [ Pass Slow ]
 
 webkit.org/b/108925 http/tests/media/video-play-stall.html [ Failure Timeout ]
+webkit.org/b/282165 http/tests/media/video-webm-stall-seek.html [ Failure ]
 
 webkit.org/b/132262 http/tests/media/video-redirect.html [ Timeout Pass Crash ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1153,6 +1153,7 @@ media/media-sources-selection.html [ ImageOnlyFailure ]
 media/media-source/media-source-webm-configuration-change.html [ Failure ]
 media/media-source/media-source-webm-configuration-framerate.html [ Failure ]
 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]
+http/tests/media/video-webm-stall-seek.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-append.html [ Skip ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -36,6 +36,7 @@
 #include "WebMResourceClient.h"
 #include <wtf/HashFunctions.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/NativePromise.h>
 #include <wtf/StdUnorderedMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -395,6 +396,7 @@ private:
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
     void seekInternal();
+    Ref<GenericPromise> seekTo(const MediaTime&);
     void maybeCompleteSeek();
     MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
     bool shouldBePlaying() const;
@@ -410,6 +412,7 @@ private:
         SeekCompleted,
     };
     SeekState m_seekState { SeekCompleted };
+    std::optional<GenericPromise::Producer> m_seekPromise;
     bool m_isSynchronizerSeeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;


### PR DESCRIPTION
#### 617de4cfcf702a68fe29fd77be9c6f13d4cdab18
<pre>
Seeking troubles on large WebM files in Safari on mac and iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=272095">https://bugs.webkit.org/show_bug.cgi?id=272095</a>
<a href="https://rdar.apple.com/125867488">rdar://125867488</a>

Reviewed by Jer Noble.

We relied on the AVSampleBufferRenderSynchronizer to perform the seek and wait.
It doesn&apos;t always behave as expected. So instead we use a NativePromise that will
be resolved once we have demuxed data at the seek location and wait to continue the seek operation.

* LayoutTests/http/tests/media/video-webm-stall-seek-expected.txt: Added.
* LayoutTests/http/tests/media/video-webm-stall-seek.html: Added.
* LayoutTests/platform/glib/TestExpectations: Add failure expectation webkit.org/b/282165
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::seekTo):
(WebCore::MediaPlayerPrivateWebM::appendCompleted):

Canonical link: <a href="https://commits.webkit.org/285986@main">https://commits.webkit.org/285986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5beaf5f5dc0dbf0e68416fad1e6cf257a2b10166

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24972 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58002 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16370 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20929 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66341 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7663 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->