### PR TITLE
Build fixes for !ENABLE(VIDEO)

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -171,11 +171,12 @@ private:
 
 #if ENABLE(VIDEO)
     GPUExternalTexture* externalTextureForDescriptor(const GPUExternalTextureDescriptor&);
-#endif
 
     WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>> m_videoElementToExternalTextureMap;
     std::pair<RefPtr<HTMLVideoElement>, RefPtr<GPUExternalTexture>> m_previouslyImportedExternalTexture;
     std::pair<Vector<GPUBindGroupEntry>, RefPtr<GPUBindGroup>> m_lastCreatedExternalTextureBindGroup;
+#endif
+
     bool m_waitingForDeviceLostPromise { false };
 };
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1084,10 +1084,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             return matchesAnimatingFullscreenTransitionPseudoClass(element);
         case CSSSelector::PseudoClass::InternalFullscreenDocument:
             return matchesFullscreenDocumentPseudoClass(element);
-#if ENABLE(VIDEO)
         case CSSSelector::PseudoClass::InternalInWindowFullscreen:
             return matchesInWindowFullscreenPseudoClass(element);
-#endif
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
         case CSSSelector::PseudoClass::PictureInPicture:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -425,16 +425,19 @@ ALWAYS_INLINE bool matchesFullscreenDocumentPseudoClass(const Element& element)
     return fullscreenManager && fullscreenManager->fullscreenElement();
 }
 
-#if ENABLE(VIDEO)
 ALWAYS_INLINE bool matchesInWindowFullscreenPseudoClass(const Element& element)
 {
+#if ENABLE(VIDEO)
     if (&element != element.document().fullscreenManager().currentFullscreenElement())
         return false;
 
     auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
     return mediaElement && mediaElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
-}
+#else
+    UNUSED_PARAM(element);
+    return false;
 #endif
+}
 
 #endif
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -914,13 +914,11 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesAnimatingFullscreenTransitionP
     return matchesAnimatingFullscreenTransitionPseudoClass(element);
 }
 
-#if ENABLE(VIDEO)
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesInWindowFullscreenPseudoClass, bool, (const Element& element))
 {
     COUNT_SELECTOR_OPERATION(operationMatchesInWindowFullscreenPseudoClass);
     return matchesInWindowFullscreenPseudoClass(element);
 }
-#endif
 
 #endif
 
@@ -1126,11 +1124,9 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesAnimatingFullscreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-#if ENABLE(VIDEO)
     case CSSSelector::PseudoClass::InternalInWindowFullscreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesInWindowFullscreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-#endif
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8793,7 +8793,7 @@ Element* eventTargetElementForDocument(Document* document)
 {
     if (!document)
         return nullptr;
-#if ENABLE(FULLSCREEN_API)
+#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO)
     if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists(); fullscreenManager && fullscreenManager->isFullscreen() && is<HTMLVideoElement>(fullscreenManager->currentFullscreenElement()))
         return fullscreenManager->currentFullscreenElement();
 #endif

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -462,6 +462,10 @@ bool FullscreenManager::isFullscreenEnabled() const
 
 bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
+#if !ENABLE(VIDEO)
+    UNUSED_PARAM(mode);
+#endif
+
     if (backForwardCacheState() != Document::NotInBackForwardCache) {
         ERROR_LOG(LOGIDENTIFIER, "Document in the BackForwardCache; bailing");
         return false;

--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
@@ -796,30 +796,5 @@ String DiagnosticLoggingKeys::audioCodecKey()
     return "audioCodec"_s;
 }
 
-String DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType sourceType)
-{
-    switch (sourceType) {
-    case HTMLMediaElementSourceType::File:
-        return "file"_s;
-    case HTMLMediaElementSourceType::HLS:
-        return "hls"_s;
-    case HTMLMediaElementSourceType::MediaSource:
-        return "mediaSource"_s;
-    case HTMLMediaElementSourceType::ManagedMediaSource:
-        return "managedMediaSource"_s;
-    case HTMLMediaElementSourceType::MediaStream:
-        return "mediaStream"_s;
-    case HTMLMediaElementSourceType::LiveStream:
-        return "liveStream"_s;
-    case HTMLMediaElementSourceType::StoredStream:
-        return "storedStream"_s;
-    }
-
-    ASSERT_NOT_REACHED();
-    return nullString();
-}
-
-
-
 } // namespace WebCore
 

--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
@@ -182,8 +182,6 @@ public:
     WEBCORE_EXPORT static String memoryUsageToDiagnosticLoggingKey(uint64_t memoryUsage);
     WEBCORE_EXPORT static String foregroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
     WEBCORE_EXPORT static String backgroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
-
-    static String mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -620,6 +620,7 @@ static String searchableTextForTarget(Element& target)
 
 static bool hasAudibleMedia(const Element& element)
 {
+#if ENABLE(VIDEO)
     if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
         return media->isAudible();
 
@@ -632,6 +633,9 @@ static bool hasAudibleMedia(const Element& element)
         if (hasAudibleMedia(documentElement))
             return true;
     }
+#else
+    UNUSED_PARAM(element);
+#endif
 
     return false;
 }
@@ -644,8 +648,10 @@ static URL urlForElement(const Element& element)
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
         return image->currentURL();
 
+#if ENABLE(VIDEO)
     if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
         return media->currentSrc();
+#endif
 
     if (CheckedPtr renderer = element.renderer()) {
         if (auto& style = renderer->style(); style.hasBackgroundImage()) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -480,9 +480,11 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
                 // in order to compute static position for out of flow boxes, the parent has to run normal flow layout as well (as opposed to simplified)
                 if (newChild->containingBlock() != &parent)
                     return false;
+#if ENABLE(VIDEO)
                 // FIXME: RenderVideo's setNeedsLayout pattern does not play well with this optimization: see webkit.org/b/276253
                 if (is<RenderVideo>(*newChild))
                     return false;
+#endif
                 // Since we can't actually run static position only layout for a block container (RenderBlockFlow::layoutBlock() does not have such fine grained layout flow)
                 // floats get rebuilt which assumes (see intruding floats) parent block containers do the same.
                 if (auto* renderBlock = dynamicDowncast<RenderBlock>(parent))

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7686,10 +7686,12 @@ const String& Internals::defaultSpatialTrackingLabel() const
     return nullString();
 }
 
+#if ENABLE(VIDEO)
 bool Internals::isEffectivelyMuted(const HTMLMediaElement& element)
 {
     return element.effectiveMuted();
 }
+#endif
 
 std::optional<RenderingMode> Internals::getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer()
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1504,7 +1504,9 @@ public:
 
     const String& defaultSpatialTrackingLabel() const;
 
+#if ENABLE(VIDEO)
     bool isEffectivelyMuted(const HTMLMediaElement&);
+#endif
 
     using RenderingMode = WebCore::RenderingMode;
     std::optional<RenderingMode> getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1410,7 +1410,7 @@ enum RenderingMode {
 
     readonly attribute DOMString defaultSpatialTrackingLabel;
 
-    boolean isEffectivelyMuted(HTMLMediaElement element);
+    [Conditional=VIDEO] boolean isEffectivelyMuted(HTMLMediaElement element);
 
     RenderingMode? getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
     Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -438,8 +438,10 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
 #endif
 
+#if ENABLE(VIDEO)
     if (RefPtr remoteMediaResourceManager = m_remoteMediaResourceManager)
         remoteMediaResourceManager->stopListeningForIPC();
+#endif
 
     Ref gpuProcess = this->gpuProcess();
     gpuProcess->connectionToWebProcessClosed(connection);

--- a/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "VideoLayerRemote.h"
 
-#if ENABLE(GPU_PROCESS)
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PlatformLayer.h>


### PR DESCRIPTION
#### 4543a47d611c6f7e8f2640621c1c19c5835f3664
<pre>
Build fixes for !ENABLE(VIDEO)
<a href="https://bugs.webkit.org/show_bug.cgi?id=281253">https://bugs.webkit.org/show_bug.cgi?id=281253</a>

Reviewed by Sihui Liu and Darin Adler.

Reland 285114@main without breaking -internal-in-window-fullscreen CSS property

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
    Flag variables only used with ENABLE(VIDEO)
        m_videoElementToExternalTextureMap
        m_previouslyImportedExternalTexture
        m_lastCreatedExternalTextureBindGroup

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesInWindowFullscreenPseudoClass):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
    Allow -internal-in-window-fullscreen to avoid warning in Selector switches

* Source/WebCore/dom/Document.cpp:
(WebCore::eventTargetElementForDocument):
    Flag HTMLVideoElement check

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
    Fix unused variable warning

* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
(WebCore::DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey): Deleted.
* Source/WebCore/page/DiagnosticLoggingKeys.h:
    Remove unused mediaElementSourceTypeDiagnosticLoggingKey after 282029@main

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::hasAudibleMedia):
(WebCore::urlForElement):
    Flag HTMLMediaElement usage

* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
    Flag RenderVideo check

* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
    Make isEffectivelyMuted conditional since it uses HTMLMediaElement

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
    m_remoteMediaResourceManager is defined only with ENABLE(VIDEO)

* Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp:
    Flag the whole file under ENABLE(VIDEO) like other media GPU Process files

Canonical link: <a href="https://commits.webkit.org/286070@main">https://commits.webkit.org/286070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd60fb52865e3b9ef21e5d7ca96d64c43e94f57b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58721 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17003 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21745 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24336 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66272 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8372 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2048 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->