### PR TITLE
Image copied from Notes and pasted in compose on gmail.com does not get attached

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm
@@ -170,6 +170,9 @@ TEST(PasteRTFD, ImageElementUsesBlobURLInHTML)
 
     [webView waitForMessage:@"loaded"];
     EXPECT_WK_STREQ("[\"text/html\"]", [webView stringByEvaluatingJavaScript:@"JSON.stringify(clipboardData.types)"]);
+    RetainPtr rawMarkup = [webView stringByEvaluatingJavaScript:@"clipboardData.values[0]"];
+    EXPECT_FALSE([rawMarkup containsString:@"<p"]);
+    EXPECT_FALSE([rawMarkup containsString:@"<br"]);
     EXPECT_TRUE([webView stringByEvaluatingJavaScript:@"imageElement = (new DOMParser).parseFromString(clipboardData.values[0], 'text/html').querySelector('img'); !!imageElement"].boolValue);
     EXPECT_WK_STREQ("blob:", [webView stringByEvaluatingJavaScript:@"new URL(imageElement.src).protocol"]);
 }


### PR DESCRIPTION
#### 73bbfdc992ca78fa0e48a2571336519226ddcd26
<pre>
Image copied from Notes and pasted in compose on gmail.com does not get attached
<a href="https://bugs.webkit.org/show_bug.cgi?id=282159">https://bugs.webkit.org/show_bug.cgi?id=282159</a>
<a href="https://rdar.apple.com/138111842">rdar://138111842</a>

Reviewed by Richard Robinson and Ryosuke Niwa.

When composing a new message in Gmail, right clicking an image in Notes and pasting into Gmail
causes an image to be inserted into the editable container, without triggering Gmail&apos;s logic to
actually upload the image data as a MIME attachment. As a result, the image appears in the compose
draft, but is lost upon sending. This happens because Gmail&apos;s logic to perform this file upload only
happens when consuming markup data, if the parsed markup doesn&apos;t contain any other tags except for
`HTML`, `HEAD`, `META`, `BODY` and a single `IMG` element.

When copying from the Notes app, a length-2 attributed string is written to the pasteboard; the
first character is the object replacement character (`0xFFFC`) that has a text attachment attribute,
and the second character is a newline character.

Pasting from Chrome inserts a markup string that contains only a single `IMG` element, but pasting
from Safari inserts a document fragment that consists of a `P` element that contains the `IMG`,
alongside a `BR` as the next sibling of the `P`. As such, we fail the aforementioned check in Gmail
and don&apos;t trigger their attachment upload logic.

To fix this, we add a heuristic to detect this case where the attributed string contains only a
single text attachment (with an optional newline character after the object replacement character),
and simplify the serialized document fragment such that it contains only a single `IMG` or `PICTURE`
element, to more closely match Chrome&apos;s behavior.

* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::simplifyFragmentForSingleTextAttachment):
(WebCore::createFragment):

See above for more details.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm:
(TEST(PasteRTFD, ImageElementUsesBlobURLInHTML)):

Augment an existing API test to exercise this change.

Canonical link: <a href="https://commits.webkit.org/285770@main">https://commits.webkit.org/285770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9bb189b3f9ff0098fafb9cb7c3aad7632dd1d17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/975 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/535 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63480 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7693 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3792 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->