### PR TITLE
Implement Observable#find

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any-expected.txt
@@ -1,11 +1,8 @@
 
-FAIL find(): Promise resolves with the first value that passes the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find((value) => value === "b")', 'source.find' is undefined)"
-FAIL find(): Promise resolves with undefined if no value passes the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => false)', 'source.find' is undefined)"
-FAIL find(): Promise rejects with the error emitted from the source Observable promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => true)', 'source.find' is undefined)"
-FAIL find(): Promise rejects with any error thrown from the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => {throw error})', 'source.find' is undefined)"
-FAIL find(): Passes the index of the value to the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find((value, index) => {
-    indices.push(index);
-    return false;
-  })', 'source.find' is undefined)"
-FAIL find(): Rejects with AbortError when the signal is aborted promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => true, { signal: controller.signal })', 'source.find' is undefined)"
+PASS find(): Promise resolves with the first value that passes the predicate
+PASS find(): Promise resolves with undefined if no value passes the predicate
+PASS find(): Promise rejects with the error emitted from the source Observable
+PASS find(): Promise rejects with any error thrown from the predicate
+PASS find(): Passes the index of the value to the predicate
+PASS find(): Rejects with AbortError when the signal is aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any.worker-expected.txt
@@ -1,11 +1,8 @@
 
-FAIL find(): Promise resolves with the first value that passes the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find((value) => value === "b")', 'source.find' is undefined)"
-FAIL find(): Promise resolves with undefined if no value passes the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => false)', 'source.find' is undefined)"
-FAIL find(): Promise rejects with the error emitted from the source Observable promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => true)', 'source.find' is undefined)"
-FAIL find(): Promise rejects with any error thrown from the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => {throw error})', 'source.find' is undefined)"
-FAIL find(): Passes the index of the value to the predicate promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find((value, index) => {
-    indices.push(index);
-    return false;
-  })', 'source.find' is undefined)"
-FAIL find(): Rejects with AbortError when the signal is aborted promise_test: Unhandled rejection with value: object "TypeError: source.find is not a function. (In 'source.find(() => true, { signal: controller.signal })', 'source.find' is undefined)"
+PASS find(): Promise resolves with the first value that passes the predicate
+PASS find(): Promise resolves with undefined if no value passes the predicate
+PASS find(): Promise rejects with the error emitted from the source Observable
+PASS find(): Promise rejects with any error thrown from the predicate
+PASS find(): Passes the index of the value to the predicate
+PASS find(): Rejects with AbortError when the signal is aborted
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1227,6 +1227,7 @@ dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverDrop.cpp
 dom/InternalObserverFilter.cpp
+dom/InternalObserverFind.cpp
 dom/InternalObserverFirst.cpp
 dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -1,0 +1,153 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverFind.h"
+
+#include "AbortSignal.h"
+#include "CallbackResult.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "PredicateCallback.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverFind final : public InternalObserver {
+public:
+    static Ref<InternalObserverFind> create(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverFind(context, WTFMove(callback), WTFMove(signal), WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref vm = globalObject->vm();
+
+        bool hasPassed = false;
+
+        {
+            JSC::JSLockHolder lock(vm);
+
+            // The exception is not reported, instead it is forwarded to the
+            // abort signal and promise rejection.
+            // As such, PredicateCallback `[RethrowsException]` and here a
+            // catch scope is declared so the error can be passed to any promise
+            // rejection handlers and abort handlers.
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            auto result = protectedCallback()->handleEvent(value, m_idx++);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                auto value = exception->value();
+                protectedPromise()->reject<IDLAny>(value);
+                protectedSignal()->signalAbort(value);
+                return;
+            }
+
+            if (result.type() == CallbackResultType::Success)
+                hasPassed = result.releaseReturnValue();
+        }
+
+        if (hasPassed) {
+            protectedPromise()->resolve<IDLAny>(value);
+            protectedSignal()->signalAbort(JSC::jsUndefined());
+        }
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        protectedPromise()->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        protectedPromise()->resolve();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<PredicateCallback> protectedCallback() const { return m_callback; }
+    Ref<AbortSignal> protectedSignal() const { return m_signal; }
+
+    InternalObserverFind(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_callback(WTFMove(callback))
+        , m_signal(WTFMove(signal))
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    uint64_t m_idx { 0 };
+    Ref<PredicateCallback> m_callback;
+    Ref<AbortSignal> m_signal;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorFind(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref signal = AbortSignal::create(&context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { signal };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverFind::create(context, WTFMove(callback), WTFMove(signal), WTFMove(promise));
+
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFind.h
+++ b/Source/WebCore/dom/InternalObserverFind.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+class PredicateCallback;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorFind(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -32,6 +32,7 @@
 #include "ExceptionCode.h"
 #include "InternalObserverDrop.h"
 #include "InternalObserverFilter.h"
+#include "InternalObserverFind.h"
 #include "InternalObserverFirst.h"
 #include "InternalObserverForEach.h"
 #include "InternalObserverFromScript.h"
@@ -134,6 +135,11 @@ void Observable::forEach(ScriptExecutionContext& context, Ref<VisitorCallback>&&
 void Observable::last(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
 {
     return createInternalObserverOperatorLast(context, *this, options, WTFMove(promise));
+}
+
+void Observable::find(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorFind(context, *this, WTFMove(callback), options, WTFMove(promise));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -69,6 +69,7 @@ public:
     void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -47,4 +47,5 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Promise<any> first(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<undefined> forEach(VisitorCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
+  [CallWith=CurrentScriptExecutionContext] Promise<any> find(PredicateCallback callback, optional SubscribeOptions options = {});
 };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -35,6 +35,7 @@
 #include "ComputedStyleExtractor.h"
 #include "Document.h"
 #include "DocumentTimeline.h"
+#include "ElementInlines.h"
 #include "FrameSnapshotting.h"
 #include "HostWindow.h"
 #include "JSDOMPromise.h"


### PR DESCRIPTION
#### fe412e8af542829beefef96a881e826620ee0283
<pre>
Implement Observable#find
<a href="https://bugs.webkit.org/show_bug.cgi?id=277508">https://bugs.webkit.org/show_bug.cgi?id=277508</a>

Reviewed by Darin Adler.

This change introduces the `.find` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-find">https://wicg.github.io/observable/#dom-observable-find</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any.worker-expected.txt: Rebaseline.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverFind.cpp: Added.
(WebCore::createInternalObserverOperatorFind):
* Source/WebCore/dom/InternalObserverFind.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::find):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
  Exposes `Promise&lt;any&gt; find(predicate, options)` as a promise-returning operator.
* Source/WebCore/dom/ViewTransition.cpp:
  Unified sources caused `hasID` to &quot;not be defined&quot;, so added an
  include of `ElementInlines.h`.

Canonical link: <a href="https://commits.webkit.org/285793@main">https://commits.webkit.org/285793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbd5b8176279fc7b00e4553c08c2c62c8b4bda51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25012 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/988 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/546 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7701 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11385 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3805 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->