### PR TITLE
Implement Observable#every

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any-expected.txt
@@ -1,24 +1,12 @@
 
-FAIL every(): Promise resolves to true if all values pass the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Promise resolves to false if any value fails the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Abort the subscription to the source if the predicate does not pass promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Lifecycle checks when all values pass the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    logs.push(`Predicate called with ${value}, ${index}`);
-    return true;
-  })', 'source.every' is undefined)"
-FAIL every(): Lifecycle checks when any value fails the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    logs.push(`Predicate called with ${value}, ${index}`);
-    return value === "good";
-  })', 'source.every' is undefined)"
-FAIL every(): Resolves with true if the observable completes without emitting a value promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true)', 'source.every' is undefined)"
-FAIL every(): Rejects with any error emitted from the source observable promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true)', 'source.every' is undefined)"
-FAIL every(): Rejects with any error thrown from the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(value => {
-    if (value <= 2) return true;
-    throw error;
-  })', 'source.every' is undefined)"
-FAIL every(): Index is passed into the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    indices.push(index);
-    return true;
-  })', 'source.every' is undefined)"
-FAIL every(): Rejects with a DOMException if the source Observable is aborted promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true, { signal: controller.signal })', 'source.every' is undefined)"
+PASS every(): Promise resolves to true if all values pass the predicate
+PASS every(): Promise resolves to false if any value fails the predicate
+PASS every(): Abort the subscription to the source if the predicate does not pass
+PASS every(): Lifecycle checks when all values pass the predicate
+PASS every(): Lifecycle checks when any value fails the predicate
+PASS every(): Resolves with true if the observable completes without emitting a value
+PASS every(): Rejects with any error emitted from the source observable
+PASS every(): Rejects with any error thrown from the predicate
+PASS every(): Index is passed into the predicate
+PASS every(): Rejects with a DOMException if the source Observable is aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any.worker-expected.txt
@@ -1,24 +1,12 @@
 
-FAIL every(): Promise resolves to true if all values pass the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Promise resolves to false if any value fails the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Abort the subscription to the source if the predicate does not pass promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value) => value === "good")', 'source.every' is undefined)"
-FAIL every(): Lifecycle checks when all values pass the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    logs.push(`Predicate called with ${value}, ${index}`);
-    return true;
-  })', 'source.every' is undefined)"
-FAIL every(): Lifecycle checks when any value fails the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    logs.push(`Predicate called with ${value}, ${index}`);
-    return value === "good";
-  })', 'source.every' is undefined)"
-FAIL every(): Resolves with true if the observable completes without emitting a value promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true)', 'source.every' is undefined)"
-FAIL every(): Rejects with any error emitted from the source observable promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true)', 'source.every' is undefined)"
-FAIL every(): Rejects with any error thrown from the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(value => {
-    if (value <= 2) return true;
-    throw error;
-  })', 'source.every' is undefined)"
-FAIL every(): Index is passed into the predicate promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every((value, index) => {
-    indices.push(index);
-    return true;
-  })', 'source.every' is undefined)"
-FAIL every(): Rejects with a DOMException if the source Observable is aborted promise_test: Unhandled rejection with value: object "TypeError: source.every is not a function. (In 'source.every(() => true, { signal: controller.signal })', 'source.every' is undefined)"
+PASS every(): Promise resolves to true if all values pass the predicate
+PASS every(): Promise resolves to false if any value fails the predicate
+PASS every(): Abort the subscription to the source if the predicate does not pass
+PASS every(): Lifecycle checks when all values pass the predicate
+PASS every(): Lifecycle checks when any value fails the predicate
+PASS every(): Resolves with true if the observable completes without emitting a value
+PASS every(): Rejects with any error emitted from the source observable
+PASS every(): Rejects with any error thrown from the predicate
+PASS every(): Index is passed into the predicate
+PASS every(): Rejects with a DOMException if the source Observable is aborted
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1226,6 +1226,7 @@ dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverDrop.cpp
+dom/InternalObserverEvery.cpp
 dom/InternalObserverFilter.cpp
 dom/InternalObserverFind.cpp
 dom/InternalObserverFirst.cpp

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -1,0 +1,152 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverEvery.h"
+
+#include "AbortSignal.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "PredicateCallback.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverEvery final : public InternalObserver {
+public:
+    static Ref<InternalObserverEvery> create(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverEvery(context, WTFMove(callback), WTFMove(signal), WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref vm = globalObject->vm();
+
+        bool hasPassed = false;
+
+        {
+            JSC::JSLockHolder lock(vm);
+
+            // The exception is not reported, instead it is forwarded to the
+            // abort signal and promise rejection.
+            // As such, PredicateCallback `[RethrowsException]` and here a
+            // catch scope is declared so the error can be passed to any promise
+            // rejection handlers and abort handlers.
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            auto result = protectedCallback()->handleEvent(value, m_idx++);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                auto value = exception->value();
+                protectedPromise()->reject<IDLAny>(value);
+                protectedSignal()->signalAbort(value);
+                return;
+            }
+
+            if (result.type() == CallbackResultType::Success)
+                hasPassed = result.releaseReturnValue();
+        }
+
+        if (!hasPassed) {
+            protectedPromise()->resolve<IDLBoolean>(false);
+            protectedSignal()->signalAbort(JSC::jsUndefined());
+        }
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        protectedPromise()->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        protectedPromise()->resolve<IDLBoolean>(true);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    Ref<AbortSignal> protectedSignal() const { return m_signal; }
+    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<PredicateCallback> protectedCallback() const { return m_callback; }
+
+    InternalObserverEvery(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_callback(WTFMove(callback))
+        , m_signal(WTFMove(signal))
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    uint64_t m_idx { 0 };
+    Ref<PredicateCallback> m_callback;
+    Ref<AbortSignal> m_signal;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorEvery(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref signal = AbortSignal::create(&context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { signal };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverEvery::create(context, WTFMove(callback), WTFMove(signal), WTFMove(promise));
+
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverEvery.h
+++ b/Source/WebCore/dom/InternalObserverEvery.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+class PredicateCallback;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorEvery(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -31,6 +31,7 @@
 #include "Exception.h"
 #include "ExceptionCode.h"
 #include "InternalObserverDrop.h"
+#include "InternalObserverEvery.h"
 #include "InternalObserverFilter.h"
 #include "InternalObserverFind.h"
 #include "InternalObserverFirst.h"
@@ -140,6 +141,11 @@ void Observable::last(ScriptExecutionContext& context, const SubscribeOptions& o
 void Observable::find(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
 {
     return createInternalObserverOperatorFind(context, *this, WTFMove(callback), options, WTFMove(promise));
+}
+
+void Observable::every(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorEvery(context, *this, WTFMove(callback), options, WTFMove(promise));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -70,6 +70,7 @@ public:
     void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -48,4 +48,6 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Promise<undefined> forEach(VisitorCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> find(PredicateCallback callback, optional SubscribeOptions options = {});
+  [CallWith=CurrentScriptExecutionContext] Promise<boolean> every(PredicateCallback callback, optional SubscribeOptions options = {});
+
 };


### PR DESCRIPTION
#### dff7ea7eb7e5292abf6f4d44714c53b3d45dbed1
<pre>
Implement Observable#every
<a href="https://bugs.webkit.org/show_bug.cgi?id=277506">https://bugs.webkit.org/show_bug.cgi?id=277506</a>

Reviewed by Chris Dumez.

This change introduces the `.every` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-every">https://wicg.github.io/observable/#dom-observable-every</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any.worker-expected.txt: Rebaseline.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverEvery.cpp: Added.
(WebCore::createInternalObserverOperatorEvery):
* Source/WebCore/dom/InternalObserverEvery.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::every):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
  Exposes `Promise&lt;boolean&gt; every(predicate, options)` as a promise-returning operator.

Canonical link: <a href="https://commits.webkit.org/285818@main">https://commits.webkit.org/285818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b68030c578b28315760ce547a1bec4762bcfe9d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66421 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65700 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9596 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3917 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->