### PR TITLE
[Intelligence Effects] Support adding intelligence effects to Writing Tools Proofreading operations

### DIFF
--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
@@ -33,6 +33,7 @@
 #include "RenderedDocumentMarker.h"
 #include "SimpleRange.h"
 #include "TextIndicator.h"
+#include <wtf/UUID.h>
 
 namespace WebCore {
 namespace IntelligenceTextEffectsSupport {
@@ -60,54 +61,64 @@ Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordinates(Document&
 }
 #endif
 
-void updateTextVisibility(Document& document, const SimpleRange& scope, const CharacterRange& range, bool visible)
+void updateTextVisibility(Document& document, const SimpleRange& scope, const CharacterRange& range, bool visible, const WTF::UUID& identifier)
 {
-    auto resolvedRange = resolveCharacterRange(scope, range);
-
-    if (visible)
-        document.markers().removeMarkers(resolvedRange, { WebCore::DocumentMarker::Type::TransparentContent });
-    else {
-        // FIXME: Remove the UUID parameter once the old animation system is removed and it's no longer needed.
-        document.markers().addTransparentContentMarker(resolvedRange, WTF::UUID { 0 });
+    if (visible) {
+        document.markers().removeMarkers({ WebCore::DocumentMarker::Type::TransparentContent }, [identifier](auto& marker) {
+            auto& data = std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data());
+            return data.uuid == identifier ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
+        });
+    } else {
+        auto resolvedRange = resolveCharacterRange(scope, range);
+        document.markers().addTransparentContentMarker(resolvedRange, identifier);
     }
 }
 
-std::optional<TextIndicatorData> textPreviewDataForRange(Document& document, const SimpleRange& scope, const CharacterRange& range)
+std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange& range)
 {
     auto resolvedRange = resolveCharacterRange(scope, range);
-
-    // Temporarily remove any transparent content document markers so that when the snapshot is created, the text is visible.
-    // The markers are then re-added in the same run loop, so there will be no user-visible flickering of the text.
-
-    auto& markers = document.markers();
-
-    Vector<SimpleRange> transparentMarkerRangesToReinsert;
-
-    markers.forEach(resolvedRange, { WebCore::DocumentMarker::Type::TransparentContent }, [&](auto& node, auto& marker) {
-        auto markerRange = makeSimpleRange(node, marker);
-        transparentMarkerRangesToReinsert.append(markerRange);
-
-        return false;
-    });
 
     static constexpr OptionSet textIndicatorOptions {
         TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
         TextIndicatorOption::ExpandClipBeyondVisibleRect,
         TextIndicatorOption::SkipReplacedContent,
         TextIndicatorOption::RespectTextColor,
+        TextIndicatorOption::DoNotClipToVisibleRect,
     };
 
     RefPtr textIndicator = WebCore::TextIndicator::createWithRange(resolvedRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });
     if (!textIndicator)
         return std::nullopt;
 
-    for (const auto& markerRange : transparentMarkerRangesToReinsert) {
-        // FIXME: Remove the UUID parameter once the old animation system is removed and it's no longer needed.
-        markers.addTransparentContentMarker(markerRange, WTF::UUID { 0 });
-    }
-
     return textIndicator->data();
 }
+
+#if ENABLE(WRITING_TOOLS)
+void decorateWritingToolsTextReplacements(Document& document, const SimpleRange& scope, const CharacterRange& range)
+{
+    auto resolvedRange = resolveCharacterRange(scope, range);
+
+    auto& markers = document.markers();
+
+    Vector<std::tuple<SimpleRange, DocumentMarker::WritingToolsTextSuggestionData>> markersToReinsert;
+
+    markers.forEach(resolvedRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
+        auto range = makeSimpleRange(node, marker);
+        auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
+
+        markersToReinsert.append({ range, data });
+
+        return false;
+    });
+
+    markers.removeMarkers(resolvedRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
+
+    for (const auto& [range, oldData] : markersToReinsert) {
+        auto newData = DocumentMarker::WritingToolsTextSuggestionData { oldData.originalText, oldData.suggestionID, oldData.state, DocumentMarker::WritingToolsTextSuggestionData::Decoration::Underline };
+        markers.addMarker(range, DocumentMarker::Type::WritingToolsTextSuggestion, newData);
+    }
+}
+#endif
 
 } // namespace IntelligenceTextEffectsSupport
 } // namespace WebCore

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.h
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+namespace WTF {
+class UUID;
+}
+
 namespace WebCore {
 
 class Document;
@@ -40,9 +44,13 @@ namespace IntelligenceTextEffectsSupport {
 WEBCORE_EXPORT Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordinates(Document&, const SimpleRange& scope, const CharacterRange&);
 #endif
 
-WEBCORE_EXPORT void updateTextVisibility(Document&, const SimpleRange& scope, const CharacterRange&, bool visible);
+WEBCORE_EXPORT void updateTextVisibility(Document&, const SimpleRange& scope, const CharacterRange&, bool visible, const WTF::UUID&);
 
 WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange&);
+
+#if ENABLE(WRITING_TOOLS)
+WEBCORE_EXPORT void decorateWritingToolsTextReplacements(Document&, const SimpleRange& scope, const CharacterRange&);
+#endif
 
 } // namespace IntelligenceTextEffectsSupport
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5020,19 +5020,19 @@ void Page::didBeginWritingToolsSession(const WritingTools::Session& session, con
     m_writingToolsController->didBeginWritingToolsSession(session, contexts);
 }
 
-void Page::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
+void Page::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const CharacterRange& processedRange, const WritingTools::Context& context, bool finished)
 {
-    m_writingToolsController->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
-}
-
-void Page::proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
-{
-    m_writingToolsController->proofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished);
+    m_writingToolsController->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
 }
 
 void Page::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session& session, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion& suggestion, const WritingTools::Context& context)
 {
     m_writingToolsController->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
+}
+
+void Page::willEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
+{
+    m_writingToolsController->willEndWritingToolsSession(session, accepted);
 }
 
 void Page::didEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
@@ -5083,7 +5083,7 @@ Vector<FloatRect> Page::proofreadingSessionSuggestionTextRectsInRootViewCoordina
     return IntelligenceTextEffectsSupport::writingToolsTextSuggestionRectsInRootViewCoordinates(*document, *scope, enclosingRangeRelativeToSessionRange);
 }
 
-void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange, bool visible)
+void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier)
 {
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
     RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
@@ -5098,7 +5098,7 @@ void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange
         return;
     }
 
-    IntelligenceTextEffectsSupport::updateTextVisibility(*document, *scope, rangeRelativeToSessionRange, visible);
+    IntelligenceTextEffectsSupport::updateTextVisibility(*document, *scope, rangeRelativeToSessionRange, visible, identifier);
 }
 
 std::optional<TextIndicatorData> Page::textPreviewDataForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
@@ -5117,6 +5117,47 @@ std::optional<TextIndicatorData> Page::textPreviewDataForActiveWritingToolsSessi
     }
 
     return IntelligenceTextEffectsSupport::textPreviewDataForRange(*document, *scope, rangeRelativeToSessionRange);
+}
+
+void Page::decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
+{
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto scope = m_writingToolsController->activeSessionRange();
+    if (!scope) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements(*document, *scope, rangeRelativeToSessionRange);
+}
+
+void Page::setSelectionForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
+{
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto scope = m_writingToolsController->activeSessionRange();
+    if (!scope) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto resolvedRange = resolveCharacterRange(*scope, rangeRelativeToSessionRange);
+    auto visibleSelection = VisibleSelection { resolvedRange };
+    if (visibleSelection.isNoneOrOrphaned())
+        return;
+
+    document->selection().setSelection(visibleSelection);
 }
 
 std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1185,11 +1185,11 @@ public:
 
     WEBCORE_EXPORT void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    WEBCORE_EXPORT void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
-
-    WEBCORE_EXPORT void proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    WEBCORE_EXPORT void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
     WEBCORE_EXPORT void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestion&, const WritingTools::Context&);
+
+    WEBCORE_EXPORT void willEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
     WEBCORE_EXPORT void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
@@ -1203,8 +1203,10 @@ public:
     void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
     WEBCORE_EXPORT Vector<FloatRect> proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const CharacterRange&) const;
-    WEBCORE_EXPORT void updateTextVisibilityForActiveWritingToolsSession(const CharacterRange&, bool);
+    WEBCORE_EXPORT void updateTextVisibilityForActiveWritingToolsSession(const CharacterRange&, bool, const WTF::UUID&);
     WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForActiveWritingToolsSession(const CharacterRange&);
+    WEBCORE_EXPORT void decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange&);
+    WEBCORE_EXPORT void setSelectionForActiveWritingToolsSession(const CharacterRange&);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
     WEBCORE_EXPORT void intelligenceTextAnimationsDidComplete();

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -60,11 +60,11 @@ public:
 
     void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State, const WritingTools::TextSuggestion&, const WritingTools::Context&);
+
+    void willEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
     void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
@@ -182,6 +182,9 @@ private:
 
     template<WritingTools::Session::Type Type>
     void writingToolsSessionDidReceiveAction(WritingTools::Action);
+
+    template<WritingTools::Session::Type Type>
+    void willEndWritingToolsSession(bool accepted);
 
     template<WritingTools::Session::Type Type>
     void didEndWritingToolsSession(bool accepted);

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -38,6 +38,7 @@
 #import "FrameSelection.h"
 #import "GeometryUtilities.h"
 #import "HTMLConverter.h"
+#import "IntelligenceTextEffectsSupport.h"
 #import "Logging.h"
 #import "NodeRenderStyle.h"
 #import "RenderedDocumentMarker.h"
@@ -256,12 +257,25 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
     completionHandler({ { WTF::UUID { 0 }, attributedStringFromRange, selectedTextCharacterRange } });
 }
 
-void WritingToolsController::didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>& contexts)
+void WritingToolsController::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::didBeginWritingToolsSession [received contexts: %zu]", contexts.size());
+
+    if (session.type != WritingTools::Session::Type::Proofreading) {
+        // FIXME: Refactor this function into specialized functions per session type.
+        return;
+    }
+
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    document->selection().clear();
 }
 
-void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
+void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const CharacterRange& processedRange, const WritingTools::Context& context, bool finished)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::proofreadingSessionDidReceiveSuggestion [received suggestions: %zu, finished: %d]", suggestions.size(), finished);
 
@@ -277,11 +291,35 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
         return;
     }
 
-    m_page->chrome().client().removeInitialTextAnimationForActiveWritingToolsSession();
-
-    document->selection().clear();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
 
     auto sessionRange = makeSimpleRange(state->contextRange);
+
+    // Determine if the range for this batch of suggestions, relative to the current text, is covered by transparent content markers or not.
+    // If so, the markers should be removed, and then re-added to the range after the replacement, accounting for any offset that the
+    // replacement operation results in.
+    //
+    // Because this happens in the same run-loop cycle, this change will not be seen by the user.
+
+    auto replacementLocationOffsetBeforeBatch = state->replacementLocationOffset;
+    auto adjustedProcessedRangeLocation = processedRange.location + replacementLocationOffsetBeforeBatch;
+
+    auto adjustedProcessedRangeBeforeReplacement = resolveCharacterRange(sessionRange, { adjustedProcessedRangeLocation, processedRange.length });
+
+    HashSet<WTF::UUID> transparentContentMarkerIdentifiers;
+
+    document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarker::Type::TransparentContent }, [&](auto&, auto marker) {
+        auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());
+        transparentContentMarkerIdentifiers.add(data.uuid);
+
+        return false;
+    });
+
+    for (auto& transparentContentMarkerIdentifier : transparentContentMarkerIdentifiers)
+        IntelligenceTextEffectsSupport::updateTextVisibility(*document, sessionRange, { adjustedProcessedRangeLocation, processedRange.length }, true, transparentContentMarkerIdentifier);
+
+    auto attributedTextString = context.attributedText.string;
 
     // The tracking of the additional replacement location offset needs to be scoped to a particular instance
     // of this class, instead of just this function, because the function may need to be called multiple times.
@@ -306,68 +344,29 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
         auto newRangeWithOffset = CharacterRange { locationWithOffset, suggestion.replacement.length() };
         auto newResolvedRange = resolveCharacterRange(sessionRange, newRangeWithOffset);
 
-        auto originalString = [context.attributedText.nsAttributedString() attributedSubstringFromRange:suggestion.originalRange];
+        auto originalString = attributedTextString.substring(suggestion.originalRange.location, suggestion.originalRange.length);
 
-        auto markerData = DocumentMarker::WritingToolsTextSuggestionData { originalString.string, suggestion.identifier, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted, DocumentMarker::WritingToolsTextSuggestionData::Decoration::None };
+        auto markerData = DocumentMarker::WritingToolsTextSuggestionData { originalString, suggestion.identifier, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted, DocumentMarker::WritingToolsTextSuggestionData::Decoration::None };
         addMarker(newResolvedRange, DocumentMarker::Type::WritingToolsTextSuggestion, markerData);
 
         state->replacementLocationOffset += static_cast<int>(suggestion.replacement.length()) - static_cast<int>(suggestion.originalRange.length);
     }
 
-    if (finished) {
+    for (auto& transparentContentMarkerIdentifier : transparentContentMarkerIdentifiers) {
+        // Re-add the transparent content document markers if applicable, adjusted for the character difference after replacement,
+        // and still relative to the current text.
+
+        auto replacementLocationOffsetAfterBatch = state->replacementLocationOffset;
+        auto characterDelta = replacementLocationOffsetAfterBatch - replacementLocationOffsetBeforeBatch;
+        auto adjustedProcessedRangeAfterReplacement = CharacterRange { adjustedProcessedRangeLocation, processedRange.length + characterDelta };
+
+        IntelligenceTextEffectsSupport::updateTextVisibility(*document, sessionRange, adjustedProcessedRangeAfterReplacement, false, transparentContentMarkerIdentifier);
+    }
+
+    document->selection().clear();
+
+    if (finished)
         document->editor().setSuppressEditingForWritingTools(false);
-        document->selection().setSelection({ sessionRange });
-    }
-}
-
-void WritingToolsController::proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context&, bool)
-{
-    CheckedPtr state = currentState<WritingTools::Session::Type::Proofreading>();
-    if (!state) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    RefPtr document = this->document();
-    if (!document) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    auto sessionRange = makeSimpleRange(state->contextRange);
-
-    auto& markers = document->markers();
-
-    markers.forEach(sessionRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
-        auto oldData = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
-        if (oldData.decoration != DocumentMarker::WritingToolsTextSuggestionData::Decoration::None)
-            return false;
-
-#if ASSERT_ENABLED
-        // All previously received suggestions in the session range should already have been decorated,
-        // so this condition should never be `false` given the above check.
-
-        auto isInMostRecentSuggestionBatch = std::ranges::any_of(suggestions, [oldData](auto& suggestion) {
-            return suggestion.identifier == oldData.suggestionID;
-        });
-
-        ASSERT(isInMostRecentSuggestionBatch);
-
-        // An early return is intentionally omitted here because if there are suggestions in prior batches
-        // that were never made visible for some reason by this point, they certainly should be.
-#else
-        UNUSED_PARAM(suggestions);
-#endif
-
-        auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
-
-        markers.removeMarkers(node, offsetRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
-
-        auto newData = DocumentMarker::WritingToolsTextSuggestionData { oldData.originalText, oldData.suggestionID, oldData.state, DocumentMarker::WritingToolsTextSuggestionData::Decoration::Underline };
-        markers.addMarker(node, DocumentMarker { DocumentMarker::Type::WritingToolsTextSuggestion, offsetRange, WTFMove(newData) });
-
-        return false;
-    });
 }
 
 void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State newTextSuggestionState, const WritingTools::TextSuggestion& textSuggestion, const WritingTools::Context&)
@@ -773,7 +772,7 @@ void WritingToolsController::writingToolsSessionDidReceiveAction(const WritingTo
 }
 
 template<>
-void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool accepted)
+void WritingToolsController::willEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool accepted)
 {
     RefPtr document = this->document();
 
@@ -803,8 +802,28 @@ void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Ty
 
         return false;
     });
+}
 
-    state = nullptr;
+template<>
+void WritingToolsController::willEndWritingToolsSession<WritingTools::Session::Type::Composition>(bool)
+{
+}
+
+void WritingToolsController::willEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
+{
+    switch (session.type) {
+    case WritingTools::Session::Type::Proofreading:
+        willEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(accepted);
+        break;
+    case WritingTools::Session::Type::Composition:
+        willEndWritingToolsSession<WritingTools::Session::Type::Composition>(accepted);
+        break;
+    }
+}
+
+template<>
+void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool)
+{
     m_state = { };
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -266,12 +266,6 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails& 
     return adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:errorCode userInfo:userInfo.get()]);
 }
 
-#if PLATFORM(IOS_FAMILY)
-typedef UIView PlatformView;
-#else
-typedef NSView PlatformView;
-#endif
-
 @implementation WKWebView
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -2158,6 +2152,11 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     }
 
     _page->didBeginWritingToolsSession(*webSession, contextData);
+
+    if (session.type == WTSessionTypeProofreading) {
+        _intelligenceTextEffectCoordinator = adoptNS([WebKit::allocWKIntelligenceTextEffectCoordinatorInstance() initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)self]);
+        [_intelligenceTextEffectCoordinator startAnimationForRange:contexts.firstObject.range completion:^{ }];
+    }
 }
 
 - (void)proofreadingSession:(WTSession *)session didReceiveSuggestions:(NSArray<WTTextSuggestion *> *)suggestions processedRange:(NSRange)range inContext:(WTContext *)context finished:(BOOL)finished
@@ -2187,15 +2186,21 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         [_writingToolsTextSuggestions setObject:suggestion forKey:suggestion.uuid];
     }
 
-    _page->proofreadingSessionDidReceiveSuggestions(*webSession, replacementData, *webContext, finished, [webSession, replacementData, webContext, finished, page = WeakPtr { _page.get() }] {
-        if (!page)
-            return;
+    NSInteger delta = [WebKit::getWKIntelligenceTextEffectCoordinatorClass() characterDeltaForReceivedSuggestions:suggestions];
 
-        // FIXME: Wait for the animation to finish before invoking this method.
-        page->proofreadingSessionDidCompletePartialReplacement(*webSession, replacementData, *webContext, finished, [] {
-            // FIXME: Once the animations are implemented, this completion handler will be used to inform the coordinator that this async operation is complete.
+    auto operation = makeBlockPtr([webSession, replacementData, range, webContext, finished, weakSelf = WeakObjCPtr<WKWebView>(self)](void (^completion)(void)) {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completion();
+            return;
+        }
+
+        strongSelf->_page->proofreadingSessionDidReceiveSuggestions(*webSession, replacementData, range, *webContext, finished, [completion = makeBlockPtr(completion)] {
+            completion();
         });
     });
+
+    [_intelligenceTextEffectCoordinator requestReplacementWithProcessedRange:range finished:finished characterDelta:delta operation:operation.get() completion:^{ }];
 }
 
 - (void)proofreadingSession:(WTSession *)session didUpdateState:(WTTextSuggestionState)state forSuggestionWithUUID:(NSUUID *)suggestionUUID inContext:(WTContext *)context
@@ -2240,9 +2245,31 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     _activeWritingToolsSession = nil;
     [_writingToolsTextSuggestions removeAllObjects];
 
-    _page->setWritingToolsActive(false);
+    if (session.type != WTSessionTypeProofreading) {
+        _page->setWritingToolsActive(false);
+        _page->didEndWritingToolsSession(*webSession, accepted);
+        return;
+    }
 
-    _page->didEndWritingToolsSession(*webSession, accepted);
+    // Flush and invoke all replacement operations, then dismiss the markers (and revert the text if not accepted),
+    // then set the selection to the updated context range, and finally clear the state in the web process.
+    //
+    // It's possible that the selection has already been restored by this point if the entire animation has already
+    // finished, but this is not guaranteed.
+
+    [_intelligenceTextEffectCoordinator flushReplacementsWithCompletion:makeBlockPtr([webSession, accepted, weakSelf = WeakObjCPtr<WKWebView>(self)] {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        strongSelf->_page->setWritingToolsActive(false);
+
+        strongSelf->_page->willEndWritingToolsSession(*webSession, accepted, [webSession, accepted, weakSelf] {
+            [weakSelf.get()->_intelligenceTextEffectCoordinator restoreSelectionAcceptedReplacements:accepted completion:makeBlockPtr([webSession, accepted, weakSelf] {
+                weakSelf.get()->_page->didEndWritingToolsSession(*webSession, accepted);
+            }).get()];
+        });
+    }).get()];
 }
 
 - (void)compositionSession:(WTSession *)session didReceiveText:(NSAttributedString *)attributedText replacementRange:(NSRange)range inContext:(WTContext *)context finished:(BOOL)finished
@@ -2287,10 +2314,17 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
 #if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS)
 
-- (PlatformView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator
+#if PLATFORM(IOS_FAMILY)
+- (UIView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator
+{
+    return _contentView.get();
+}
+#else
+- (NSView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator
 {
     return self;
 }
+#endif
 
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator rectsForProofreadingSuggestionsInRange:(NSRange)range completion:(void (^)(NSArray<NSValue *> *))completion
 {
@@ -2303,10 +2337,24 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     });
 }
 
-- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible completion:(void (^)(void))completion
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible identifier:(NSUUID *)identifier completion:(void (^)(void))completion
 {
-    _page->updateTextVisibilityForActiveWritingToolsSession(range, visible, [completion = makeBlockPtr(completion)] {
+    auto convertedIdentifier = WTF::UUID::fromNSUUID(identifier);
+    if (!convertedIdentifier) {
+        ASSERT_NOT_REACHED();
         completion();
+        return;
+    }
+
+    _page->updateTextVisibilityForActiveWritingToolsSession(range, visible, *convertedIdentifier, [completion = makeBlockPtr(completion), weakSelf = WeakObjCPtr<WKWebView>(self)] {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completion();
+            return;
+        }
+
+        // Ensure the rendering of the visibility has actually taken effect.
+        [strongSelf _doAfterNextPresentationUpdate:completion.get()];
     });
 }
 
@@ -2376,6 +2424,20 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     });
 }
 #endif
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator decorateReplacementsForRange:(NSRange)range completion:(void (^)(void))completion
+{
+    _page->decorateTextReplacementsForActiveWritingToolsSession(range, [completion = makeBlockPtr(completion)] {
+        completion();
+    });
+}
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator setSelectionForRange:(NSRange)range completion:(void (^)(void))completion
+{
+    _page->setSelectionForActiveWritingToolsSession(range, [completion = makeBlockPtr(completion)] {
+        completion();
+    });
+}
 
 #endif
 
@@ -5026,7 +5088,7 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
             return;
         }
 
-        RetainPtr preview = [strongSelf->_contentView _createTargetedPreviewFromTextIndicator:*textIndicatorData previewContainer:strongSelf.get()];
+        RetainPtr preview = [strongSelf->_contentView _createTargetedPreviewFromTextIndicator:*textIndicatorData previewContainer:[strongSelf scrollView]];
         completionHandler(preview.get());
     });
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -252,6 +252,8 @@ struct PerWebProcessState {
     RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
     RetainPtr<WTSession> _activeWritingToolsSession;
 
+    RetainPtr<WKIntelligenceTextEffectCoordinator> _intelligenceTextEffectCoordinator;
+
     NSUInteger _partialIntelligenceTextAnimationCount;
     BOOL _writingToolsTextReplacementsFinished;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1263,19 +1263,19 @@ void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Sess
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::DidBeginWritingToolsSession(session, contexts), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
+void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::CharacterRange& processedRange, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
-}
-
-void WebPageProxy::proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
-{
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::ProofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::willEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::WillEndWritingToolsSession(session, accepted), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
@@ -1298,14 +1298,24 @@ void WebPageProxy::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(c
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionSuggestionTextRectsInRootViewCoordinates(enclosingRangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, CompletionHandler<void()>&& completionHandler)
+void WebPageProxy::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier, CompletionHandler<void()>&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::UpdateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::UpdateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
 {
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::TextPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::DecorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::SetSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& elementID)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2470,11 +2470,11 @@ public:
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
+
+    void willEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted, CompletionHandler<void()>&&);
 
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
@@ -2483,8 +2483,10 @@ public:
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange&, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&) const;
-    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, CompletionHandler<void()>&&);
+    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
+    void setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     bool isWritingToolsActive() const { return m_isWritingToolsActive; }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -25,7 +25,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if !TARGET_OS_WATCH && !TARGET_OS_TV
+#if !TARGET_OS_WATCH && !TARGET_OS_TV && __has_include(<WritingTools/WritingTools.h>)
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -34,10 +34,15 @@
 #import <WebKit/_WKTextPreview.h>
 #endif
 
+#import <WebKit/WKWebView.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class WKIntelligenceTextEffectCoordinator;
 
+@class WTTextSuggestion;
+
+NS_SWIFT_UI_ACTOR
 @protocol WKIntelligenceTextEffectCoordinatorDelegate <NSObject>
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
@@ -54,11 +59,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator rectsForProofreadingSuggestionsInRange:(NSRange)range completion:(void (^)(NSArray<NSValue *> *))completion;
 
-- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible completion:(void (^)(void))completion;
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible identifier:(NSUUID *)identifier completion:(void (^)(void))completion;
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator decorateReplacementsForRange:(NSRange)range completion:(void (^)(void))completion;
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator setSelectionForRange:(NSRange)range completion:(void (^)(void))completion;
 
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKIntelligenceTextEffectCoordinator : NSObject
+
++ (NSInteger)characterDeltaForReceivedSuggestions:(NSArray<WTTextSuggestion *> *)suggestions;
+
+- (instancetype)initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)delegate;
+
+- (void)startAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
+
+- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
+
+- (void)flushReplacementsWithCompletion:(void (^)(void))completion;
+
+- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completion:(void (^)(void))completion;
 
 @end
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
@@ -2,13 +2,475 @@
 // Copyright (C) 2024 Apple Inc. All rights reserved.
 //
 
+#if canImport(WritingTools)
+
 import Foundation
 import WebKit
 import WebKitSwift
+@_spi(Private) import WebKit
+@_spiOnly import WritingTools
+@_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
 
-@objc(WKIntelligenceTextEffectCoordinator)
-public final class WKIntelligenceTextEffectCoordinator: NSObject {
-    @objc
-    override public init() {
+// MARK: Implementation
+
+@_objcImplementation extension WKIntelligenceTextEffectCoordinator {
+    private struct ReplacementOperationRequest {
+        let processedRange: Range<Int>
+        let finished: Bool
+        let characterDelta: Int
+        let operation: (() async -> Void)
+    }
+
+    @nonobjc final private let delegate: (any WKIntelligenceTextEffectCoordinatorDelegate)
+    @nonobjc final private var effectView: PlatformIntelligenceTextEffectView<WKIntelligenceTextEffectCoordinator>? = nil
+
+    @nonobjc final private var processedRangeOffset = 0
+    @nonobjc final private var contextRange: Range<Int>? = nil
+
+    // Use the corresponding setter functions instead of setting these directly.
+    @nonobjc final private var activePonderingEffect: PlatformIntelligencePonderingTextEffect<Chunk>? = nil
+    @nonobjc final private var activeReplacementEffect: PlatformIntelligenceReplacementTextEffect<Chunk>? = nil
+
+    // The transparent content document markers associated with the visibility of each chunk need to
+    // maintain identifiers so that if chunk A makes range R hidden, chunk B makes R hidden, then chunk A makes
+    // R visible, R must still be hidden due to B.
+    @nonobjc final private var textVisibilityRegionIdentifiers: [Chunk: UUID] = [:]
+
+    // Maintain a replacement operation queue to ensure that no matter how many batches of replacements are received,
+    // there is only ever one ongoing effect at a time.
+    @nonobjc final private var replacementQueue: [ReplacementOperationRequest] = []
+
+    // If there are still pending replacements/animations when the user has accepted or rejected the Writing Tools
+    // suggestions, they first need to all be flushed out and invoked so that the state is not incomplete, and then
+    // the acceptance/rejection can properly occur.
+    @nonobjc final private var onFlushCompletion: (() async -> Void)? = nil
+
+    @objc(characterDeltaForReceivedSuggestions:)
+    public class func characterDelta(forReceivedSuggestions suggestions: [WTTextSuggestion]) -> Int {
+        suggestions.reduce(0) { partialResult, suggestion in
+            partialResult + (suggestion.replacement.count - suggestion.originalRange.length)
+        }
+    }
+
+    @objc(initWithDelegate:)
+    public init(delegate: any WKIntelligenceTextEffectCoordinatorDelegate) {
+        self.delegate = delegate
+    }
+
+    @objc(startAnimationForRange:completion:)
+    public func startAnimation(for range: NSRange) async {
+        self.reset()
+
+        assert(self.activePonderingEffect == nil, "Intelligence text effect coordinator: cannot start a new animation while a pondering effect is already active")
+        assert(self.activeReplacementEffect == nil, "Intelligence text effect coordinator: cannot start a new animation while a replacement effect is already active")
+
+        guard let contextRange = Range(range) else {
+            assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange \(range)")
+            return
+        }
+
+        self.contextRange = contextRange
+
+        let chunk = Self.Chunk.Pondering(range: contextRange)
+        let effect = PlatformIntelligencePonderingTextEffect(chunk: chunk as Chunk)
+
+        await self.setActivePonderingEffect(effect)
+    }
+
+    @objc(requestReplacementWithProcessedRange:finished:characterDelta:operation:completion:)
+    public func requestReplacement(withProcessedRange processedRange: NSRange, finished: Bool, characterDelta: Int, operation: @escaping (@escaping () -> Void) -> Void) async {
+        guard let range = Range(processedRange) else {
+            assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange \(processedRange)")
+            return
+        }
+
+        let asyncBlock = async(operation)
+        let request = Self.ReplacementOperationRequest(processedRange: range, finished: finished, characterDelta: characterDelta, operation: asyncBlock)
+
+        self.replacementQueue.append(request)
+
+        if self.replacementQueue.count == 1 {
+            await self.startReplacementAnimation(using: request)
+        }
+    }
+
+    @objc(flushReplacementsWithCompletion:)
+    public func flushReplacements() async {
+        assert(self.onFlushCompletion == nil)
+
+        // If the replacement queue is empty, there's no effects pending completion and nothing to flush,
+        // so no need to create a completion block, and instead just invoke `removeActiveEffects` immediately.
+
+        if self.replacementQueue.isEmpty {
+            await self.removeActiveEffects()
+            return
+        }
+
+        // This can't be performed immediately since a replacement animation may be ongoing, and they are not interruptible.
+        // So instead, the completion of this async method is stored in state, so that when the current replacement is complete,
+        // the actual flush can occur.
+
+        await withCheckedContinuation { continuation in
+            self.onFlushCompletion = {
+                await self.removeActiveEffects()
+                continuation.resume()
+            }
+        }
+    }
+
+    @objc(restoreSelectionAcceptedReplacements:completion:)
+    public func restoreSelection(acceptedReplacements: Bool) async {
+        guard let contextRange = self.contextRange else {
+            assertionFailure()
+            return
+        }
+
+        let range = acceptedReplacements ? contextRange.lowerBound..<(contextRange.upperBound + self.processedRangeOffset) : contextRange;
+        await self.delegate.intelligenceTextEffectCoordinator(self, setSelectionFor: NSRange(range))
+    }
+
+    @nonobjc final private func removeActiveEffects() async {
+        if self.activePonderingEffect != nil {
+            await self.setActivePonderingEffect(nil)
+        }
+
+        if self.activeReplacementEffect != nil {
+            await self.setActiveReplacementEffect(nil)
+        }
+    }
+
+    @nonobjc final private func startReplacementAnimation(using request: WKIntelligenceTextEffectCoordinator.ReplacementOperationRequest) async {
+        assert(self.activeReplacementEffect == nil, "Intelligence text effect coordinator: cannot start a new replacement animation while one is already active")
+
+        let processedRange = request.processedRange
+        let characterDelta = request.characterDelta
+
+        let processedRangeRelativeToCurrentText = (processedRange.lowerBound + self.processedRangeOffset)..<(processedRange.upperBound + self.processedRangeOffset)
+
+        let chunk = Self.Chunk.Replacement(
+            range: processedRangeRelativeToCurrentText,
+            rangeAfterReplacement: processedRangeRelativeToCurrentText.lowerBound..<(processedRangeRelativeToCurrentText.upperBound + characterDelta),
+            finished: request.finished,
+            replacement: request.operation
+        )
+
+        let effect = PlatformIntelligenceReplacementTextEffect(chunk: chunk as Chunk)
+
+        // Start the replacement effect while the pondering effect is still ongoing, so that it can perform
+        // the async replacement without it being visible to the user and without any flickering.
+        await self.setActiveReplacementEffect(effect)
+
+        self.processedRangeOffset += characterDelta
+    }
+
+    @nonobjc final private func setupViewIfNeeded() {
+        guard self.effectView == nil else {
+            return
+        }
+
+        let contentView = self.delegate.view(for: self)
+        let effectView = PlatformIntelligenceTextEffectView(source: self)
+
+#if os(iOS)
+        effectView.isUserInteractionEnabled = false
+        effectView.frame = contentView.frame
+        contentView.superview!.addSubview(effectView)
+#else
+        effectView.frame = contentView.bounds
+        contentView.addSubview(effectView)
+#endif
+
+        // UIKit expects subviews of the effect view to be added after the effect view is added to its parent.
+        effectView.initializeSubviews()
+
+        self.effectView = effectView
+    }
+
+    @nonobjc final private func destroyViewIfNeeded() {
+        guard self.activePonderingEffect == nil && self.activeReplacementEffect == nil else {
+            return
+        }
+
+        self.effectView?.removeFromSuperview()
+        self.effectView = nil
+    }
+
+    @nonobjc final private func setActivePonderingEffect(_ effect: PlatformIntelligencePonderingTextEffect<Chunk>?) async {
+        guard (self.activePonderingEffect == nil && effect != nil) || (self.activePonderingEffect != nil && effect == nil) else {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new pondering effect when there is an ongoing one, or trying to remove an effect when there are none.")
+            return
+        }
+
+        if let effect {
+            self.setupViewIfNeeded()
+            await self.effectView?.addEffect(effect)
+        } else {
+            // This needs to be manually invoked rather than relying on the associated delegate method being called. This is
+            // because when removing an effect, the delegate method is invoked after the effect removal function ends. Invoking
+            // this method manually ensures that the replacement effect doesn't start until the visibility has actually changed
+            // and this function terminates.
+            //
+            // Therefore, the delegate method itself must avoid any work so that it can be synchronous, which is what the platform
+            // interfaces expect.
+            await self.updateTextChunkVisibility(self.activePonderingEffect!.chunk, visible: true, force: true)
+
+            await self.effectView?.removeEffect(self.activePonderingEffect!.id)
+
+            self.destroyViewIfNeeded()
+        }
+
+        self.activePonderingEffect = effect
+    }
+
+    @nonobjc final private func setActiveReplacementEffect(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>?) async {
+        guard (self.activeReplacementEffect == nil && effect != nil) || (self.activeReplacementEffect != nil && effect == nil) else {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new replacement effect when there is an ongoing one, or trying to remove an effect when there are none.")
+            return
+        }
+
+        if let effect {
+            self.setupViewIfNeeded()
+            await self.effectView?.addEffect(effect)
+        } else {
+            await self.effectView?.removeEffect(self.activeReplacementEffect!.id)
+            self.destroyViewIfNeeded()
+        }
+
+        self.activeReplacementEffect = effect
+    }
+
+    @nonobjc final private func reset() {
+        self.effectView?.removeAllEffects()
+        self.effectView?.removeFromSuperview()
+        self.effectView = nil
+
+        self.processedRangeOffset = 0
+        self.contextRange = nil
+
+        self.activePonderingEffect = nil
+        self.activeReplacementEffect = nil
+
+        self.textVisibilityRegionIdentifiers = [:]
+        self.replacementQueue = []
     }
 }
+
+// MARK: WKIntelligenceTextEffectCoordinator + PlatformIntelligenceTextEffectViewSource conformance
+
+extension WKIntelligenceTextEffectCoordinator: PlatformIntelligenceTextEffectViewSource {
+    func textPreview(for chunk: Chunk) async -> PlatformTextPreview? {
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+
+#if canImport(UIKit)
+        return previews
+#else
+        return previews.map {
+            _WTTextPreview(snapshotImage: $0.previewImage, presentationFrame: $0.presentationFrame)
+        }
+#endif
+    }
+
+    private func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool, force: Bool) async {
+        if chunk is Chunk.Pondering && visible && !force {
+            // Typically, if `chunk` is part of a pondering effect, this delegate method will get called with `visible == true`
+            // once the pondering effect is removed. However, instead of performing that logic here, it is done in `setActivePonderingEffect`
+            // instead.
+            //
+            // This effectively makes this function synchronous in this case.
+            return
+        }
+
+        // Get the associated visibility identifier for the chunk, or make a new one if needed.
+
+        let id: UUID
+        if let cachedID = self.textVisibilityRegionIdentifiers[chunk] {
+            id = cachedID
+        } else {
+            id = UUID()
+            self.textVisibilityRegionIdentifiers[chunk] = id
+        }
+
+        await self.delegate.intelligenceTextEffectCoordinator(self, updateTextVisibilityFor: NSRange(chunk.range), visible: visible, identifier: id)
+    }
+
+    func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool) async {
+        await self.updateTextChunkVisibility(chunk, visible: visible, force: false)
+    }
+
+    func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>, animation: PlatformIntelligenceReplacementTextEffect<Chunk>.AnimationParameters) async -> PlatformTextPreview? {
+        guard let chunk = chunk as? Chunk.Replacement else {
+            fatalError()
+        }
+
+        let characterDelta = chunk.rangeAfterReplacement.upperBound - chunk.range.upperBound
+
+        await chunk.replacement()
+        chunk.range = chunk.rangeAfterReplacement
+
+        // If there is an active pondering effect ongoing that predated the replacement, adjust its range to account
+        // for the replacement character delta. This ensures that when the pondering effect ends, the semantic chunk
+        // remains the same so that the text visibility is restored for the updated range.
+        //
+        // Additionally, the range's start offset can be truncated to now start at the end of the replacement range,
+        // since the range [activePonderingEffect.chunk.range.lowerBound, chunk.range.upperBound] will be covered by
+        // the replacement range so there's no need for the pondering effect to also try to affect it.
+        if let activePonderingEffect = self.activePonderingEffect {
+            activePonderingEffect.chunk.range = chunk.range.upperBound..<(activePonderingEffect.chunk.range.upperBound + characterDelta)
+        }
+
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+
+#if canImport(UIKit)
+        return previews
+#else
+        let suggestionRects = await self.delegate.intelligenceTextEffectCoordinator(self, rectsForProofreadingSuggestionsIn: NSRange(chunk.range))
+        return previews.map {
+            _WTTextPreview(snapshotImage: $0.previewImage, presentationFrame: $0.presentationFrame, backgroundColor: nil, clippingPath: nil, scale: 1, candidateRects: suggestionRects)
+        }
+#endif
+    }
+
+    func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async {
+        // Stop the current pondering effect, and then create a new pondering effect once the replacement effect is complete.
+        await self.setActivePonderingEffect(nil)
+    }
+
+    @discardableResult private func flushRemainingReplacementsIfNeeded() async -> Bool {
+        guard let onFlushCompletion = self.onFlushCompletion else {
+            return false
+        }
+
+        // Iterate through all replacements in the queue (except for the first one, which will have been completed by this point,
+        // but not yet removed from the queue), and immediately apply their operations and update the offset state.
+
+        for request in self.replacementQueue.dropFirst() {
+            await request.operation()
+            self.processedRangeOffset += request.characterDelta
+        }
+
+        await onFlushCompletion()
+
+        self.replacementQueue = []
+        self.onFlushCompletion = nil
+
+        return true
+    }
+
+    func replacementEffectDidComplete(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async {
+        guard let contextRange = self.contextRange else {
+            assertionFailure("Intelligence text effect coordinator: Invariant failed (replacement effect completed without a context range)")
+            return
+        }
+
+        guard let chunk = effect.chunk as? Chunk.Replacement else {
+            assertionFailure("Intelligence text effect coordinator: Replacement effect chunk is not Chunk.Replacement")
+            return
+        }
+
+        // At this point, the text has been replaced, and the effect's chunk's range has been updated to account for the latest character delta.
+        let rangeAfterReplacement = chunk.range
+
+        // Inform the coordinator the active replacement effect is over, and then inform the delegate to decorate the replacements if needed.
+        await self.setActiveReplacementEffect(nil)
+        await self.delegate.intelligenceTextEffectCoordinator(self, decorateReplacementsFor: NSRange(rangeAfterReplacement))
+
+        // If this is the last chunk, that means that there will be no subsequent replacements, and no replacements other than
+        // this one are in the replacement queue.
+        //
+        // Therefore, the entire animation is over and the selection can be restored to the context range.
+
+        if chunk.finished {
+            self.replacementQueue.removeFirst()
+            await self.restoreSelectionAcceptedReplacements(true)
+            return
+        }
+
+        // Now that the coordinator is in-between replacements, if a flush has previously been requested, flush out
+        // all the remaining replacements from the queue as fast as possible and without any effects.
+        //
+        // If the replacements are flushed, there's no need to continue adding effects for the unprocessed range.
+
+        let didFlush = await self.flushRemainingReplacementsIfNeeded()
+        guard !didFlush else {
+            return
+        }
+
+        // Add a new pondering effect, from the end of the most recently replaced range to the end of the context range, adjusted
+        // for the offset relative to the original text.
+
+        let endOfContextRangeRelativeToCurrentText = contextRange.upperBound + self.processedRangeOffset
+        let unprocessedRangeChunk = Self.Chunk.Pondering(range: rangeAfterReplacement.upperBound..<endOfContextRangeRelativeToCurrentText)
+        let ponderEffectForUnprocessedRange = PlatformIntelligencePonderingTextEffect(chunk: unprocessedRangeChunk as Chunk)
+
+        // When all text has been processed, the unprocessed range will be empty, and no pondering effect need be created.
+        if !unprocessedRangeChunk.range.isEmpty {
+            await self.setActivePonderingEffect(ponderEffectForUnprocessedRange)
+        }
+
+        // Now that the first replacement is complete, remove it from the queue, and start the next one in line.
+
+        self.replacementQueue.removeFirst()
+
+        if let next = self.replacementQueue.first {
+            await self.startReplacementAnimation(using: next)
+        }
+    }
+}
+
+// MARK: WKIntelligenceTextEffectCoordinator.Chunk
+
+extension WKIntelligenceTextEffectCoordinator {
+    class Chunk: PlatformIntelligenceTextEffectChunk {
+        fileprivate class Pondering: Chunk {
+            override init(range: Range<Int>) {
+                super.init(range: range)
+            }
+        }
+
+        fileprivate class Replacement: Chunk {
+            let rangeAfterReplacement: Range<Int>
+            let finished: Bool
+            let replacement: (() async -> Void)
+
+            init(range: Range<Int>, rangeAfterReplacement: Range<Int>, finished: Bool, replacement: @escaping (() async -> Void)) {
+                self.rangeAfterReplacement = rangeAfterReplacement
+                self.finished = finished
+                self.replacement = replacement
+                super.init(range: range)
+            }
+        }
+
+        let id = UUID()
+
+        fileprivate var range: Range<Int>
+
+        private init(range: Range<Int>) {
+            self.range = range
+        }
+    }
+}
+
+// MARK: WKIntelligenceTextEffectCoordinator.Chunk + Hashable & Equatable
+
+extension WKIntelligenceTextEffectCoordinator.Chunk: Hashable, Equatable {
+    static func == (lhs: WKIntelligenceTextEffectCoordinator.Chunk, rhs: WKIntelligenceTextEffectCoordinator.Chunk) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        self.id.hash(into: &hasher)
+    }
+}
+
+// MARK: Misc. helper functions
+
+/// Converts a block with a completion handler into an async block.
+fileprivate func async(_ block: @escaping (@escaping () -> Void) -> Void) -> (() async -> Void) {
+    { @MainActor in
+        await withCheckedContinuation { continuation in
+            block(continuation.resume)
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -949,21 +949,21 @@ void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& 
     corePage()->didBeginWritingToolsSession(session, contexts);
 }
 
-void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
+void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::CharacterRange& processedRange, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    corePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
-    completionHandler();
-}
-
-void WebPage::proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
-{
-    corePage()->proofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished);
+    corePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
     completionHandler();
 }
 
 void WebPage::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
     corePage()->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
+}
+
+void WebPage::willEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted, CompletionHandler<void()>&& completionHandler)
+{
+    corePage()->willEndWritingToolsSession(session, accepted);
+    completionHandler();
 }
 
 void WebPage::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
@@ -1060,9 +1060,9 @@ void WebPage::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const 
     completionHandler(WTFMove(rects));
 }
 
-void WebPage::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, CompletionHandler<void()>&& completionHandler)
+void WebPage::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier, CompletionHandler<void()>&& completionHandler)
 {
-    corePage()->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible);
+    corePage()->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier);
     completionHandler();
 }
 
@@ -1070,6 +1070,18 @@ void WebPage::textPreviewDataForActiveWritingToolsSession(const WebCore::Charact
 {
     auto data = corePage()->textPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler(WTFMove(data));
+}
+
+void WebPage::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
+{
+    corePage()->decorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    completionHandler();
+}
+
+void WebPage::setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
+{
+    corePage()->setSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    completionHandler();
 }
 
 void WebPage::intelligenceTextAnimationsDidComplete()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2336,11 +2336,11 @@ private:
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
+
+    void willEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted, CompletionHandler<void()>&&);
 
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
@@ -2349,8 +2349,10 @@ private:
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange&, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&) const;
-    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, CompletionHandler<void()>&&);
+    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
+    void setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     // Old animation system methods:
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -790,11 +790,11 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     DidBeginWritingToolsSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
 
-    ProofreadingSessionDidReceiveSuggestions(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::WritingTools::Context context, bool finished) -> ()
-
-    ProofreadingSessionDidCompletePartialReplacement(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::WritingTools::Context context, bool finished) -> ()
+    ProofreadingSessionDidReceiveSuggestions(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::CharacterRange processedRange, struct WebCore::WritingTools::Context context, bool finished) -> ()
 
     ProofreadingSessionDidUpdateStateForSuggestion(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::TextSuggestionState state, struct WebCore::WritingTools::TextSuggestion suggestion, struct WebCore::WritingTools::Context context)
+
+    WillEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted) -> ()
 
     DidEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted)
 
@@ -804,9 +804,13 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     ProofreadingSessionSuggestionTextRectsInRootViewCoordinates(struct WebCore::CharacterRange enclosingRangeRelativeToSessionRange) -> (Vector<WebCore::FloatRect> rects)
 
-    UpdateTextVisibilityForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange, bool visible) -> ()
+    UpdateTextVisibilityForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange, bool visible, WTF::UUID identifier) -> ()
 
     TextPreviewDataForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> (std::optional<WebCore::TextIndicatorData> data)
+
+    SetSelectionForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> ()
+
+    DecorateTextReplacementsForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> ()
 
     CreateTextIndicatorForTextAnimationID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
     UpdateUnderlyingTextVisibilityForTextAnimationID(WTF::UUID uuid, bool visible) -> ()


### PR DESCRIPTION
#### fc0f18354ef6bd05c8504089231bb20f50e6b685
<pre>
[Intelligence Effects] Support adding intelligence effects to Writing Tools Proofreading operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=282161">https://bugs.webkit.org/show_bug.cgi?id=282161</a>
<a href="https://rdar.apple.com/138751347">rdar://138751347</a>

Reviewed by Aditya Keerthi.

When performing Proofreading, the text will now animate using the intelligence text effects.

The implementation details are described throughout the change in comments.

* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::updateTextVisibility):
(WebCore::IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements):
* Source/WebCore/page/IntelligenceTextEffectsSupport.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::proofreadingSessionDidReceiveSuggestions):
(WebCore::Page::updateTextVisibilityForActiveWritingToolsSession):
(WebCore::Page::decorateTextReplacementsForActiveWritingToolsSession):
(WebCore::Page::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::didBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView intelligenceTextEffectCoordinator:updateTextVisibilityForRange:visible:identifier:completion:]):
(-[WKWebView intelligenceTextEffectCoordinator:decorateReplacementsForRange:completion:]):
(-[WKWebView intelligenceTextEffectCoordinator:updateTextVisibilityForRange:visible:completion:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
(PlatformIntelligenceTextEffectViewSource.replacementEffectDidComplete(_:)):
(UITextEffectViewSourceAdapter.targetedPreview(for:)):
(UITextEffectViewSourceAdapter.updateTextChunkVisibilityForAnimation(_:visible:)):
(UIReplacementTextEffectDelegateAdapter.replacementEffectDidComplete(_:)):
(UIReplacementTextEffectDelegateAdapter.performReplacementAndGeneratePreview(for:effect:animation:)):
(WTTextPreviewAsyncSourceAdapter.textPreviews(for:)):
(WTTextPreviewAsyncSourceAdapter.updateIsTextVisible(_:for:)):
(PlatformIntelligenceTextEffectView.wrappedEffectIDToPlatformEffects):
(PlatformIntelligenceTextEffectView.frame):
(PlatformIntelligenceTextEffectView.removeEffect(_:)):
(PlatformIntelligenceTextEffectView.removeAllEffects):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift:
(effectView):
(contextRange):
(activePonderingEffect):
(activeReplacementEffect):
(textVisibilityRegionIdentifiers):
(replacementQueue):
(onFlushCompletion):
(characterDelta(forReceivedSuggestions:)):
(startAnimation(for:)):
(requestReplacement(withProcessedRange:characterDelta:operation:)):
(flushReplacements):
(startReplacementAnimation(using:)):
(setupViewIfNeeded):
(destroyViewIfNeeded):
(setActivePonderingEffect(_:)):
(setActiveReplacementEffect(_:)):
(reset):
(WKIntelligenceTextEffectCoordinator.textPreview(for:)):
(WKIntelligenceTextEffectCoordinator.updateTextChunkVisibility(_:visible:force:)):
(WKIntelligenceTextEffectCoordinator.updateTextChunkVisibility(_:visible:)):
(WKIntelligenceTextEffectCoordinator.performReplacementAndGeneratePreview(for:effect:animation:)):
(WKIntelligenceTextEffectCoordinator.replacementEffectWillBegin(_:)):
(WKIntelligenceTextEffectCoordinator.flushRemainingReplacementsIfNeeded):
(WKIntelligenceTextEffectCoordinator.replacementEffectDidComplete(_:)):
(range):
(WKIntelligenceTextEffectCoordinator.hash(into:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPage::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPage::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPage::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilityForRange)):

Canonical link: <a href="https://commits.webkit.org/286126@main">https://commits.webkit.org/286126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a1c8e748cdfa3f29f75fc2783cc4a5ee0172aea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77025 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/63474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/63474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64365 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/63474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21864 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/63474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2226 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16493 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2191 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->