### PR TITLE
Always pass a span to String/StringImpl's createUninitialized()

### DIFF
--- a/Source/JavaScriptCore/runtime/FuzzerPredictions.cpp
+++ b/Source/JavaScriptCore/runtime/FuzzerPredictions.cpp
@@ -39,9 +39,9 @@ static String readFileIntoString(const char* fileName)
     RELEASE_ASSERT(bufferCapacity != -1);
     RELEASE_ASSERT(fseek(file, 0, SEEK_SET) != -1);
 
-    LChar* buffer;
+    std::span<LChar> buffer;
     String string = String::createUninitialized(bufferCapacity, buffer);
-    size_t readSize = fread(buffer, 1, bufferCapacity, file);
+    size_t readSize = fread(buffer.data(), 1, buffer.size(), file);
     fclose(file);
     RELEASE_ASSERT(readSize == static_cast<size_t>(bufferCapacity));
     return string;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -229,9 +229,9 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
         return { };
     }
 
-    LChar* buffer = nullptr;
+    std::span<LChar> buffer;
     auto result = StringImpl::createUninitialized(length * 2, buffer);
-    LChar* bufferEnd = buffer + length * 2;
+    LChar* bufferEnd = buffer.data() + length * 2;
     constexpr size_t stride = 8; // Because loading uint8x8_t.
     if (length >= stride) {
         auto encodeVector = [&](auto input) {
@@ -257,14 +257,14 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
         };
 
         const auto* cursor = data;
-        auto* output = buffer;
+        auto* output = buffer.data();
         for (; cursor + (stride - 1) < end; cursor += stride, output += stride * 2)
             simde_vst1q_u8(output, encodeVector(simde_vld1_u8(cursor)));
         if (cursor < end)
             simde_vst1q_u8(bufferEnd - stride * 2, encodeVector(simde_vld1_u8(end - stride)));
     } else {
         const auto* cursor = data;
-        auto* output = buffer;
+        auto* output = buffer.data();
         for (; cursor < end; cursor += 1, output += 2) {
             auto character = *cursor;
             *output = radixDigits[character / 16];

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -89,15 +89,15 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
         return JSValue::encode(jsSingleCharacterString(vm, code));
     }
 
-    LChar* buf8Bit;
+    std::span<LChar> buf8Bit;
     auto impl8Bit = StringImpl::createUninitialized(length, buf8Bit);
     for (unsigned i = 0; i < length; ++i) {
         UChar character = static_cast<UChar>(callFrame->uncheckedArgument(i).toUInt32(globalObject));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         if (UNLIKELY(!isLatin1(character))) {
-            UChar* buf16Bit;
+            std::span<UChar> buf16Bit;
             auto impl16Bit = StringImpl::createUninitialized(length, buf16Bit);
-            StringImpl::copyCharacters(buf16Bit, { buf8Bit, i });
+            StringImpl::copyCharacters(buf16Bit.data(), buf8Bit.first(i));
             buf16Bit[i] = character;
             ++i;
             for (; i < length; ++i) {

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -765,7 +765,6 @@ template<typename T, typename U, std::size_t Extent>
 constexpr std::span<T, Extent == std::dynamic_extent ? std::dynamic_extent : (sizeof(U) * Extent) / sizeof(T)> spanReinterpretCast(std::span<U, Extent> span)
 {
     static_assert(std::is_const_v<T> || (!std::is_const_v<T> && !std::is_const_v<U>), "spanReinterpretCast will not remove constness from source");
-    static_assert(!std::is_same_v<std::remove_const_t<T>, std::remove_const_t<U>>, "Unnecessary call to spanReinterpretCast");
 
     if constexpr (Extent == std::dynamic_extent) {
         if constexpr (sizeof(U) < sizeof(T) || sizeof(U) % sizeof(T))

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -54,9 +54,9 @@ String bytesAsString(CFURLRef url)
     auto bytesLength = CFURLGetBytes(url, nullptr, 0);
     RELEASE_ASSERT(bytesLength != -1);
     RELEASE_ASSERT(bytesLength <= static_cast<CFIndex>(String::MaxLength));
-    LChar* buffer;
+    std::span<LChar> buffer;
     auto result = String::createUninitialized(bytesLength, buffer);
-    CFURLGetBytes(url, buffer, bytesLength);
+    CFURLGetBytes(url, buffer.data(), buffer.size());
     return result;
 }
 

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -114,9 +114,9 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t 
     if (!decoder.bufferIsLargeEnoughToContain<CharacterType>(length))
         return std::nullopt;
 
-    CharacterType* buffer;
+    std::span<CharacterType> buffer;
     String string = String::createUninitialized(length, buffer);
-    if (!decoder.decodeFixedLengthData({ reinterpret_cast<uint8_t*>(buffer), length * sizeof(CharacterType) }))
+    if (!decoder.decodeFixedLengthData(spanReinterpretCast<uint8_t>(buffer)))
         return std::nullopt;
     
     return string;

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -143,10 +143,10 @@ struct HashedUTF8CharactersTranslator {
 
     static void translate(AtomStringTable::StringEntry& location, const HashedUTF8Characters& characters, unsigned hash)
     {
-        UChar* target;
+        std::span<UChar> target;
         auto newString = StringImpl::createUninitialized(characters.length.lengthUTF16, target);
 
-        auto result = Unicode::convert(characters.characters, { target, characters.length.lengthUTF16 });
+        auto result = Unicode::convert(characters.characters, target);
         RELEASE_ASSERT(result.code == Unicode::ConversionResultCode::Success);
 
         if (result.isAllASCII)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -270,10 +270,6 @@ public:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, std::span<LChar>&);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, std::span<UChar>&);
 
-    // FIXME: Port call sites to the overloads taking in a span and drop.
-    WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, LChar*&);
-    WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, UChar*&);
-
     template<typename CharacterType> static RefPtr<StringImpl> tryCreateUninitialized(size_t length, CharacterType*&);
 
     static Ref<StringImpl> createByReplacingInCharacters(std::span<const LChar>, UChar target, UChar replacement, size_t indexOfFirstTargetCharacter);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -449,9 +449,9 @@ CString String::utf8(ConversionMode mode) const
 
 String String::make8Bit(std::span<const UChar> source)
 {
-    LChar* destination;
+    std::span<LChar> destination;
     String result = String::createUninitialized(source.size(), destination);
-    StringImpl::copyCharacters(destination, source);
+    StringImpl::copyCharacters(destination.data(), source);
     return result;
 }
 
@@ -459,9 +459,9 @@ void String::convertTo16Bit()
 {
     if (isNull() || !is8Bit())
         return;
-    UChar* destination;
+    std::span<UChar> destination;
     auto convertedString = String::createUninitialized(length(), destination);
-    StringImpl::copyCharacters(destination, span8());
+    StringImpl::copyCharacters(destination.data(), span8());
     *this = WTFMove(convertedString);
 }
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -212,24 +212,6 @@ public:
     static String createUninitialized(unsigned length, std::span<UChar>& data) { return StringImpl::createUninitialized(length, data); }
     static String createUninitialized(unsigned length, std::span<LChar>& data) { return StringImpl::createUninitialized(length, data); }
 
-    // FIXME: Port call sites to the overload taking in a span and remove.
-    static String createUninitialized(unsigned length, UChar*& data)
-    {
-        std::span<UChar> span;
-        auto result = StringImpl::createUninitialized(length, span);
-        data = span.data();
-        return result;
-    }
-
-    // FIXME: Port call sites to the overload taking in a span and remove.
-    static String createUninitialized(unsigned length, LChar*& data)
-    {
-        std::span<LChar> span;
-        auto result = StringImpl::createUninitialized(length, span);
-        data = span.data();
-        return result;
-    }
-
     using SplitFunctor = WTF::Function<void(StringView)>;
 
     WTF_EXPORT_PRIVATE void split(UChar separator, const SplitFunctor&) const;

--- a/Source/WTF/wtf/win/LanguageWin.cpp
+++ b/Source/WTF/wtf/win/LanguageWin.cpp
@@ -44,9 +44,9 @@ static String localeInfo(LCTYPE localeType, const String& fallback)
     int localeChars = GetLocaleInfo(langID, localeType, nullptr, 0);
     if (!localeChars)
         return fallback;
-    UChar* localeNameBuf;
+    std::span<UChar> localeNameBuf;
     String localeName = String::createUninitialized(localeChars, localeNameBuf);
-    localeChars = GetLocaleInfo(langID, localeType, wcharFrom(localeNameBuf), localeChars);
+    localeChars = GetLocaleInfo(langID, localeType, wcharFrom(localeNameBuf.data()), localeChars);
     if (!localeChars)
         return fallback;
     if (localeName.isEmpty())

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3512,7 +3512,7 @@ private:
             str = String({ reinterpret_cast<const UChar*>(ptr), length });
         ptr += length * sizeof(UChar);
 #else
-        UChar* characters;
+        std::span<UChar> characters;
         str = String::createUninitialized(length, characters);
         for (unsigned i = 0; i < length; ++i) {
             uint16_t c;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -111,10 +111,10 @@ static String reversed(StringView string)
     auto length = string.length();
     if (length <= 1)
         return string.toString();
-    UChar* characters;
+    std::span<UChar> characters;
     auto result = String::createUninitialized(length, characters);
     for (unsigned i = 0; i < length; ++i)
-        *characters++ = string[length - i - 1];
+        characters[i] = string[length - i - 1];
     return result;
 }
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1680,7 +1680,7 @@ void RenderText::secureText(UChar maskingCharacter)
         }
     }
 
-    UChar* characters;
+    std::span<UChar> characters;
     m_text = String::createUninitialized(length, characters);
 
     for (unsigned i = 0; i < length; ++i)

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -63,7 +63,7 @@ template<typename T> struct Coder<T, typename std::enable_if_t<std::is_arithmeti
     }
     template<typename Decoder> static std::optional<T> decode(Decoder& decoder)
     {
-        if (T result; decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&result), sizeof(T)))
+        if (T result; decoder.decodeFixedLengthData(asMutableByteSpan(result)))
             return result;
         return std::nullopt;
     }
@@ -159,9 +159,9 @@ template<> struct Coder<WTF::String> {
         if (!decoder.template bufferIsLargeEnoughToContain<CharacterType>(length))
             return std::nullopt;
 
-        CharacterType* buffer;
+        std::span<CharacterType> buffer;
         String string = String::createUninitialized(length, buffer);
-        if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(buffer), length * sizeof(CharacterType)))
+        if (!decoder.decodeFixedLengthData(spanReinterpretCast<uint8_t>(buffer)))
             return std::nullopt;
 
         return string;

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DaemonDecoder.h"
 
+#include <wtf/StdLibExtras.h>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
@@ -42,12 +44,12 @@ bool Decoder::bufferIsLargeEnoughToContainBytes(size_t bytes) const
     return bytes <= m_buffer.size() - m_bufferPosition;
 }
 
-bool Decoder::decodeFixedLengthData(uint8_t* data, size_t size)
+bool Decoder::decodeFixedLengthData(std::span<uint8_t> data)
 {
-    if (!bufferIsLargeEnoughToContainBytes(size))
+    if (!bufferIsLargeEnoughToContainBytes(data.size()))
         return false;
-    memcpy(data, m_buffer.data() + m_bufferPosition, size);
-    m_bufferPosition += size;
+    memcpySpan(data, m_buffer.subspan(m_bufferPosition, data.size()));
+    m_bufferPosition += data.size();
     return true;
 }
 
@@ -55,9 +57,9 @@ std::span<const uint8_t> Decoder::decodeFixedLengthReference(size_t size)
 {
     if (!bufferIsLargeEnoughToContainBytes(size))
         return { };
-    const uint8_t* data = m_buffer.data() + m_bufferPosition;
+    auto data = m_buffer.subspan(m_bufferPosition, size);
     m_bufferPosition += size;
-    return { data, size };
+    return data;
 }
 
 } // namespace Daemon

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -59,7 +59,7 @@ public:
         return bufferIsLargeEnoughToContainBytes(numElements * sizeof(T));
     }
 
-    WARN_UNUSED_RETURN bool decodeFixedLengthData(uint8_t* data, size_t);
+    WARN_UNUSED_RETURN bool decodeFixedLengthData(std::span<uint8_t> data);
     std::span<const uint8_t> decodeFixedLengthReference(size_t);
 
 private:

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -221,11 +221,7 @@ inline std::span<const T> Decoder::decodeSpan(size_t size)
     }
 
     m_bufferPosition = m_buffer.begin() + alignedBufferPosition + bytesNeeded;
-
-    if constexpr (std::is_same_v<std::remove_const_t<T>, uint8_t>)
-        return m_buffer.subspan(alignedBufferPosition, bytesNeeded);
-    else
-        return spanReinterpretCast<const T>(m_buffer.subspan(alignedBufferPosition, bytesNeeded));
+    return spanReinterpretCast<const T>(m_buffer.subspan(alignedBufferPosition, bytesNeeded));
 }
 
 template<typename T>


### PR DESCRIPTION
#### 98dc165d6ab86086c87d419d5fbd8d198826e76d
<pre>
Always pass a span to String/StringImpl&apos;s createUninitialized()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282175">https://bugs.webkit.org/show_bug.cgi?id=282175</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/runtime/FuzzerPredictions.cpp:
(JSC::readFileIntoString):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::bytesAsString):
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::decodeStringText):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashedUTF8CharactersTranslator::translate):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit):
(WTF::StringImpl::convertToUppercaseWithoutLocaleUpconvert):
(WTF::StringImpl::convertToLowercaseWithLocale):
(WTF::StringImpl::convertToUppercaseWithLocale):
(WTF::StringImpl::replace):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.cpp:
(WTF::convertASCIICase):
(WTF::normalizedNFC):
(WTF::makeStringBySimplifyingNewLinesSlowCase):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::make8Bit):
(WTF::String::convertTo16Bit):
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/win/LanguageWin.cpp:
(WTF::localeInfo):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readString):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::reversed):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::secureText):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::String&gt;::decodeStringText):
* Source/WebKit/Platform/IPC/DaemonDecoder.cpp:
(WebKit::Daemon::Decoder::decodeFixedLengthData):
(WebKit::Daemon::Decoder::decodeFixedLengthReference):
* Source/WebKit/Platform/IPC/DaemonDecoder.h:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeSpan):

Canonical link: <a href="https://commits.webkit.org/285785@main">https://commits.webkit.org/285785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca204ec099ee332e47a2cfa379ae8373c0bcd05b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/977 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16402 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44955 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20964 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23334 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66900 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79652 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73021 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66375 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65654 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7699 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94802 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3794 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20849 "Found 2 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->