### PR TITLE
[WPE][GTK] Cannot follow links on DuckDuckGo

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -133,7 +133,7 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
     if (domain == "www.sspa.juntadeandalucia.es"_s)
         return true;
 
-    // Atlassian Confluence discrimates against WebKitGTK's standard user agent
+    // Atlassian Confluence discriminates against WebKitGTK's standard user agent
     // by completely blocking access to the application. It runs on different
     // subdomains for each Atlassian customer so the quirk must apply broadly.
     if (baseDomain == "atlassian.net"_s)
@@ -142,6 +142,11 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
     // Rosetta Stone discriminates against WebKitGTK's standard mobile user agent
     // by redirecting to an intent:// URL, which will of course fail to load.
     if (domain == "totale.rosettastone.com"_s)
+        return true;
+
+    // DuckDuckGo discriminates against WebKitGTK's standard user agent by
+    // returning an HTTP 400 Bad Request error when loading every search result.
+    if (domain == "duckduckgo.com"_s)
         return true;
 
     return false;

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -109,6 +109,7 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasMacPlatformQuirk("http://www.sspa.juntadeandalucia.es/");
     assertUserAgentForURLHasMacPlatformQuirk("http://foobar.atlassian.net/");
     assertUserAgentForURLHasMacPlatformQuirk("http://totale.rosettastone.com/");
+    assertUserAgentForURLHasMacPlatformQuirk("http://duckduckgo.com/");
 
     assertUserAgentForURLHasEmptyQuirk("http://accounts.google.com/");
     assertUserAgentForURLHasEmptyQuirk("http://docs.google.com/");


### PR DESCRIPTION
#### 5c43a5e8573f45ed07a9cd061f187075062c58c6
<pre>
[WPE][GTK] Cannot follow links on DuckDuckGo
<a href="https://bugs.webkit.org/show_bug.cgi?id=282173">https://bugs.webkit.org/show_bug.cgi?id=282173</a>

Reviewed by Sergio Villar Senin and Adrian Perez de Castro.

Our safest user agent header quirk, the macOS platform quirk, is
sufficient to fix DuckDuckGo.

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresMacintoshPlatform):
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
(TestWebKitAPI::TEST(UserAgentTest, Quirks)):

Canonical link: <a href="https://commits.webkit.org/285806@main">https://commits.webkit.org/285806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f47e5ec8ff95c81ee73797d6559af478e5fa9fa8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23441 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9585 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1151 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->