### PR TITLE
[JSC] Change Gigacage::Kind to an enum class

### DIFF
--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -98,17 +98,18 @@ void ensureGigacage()
             // alignment we need for freezing the Config.
             RELEASE_BASSERT(!(reinterpret_cast<size_t>(&WebConfig::g_config) & (vmPageSize() - 1)));
 
-            Kind shuffledKinds[NumberOfKinds];
-            for (unsigned i = 0; i < NumberOfKinds; ++i)
+            constexpr size_t numberOfKinds = static_cast<size_t>(NumberOfKinds);
+            Kind shuffledKinds[numberOfKinds];
+            for (unsigned i = 0; i < numberOfKinds; ++i)
                 shuffledKinds[i] = static_cast<Kind>(i);
             
             // We just go ahead and assume that 64 bits is enough randomness. That's trivially true right
             // now, but would stop being true if we went crazy with gigacages. Based on my math, 21 is the
             // largest value of n so that n! <= 2^64.
-            static_assert(NumberOfKinds <= 21, "too many kinds");
+            static_assert(numberOfKinds <= 21, "too many kinds");
             uint64_t random;
             cryptoRandom(reinterpret_cast<unsigned char*>(&random), sizeof(random));
-            for (unsigned i = NumberOfKinds; i--;) {
+            for (unsigned i = numberOfKinds; i--;) {
                 unsigned limit = i + 1;
                 unsigned j = static_cast<unsigned>(random % limit);
                 random /= limit;
@@ -186,7 +187,7 @@ void disablePrimitiveGigacage()
 
     ensureGigacage();
     disablePrimitiveGigacageRequested = true;
-    if (!g_gigacageConfig.basePtrs[Primitive]) {
+    if (!g_gigacageConfig.basePtrs[static_cast<size_t>(Primitive)]) {
         // It was never enabled. That means that we never even saved any callbacks. Or, we had already disabled
         // it before, and already called the callbacks.
         return;
@@ -202,7 +203,7 @@ void disablePrimitiveGigacage()
 void addPrimitiveDisableCallback(void (*function)(void*), void* argument)
 {
     ensureGigacage();
-    if (!g_gigacageConfig.basePtrs[Primitive]) {
+    if (!g_gigacageConfig.basePtrs[static_cast<size_t>(Primitive)]) {
         // It was already disabled or we were never able to enable it.
         function(argument);
         return;
@@ -230,7 +231,7 @@ void removePrimitiveDisableCallback(void (*function)(void*), void* argument)
 static bool verifyGigacageIsEnabled()
 {
     bool isEnabled = g_gigacageConfig.isEnabled;
-    for (size_t i = 0; i < NumberOfKinds; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(NumberOfKinds); ++i)
         isEnabled = isEnabled && g_gigacageConfig.basePtrs[i];
     isEnabled = isEnabled && g_gigacageConfig.start;
     isEnabled = isEnabled && g_gigacageConfig.totalSize;

--- a/Source/bmalloc/bmalloc/Gigacage.h
+++ b/Source/bmalloc/bmalloc/Gigacage.h
@@ -87,7 +87,7 @@ constexpr size_t gigacageSizeToMask(size_t size) { return size - 1; }
 constexpr size_t primitiveGigacageMask = gigacageSizeToMask(primitiveGigacageSize);
 
 // These constants are needed by the LLInt.
-constexpr ptrdiff_t offsetOfPrimitiveGigacageBasePtr = Kind::Primitive * sizeof(void*);
+constexpr ptrdiff_t offsetOfPrimitiveGigacageBasePtr = static_cast<ptrdiff_t>(Primitive) * sizeof(void*);
 
 extern "C" BEXPORT bool disablePrimitiveGigacageRequested;
 
@@ -129,7 +129,7 @@ BINLINE void* basePtr(Kind kind)
 BINLINE void* addressOfBasePtr(Kind kind)
 {
     RELEASE_BASSERT(kind < NumberOfKinds);
-    return &g_gigacageConfig.basePtrs[kind];
+    return &g_gigacageConfig.basePtrs[static_cast<size_t>(kind)];
 }
 
 BINLINE constexpr size_t maxSize(Kind kind)

--- a/Source/bmalloc/bmalloc/GigacageConfig.h
+++ b/Source/bmalloc/bmalloc/GigacageConfig.h
@@ -43,37 +43,37 @@ struct Config {
     void* basePtr(Kind kind) const
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        return basePtrs[kind];
+        return basePtrs[static_cast<size_t>(kind)];
     }
 
     void setBasePtr(Kind kind, void* ptr)
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        basePtrs[kind] = ptr;
+        basePtrs[static_cast<size_t>(kind)] = ptr;
     }
 
     void* allocBasePtr(Kind kind) const
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        return allocBasePtrs[kind];
+        return allocBasePtrs[static_cast<size_t>(kind)];
     }
 
     void setAllocBasePtr(Kind kind, void* ptr)
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        allocBasePtrs[kind] = ptr;
+        allocBasePtrs[static_cast<size_t>(kind)] = ptr;
     }
 
     size_t allocSize(Kind kind) const
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        return allocSizes[kind];
+        return allocSizes[static_cast<size_t>(kind)];
     }
 
     void setAllocSize(Kind kind, size_t size)
     {
         RELEASE_BASSERT(kind < NumberOfKinds);
-        allocSizes[kind] = size;
+        allocSizes[static_cast<size_t>(kind)] = size;
     }
 
     // All the fields in this struct should be chosen such that their
@@ -93,9 +93,9 @@ struct Config {
 
     void* start;
     size_t totalSize;
-    void* basePtrs[NumberOfKinds];
-    void* allocBasePtrs[NumberOfKinds];
-    size_t allocSizes[NumberOfKinds];
+    void* basePtrs[static_cast<size_t>(NumberOfKinds)];
+    void* allocBasePtrs[static_cast<size_t>(NumberOfKinds)];
+    size_t allocSizes[static_cast<size_t>(NumberOfKinds)];
 };
 
 // The first 4 slots are reserved for the use of the ExecutableAllocator.

--- a/Source/bmalloc/bmalloc/GigacageKind.h
+++ b/Source/bmalloc/bmalloc/GigacageKind.h
@@ -27,9 +27,11 @@
 
 namespace Gigacage {
 
-enum Kind {
-    Primitive,
+enum class Kind {
+    Primitive = 0,
     NumberOfKinds
 };
+
+using enum Kind;
 
 } // namespace Gigacage

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -45,7 +45,7 @@ namespace {
 static const bmalloc_type primitiveGigacageType = BMALLOC_TYPE_INITIALIZER(1, 1, "Primitive Gigacage");
 } // anonymous namespace
 
-pas_primitive_heap_ref gigacageHeaps[Gigacage::NumberOfKinds] = {
+pas_primitive_heap_ref gigacageHeaps[static_cast<size_t>(Gigacage::NumberOfKinds)] = {
     BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&primitiveGigacageType),
 };
 #endif

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -49,12 +49,12 @@ namespace bmalloc {
 namespace api {
 
 #if BUSE(LIBPAS)
-extern pas_primitive_heap_ref gigacageHeaps[Gigacage::NumberOfKinds];
+extern pas_primitive_heap_ref gigacageHeaps[static_cast<size_t>(Gigacage::NumberOfKinds)];
 
 inline pas_primitive_heap_ref& heapForKind(Gigacage::Kind kind)
 {
-    RELEASE_BASSERT(static_cast<unsigned>(kind) < Gigacage::NumberOfKinds);
-    return gigacageHeaps[static_cast<unsigned>(kind)];
+    RELEASE_BASSERT(static_cast<size_t>(kind) < static_cast<size_t>(Gigacage::NumberOfKinds));
+    return gigacageHeaps[static_cast<size_t>(kind)];
 }
 #endif
 


### PR DESCRIPTION
#### cd44912a57e9f39ae77669d1b140deb1bc61bf6d
<pre>
[JSC] Change Gigacage::Kind to an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=282123">https://bugs.webkit.org/show_bug.cgi?id=282123</a>
<a href="https://rdar.apple.com/138671348">rdar://138671348</a>

Reviewed by Keith Miller.

This prevents the compiler from coercing an `int` parameter to
Gigacage::Kind in bmalloc::heapKind.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetIndexedPropertyStorage):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
(JSC::Heap::gigacageAuxiliarySpace):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::cageConditionally):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::toBigInt64):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::primitiveGigacageDestructor):
(JSC::ArrayBufferContents::tryAllocate):
(JSC::ArrayBuffer::createFromBytes):
(JSC::ArrayBufferContents::fromSpan):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::freeFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::freeGrowableBoundsCheckingMemory):
(JSC::BufferMemoryHandle::nullBasePointer):
(JSC::BufferMemoryHandle::~BufferMemoryHandle):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/GenericArguments.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::ConstructionContext::ConstructionContext):
(JSC::JSArrayBufferView::finalize):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::loadWebAssemblyGlobalState):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::restoreWebAssemblyGlobalStateAfterWasmCall):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::grow):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::reloadMemoryRegistersFromInstance):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::reloadMemoryRegistersFromInstance):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmJITShared):
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
(Gigacage::disablePrimitiveGigacage):
(Gigacage::addPrimitiveDisableCallback):
(Gigacage::verifyGigacageIsEnabled):
* Source/bmalloc/bmalloc/Gigacage.h:
(Gigacage::name):
(Gigacage::isEnabled):
(Gigacage::addressOfBasePtr):
(Gigacage::maxSize):
(Gigacage::forEachKind):
* Source/bmalloc/bmalloc/GigacageConfig.h:
(Gigacage::Config::basePtr const):
(Gigacage::Config::setBasePtr):
(Gigacage::Config::allocBasePtr const):
(Gigacage::Config::setAllocBasePtr):
(Gigacage::Config::allocSize const):
(Gigacage::Config::setAllocSize):
* Source/bmalloc/bmalloc/GigacageKind.h:
(): Deleted.
* Source/bmalloc/bmalloc/HeapKind.h:
(bmalloc::gigacageKind):
(bmalloc::heapKind):
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::mallocOutOfLine):
* Source/bmalloc/bmalloc/bmalloc.h:
(bmalloc::api::heapForKind):

Canonical link: <a href="https://commits.webkit.org/285829@main">https://commits.webkit.org/285829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf6b6f040f15d0b3522088fd65deaaa946fec8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25053 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58111 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23386 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66952 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79704 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73073 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63528 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65673 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7733 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94854 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1096 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20854 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->