### PR TITLE
Implement Observable#some

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL some(): subscriber is inactive after the first value that passes the predicate, because the source was unsubscribed from promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL observable-some promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL observable-some 1 promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL some(): The returned promise rejects with an error if the predicate errors promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => {throw error})', 'source.some' is undefined)"
-FAIL some(): The returned promise rejects with an error if the source observable errors promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true)', 'source.some' is undefined)"
-FAIL some(): The returned promise resolves as false if the source observable completes without emitting a value promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true)', 'source.some' is undefined)"
-FAIL some(): The return promise rejects with a DOMException if the signal is aborted promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true, { signal: controller.signal })', 'source.some' is undefined)"
+PASS some(): subscriber is inactive after the first value that passes the predicate, because the source was unsubscribed from
+PASS observable-some
+PASS observable-some 1
+PASS some(): The returned promise rejects with an error if the predicate errors
+PASS some(): The returned promise rejects with an error if the source observable errors
+PASS some(): The returned promise resolves as false if the source observable completes without emitting a value
+PASS some(): The return promise rejects with a DOMException if the signal is aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any.worker-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL some(): subscriber is inactive after the first value that passes the predicate, because the source was unsubscribed from promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL observable-some promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL observable-some 1 promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some((value) => value === "good")', 'source.some' is undefined)"
-FAIL some(): The returned promise rejects with an error if the predicate errors promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => {throw error})', 'source.some' is undefined)"
-FAIL some(): The returned promise rejects with an error if the source observable errors promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true)', 'source.some' is undefined)"
-FAIL some(): The returned promise resolves as false if the source observable completes without emitting a value promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true)', 'source.some' is undefined)"
-FAIL some(): The return promise rejects with a DOMException if the signal is aborted promise_test: Unhandled rejection with value: object "TypeError: source.some is not a function. (In 'source.some(() => true, { signal: controller.signal })', 'source.some' is undefined)"
+PASS some(): subscriber is inactive after the first value that passes the predicate, because the source was unsubscribed from
+PASS observable-some
+PASS observable-some 1
+PASS some(): The returned promise rejects with an error if the predicate errors
+PASS some(): The returned promise rejects with an error if the source observable errors
+PASS some(): The returned promise resolves as false if the source observable completes without emitting a value
+PASS some(): The return promise rejects with a DOMException if the signal is aborted
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1234,6 +1234,7 @@ dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp
 dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp
+dom/InternalObserverSome.cpp
 dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -1,0 +1,153 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverSome.h"
+
+#include "AbortSignal.h"
+#include "CallbackResult.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "PredicateCallback.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverSome final : public InternalObserver {
+public:
+    static Ref<InternalObserverSome> create(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverSome(context, WTFMove(callback), WTFMove(signal), WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref vm = globalObject->vm();
+
+        bool hasPassed = false;
+
+        {
+            JSC::JSLockHolder lock(vm);
+
+            // The exception is not reported, instead it is forwarded to the
+            // abort signal and promise rejection.
+            // As such, PredicateCallback `[RethrowsException]` and here a
+            // catch scope is declared so the error can be passed to any promise
+            // rejection handlers and abort handlers.
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            auto result = protectedCallback()->handleEvent(value, m_idx++);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                auto value = exception->value();
+                protectedPromise()->reject<IDLAny>(value);
+                protectedSignal()->signalAbort(value);
+                return;
+            }
+
+            if (result.type() == CallbackResultType::Success)
+                hasPassed = result.releaseReturnValue();
+        }
+
+        if (hasPassed) {
+            protectedPromise()->resolve<IDLBoolean>(true);
+            protectedSignal()->signalAbort(JSC::jsUndefined());
+        }
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        protectedPromise()->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        protectedPromise()->resolve<IDLBoolean>(false);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<PredicateCallback> protectedCallback() const { return m_callback; }
+    Ref<AbortSignal> protectedSignal() const { return m_signal; }
+
+    InternalObserverSome(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_callback(WTFMove(callback))
+        , m_signal(WTFMove(signal))
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    uint64_t m_idx { 0 };
+    Ref<PredicateCallback> m_callback;
+    Ref<AbortSignal> m_signal;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorSome(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref signal = AbortSignal::create(&context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { signal };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverSome::create(context, WTFMove(callback), WTFMove(signal), WTFMove(promise));
+
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverSome.h
+++ b/Source/WebCore/dom/InternalObserverSome.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+class PredicateCallback;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorSome(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -39,6 +39,7 @@
 #include "InternalObserverFromScript.h"
 #include "InternalObserverLast.h"
 #include "InternalObserverMap.h"
+#include "InternalObserverSome.h"
 #include "InternalObserverTake.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSSubscriptionObserverCallback.h"
@@ -146,6 +147,11 @@ void Observable::find(ScriptExecutionContext& context, Ref<PredicateCallback>&& 
 void Observable::every(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
 {
     return createInternalObserverOperatorEvery(context, *this, WTFMove(callback), options, WTFMove(promise));
+}
+
+void Observable::some(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorSome(context, *this, WTFMove(callback), options, WTFMove(promise));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -71,6 +71,7 @@ public:
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void some(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -49,5 +49,5 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> find(PredicateCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<boolean> every(PredicateCallback callback, optional SubscribeOptions options = {});
-
+  [CallWith=CurrentScriptExecutionContext] Promise<boolean> some(PredicateCallback callback, optional SubscribeOptions options = {});
 };


### PR DESCRIPTION
#### f8a55904a2687f94d34099e640f74bfb04844858
<pre>
Implement Observable#some
<a href="https://bugs.webkit.org/show_bug.cgi?id=277513">https://bugs.webkit.org/show_bug.cgi?id=277513</a>

Reviewed by Darin Adler.

This change introduces the `.some` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-some">https://wicg.github.io/observable/#dom-observable-some</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-some.any.worker-expected.txt: Rebaseline.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverSome.cpp: Added.
(WebCore::createInternalObserverOperatorSome):
* Source/WebCore/dom/InternalObserverSome.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::some):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
  Exposes `Promise&lt;boolean&gt; some(predicate, options)` as a promise-returning operator.

Canonical link: <a href="https://commits.webkit.org/285833@main">https://commits.webkit.org/285833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c28ee4be67ffe77770052b1e0dede7353690ba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79825 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66451 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16282 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7806 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1216 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1245 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->