### PR TITLE
[WPE][GTK] Clang 19 unsafe-buffer warnings

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -65,7 +65,9 @@ std::span<const uint8_t> Data::span() const
 {
     if (!m_buffer)
         return { };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return { reinterpret_cast<const uint8_t*>(g_bytes_get_data(m_buffer.get(), nullptr)), g_bytes_get_size(m_buffer.get()) };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 size_t Data::size() const
@@ -85,7 +87,9 @@ bool Data::apply(const Function<bool(std::span<const uint8_t>)>& applier) const
 
     gsize length;
     const auto* data = g_bytes_get_data(m_buffer.get(), &length);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return applier({ reinterpret_cast<const uint8_t*>(data), length });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 Data Data::subrange(size_t offset, size_t size) const

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -180,7 +180,9 @@ void WebSocketTask::didReceiveMessageCallback(WebSocketTask* task, SoupWebsocket
 
     gsize dataSize;
     const auto* data = g_bytes_get_data(message, &dataSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     std::span dataSpan { static_cast<const uint8_t*>(data), dataSize };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     switch (dataType) {
     case SOUP_WEBSOCKET_DATA_TEXT:

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -96,7 +96,9 @@ public:
             std::swap(m_body, other.m_body);
             std::swap(m_bodyOwned, other.m_bodyOwned);
         } else if (!m_messageInfo.isBodyOutOfLine()) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             m_body = std::span { static_cast<uint8_t*>(fastMalloc(m_messageInfo.bodySize())), m_messageInfo.bodySize() };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             memcpySpan(m_body, other.m_body);
             m_bodyOwned = true;
             other.m_body = { };

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -43,7 +43,9 @@ void ArgumentCoder<GRefPtr<GByteArray>>::encode(Encoder& encoder, const GRefPtr<
     }
 
     encoder << true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     encoder << std::span(array->data, array->len);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 std::optional<GRefPtr<GByteArray>> ArgumentCoder<GRefPtr<GByteArray>>::decode(Decoder& decoder)
@@ -73,7 +75,9 @@ void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, const GRefPtr<GV
     }
 
     encoder << CString(g_variant_get_type_string(variant.get()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     encoder << std::span(static_cast<const uint8_t*>(g_variant_get_data(variant.get())), g_variant_get_size(variant.get()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decoder& decoder)

--- a/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
@@ -51,8 +51,10 @@ public:
     {
         if (!m_serializedColorSpace)
             m_serializedColorSpace = m_skColorSpace->serialize();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (m_serializedColorSpace)
             return { m_serializedColorSpace->bytes(), m_serializedColorSpace->size() };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return { };
     }
 

--- a/Source/WebKit/Shared/skia/CoreIPCSkData.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkData.h
@@ -47,7 +47,9 @@ public:
 
     std::span<const uint8_t> dataReference() const
     {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return { m_skData->bytes(), m_skData->size() };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -268,7 +268,9 @@ static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsync
         return;
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     priv->task->didReceiveData(SharedBuffer::create(std::span(priv->readBuffer, bytesRead)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     priv->bytesRead += bytesRead;
     g_input_stream_read_async(inputStream, priv->readBuffer, gReadBufferSize, RunLoopSourcePriority::AsyncIONetwork, priv->cancellable.get(),
         reinterpret_cast<GAsyncReadyCallback>(webkitURISchemeRequestReadCallback), g_object_ref(request.get()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
@@ -196,7 +196,9 @@ static void webkitUserContentFilterStoreSaveBytes(GRefPtr<GTask>&& task, String&
     }
 
     auto* store = WEBKIT_USER_CONTENT_FILTER_STORE(g_task_get_source_object(task.get()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     store->priv->store->compileContentRuleList(WTFMove(identifier), String::fromUTF8({ sourceData, sourceSize }), [task = WTFMove(task)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (g_task_return_error_if_cancelled(task.get()))
             return;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3381,7 +3381,9 @@ void webkit_web_view_load_html(WebKitWebView* webView, const gchar* content, con
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(content);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     getPage(webView).loadData(WebCore::SharedBuffer::create(std::span { reinterpret_cast<const uint8_t*>(content), content ? strlen(content) : 0 }), "text/html"_s, "UTF-8"_s, String::fromUTF8(baseURI));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -3404,7 +3406,9 @@ void webkit_web_view_load_alternate_html(WebKitWebView* webView, const gchar* co
     g_return_if_fail(content);
     g_return_if_fail(contentURI);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     getPage(webView).loadAlternateHTML(WebCore::DataSegment::create(Vector(std::span { reinterpret_cast<const uint8_t*>(content), content ? strlen(content) : 0 })), "UTF-8"_s, URL { String::fromUTF8(baseURI) }, URL { String::fromUTF8(contentURI) });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -3451,8 +3455,10 @@ void webkit_web_view_load_bytes(WebKitWebView* webView, GBytes* bytes, const cha
     gconstpointer bytesData = g_bytes_get_data(bytes, &bytesDataSize);
     g_return_if_fail(bytesDataSize);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     getPage(webView).loadData(WebCore::SharedBuffer::create(std::span { reinterpret_cast<const uint8_t*>(bytesData), bytesDataSize }), mimeType ? String::fromUTF8(mimeType) : String::fromUTF8("text/html"),
         encoding ? String::fromUTF8(encoding) : String::fromUTF8("UTF-8"), String::fromUTF8(baseURI));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**
@@ -4222,7 +4228,9 @@ static void webkitWebViewEvaluateJavascriptInternal(WebKitWebView* webView, cons
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(script);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     RunJavaScriptParameters params = { String::fromUTF8(std::span(script, length < 0 ? strlen(script) : length)), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::No, std::nullopt, ForceUserGesture::Yes, RemoveTransientActivation::Yes };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
 }
 
@@ -4358,7 +4366,9 @@ static void webkitWebViewCallAsyncJavascriptFunctionInternal(WebKitWebView* webV
         return;
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     RunJavaScriptParameters params = { String::fromUTF8(std::span(body, length < 0 ? strlen(body) : length)), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::Yes, WTFMove(argumentsMap), ForceUserGesture::Yes, RemoveTransientActivation::Yes };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -201,7 +201,9 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 gsize length;
                 const auto* urlData = static_cast<const char*>(g_bytes_get_data(data.get(), &length));
                 if (length) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     Vector<String> tokens = String::fromUTF8(std::span(urlData, length)).split('\n');
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     URL url({ }, tokens[0]);
                     if (url.isValid())
                         m_selectionData->setURL(url, tokens.size() > 1 ? tokens[1] : String());
@@ -210,7 +212,9 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 gsize length;
                 const auto* uriListData = static_cast<const char*>(g_bytes_get_data(data.get(), &length));
                 if (length) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     String uriListString(String::fromUTF8(std::span(uriListData, length)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     for (auto& line : uriListString.split('\n')) {
                         line = line.trim(deprecatedIsSpaceOrNewline);
                         if (line.isEmpty())

--- a/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
@@ -200,7 +200,9 @@ static void webkitInputMethodContextImplGtkNotifyCursorArea(WebKitInputMethodCon
 static void webkitInputMethodContextImplGtkNotifySurrounding(WebKitInputMethodContext* context, const gchar* text, unsigned length, unsigned cursorIndex, unsigned)
 {
     auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_GTK(context)->priv;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     priv->surroundingText = std::span { text, length };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     priv->surroundingCursorIndex = cursorIndex;
 }
 

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -348,7 +348,9 @@ static std::optional<String> base64EncodedPNGData(GdkTexture* texture)
     size_t pngSize;
     auto* pngData = static_cast<const uint8_t*>(g_bytes_get_data(pngBytes.get(), &pngSize));
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return base64EncodeToString(std::span<const uint8_t>(pngData, pngSize));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 #else
 static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)

--- a/Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
+++ b/Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
@@ -48,7 +48,9 @@ static std::optional<String> base64EncodedPNGData(SkImage& image)
     if (!data)
         return std::nullopt;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return base64EncodeToString(std::span<const uint8_t>(data->bytes(), data->size()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(ShareableBitmap::Handle&& handle)

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -134,7 +134,9 @@ void RemoteInspectorHTTPServer::handleWebSocket(const char* path, SoupWebsocketC
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);
         gsize dataSize;
         const auto* data = static_cast<const char*>(g_bytes_get_data(message, &dataSize));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         httpServer.sendMessageToBackend(connection, String::fromUTF8(std::span(data, dataSize)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }), this);
     g_signal_connect(connection, "closed", G_CALLBACK(+[](SoupWebsocketConnection* connection, gpointer userData) {
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);

--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -82,6 +82,7 @@ static void showHelpCallback(GtkWidget* widget, KeyBindingTranslator*)
 }
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static const char* const gtkDeleteCommands[][2] = {
     { "DeleteBackward",               "DeleteForward"                        }, // Characters
     { "DeleteWordBackward",           "DeleteWordForward"                    }, // Word ends
@@ -92,6 +93,7 @@ static const char* const gtkDeleteCommands[][2] = {
     { "DeleteToBeginningOfParagraph", "DeleteToEndOfParagraph"               }, // Paragraphs
     { 0,                              0                                      } // Whitespace (M-\ in Emacs)
 };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType, gint count, KeyBindingTranslator* translator)
 {
@@ -121,7 +123,9 @@ static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType
             translator->addPendingEditorCommand("MoveToEndOfParagraph");
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* rawCommand = gtkDeleteCommands[deleteType][direction];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!rawCommand)
         return;
 
@@ -129,6 +133,7 @@ static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType
         translator->addPendingEditorCommand(rawCommand);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static const char* const gtkMoveCommands[][4] = {
     { "MoveBackward",                                   "MoveForward",
       "MoveBackwardAndModifySelection",                 "MoveForwardAndModifySelection"             }, // Forward/backward grapheme
@@ -151,6 +156,7 @@ static const char* const gtkMoveCommands[][4] = {
     { 0,                                                0,
       0,                                                0                                           } // Horizontal page movement
 };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint count, gboolean extendSelection, KeyBindingTranslator* translator)
 {
@@ -162,7 +168,9 @@ static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint cou
     if (static_cast<unsigned>(step) >= G_N_ELEMENTS(gtkMoveCommands))
         return;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* rawCommand = gtkMoveCommands[step][direction];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!rawCommand)
         return;
 
@@ -220,6 +228,7 @@ static const KeyCombinationEntry customKeyBindings[] = {
     { GDK_KEY_V,         GDK_CONTROL_MASK | GDK_SHIFT_MASK, "PasteAsPlainText"_s },
 };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static Vector<String> handleKeyBindingsForMap(const KeyCombinationEntry* map, unsigned mapSize, unsigned keyval, GdkModifierType state)
 {
     // For keypress events, we want charCode(), but keyCode() does that.
@@ -234,6 +243,7 @@ static Vector<String> handleKeyBindingsForMap(const KeyCombinationEntry* map, un
 
     return { };
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static Vector<String> handleCustomKeyBindings(unsigned keyval, GdkModifierType state)
 {

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -58,11 +58,15 @@ bool SystemSettingsManagerProxy::darkMode() const
     // FIXME: These are just heuristics, we should get the dark mode from libhandy/libadwaita, falling back to the settings portal.
 
     if (auto* themeNameEnv = g_getenv("GTK_THEME"))
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return g_str_has_suffix(themeNameEnv, "-dark") || g_str_has_suffix(themeNameEnv, "-Dark") || g_str_has_suffix(themeNameEnv, ":dark");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     GUniqueOutPtr<char> themeName;
     g_object_get(m_settings, "gtk-theme-name", &themeName.outPtr(), nullptr);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (g_str_has_suffix(themeName.get(), "-dark") || (g_str_has_suffix(themeName.get(), "-Dark")))
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return true;
 
     return false;


### PR DESCRIPTION
#### 8471a1156fd686d067c8ac4b6ce60b919738db76
<pre>
[WPE][GTK] Clang 19 unsafe-buffer warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=281989">https://bugs.webkit.org/show_bug.cgi?id=281989</a>

Unreviewed, fix build with Clang 19

* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::span const):
(WebKit::NetworkCache::Data::apply const):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::didReceiveMessageCallback):
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::UnixMessage::UnixMessage):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::encode):
* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h:
(WebKit::CoreIPCSkColorSpace::dataReference const):
* Source/WebKit/Shared/skia/CoreIPCSkData.h:
(WebKit::CoreIPCSkData::dataReference const):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
(webkitURISchemeRequestReadCallback):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp:
(webkitUserContentFilterStoreSaveBytes):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_load_html):
(webkit_web_view_load_alternate_html):
(webkit_web_view_load_bytes):
(webkitWebViewEvaluateJavascriptInternal):
(webkitWebViewCallAsyncJavascriptFunctionInternal):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept):
* Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp:
(webkitInputMethodContextImplGtkNotifySurrounding):
* Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp:
(WebKit::base64EncodedPNGData):
* Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp:
(WebKit::base64EncodedPNGData):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp:
* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
(WebKit::deleteFromCursorCallback):
(WebKit::moveCursorCallback):
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::darkMode const):

Canonical link: <a href="https://commits.webkit.org/285787@main">https://commits.webkit.org/285787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/409d1cc0fd6f387d0a4adc5bc8546a39a45a940e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26628 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76884 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63510 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/44999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79706 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1134 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63522 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9550 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1098 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->