### PR TITLE
[GTK] Use std::array and ASCIILiteral in KeyBindingTranslator.cpp

### DIFF
--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -82,26 +82,21 @@ static void showHelpCallback(GtkWidget* widget, KeyBindingTranslator*)
 }
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static const char* const gtkDeleteCommands[][2] = {
-    { "DeleteBackward",               "DeleteForward"                        }, // Characters
-    { "DeleteWordBackward",           "DeleteWordForward"                    }, // Word ends
-    { "DeleteWordBackward",           "DeleteWordForward"                    }, // Words
-    { "DeleteToBeginningOfLine",      "DeleteToEndOfLine"                    }, // Lines
-    { "DeleteToBeginningOfLine",      "DeleteToEndOfLine"                    }, // Line ends
-    { "DeleteToBeginningOfParagraph", "DeleteToEndOfParagraph"               }, // Paragraph ends
-    { "DeleteToBeginningOfParagraph", "DeleteToEndOfParagraph"               }, // Paragraphs
-    { 0,                              0                                      } // Whitespace (M-\ in Emacs)
-};
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static constexpr auto gtkDeleteCommands = std::to_array<std::array<ASCIILiteral, 2>>({
+    { "DeleteBackward"_s,               "DeleteForward"_s          }, // Characters
+    { "DeleteWordBackward"_s,           "DeleteWordForward"_s      }, // Word ends
+    { "DeleteWordBackward"_s,           "DeleteWordForward"_s      }, // Words
+    { "DeleteToBeginningOfLine"_s,      "DeleteToEndOfLine"_s      }, // Lines
+    { "DeleteToBeginningOfLine"_s,      "DeleteToEndOfLine"_s      }, // Line ends
+    { "DeleteToBeginningOfParagraph"_s, "DeleteToEndOfParagraph"_s }, // Paragraph ends
+    { "DeleteToBeginningOfParagraph"_s, "DeleteToEndOfParagraph"_s }, // Paragraphs
+    { nullptr,                          nullptr                    } // Whitespace (M-\ in Emacs)
+});
 
 static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType, gint count, KeyBindingTranslator* translator)
 {
     g_signal_stop_emission_by_name(widget, "delete-from-cursor");
     int direction = count > 0 ? 1 : 0;
-
-    // Ensuring that deleteType <= G_N_ELEMENTS here results in a compiler warning
-    // that the condition is always true.
 
     if (deleteType == GTK_DELETE_WORDS) {
         if (!direction) {
@@ -133,30 +128,18 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         translator->addPendingEditorCommand(rawCommand);
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static const char* const gtkMoveCommands[][4] = {
-    { "MoveBackward",                                   "MoveForward",
-      "MoveBackwardAndModifySelection",                 "MoveForwardAndModifySelection"             }, // Forward/backward grapheme
-    { "MoveLeft",                                       "MoveRight",
-      "MoveBackwardAndModifySelection",                 "MoveForwardAndModifySelection"             }, // Left/right grapheme
-    { "MoveWordBackward",                               "MoveWordForward",
-      "MoveWordBackwardAndModifySelection",             "MoveWordForwardAndModifySelection"         }, // Forward/backward word
-    { "MoveUp",                                         "MoveDown",
-      "MoveUpAndModifySelection",                       "MoveDownAndModifySelection"                }, // Up/down line
-    { "MoveToBeginningOfLine",                          "MoveToEndOfLine",
-      "MoveToBeginningOfLineAndModifySelection",        "MoveToEndOfLineAndModifySelection"         }, // Up/down line ends
-    { 0,                                                0,
-      "MoveParagraphBackwardAndModifySelection",        "MoveParagraphForwardAndModifySelection"    }, // Up/down paragraphs
-    { "MoveToBeginningOfParagraph",                     "MoveToEndOfParagraph",
-      "MoveToBeginningOfParagraphAndModifySelection",   "MoveToEndOfParagraphAndModifySelection"    }, // Up/down paragraph ends.
-    { "MovePageUp",                                     "MovePageDown",
-      "MovePageUpAndModifySelection",                   "MovePageDownAndModifySelection"            }, // Up/down page
-    { "MoveToBeginningOfDocument",                      "MoveToEndOfDocument",
-      "MoveToBeginningOfDocumentAndModifySelection",    "MoveToEndOfDocumentAndModifySelection"     }, // Begin/end of buffer
-    { 0,                                                0,
-      0,                                                0                                           } // Horizontal page movement
-};
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static constexpr auto gtkMoveCommands = std::to_array<std::array<ASCIILiteral, 4>>({
+    { "MoveBackward"_s,               "MoveForward"_s,          "MoveBackwardAndModifySelection"_s,               "MoveForwardAndModifySelection"_s          }, // Forward/backward grapheme
+    { "MoveLeft"_s,                   "MoveRight"_s,            "MoveBackwardAndModifySelection"_s,               "MoveForwardAndModifySelection"_s          }, // Left/right grapheme
+    { "MoveWordBackward"_s,           "MoveWordForward"_s,      "MoveWordBackwardAndModifySelection"_s,           "MoveWordForwardAndModifySelection"_s      }, // Forward/backward word
+    { "MoveUp"_s,                     "MoveDown"_s,             "MoveUpAndModifySelection"_s,                     "MoveDownAndModifySelection"_s             }, // Up/down line
+    { "MoveToBeginningOfLine"_s,      "MoveToEndOfLine"_s,      "MoveToBeginningOfLineAndModifySelection"_s,      "MoveToEndOfLineAndModifySelection"_s      }, // Up/down line ends
+    { nullptr,                        nullptr,                  "MoveParagraphBackwardAndModifySelection"_s,      "MoveParagraphForwardAndModifySelection"_s }, // Up/down paragraphs
+    { "MoveToBeginningOfParagraph"_s, "MoveToEndOfParagraph"_s, "MoveToBeginningOfParagraphAndModifySelection"_s, "MoveToEndOfParagraphAndModifySelection"_s }, // Up/down paragraph ends.
+    { "MovePageUp"_s,                 "MovePageDown"_s,         "MovePageUpAndModifySelection"_s,                 "MovePageDownAndModifySelection"_s         }, // Up/down page
+    { "MoveToBeginningOfDocument"_s,  "MoveToEndOfDocument"_s,  "MoveToBeginningOfDocumentAndModifySelection"_s,  "MoveToEndOfDocumentAndModifySelection"_s  }, // Begin/end of buffer
+    { nullptr,                        nullptr,                  nullptr,                                          nullptr                                    }, // Horizontal page movement
+});
 
 static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint count, gboolean extendSelection, KeyBindingTranslator* translator)
 {
@@ -212,42 +195,40 @@ struct KeyCombinationEntry {
     ASCIILiteral name;
 };
 
-static const KeyCombinationEntry customKeyBindings[] = {
-    { GDK_KEY_b,         GDK_CONTROL_MASK,                  "ToggleBold"_s      },
-    { GDK_KEY_i,         GDK_CONTROL_MASK,                  "ToggleItalic"_s    },
-    { GDK_KEY_Escape,    0,                                 "Cancel"_s          },
-    { GDK_KEY_greater,   GDK_CONTROL_MASK,                  "Cancel"_s          },
-    { GDK_KEY_Tab,       0,                                 "InsertTab"_s       },
-    { GDK_KEY_Tab,       GDK_SHIFT_MASK,                    "InsertBacktab"_s   },
-    { GDK_KEY_Return,    0,                                 "InsertNewLine"_s   },
-    { GDK_KEY_KP_Enter,  0,                                 "InsertNewLine"_s   },
-    { GDK_KEY_ISO_Enter, 0,                                 "InsertNewLine"_s   },
-    { GDK_KEY_Return,    GDK_SHIFT_MASK,                    "InsertLineBreak"_s },
-    { GDK_KEY_KP_Enter,  GDK_SHIFT_MASK,                    "InsertLineBreak"_s },
-    { GDK_KEY_ISO_Enter, GDK_SHIFT_MASK,                    "InsertLineBreak"_s },
-    { GDK_KEY_V,         GDK_CONTROL_MASK | GDK_SHIFT_MASK, "PasteAsPlainText"_s },
-};
+static constexpr auto customKeyBindings = std::to_array<const KeyCombinationEntry>({
+    { GDK_KEY_b,         GDK_CONTROL_MASK,                  "ToggleBold"_s       },
+    { GDK_KEY_i,         GDK_CONTROL_MASK,                  "ToggleItalic"_s     },
+    { GDK_KEY_Escape,    0,                                 "Cancel"_s           },
+    { GDK_KEY_greater,   GDK_CONTROL_MASK,                  "Cancel"_s           },
+    { GDK_KEY_Tab,       0,                                 "InsertTab"_s        },
+    { GDK_KEY_Tab,       GDK_SHIFT_MASK,                    "InsertBacktab"_s    },
+    { GDK_KEY_Return,    0,                                 "InsertNewLine"_s    },
+    { GDK_KEY_KP_Enter,  0,                                 "InsertNewLine"_s    },
+    { GDK_KEY_ISO_Enter, 0,                                 "InsertNewLine"_s    },
+    { GDK_KEY_Return,    GDK_SHIFT_MASK,                    "InsertLineBreak"_s  },
+    { GDK_KEY_KP_Enter,  GDK_SHIFT_MASK,                    "InsertLineBreak"_s  },
+    { GDK_KEY_ISO_Enter, GDK_SHIFT_MASK,                    "InsertLineBreak"_s  },
+    { GDK_KEY_V,         GDK_CONTROL_MASK | GDK_SHIFT_MASK, "PasteAsPlainText"_s }
+});
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static Vector<String> handleKeyBindingsForMap(const KeyCombinationEntry* map, unsigned mapSize, unsigned keyval, GdkModifierType state)
+static Vector<String> handleKeyBindingsForMap(const std::span<const KeyCombinationEntry> mapping, unsigned keyval, GdkModifierType state)
 {
     // For keypress events, we want charCode(), but keyCode() does that.
     unsigned mapKey = (state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) << 16 | keyval;
     if (!mapKey)
         return { };
 
-    for (unsigned i = 0; i < mapSize; ++i) {
-        if (mapKey == (map[i].state << 16 | map[i].gdkKeyCode))
-            return { map[i].name };
+    for (const auto& item : mapping) {
+        if (mapKey == (item.state << 16 | item.gdkKeyCode))
+            return { item.name };
     }
 
     return { };
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static Vector<String> handleCustomKeyBindings(unsigned keyval, GdkModifierType state)
 {
-    return handleKeyBindingsForMap(customKeyBindings, G_N_ELEMENTS(customKeyBindings), keyval, state);
+    return handleKeyBindingsForMap(std::span(customKeyBindings), keyval, state);
 }
 
 #if USE(GTK4)
@@ -279,7 +260,7 @@ Vector<String> KeyBindingTranslator::commandsForKeyEvent(GdkEventKey* event)
 }
 #endif
 
-static const KeyCombinationEntry predefinedKeyBindings[] = {
+static constexpr auto predefinedKeyBindings = std::to_array<const KeyCombinationEntry>({
     { GDK_KEY_Left,         0,                                 "MoveLeft"_s },
     { GDK_KEY_KP_Left,      0,                                 "MoveLeft"_s },
     { GDK_KEY_Left,         GDK_SHIFT_MASK,                    "MoveBackwardAndModifySelection"_s },
@@ -345,11 +326,11 @@ static const KeyCombinationEntry predefinedKeyBindings[] = {
     { GDK_KEY_KP_Delete,    GDK_SHIFT_MASK,                    "Cut"_s },
     { GDK_KEY_KP_Insert,    GDK_CONTROL_MASK,                  "Copy"_s },
     { GDK_KEY_KP_Insert,    GDK_SHIFT_MASK,                    "Paste"_s }
-};
+});
 
 Vector<String> KeyBindingTranslator::commandsForKeyval(unsigned keyval, unsigned modifiers)
 {
-    auto commands = handleKeyBindingsForMap(predefinedKeyBindings, G_N_ELEMENTS(predefinedKeyBindings), keyval, static_cast<GdkModifierType>(modifiers));
+    auto commands = handleKeyBindingsForMap(predefinedKeyBindings, keyval, static_cast<GdkModifierType>(modifiers));
     if (!commands.isEmpty())
         return commands;
 


### PR DESCRIPTION
#### 57c6ca3ab9ef6ce3b417d127ff0f592ce6493adc
<pre>
[GTK] Use std::array and ASCIILiteral in KeyBindingTranslator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282170">https://bugs.webkit.org/show_bug.cgi?id=282170</a>

Reviewed by Michael Catanzaro.

Convert gtkDeleteCommands, gtkMoveCommands, customKeyBindings, and
predefinedKeyBindings to use std::array, containing ASCIILiteral values
where appropriate.

* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
(WebKit::deleteFromCursorCallback): Remove comment about array bounds
checking now that they are using std::array.
(WebKit::handleKeyBindingsForMap): Receive a std::span instead of a raw
pointer and item count.
(WebKit::handleCustomKeyBindings): Adapt to pass a std::span.
(WebKit::KeyBindingTranslator::commandsForKeyval): Ditto.

Canonical link: <a href="https://commits.webkit.org/285804@main">https://commits.webkit.org/285804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b252a904961063b240d36d441ee98f6740654472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25106 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1082 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16436 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45045 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79757 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1185 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9583 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1149 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->