### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebKit/Shared

### DIFF
--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -32,16 +32,15 @@
 #include <WebCore/SharedMemory.h>
 #include <wtf/Atomics.h>
 #include <wtf/Function.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace WebKit {
 
 class SharedCARingBufferBase : public WebCore::CARingBuffer {
 protected:
     SharedCARingBufferBase(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStream, Ref<WebCore::SharedMemory>);
-    void* data() final { return byteCast<Byte>(m_storage->mutableSpan().data()) + sizeof(TimeBoundsBuffer); }
-    TimeBoundsBuffer& timeBoundsBuffer() final { return *reinterpret_cast<TimeBoundsBuffer*>(m_storage->mutableSpan().data()); }
+    void* data() final { return byteCast<Byte>(m_storage->mutableSpan().subspan(sizeof(TimeBoundsBuffer)).data()); }
+    TimeBoundsBuffer& timeBoundsBuffer() final { return spanReinterpretCast<TimeBoundsBuffer>(m_storage->mutableSpan().first(sizeof(TimeBoundsBuffer))).front(); }
 
     Ref<WebCore::SharedMemory> m_storage;
 };
@@ -81,5 +80,3 @@ protected:
 }
 
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -39,10 +39,9 @@
 #import <wtf/HashSet.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RunLoop.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/darwin/XPCSPI.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 // FIXME: Add daemon plist to repository.
 
@@ -125,13 +124,14 @@ static void connectionRemoved(xpc_connection_t connection)
 
 int PCMDaemonMain(int argc, const char** argv)
 {
-    if (argc < 5 || strcmp(argv[1], "--machServiceName") || strcmp(argv[3], "--storageLocation")) {
-        NSLog(@"Usage: %s --machServiceName <name> --storageLocation <location> [--startActivity]", argv[0]);
+    auto arguments = unsafeForgeSpan(argv, argc);
+    if (arguments.size() < 5 || strcmp(arguments[1], "--machServiceName") || strcmp(arguments[3], "--storageLocation")) {
+        NSLog(@"Usage: %s --machServiceName <name> --storageLocation <location> [--startActivity]", arguments[0]);
         return -1;
     }
-    const char* machServiceName = argv[2];
-    const char* storageLocation = argv[4];
-    bool startActivity = argc > 5 && !strcmp(argv[5], "--startActivity");
+    const char* machServiceName = arguments[2];
+    const char* storageLocation = arguments[4];
+    bool startActivity = arguments.size() > 5 && !strcmp(arguments[5], "--startActivity");
 
     @autoreleasepool {
 #if ENABLE(CFPREFS_DIRECT_MODE)
@@ -152,5 +152,3 @@ int PCMDaemonMain(int argc, const char** argv)
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -37,13 +37,9 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
-XPCServiceInitializerDelegate::~XPCServiceInitializerDelegate()
-{
-}
+XPCServiceInitializerDelegate::~XPCServiceInitializerDelegate() = default;
 
 bool XPCServiceInitializerDelegate::checkEntitlements()
 {
@@ -187,7 +183,9 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
 
 void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode enableLockdownMode, bool isWebContentProcess)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     RELEASE_ASSERT(!g_jscConfig.initializeHasBeenCalled);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     bool optionsChanged = false;
     if (xpc_dictionary_get_bool(initializerMessage, "configure-jsc-for-testing"))
@@ -238,5 +236,3 @@ void XPCServiceExit()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -39,6 +39,7 @@
 #import <wtf/Language.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WTFProcess.h>
 #import <wtf/spi/cocoa/OSLogSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
@@ -48,8 +49,6 @@
 #if __has_include(<WebKitAdditions/DyldCallbackAdditions.h>)
 #import <WebKitAdditions/DyldCallbackAdditions.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -100,10 +99,10 @@ static void initializeLogd(bool disableLogging)
     // Log a long message to make sure the XPC connection to the log daemon for oversized messages is opened.
     // This is needed to block launchd after the WebContent process has launched, since access to launchd is
     // required when opening new XPC connections.
-    char stringWithSpaces[1024];
-    memset(stringWithSpaces, ' ', sizeof(stringWithSpaces));
-    stringWithSpaces[sizeof(stringWithSpaces) - 1] = 0;
-    RELEASE_LOG(Process, "Initialized logd %s", stringWithSpaces);
+    std::array<char, 1024> stringWithSpaces;
+    memsetSpan(std::span { stringWithSpaces }, ' ');
+    stringWithSpaces.back() = '\0';
+    RELEASE_LOG(Process, "Initialized logd %s", stringWithSpaces.data());
 }
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
@@ -280,5 +279,3 @@ int XPCServiceMain(int, const char**)
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -30,8 +30,6 @@
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 using namespace WebCore;
@@ -138,9 +136,8 @@ void SharedStringHashStore::resizeTable(unsigned newTableLength)
         RELEASE_ASSERT(currentTableMemory->size() == (Checked<unsigned>(currentTableLength) * sizeof(SharedStringHash)).value());
 
         // Go through the current hash table and re-add all entries to the new hash table.
-        auto* currentSharedStringHashes = reinterpret_cast<const SharedStringHash*>(currentTableMemory->span().data());
-        for (unsigned i = 0; i < currentTableLength; ++i) {
-            auto sharedStringHash = currentSharedStringHashes[i];
+        auto currentSharedStringHashes = spanReinterpretCast<const SharedStringHash>(currentTableMemory->span());
+        for (auto& sharedStringHash : currentSharedStringHashes) {
             if (!sharedStringHash)
                 continue;
 
@@ -212,5 +209,3 @@ void SharedStringHashStore::processPendingOperations()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
@@ -48,9 +48,8 @@ protected:
     WebCore::SharedStringHash* findSlot(WebCore::SharedStringHash) const;
 
     RefPtr<WebCore::SharedMemory> m_sharedMemory;
-    unsigned m_tableSize { 0 };
     unsigned m_tableSizeMask { 0 };
-    WebCore::SharedStringHash* m_table { nullptr };
+    std::span<WebCore::SharedStringHash> m_table;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f48fe0b8ff3db511510e4c7ec975a75ecc2ae67c
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=282188">https://bugs.webkit.org/show_bug.cgi?id=282188</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::PCMDaemonMain):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setJSCOptions):
(WebKit::XPCServiceInitializerDelegate::~XPCServiceInitializerDelegate): Deleted.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::initializeLogd):
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::resizeTable):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::SharedStringHashTableReadOnly::setSharedMemory):
(WebKit::SharedStringHashTableReadOnly::findSlot const):
(WebKit::SharedStringHashTableReadOnly::SharedStringHashTableReadOnly): Deleted.
(WebKit::SharedStringHashTableReadOnly::~SharedStringHashTableReadOnly): Deleted.
* Source/WebKit/Shared/SharedStringHashTableReadOnly.h:

Canonical link: <a href="https://commits.webkit.org/285795@main">https://commits.webkit.org/285795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af2bf40b6737c9d4b86cabec88fd39857394d273

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25044 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16418 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44989 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1123 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/567 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66388 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65667 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7721 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11388 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->