### PR TITLE
REGRESSION(285320@main): Crash in SystemSettings::updateSettings

### DIFF
--- a/Source/WebCore/platform/glib/SystemSettings.cpp
+++ b/Source/WebCore/platform/glib/SystemSettings.cpp
@@ -82,8 +82,12 @@ void SystemSettings::updateSettings(const SystemSettings::State& state)
     if (state.enableAnimations)
         m_state.enableAnimations = state.enableAnimations;
 
-    for (const auto& observer : m_observers.values())
-        observer(state);
+    for (auto* context : copyToVector(m_observers.keys())) {
+        const auto it = m_observers.find(context);
+        if (it == m_observers.end())
+            continue;
+        it->value(state);
+    }
 }
 
 std::optional<FontRenderOptions::Hinting> SystemSettings::hintStyle() const


### PR DESCRIPTION
#### 1f3ae07b8e51f7746581f12af28f9728cdaefe68
<pre>
REGRESSION(285320@main): Crash in SystemSettings::updateSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=282156">https://bugs.webkit.org/show_bug.cgi?id=282156</a>

Reviewed by Adrian Perez de Castro.

The problem is that SystemSettings::updateSettings() doesn&apos;t allow
changes in the observers HashMap while it&apos;s being iterated. This
regressed in 285320@main because now we are properly applying the initial
settings on web process initialization, and RenderTheme singleton is
created from the web process settings observer, which adds its own
observer. We need to use copyToVector when iterating the observers, but
the values are non copyable, so we copy the keys instead and get the
value to call the observer function.

* Source/WebCore/platform/glib/SystemSettings.cpp:
(WebCore::SystemSettings::updateSettings):

Canonical link: <a href="https://commits.webkit.org/285761@main">https://commits.webkit.org/285761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c7fd466a16c161611fcde81814617cc5bf1190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20937 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/516 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66345 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65624 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9489 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11370 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->