### PR TITLE
Add a helper function to create CFStringRef from ASCIILiteral

### DIFF
--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -37,7 +37,7 @@ bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
 {
     if (!task)
         return false;
-    auto string = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, entitlement.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
+    auto string = entitlement.createCFString();
     return adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
 }
 
@@ -69,7 +69,7 @@ bool hasEntitlementValue(audit_token_t token, ASCIILiteral entitlement, ASCIILit
     if (!secTaskForToken)
         return false;
 
-    auto string = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, entitlement.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
+    auto string = entitlement.createCFString();
     String entitlementValue = dynamic_cf_cast<CFStringRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get());
     return entitlementValue == value;
 }
@@ -80,7 +80,7 @@ bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, A
     if (!secTaskForToken)
         return false;
 
-    auto string = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, entitlement.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
+    auto string = entitlement.createCFString();
     auto entitlementValue = adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get();
     if (!entitlementValue || CFGetTypeID(entitlementValue) != CFArrayGetTypeID())
         return false;

--- a/Source/WTF/wtf/text/ASCIILiteral.cpp
+++ b/Source/WTF/wtf/text/ASCIILiteral.cpp
@@ -37,4 +37,11 @@ void ASCIILiteral::dump(PrintStream& out) const
     out.print(StringView(span8()));
 }
 
+#if USE(CF)
+RetainPtr<CFStringRef> ASCIILiteral::createCFString() const
+{
+    return adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, characters(), kCFStringEncodingASCII, kCFAllocatorNull));
+}
+#endif
+
 } // namespace WTF

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -36,6 +36,10 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/SuperFastHash.h>
 
+#if USE(CF)
+typedef const struct __CFString * CFStringRef;
+#endif
+
 OBJC_CLASS NSString;
 
 namespace WTF {
@@ -78,6 +82,10 @@ public:
 
     static ASCIILiteral deletedValue();
     bool isDeletedValue() const { return characters() == reinterpret_cast<char*>(-1); }
+
+#if USE(CF)
+    WTF_EXPORT_PRIVATE RetainPtr<CFStringRef> createCFString() const;
+#endif
 
 private:
     constexpr explicit ASCIILiteral(std::span<const char> spanWithNullTerminator)

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -184,16 +184,11 @@ static RefPtr<NativeImage> createNativeImageFromData(std::span<const uint8_t> da
     return NativeImage::create(WTFMove(image));
 }
 
-static RetainPtr<CFStringRef> cfString(ASCIILiteral string)
-{
-    return adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, string.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
-}
-
 static RefPtr<SharedBuffer> expandNativeImageToData(NativeImage& image, ASCIILiteral uti, std::span<const unsigned> lengths)
 {
     RetainPtr colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     RetainPtr destinationData = adoptCF(CFDataCreateMutable(0, 0));
-    RetainPtr cfUTI = cfString(uti);
+    RetainPtr cfUTI = uti.createCFString();
     RetainPtr destination = adoptCF(CGImageDestinationCreateWithData(destinationData.get(), cfUTI.get(), lengths.size(), nullptr));
     for (auto length : lengths) {
         RetainPtr context = adoptCF(CGBitmapContextCreate(nullptr, length, length, 8, length * 4, colorSpace.get(), kCGImageAlphaPremultipliedLast));


### PR DESCRIPTION
#### a56352209cf305f66f19b352d67edca89073f834
<pre>
Add a helper function to create CFStringRef from ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=282192">https://bugs.webkit.org/show_bug.cgi?id=282192</a>
<a href="https://rdar.apple.com/138782063">rdar://138782063</a>

Reviewed by Chris Dumez.

* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
(WTF::hasEntitlementValue):
(WTF::hasEntitlementValueInArray):
* Source/WTF/wtf/text/ASCIILiteral.cpp:
(WTF::ASCIILiteral::createCFString const):
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::expandNativeImageToData):
(WebCore::cfString): Deleted.

Canonical link: <a href="https://commits.webkit.org/285788@main">https://commits.webkit.org/285788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f90ea87ecab928d288d6e2a3607237c64300840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63513 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21002 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66950 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79702 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73071 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63525 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9548 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3844 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20853 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->