### PR TITLE
Remove current IBL resource if empty or incorrect URL provided.

### DIFF
--- a/LayoutTests/model-element/model-element-environment-map-ready-expected.txt
+++ b/LayoutTests/model-element/model-element-environment-map-ready-expected.txt
@@ -3,4 +3,5 @@ PASS <model> rejects the environmentMapReady promise when provided with an unkno
 PASS <model> rejects the environmentMapReady promise when provided with an unknown resource via JS environmentMap.
 PASS <model> rejects the environmentMapReady promise when its environmentMap load is aborted.
 PASS <model> resolves the environmentMapReady promise when provided with a known resource.
+PASS <model> resolves the environmentMapReady promise when new model resource is loaded.
 

--- a/LayoutTests/model-element/model-element-environment-map-ready.html
+++ b/LayoutTests/model-element/model-element-environment-map-ready.html
@@ -51,5 +51,17 @@ promise_test(async t => {
     await model.environmentMapReady;
 }, `<model> resolves the environmentMapReady promise when provided with a known resource.`);
 
+promise_test(async t => {
+    const blueResource = "resources/blue.hdr";
+
+    const [model, source] = createModelWithAttributesAndSource(t, {environmentmap: blueResource }, "resources/cube.usdz");
+    assert_true(model.environmentMap.includes(blueResource));
+    await model.environmentMapReady;
+
+    model.children[0].src = "resources/heart.usdz"
+    assert_true(model.environmentMap.includes(blueResource));
+    await model.environmentMapReady;
+}, `<model> resolves the environmentMapReady promise when new model resource is loaded.`);
+
 </script>
 </body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -307,6 +307,8 @@ void HTMLModelElement::createModelPlayer()
 #if ENABLE(MODEL_PROCESS)
     if (m_pendingEnvironmentMapData)
         m_modelPlayer->setEnvironmentMap(m_pendingEnvironmentMapData.takeAsContiguous().get());
+    else if (!m_environmentMapURL.isEmpty())
+        environmentMapRequestResource();
 #endif
 }
 
@@ -444,9 +446,14 @@ void HTMLModelElement::didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D& ce
     m_boundingBoxExtents = DOMPointReadOnly::fromFloatPoint(extents);
 }
 
-void HTMLModelElement::didFinishEnvironmentMapLoading()
+void HTMLModelElement::didFinishEnvironmentMapLoading(bool succeeded)
 {
-    m_environmentMapReadyPromise->resolve();
+    if (!m_environmentMapReadyPromise->isFulfilled()) {
+        if (succeeded)
+            m_environmentMapReadyPromise->resolve();
+        else
+            m_environmentMapReadyPromise->reject(Exception { ExceptionCode::AbortError });
+    }
 }
 #endif // ENABLE(MODEL_PROCESS)
 
@@ -698,18 +705,41 @@ void HTMLModelElement::setEnvironmentMap(const URL& url)
 
     m_environmentMapURL = url;
 
-    m_pendingEnvironmentMapData.reset();
-
-    if (m_environmentMapResource) {
-        m_environmentMapResource->removeClient(*this);
-        m_environmentMapResource = nullptr;
-    }
-
-    if (!m_environmentMapReadyPromise->isFulfilled())
-        m_environmentMapReadyPromise->reject(Exception { ExceptionCode::AbortError });
-
+    environmentMapResetAndReject(Exception { ExceptionCode::AbortError });
     m_environmentMapReadyPromise = makeUniqueRef<EnvironmentMapPromise>();
 
+    if (m_environmentMapURL.isEmpty()) {
+        // sending a message with empty data to indicate resource removal
+        if (m_modelPlayer)
+            m_modelPlayer->setEnvironmentMap(SharedBuffer::create());
+        return;
+    }
+
+    environmentMapRequestResource();
+}
+
+void HTMLModelElement::updateEnvironmentMap()
+{
+    setEnvironmentMap(selectEnvironmentMapURL());
+}
+
+URL HTMLModelElement::selectEnvironmentMapURL() const
+{
+    if (!document().hasBrowsingContext())
+        return { };
+
+    if (hasAttributeWithoutSynchronization(environmentmapAttr)) {
+        const auto& attr = attributeWithoutSynchronization(environmentmapAttr).string().trim(isASCIIWhitespace);
+        if (StringView(attr).containsOnly<isASCIIWhitespace<UChar>>())
+            return { };
+        return getURLAttribute(environmentmapAttr);
+    }
+
+    return { };
+}
+
+void HTMLModelElement::environmentMapRequestResource()
+{
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.destination = FetchOptions::Destination::Environmentmap;
 
@@ -733,32 +763,24 @@ void HTMLModelElement::setEnvironmentMap(const URL& url)
     m_environmentMapResource->addClient(*this);
 }
 
-void HTMLModelElement::updateEnvironmentMap()
+void HTMLModelElement::environmentMapResetAndReject(Exception&& exception)
 {
-    setEnvironmentMap(selectEnvironmentMapURL());
-}
+    m_pendingEnvironmentMapData.reset();
 
-URL HTMLModelElement::selectEnvironmentMapURL() const
-{
-    if (!document().hasBrowsingContext())
-        return { };
+    if (m_environmentMapResource) {
+        m_environmentMapResource->removeClient(*this);
+        m_environmentMapResource = nullptr;
+    }
 
-    if (hasAttributeWithoutSynchronization(environmentmapAttr))
-        return getURLAttribute(environmentmapAttr);
-
-    return { };
+    if (!m_environmentMapReadyPromise->isFulfilled())
+        m_environmentMapReadyPromise->reject(WTFMove(exception));
 }
 
 void HTMLModelElement::environmentMapResourceFinished()
 {
-    if (m_environmentMapResource->loadFailedOrCanceled()) {
-        m_pendingEnvironmentMapData.reset();
-
-        m_environmentMapResource->removeClient(*this);
-        m_environmentMapResource = nullptr;
-
-        if (!m_environmentMapReadyPromise->isFulfilled())
-            m_environmentMapReadyPromise->reject(Exception { ExceptionCode::NetworkError });
+    int status = m_environmentMapResource->response().httpStatusCode();
+    if (m_environmentMapResource->loadFailedOrCanceled() || (status && (status < 200 || status > 299))) {
+        environmentMapResetAndReject(Exception { ExceptionCode::NetworkError });
 
         // sending a message with empty data to indicate resource removal
         if (m_modelPlayer)

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -196,7 +196,7 @@ private:
 #if ENABLE(MODEL_PROCESS)
     void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) final;
     void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) final;
-    void didFinishEnvironmentMapLoading() final;
+    void didFinishEnvironmentMapLoading(bool succeeded) final;
 #endif
     std::optional<PlatformLayerIdentifier> platformLayerID() final;
 
@@ -218,6 +218,8 @@ private:
     void updateLoop();
     void updateEnvironmentMap();
     URL selectEnvironmentMapURL() const;
+    void environmentMapRequestResource();
+    void environmentMapResetAndReject(Exception&&);
     void environmentMapResourceFinished();
 #endif
     void modelResourceFinished();

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -56,7 +56,7 @@ public:
 #if ENABLE(MODEL_PROCESS)
     virtual void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) = 0;
     virtual void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) = 0;
-    virtual void didFinishEnvironmentMapLoading() = 0;
+    virtual void didFinishEnvironmentMapLoading(bool succeeded) = 0;
 #endif
     virtual std::optional<PlatformLayerIdentifier> platformLayerID() = 0;
 };

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -583,12 +583,15 @@ void ModelProcessModelPlayerProxy::setEnvironmentMap(Ref<WebCore::SharedBuffer>&
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()
 {
     if (m_environmentMapData) {
-        if (m_environmentMapData->size() > 0)
-            [m_modelRKEntity applyIBLData:m_environmentMapData->createNSData().get()];
-        else
+        if (m_environmentMapData->size() > 0) {
+            [m_modelRKEntity applyIBLData:m_environmentMapData->createNSData().get() withCompletion:^(BOOL succeeded) {
+                send(Messages::ModelProcessModelPlayer::DidFinishEnvironmentMapLoading(succeeded));
+            }];
+        } else {
             [m_modelRKEntity removeIBL];
+            send(Messages::ModelProcessModelPlayer::DidFinishEnvironmentMapLoading(true));
+        }
         m_environmentMapData = nullptr;
-        send(Messages::ModelProcessModelPlayer::DidFinishEnvironmentMapLoading());
     }
 }
 

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -187,14 +187,16 @@ public final class WKSRKEntity: NSObject {
         }
     }
 
-    @objc(applyIBLData:) public func applyIBL(data: Data) {
+    @objc(applyIBLData:withCompletion:) public func applyIBL(data: Data, completion: @escaping (Bool) -> Void) {
 #if canImport(RealityKit, _version: 366)
         guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else {
             Logger.realityKitEntity.error("Cannot get CGImageSource from IBL image data")
+            completion(false)
             return
         }
         guard let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
             Logger.realityKitEntity.error("Cannot get CGImage from CGImageSource")
+            completion(false)
             return
         }
 
@@ -207,8 +209,10 @@ public final class WKSRKEntity: NSObject {
                     entity.components[ImageBasedLightComponent.self] = .init(source: .single(environment))
                     entity.components[ImageBasedLightReceiverComponent.self] = .init(imageBasedLight: entity)
                 }
+                completion(true)
             } catch {
                 Logger.realityKitEntity.error("Cannot load environment resource from CGImage")
+                completion(false)
             }
         }
 #endif

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -58,7 +58,7 @@ typedef struct {
 
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
-- (void)applyIBLData:(NSData *)data;
+- (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)removeIBL;
 @end
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -107,9 +107,9 @@ void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(bool isPaused, dou
     m_lastCachedClockTimestamp = clockTimestamp;
 }
 
-void ModelProcessModelPlayer::didFinishEnvironmentMapLoading()
+void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 {
-    m_client->didFinishEnvironmentMapLoading();
+    m_client->didFinishEnvironmentMapLoading(succeeded);
 }
 
 // MARK: - WebCore::ModelPlayer
@@ -319,9 +319,6 @@ void ModelProcessModelPlayer::setCurrentTime(Seconds currentTime, CompletionHand
 
 void ModelProcessModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
 {
-    if (data->isEmpty())
-        return;
-
     send(Messages::ModelProcessModelPlayerProxy::SetEnvironmentMap(WTFMove(data)));
 }
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -64,7 +64,7 @@ private:
     void didFinishLoading(const WebCore::FloatPoint3D&, const WebCore::FloatPoint3D&);
     void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
     void didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
-    void didFinishEnvironmentMapLoading();
+    void didFinishEnvironmentMapLoading(bool succeeded);
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -27,7 +27,7 @@ messages -> ModelProcessModelPlayer {
     [EnabledIf='modelProcessEnabled()'] DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
     [EnabledIf='modelProcessEnabled()'] DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
     [EnabledIf='modelProcessEnabled()'] DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
-    [EnabledIf='modelProcessEnabled()'] DidFinishEnvironmentMapLoading()
+    [EnabledIf='modelProcessEnabled()'] DidFinishEnvironmentMapLoading(bool succeeded)
 }
 
 #endif // ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### 2d152608cf6e96e894c616aa7702aa768b6c4365
<pre>
Remove current IBL resource if empty or incorrect URL provided.

<a href="https://bugs.webkit.org/show_bug.cgi?id=282182">https://bugs.webkit.org/show_bug.cgi?id=282182</a>
<a href="https://rdar.apple.com/137812845">rdar://137812845</a>

Reviewed by Ada Chan.

These changes make sure that an empty URL removes provided IBL lighting and
resolves environmentMapPromise. An invalid URL removes IBL lighting as well but
rejects environmentMapPromise.
Also, WKSRKEntity::applyIBL takes a completion handler to provide result of
the asynchronous call. The result is propagated all the way to HTMLModelElement
via didFinishEnvironmentMapLoading(bool).
Last but not least, when environment map resource/URL is provided before model
data is ready, the environment lighting will be applied to the model. That covers
a case when model resource is changed but environment map stays the same.

Canonical link: <a href="https://commits.webkit.org/285878@main">https://commits.webkit.org/285878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/381ca0c214b2c4657da8e5bf4a3a38b40dfccaef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58206 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16568 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38617 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7896 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1336 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->