### PR TITLE
[Clipboard API] Address narrowing conversion warnings

### DIFF
--- a/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
@@ -59,7 +59,8 @@ void PlatformPasteboard::getTypes(Vector<String>& types) const
 
     for (unsigned i = 0; i < pasteboardTypes.length; ++i) {
         auto& typeString = pasteboardTypes.strings[i];
-        types.append(String({ typeString.data, typeString.length }));
+        const auto length = std::min(static_cast<size_t>(typeString.length), std::numeric_limits<size_t>::max());
+        types.append(String({ typeString.data, length }));
     }
 
     wpe_pasteboard_string_vector_free(&pasteboardTypes);
@@ -72,7 +73,8 @@ String PlatformPasteboard::readString(size_t, const String& type) const
     if (!string.length)
         return String();
 
-    String returnValue({ string.data, string.length });
+    const auto length = std::min(static_cast<size_t>(string.length), std::numeric_limits<size_t>::max());
+    String returnValue({ string.data, length });
 
     wpe_pasteboard_string_free(&string);
     return returnValue;


### PR DESCRIPTION
#### 4c0ebd7617b524c392864a362340590a163b8d12
<pre>
[Clipboard API] Address narrowing conversion warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=282166">https://bugs.webkit.org/show_bug.cgi?id=282166</a>

Reviewed by Adrian Perez de Castro.

Updated `getTypes` and `readString` methods in PlatformPasteboardLibWPE
by adding checks that constrain the length values within the bounds of
`size_t`.

This avoids narrowing conversion warnings when assigning `uint64_t` values
to `size_t` across platforms with varying definitions for `size_t`.

* Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp:
(WebCore::PlatformPasteboard::getTypes const):
(WebCore::PlatformPasteboard::readString const):

Canonical link: <a href="https://commits.webkit.org/286214@main">https://commits.webkit.org/286214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9ae2475b87bf8981678251069ba2aa5b23bc52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58888 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17154 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21937 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24584 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68150 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80932 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67140 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66441 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8540 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2296 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->