### PR TITLE
Null pointer dereference in IndexValueStore::Iterator::nextIndexEntry

### DIFF
--- a/LayoutTests/storage/indexeddb/cursor-continue-add-failure-expected.txt
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-failure-expected.txt
@@ -1,0 +1,20 @@
+Adding record fails during cursor iteration.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+cursorRequest = scoreIndex.openCursor(null, 'nextunique')
+cursor = event.target.result
+PASS cursor.key is 100
+cursor.continue()
+cursor = event.target.result
+PASS cursor.key is 200
+cursor.continue()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/cursor-continue-add-failure-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-failure-private-expected.txt
@@ -1,0 +1,20 @@
+Adding record fails during cursor iteration.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+cursorRequest = scoreIndex.openCursor(null, 'nextunique')
+cursor = event.target.result
+PASS cursor.key is 100
+cursor.continue()
+cursor = event.target.result
+PASS cursor.key is 200
+cursor.continue()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/cursor-continue-add-failure-private.html
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-failure-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/cursor-continue-add-failure.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/cursor-continue-add-failure.html
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-failure.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/cursor-continue-add-failure.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/cursor-continue-add-failure.js
+++ b/LayoutTests/storage/indexeddb/resources/cursor-continue-add-failure.js
@@ -1,0 +1,41 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Adding record fails during cursor iteration.");
+
+function prepareDatabase()
+{
+    database = event.target.result;
+    transaction = event.target.transaction;
+    // Transaction will be aborted due to failed request.
+    transaction.onabort = finishJSTest;
+
+    objectStore = database.createObjectStore('records', {autoIncrement: true});
+    objectStore.add({userid:10, score:100}).onerror = unexpectedErrorCallback;
+    objectStore.add({userid:20, score:200}).onerror = unexpectedErrorCallback;
+    objectStore.add({userid:30, score:200}).onerror = unexpectedErrorCallback;
+
+    // Different users can have same score.
+    scoreIndex = objectStore.createIndex('index1', 'score', {unique: false});
+    // One user can only have one record.
+    userIndex = objectStore.createIndex('index2', 'userid', {unique: true});
+
+    expectedScores = [100, 200];
+    evalAndLog("cursorRequest = scoreIndex.openCursor(null, 'nextunique')");
+    cursorRequest.onsuccess = (event) => {
+        evalAndLog("cursor = event.target.result");
+        if (cursor) {
+            shouldBe("cursor.key", expectedScores.shift().toString());
+            if (cursor.key == 200) {
+                // This insertion should fail because user cannot have two records.
+                addRequest = objectStore.add({userid:30, score:300});
+                addRequest.onsuccess = unexpectedSuccessCallback;
+            }
+            evalAndLog("cursor.continue()");
+        }
+    }
+}
+
+indexedDBTest(prepareDatabase);

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -107,8 +107,10 @@ void IndexValueStore::removeRecord(const IDBKeyData& indexKey, const IDBKeyData&
     if (!iterator->value)
         return;
 
-    if (iterator->value->removeKey(valueKey))
+    if (iterator->value->removeKey(valueKey)) {
         m_records.remove(iterator);
+        m_orderedKeys.erase(indexKey);
+    }
 }
 
 void IndexValueStore::removeEntriesWithValueKey(MemoryIndex& index, const IDBKeyData& valueKey)


### PR DESCRIPTION
#### 5352e86541903824cd9b009ee7c0839ecf4b1b45
<pre>
Null pointer dereference in IndexValueStore::Iterator::nextIndexEntry
<a href="https://bugs.webkit.org/show_bug.cgi?id=282186">https://bugs.webkit.org/show_bug.cgi?id=282186</a>
<a href="https://rdar.apple.com/136799874">rdar://136799874</a>

Reviewed by Chris Dumez.

Ensure IndexValueStore::removeRecord updates m_orderedKeys when it updates m_records, otherwise when we retrieve record
from m_records with key from m_orderedKeys (like in IndexValueStore::Iterator::nextIndexEntry), there can be null
pointer derererence.

New tests:
LayoutTests/storage/indexeddb/cursor-continue-add-failure.html
LayoutTests/storage/indexeddb/cursor-continue-add-failure-private.html

* LayoutTests/storage/indexeddb/cursor-continue-add-failure-expected.txt: Added.
* LayoutTests/storage/indexeddb/cursor-continue-add-failure-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/cursor-continue-add-failure-private.html: Added.
* LayoutTests/storage/indexeddb/cursor-continue-add-failure.html: Added.
* LayoutTests/storage/indexeddb/resources/cursor-continue-add-failure.js: Added.
(prepareDatabase):
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::removeRecord):

Canonical link: <a href="https://commits.webkit.org/285814@main">https://commits.webkit.org/285814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dd41cfb57d6b3de86f0784c0a4fd56a7cf7df30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65664 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7715 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3832 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->