### PR TITLE
[WebGPU] webgpu.github.io/webgpu-samples/?sample=renderBundles uses excessive memory

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
@@ -38,4 +38,10 @@ void GPUCommandBuffer::setLabel(String&& label)
     m_backing->setLabel(WTFMove(label));
 }
 
+void GPUCommandBuffer::setBacking(WebGPU::CommandEncoder& commandEncoder, WebGPU::CommandBuffer& commandBuffer)
+{
+    m_encoder->setBacking(commandEncoder);
+    m_backing = commandBuffer;
+}
+
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUCommandEncoder.h"
 #include "WebGPUCommandBuffer.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -32,11 +33,15 @@
 
 namespace WebCore {
 
+namespace WebGPU {
+class CommandEncoder;
+}
+
 class GPUCommandBuffer : public RefCounted<GPUCommandBuffer> {
 public:
-    static Ref<GPUCommandBuffer> create(Ref<WebGPU::CommandBuffer>&& backing)
+    static Ref<GPUCommandBuffer> create(Ref<WebGPU::CommandBuffer>&& backing, GPUCommandEncoder& encoder)
     {
-        return adoptRef(*new GPUCommandBuffer(WTFMove(backing)));
+        return adoptRef(*new GPUCommandBuffer(WTFMove(backing), encoder));
     }
 
     String label() const;
@@ -44,14 +49,17 @@ public:
 
     WebGPU::CommandBuffer& backing() { return m_backing; }
     const WebGPU::CommandBuffer& backing() const { return m_backing; }
+    void setBacking(WebGPU::CommandEncoder&, WebGPU::CommandBuffer&);
 
 private:
-    GPUCommandBuffer(Ref<WebGPU::CommandBuffer>&& backing)
+    GPUCommandBuffer(Ref<WebGPU::CommandBuffer>&& backing, GPUCommandEncoder& encoder)
         : m_backing(WTFMove(backing))
+        , m_encoder(encoder)
     {
     }
 
     Ref<WebGPU::CommandBuffer> m_backing;
+    Ref<GPUCommandEncoder> m_encoder;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
@@ -27,9 +27,17 @@
 #include "GPUCommandEncoder.h"
 
 #include "GPUBuffer.h"
+#include "GPUCommandBuffer.h"
 #include "GPUQuerySet.h"
+#include "WebGPUDevice.h"
 
 namespace WebCore {
+
+GPUCommandEncoder::GPUCommandEncoder(Ref<WebGPU::CommandEncoder>&& backing, WebGPU::Device& device)
+    : m_backing(WTFMove(backing))
+    , m_device(&device)
+{
+}
 
 String GPUCommandEncoder::label() const
 {
@@ -44,17 +52,17 @@ void GPUCommandEncoder::setLabel(String&& label)
 ExceptionOr<Ref<GPURenderPassEncoder>> GPUCommandEncoder::beginRenderPass(const GPURenderPassDescriptor& renderPassDescriptor)
 {
     RefPtr encoder = m_backing->beginRenderPass(renderPassDescriptor.convertToBacking());
-    if (!encoder)
+    if (!encoder || !m_device.get())
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.beginRenderPass: Unable to begin render pass."_s };
-    return GPURenderPassEncoder::create(encoder.releaseNonNull());
+    return GPURenderPassEncoder::create(encoder.releaseNonNull(), *m_device.get());
 }
 
 ExceptionOr<Ref<GPUComputePassEncoder>> GPUCommandEncoder::beginComputePass(const std::optional<GPUComputePassDescriptor>& computePassDescriptor)
 {
     RefPtr computePass = m_backing->beginComputePass(computePassDescriptor ? std::optional { computePassDescriptor->convertToBacking() } : std::nullopt);
-    if (!computePass)
+    if (!computePass || !m_device.get())
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.beginComputePass: Unable to begin compute pass."_s };
-    return GPUComputePassEncoder::create(computePass.releaseNonNull());
+    return GPUComputePassEncoder::create(computePass.releaseNonNull(), *m_device.get());
 }
 
 void GPUCommandEncoder::copyBufferToBuffer(
@@ -143,7 +151,12 @@ ExceptionOr<Ref<GPUCommandBuffer>> GPUCommandEncoder::finish(const std::optional
     RefPtr buffer = m_backing->finish(convertToBacking(commandBufferDescriptor));
     if (!buffer)
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.finish: Unable to finish."_s };
-    return GPUCommandBuffer::create(buffer.releaseNonNull());
+    return GPUCommandBuffer::create(buffer.releaseNonNull(), *this);
+}
+
+void GPUCommandEncoder::setBacking(WebGPU::CommandEncoder& newBacking)
+{
+    m_backing = newBacking;
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "GPUCommandBuffer.h"
 #include "GPUCommandBufferDescriptor.h"
 #include "GPUComputePassDescriptor.h"
 #include "GPUComputePassEncoder.h"
@@ -44,13 +43,18 @@
 namespace WebCore {
 
 class GPUBuffer;
+class GPUCommandBuffer;
 class GPUQuerySet;
+
+namespace WebGPU {
+class Device;
+}
 
 class GPUCommandEncoder : public RefCounted<GPUCommandEncoder> {
 public:
-    static Ref<GPUCommandEncoder> create(Ref<WebGPU::CommandEncoder>&& backing)
+    static Ref<GPUCommandEncoder> create(Ref<WebGPU::CommandEncoder>&& backing, WebGPU::Device& device)
     {
-        return adoptRef(*new GPUCommandEncoder(WTFMove(backing)));
+        return adoptRef(*new GPUCommandEncoder(WTFMove(backing), device));
     }
 
     String label() const;
@@ -103,14 +107,13 @@ public:
 
     WebGPU::CommandEncoder& backing() { return m_backing; }
     const WebGPU::CommandEncoder& backing() const { return m_backing; }
+    void setBacking(WebGPU::CommandEncoder&);
 
 private:
-    GPUCommandEncoder(Ref<WebGPU::CommandEncoder>&& backing)
-        : m_backing(WTFMove(backing))
-    {
-    }
+    GPUCommandEncoder(Ref<WebGPU::CommandEncoder>&&, WebGPU::Device&);
 
     Ref<WebGPU::CommandEncoder> m_backing;
+    WeakPtr<WebGPU::Device> m_device;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -30,8 +30,15 @@
 #include "GPUBuffer.h"
 #include "GPUComputePipeline.h"
 #include "GPUQuerySet.h"
+#include "WebGPUDevice.h"
 
 namespace WebCore {
+
+GPUComputePassEncoder::GPUComputePassEncoder(Ref<WebGPU::ComputePassEncoder>&& backing, WebGPU::Device& device)
+    : m_backing(WTFMove(backing))
+    , m_device(&device)
+{
+}
 
 String GPUComputePassEncoder::label() const
 {
@@ -63,6 +70,8 @@ void GPUComputePassEncoder::dispatchWorkgroupsIndirect(const GPUBuffer& indirect
 void GPUComputePassEncoder::end()
 {
     m_backing->end();
+    if (m_device)
+        m_backing = m_device->invalidComputePassEncoder();
 }
 
 void GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup& bindGroup,

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
@@ -42,11 +42,15 @@ class GPUBuffer;
 class GPUComputePipeline;
 class GPUQuerySet;
 
+namespace WebGPU {
+class Device;
+}
+
 class GPUComputePassEncoder : public RefCounted<GPUComputePassEncoder> {
 public:
-    static Ref<GPUComputePassEncoder> create(Ref<WebGPU::ComputePassEncoder>&& backing)
+    static Ref<GPUComputePassEncoder> create(Ref<WebGPU::ComputePassEncoder>&& backing, WebGPU::Device& device)
     {
-        return adoptRef(*new GPUComputePassEncoder(WTFMove(backing)));
+        return adoptRef(*new GPUComputePassEncoder(WTFMove(backing), device));
     }
 
     String label() const;
@@ -74,12 +78,10 @@ public:
     const WebGPU::ComputePassEncoder& backing() const { return m_backing; }
 
 private:
-    GPUComputePassEncoder(Ref<WebGPU::ComputePassEncoder>&& backing)
-        : m_backing(WTFMove(backing))
-    {
-    }
+    GPUComputePassEncoder(Ref<WebGPU::ComputePassEncoder>&&, WebGPU::Device&);
 
     Ref<WebGPU::ComputePassEncoder> m_backing;
+    WeakPtr<WebGPU::Device> m_device;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -83,7 +83,7 @@ GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU:
     : ActiveDOMObject { scriptExecutionContext }
     , m_lostPromise(makeUniqueRef<LostPromise>())
     , m_backing(WTFMove(backing))
-    , m_queue(GPUQueue::create(Ref { m_backing->queue() }))
+    , m_queue(GPUQueue::create(Ref { m_backing->queue() }, this->backing()))
     , m_autoPipelineLayout(createAutoPipelineLayout())
 {
     m_queue->setLabel(WTFMove(queueLabel));
@@ -554,7 +554,7 @@ ExceptionOr<Ref<GPUCommandEncoder>> GPUDevice::createCommandEncoder(const std::o
     RefPtr encoder = m_backing->createCommandEncoder(convertToBacking(commandEncoderDescriptor));
     if (!encoder)
         return Exception { ExceptionCode::InvalidStateError, "GPUDevice.createCommandEncoder: Unable to make command encoder."_s };
-    return GPUCommandEncoder::create(encoder.releaseNonNull());
+    return GPUCommandEncoder::create(encoder.releaseNonNull(), m_backing.get());
 }
 
 ExceptionOr<Ref<GPURenderBundleEncoder>> GPUDevice::createRenderBundleEncoder(const GPURenderBundleEncoderDescriptor& renderBundleEncoderDescriptor)

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.h
@@ -45,11 +45,15 @@ namespace WebCore {
 
 class GPUBuffer;
 
+namespace WebGPU {
+class Device;
+}
+
 class GPUQueue : public RefCounted<GPUQueue> {
 public:
-    static Ref<GPUQueue> create(Ref<WebGPU::Queue>&& backing)
+    static Ref<GPUQueue> create(Ref<WebGPU::Queue>&& backing, WebGPU::Device& device)
     {
-        return adoptRef(*new GPUQueue(WTFMove(backing)));
+        return adoptRef(*new GPUQueue(WTFMove(backing), device));
     }
 
     String label() const;
@@ -83,12 +87,10 @@ public:
     const WebGPU::Queue& backing() const { return m_backing; }
 
 private:
-    GPUQueue(Ref<WebGPU::Queue>&& backing)
-        : m_backing(WTFMove(backing))
-    {
-    }
+    GPUQueue(Ref<WebGPU::Queue>&&, WebGPU::Device&);
 
     Ref<WebGPU::Queue> m_backing;
+    WeakPtr<WebGPU::Device> m_device;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -31,8 +31,15 @@
 #include "GPUQuerySet.h"
 #include "GPURenderBundle.h"
 #include "GPURenderPipeline.h"
+#include "WebGPUDevice.h"
 
 namespace WebCore {
+
+GPURenderPassEncoder::GPURenderPassEncoder(Ref<WebGPU::RenderPassEncoder>&& backing, WebGPU::Device& device)
+    : m_backing(WTFMove(backing))
+    , m_device(&device)
+{
+}
 
 String GPURenderPassEncoder::label() const
 {
@@ -161,6 +168,8 @@ void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles
 void GPURenderPassEncoder::end()
 {
     m_backing->end();
+    if (m_device)
+        m_backing = m_device->invalidRenderPassEncoder();
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -46,11 +46,15 @@ class GPUQuerySet;
 class GPURenderBundle;
 class GPURenderPipeline;
 
+namespace WebGPU {
+class Device;
+}
+
 class GPURenderPassEncoder : public RefCounted<GPURenderPassEncoder> {
 public:
-    static Ref<GPURenderPassEncoder> create(Ref<WebGPU::RenderPassEncoder>&& backing)
+    static Ref<GPURenderPassEncoder> create(Ref<WebGPU::RenderPassEncoder>&& backing, WebGPU::Device& device)
     {
-        return adoptRef(*new GPURenderPassEncoder(WTFMove(backing)));
+        return adoptRef(*new GPURenderPassEncoder(WTFMove(backing), device));
     }
 
     String label() const;
@@ -103,12 +107,10 @@ public:
     const WebGPU::RenderPassEncoder& backing() const { return m_backing; }
 
 private:
-    GPURenderPassEncoder(Ref<WebGPU::RenderPassEncoder>&& backing)
-        : m_backing(WTFMove(backing))
-    {
-    }
+    GPURenderPassEncoder(Ref<WebGPU::RenderPassEncoder>&& backing, WebGPU::Device&);
 
     Ref<WebGPU::RenderPassEncoder> m_backing;
+    WeakPtr<WebGPU::Device> m_device;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -778,9 +778,33 @@ void DeviceImpl::resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU
     }).get());
 }
 
+void DeviceImpl::pauseAllErrorReporting(bool pause)
+{
+    wgpuDevicePauseErrorReporting(m_backing.get(), pause);
+}
+
 void DeviceImpl::setLabelInternal(const String& label)
 {
     wgpuDeviceSetLabel(m_backing.get(), label.utf8().data());
+}
+
+Ref<CommandEncoder> DeviceImpl::invalidCommandEncoder()
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+Ref<CommandBuffer> DeviceImpl::invalidCommandBuffer()
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+Ref<RenderPassEncoder> DeviceImpl::invalidRenderPassEncoder()
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+Ref<ComputePassEncoder> DeviceImpl::invalidComputePassEncoder()
+{
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
@@ -95,6 +95,12 @@ private:
     void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&) final;
 
     void setLabelInternal(const String&) final;
+    void pauseAllErrorReporting(bool pause) final;
+
+    [[noreturn]] Ref<CommandEncoder> invalidCommandEncoder() final;
+    [[noreturn]] Ref<CommandBuffer> invalidCommandBuffer() final;
+    [[noreturn]] Ref<RenderPassEncoder> invalidRenderPassEncoder() final;
+    [[noreturn]] Ref<ComputePassEncoder> invalidComputePassEncoder() final;
 
     WebGPUPtr<WGPUDevice> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -55,8 +55,10 @@ class BindGroupLayout;
 struct BindGroupLayoutDescriptor;
 class Buffer;
 struct BufferDescriptor;
+class CommandBuffer;
 class CommandEncoder;
 struct CommandEncoderDescriptor;
+class ComputePassEncoder;
 class ComputePipeline;
 struct ComputePipelineDescriptor;
 class ExternalTexture;
@@ -71,6 +73,7 @@ struct QuerySetDescriptor;
 class Queue;
 class RenderBundleEncoder;
 struct RenderBundleEncoderDescriptor;
+class RenderPassEncoder;
 class RenderPipeline;
 struct RenderPipelineDescriptor;
 class Sampler;
@@ -131,6 +134,11 @@ public:
     virtual void popErrorScope(CompletionHandler<void(bool, std::optional<Error>&&)>&&) = 0;
     virtual void resolveUncapturedErrorEvent(CompletionHandler<void(bool, std::optional<Error>&&)>&&) = 0;
     virtual void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&) = 0;
+    virtual Ref<CommandEncoder> invalidCommandEncoder() = 0;
+    virtual Ref<CommandBuffer> invalidCommandBuffer() = 0;
+    virtual Ref<RenderPassEncoder> invalidRenderPassEncoder() = 0;
+    virtual Ref<ComputePassEncoder> invalidComputePassEncoder() = 0;
+    virtual void pauseAllErrorReporting(bool pause) = 0;
 
 protected:
     Device(Ref<SupportedFeatures>&& features, Ref<SupportedLimits>&& limits)

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -191,7 +191,7 @@ void Buffer::decrementBufferMapCount()
 void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuffer) const
 {
     UNUSED_PARAM(mayModifyBuffer);
-    m_commandEncoders.add(commandEncoder);
+    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     commandEncoder.addBuffer(m_buffer);
     if (m_state == State::Mapped || m_state == State::MappedAtCreation)
         commandEncoder.incrementBufferMapCount();

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -115,6 +115,7 @@ public:
     void setExistingEncoder(id<MTLCommandEncoder>);
     void generateInvalidEncoderStateError();
     bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
+    static void trackEncoder(CommandEncoder&, WeakHashSet<CommandEncoder>&);
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2134,6 +2134,23 @@ void CommandEncoder::lock(bool shouldLock)
         setExistingEncoder(nil);
 }
 
+void CommandEncoder::trackEncoder(CommandEncoder& commandEncoder, WeakHashSet<CommandEncoder>& encoderHashSet)
+{
+    bool removedItem;
+    do {
+        removedItem = false;
+        for (Ref commandEncoder : encoderHashSet) {
+            if (!commandEncoder->isValid()) {
+                encoderHashSet.remove(commandEncoder.get());
+                removedItem = true;
+                break;
+            }
+        }
+    } while (removedItem);
+
+    encoderHashSet.add(commandEncoder);
+}
+
 #undef GENERATE_INVALID_ENCODER_STATE_ERROR
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -186,6 +186,7 @@ public:
 #else
     constexpr bool isIntel() const { return false; }
 #endif
+    void pauseErrorReporting(bool pauseReporting);
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);
@@ -257,6 +258,7 @@ private:
 #if HAVE(COREVIDEO_METAL_SUPPORT)
     RetainPtr<CVMetalTextureCacheRef> m_coreVideoTextureCache;
 #endif
+    bool m_supressAllErrors { false };
 } SWIFT_SHARED_REFERENCE(retainDevice, releaseDevice);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -343,6 +343,9 @@ void Device::generateAValidationError(NSString * message)
 
 void Device::generateAValidationError(String&& message)
 {
+    if (m_supressAllErrors)
+        return;
+
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-generate-a-validation-error
     auto* scope = currentErrorScope(WGPUErrorFilter_Validation);
     if (scope) {
@@ -359,6 +362,9 @@ void Device::generateAValidationError(String&& message)
 
 void Device::generateAnOutOfMemoryError(String&& message)
 {
+    if (m_supressAllErrors)
+        return;
+
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-generate-an-out-of-memory-error
 
     auto* scope = currentErrorScope(WGPUErrorFilter_OutOfMemory);
@@ -377,6 +383,9 @@ void Device::generateAnOutOfMemoryError(String&& message)
 
 void Device::generateAnInternalError(String&& message)
 {
+    if (m_supressAllErrors)
+        return;
+
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-generate-an-internal-error
 
     auto* scope = currentErrorScope(WGPUErrorFilter_Internal);
@@ -884,6 +893,11 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
     return indexType == MTLIndexTypeUInt16 ? functionUshort : function;
 }
 
+void Device::pauseErrorReporting(bool pauseReporting)
+{
+    m_supressAllErrors = pauseReporting;
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs
@@ -926,6 +940,11 @@ WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, const WGPUC
 WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, const WGPUComputePipelineDescriptor* descriptor)
 {
     return WebGPU::releaseToAPI(WebGPU::protectedFromAPI(device)->createComputePipeline(*descriptor).first);
+}
+
+void wgpuDevicePauseErrorReporting(WGPUDevice device, WGPUBool pauseErrors)
+{
+    WebGPU::protectedFromAPI(device)->pauseErrorReporting(!!pauseErrors);
 }
 
 void wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, const WGPUComputePipelineDescriptor* descriptor, WGPUCreateComputePipelineAsyncCallback callback, void* userdata)

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -84,7 +84,7 @@ void ExternalTexture::undestroy()
 
 void ExternalTexture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoders.add(commandEncoder);
+    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -121,7 +121,7 @@ void QuerySet::setOverrideLocation(QuerySet&, uint32_t, uint32_t)
 
 void QuerySet::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoders.add(commandEncoder);
+    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     commandEncoder.addBuffer(m_visibilityBuffer);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3006,7 +3006,7 @@ bool Texture::waitForCommandBufferCompletion()
 
 void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoders.add(commandEncoder);
+    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     commandEncoder.addTexture(*this);
     if (!m_canvasBacking && isDestroyed())
         commandEncoder.makeSubmitInvalid();

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -181,7 +181,7 @@ void TextureView::destroy()
 
 void TextureView::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoders.add(commandEncoder);
+    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     commandEncoder.addTexture(m_parentTexture);
     if (isDestroyed() && !m_parentTexture->isCanvasBacking())
         commandEncoder.makeSubmitInvalid();

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -143,6 +143,7 @@ WGPU_EXPORT WGPULimits wgpuDefaultLimits() WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT bool wgpuBindGroupUpdateExternalTextures(WGPUBindGroup bindGroup, WGPUExternalTexture externalTexture) WGPU_FUNCTION_ATTRIBUTE;
 
 WGPU_EXPORT WGPUXRBinding wgpuDeviceCreateXRBinding(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuDevicePauseErrorReporting(WGPUDevice device, WGPUBool pauseErrors) WGPU_FUNCTION_ATTRIBUTE;
 
 WGPU_EXPORT WGPUXRProjectionLayer wgpuBindingCreateXRProjectionLayer(WGPUXRBinding binding, WGPUTextureFormat colorFormat, WGPUTextureFormat* optionalDepthStencilFormat, WGPUTextureUsageFlags flags, double scale) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUXRSubImage wgpuBindingGetViewSubImage(WGPUXRBinding binding, WGPUXRProjectionLayer layer) WGPU_FUNCTION_ATTRIBUTE;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -196,6 +196,11 @@ void RemoteDevice::setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&& han
 }
 #endif
 
+void RemoteDevice::pauseAllErrorReporting(bool pauseErrorReporting)
+{
+    protectedBacking()->pauseAllErrorReporting(pauseErrorReporting);
+}
+
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
 void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTextureDescriptor& descriptor, WebGPUIdentifier identifier)
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -160,6 +160,7 @@ private:
     void setLabel(String&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemoryHandle&&);
+    void pauseAllErrorReporting(bool pauseErrorReporting);
 
     Ref<WebCore::WebGPU::Device> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -47,6 +47,7 @@ messages -> RemoteDevice NotRefCounted Stream {
     void ResolveUncapturedErrorEvent() -> (bool hasUncapturedError, std::optional<WebKit::WebGPU::Error> error)
     void ResolveDeviceLostPromise() -> (WebCore::WebGPU::DeviceLostReason reason)
     void SetLabel(String label)
+    void PauseAllErrorReporting(bool pauseErrorReporting)
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
@@ -36,10 +36,10 @@ namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandBufferProxy);
 
-RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -39,20 +39,19 @@ class ConvertToBackingContext;
 class RemoteCommandBufferProxy final : public WebCore::WebGPU::CommandBuffer {
     WTF_MAKE_TZONE_ALLOCATED(RemoteCommandBufferProxy);
 public:
-    static Ref<RemoteCommandBufferProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteCommandBufferProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteCommandBufferProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteCommandBufferProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteCommandBufferProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteCommandBufferProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteCommandBufferProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteCommandBufferProxy(const RemoteCommandBufferProxy&) = delete;
     RemoteCommandBufferProxy(RemoteCommandBufferProxy&&) = delete;
@@ -71,7 +70,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -39,10 +39,10 @@ namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandEncoderProxy);
 
-RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 
@@ -66,7 +66,8 @@ RefPtr<WebCore::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRende
         return nullptr;
 
     auto result = RemoteRenderPassEncoderProxy::create(*this, convertToBackingContext, identifier);
-    result->setLabel(WTFMove(convertedDescriptor->label));
+    if (convertedDescriptor)
+        result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
@@ -87,7 +88,8 @@ RefPtr<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginComp
         return nullptr;
 
     auto result = RemoteComputePassEncoderProxy::create(*this, convertToBackingContext, identifier);
-    result->setLabel(WTFMove(convertedDescriptor->label));
+    if (convertedDescriptor)
+        result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
@@ -228,7 +230,7 @@ RefPtr<WebCore::WebGPU::CommandBuffer> RemoteCommandEncoderProxy::finish(const W
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteCommandBufferProxy::create(m_parent, convertToBackingContext, identifier);
+    auto result = RemoteCommandBufferProxy::create(m_root, convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -39,20 +39,19 @@ class ConvertToBackingContext;
 class RemoteCommandEncoderProxy final : public WebCore::WebGPU::CommandEncoder {
     WTF_MAKE_TZONE_ALLOCATED(RemoteCommandEncoderProxy);
 public:
-    static Ref<RemoteCommandEncoderProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteCommandEncoderProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteCommandEncoderProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteCommandEncoderProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteCommandEncoderProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteCommandEncoderProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteCommandEncoderProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteCommandEncoderProxy(const RemoteCommandEncoderProxy&) = delete;
     RemoteCommandEncoderProxy(RemoteCommandEncoderProxy&&) = delete;
@@ -123,7 +122,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -103,6 +103,7 @@ private:
     void createRenderPipelineAsync(const WebCore::WebGPU::RenderPipelineDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::RenderPipeline>&&, String&&)>&&) final;
 
     RefPtr<WebCore::WebGPU::CommandEncoder> createCommandEncoder(const std::optional<WebCore::WebGPU::CommandEncoderDescriptor>&) final;
+    Ref<WebCore::WebGPU::CommandEncoder> createInvalidCommandEncoder();
     RefPtr<WebCore::WebGPU::RenderBundleEncoder> createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor&) final;
 
     RefPtr<WebCore::WebGPU::QuerySet> createQuerySet(const WebCore::WebGPU::QuerySetDescriptor&) final;
@@ -116,6 +117,12 @@ private:
 
     Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
 
+    Ref<WebCore::WebGPU::CommandEncoder> invalidCommandEncoder() final;
+    Ref<WebCore::WebGPU::CommandBuffer> invalidCommandBuffer() final;
+    Ref<WebCore::WebGPU::RenderPassEncoder> invalidRenderPassEncoder() final;
+    Ref<WebCore::WebGPU::ComputePassEncoder> invalidComputePassEncoder() final;
+    void pauseAllErrorReporting(bool pause) final;
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteAdapterProxy> m_parent;
@@ -123,6 +130,10 @@ private:
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     WebKit::SharedVideoFrameWriter m_sharedVideoFrameWriter;
 #endif
+    Ref<WebCore::WebGPU::CommandEncoder> m_invalidCommandEncoder;
+    Ref<WebCore::WebGPU::RenderPassEncoder> m_invalidRenderPassEncoder;
+    Ref<WebCore::WebGPU::ComputePassEncoder> m_invalidComputePassEncoder;
+    Ref<WebCore::WebGPU::CommandBuffer> m_invalidCommandBuffer;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -48,6 +48,7 @@ public:
 
     RemoteAdapterProxy& parent() { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
+    void submit(Vector<Ref<WebCore::WebGPU::CommandBuffer>>&&) final;
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -73,8 +74,6 @@ private:
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
-
-    void submit(Vector<Ref<WebCore::WebGPU::CommandBuffer>>&&) final;
 
     void onSubmittedWorkDone(CompletionHandler<void()>&&) final;
 


### PR DESCRIPTION
#### 31d96d654a5c30df4010fed34a8c4c60d92be012
<pre>
[WebGPU] webgpu.github.io/webgpu-samples/?sample=renderBundles uses excessive memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=282153">https://bugs.webkit.org/show_bug.cgi?id=282153</a>
<a href="https://rdar.apple.com/138726891">rdar://138726891</a>

Reviewed by Dan Glastonbury.

Command encoders were stored in a WeakHashSet, but
we only need to store the valid ones and not invalid ones.

Remove invalid encoders to avoid a retain cycle.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::setCommandEncoder const):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::removeInvalidEncoders):
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::setCommandEncoder const):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::QuerySet::setCommandEncoder const):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::setCommandEncoder const):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::setCommandEncoder const):

Canonical link: <a href="https://commits.webkit.org/285968@main">https://commits.webkit.org/285968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abd58ed55f43bed575466673895ea1ee91a28c44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16746 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21420 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16388 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8084 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1598 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->