### PR TITLE
[JSC] Fix iteratorHelperPrivateFuncCreate since underlyingIterator can be jsNull

### DIFF
--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
@@ -43,8 +43,9 @@ JSIteratorHelper* JSIteratorHelper::createWithInitialValues(VM& vm, Structure* s
     return result;
 }
 
-JSIteratorHelper* JSIteratorHelper::create(VM& vm, Structure* structure, JSObject* generator, JSObject* underlyingIterator)
+JSIteratorHelper* JSIteratorHelper::create(VM& vm, Structure* structure, JSValue generator, JSValue underlyingIterator)
 {
+    ASSERT(generator.isObject() && (underlyingIterator.isObject() || underlyingIterator.isNull()));
     JSIteratorHelper* result = new (NotNull, allocateCell<JSIteratorHelper>(vm)) JSIteratorHelper(vm, structure);
     result->finishCreation(vm);
     result->internalField(Field::Generator).set(vm, result, generator);
@@ -74,7 +75,7 @@ DEFINE_VISIT_CHILDREN(JSIteratorHelper);
 
 JSC_DEFINE_HOST_FUNCTION(iteratorHelperPrivateFuncCreate, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return JSValue::encode(JSIteratorHelper::create(globalObject->vm(), globalObject->iteratorHelperStructure(), jsCast<JSObject*>(callFrame->uncheckedArgument(0)), jsCast<JSObject*>(callFrame->uncheckedArgument(1))));
+    return JSValue::encode(JSIteratorHelper::create(globalObject->vm(), globalObject->iteratorHelperStructure(), callFrame->uncheckedArgument(0), callFrame->uncheckedArgument(1)));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.h
@@ -57,7 +57,7 @@ public:
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
 
     static JSIteratorHelper* createWithInitialValues(VM&, Structure*);
-    static JSIteratorHelper* create(VM&, Structure*, JSObject* generator, JSObject* underlyingIterator);
+    static JSIteratorHelper* create(VM&, Structure*, JSValue generator, JSValue underlyingIterator);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;


### PR DESCRIPTION
#### 9bba5ab0c0ab6d17baf95622bf6cb46fe78b66e6
<pre>
[JSC] Fix iteratorHelperPrivateFuncCreate since underlyingIterator can be jsNull
<a href="https://bugs.webkit.org/show_bug.cgi?id=282158">https://bugs.webkit.org/show_bug.cgi?id=282158</a>
<a href="https://rdar.apple.com/138642507">rdar://138642507</a>

Reviewed by Mark Lam.

The internal field underlyingIterator of iteratorHelper can be null in
JSIteratorConstructor.js, and its nullability is checked in
JSIteratorHelperPrototype.js. This patch addresses that case by directly
passing JSValue in JSIteratorHelper::create.

* Source/JavaScriptCore/runtime/JSIteratorHelper.cpp:
(JSC::JSIteratorHelper::create):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSIteratorHelper.h:

Canonical link: <a href="https://commits.webkit.org/285757@main">https://commits.webkit.org/285757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b1ccbe768c45a16bbd58fd87e6e879bb15aae4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66849 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72975 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66322 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7646 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94751 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/11368 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/993 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20832 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->