### PR TITLE
[webkitpy] Add --udids option to run-webkit-tests.

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -342,6 +342,7 @@ def parse_args(args):
         optparse.make_option('--dedicated-simulators', action="store_true", default=False,
             help="If set, dedicated iOS simulators will always be created.  If not set, the script will attempt to use any currently running simulator."),
         optparse.make_option('--show-touches', action="store_true", default=False, help="If set, a small dot will be shown where the generated touches are. Helpful for debugging touch tests."),
+        optparse.make_option('--udid', '--udids', dest='udids', action='store', help='Specify a device UDID to pick the connected device to run tests on. Specify multiple by separating with commas. If using --*-simulator and the specified UDIDs don\'t satisfy the request, simulators will be created to fulfill the remaining requests.'),
     ]))
 
     option_group_definitions.append(("Miscellaneous Options", [

--- a/Tools/Scripts/webkitpy/port/device_port.py
+++ b/Tools/Scripts/webkitpy/port/device_port.py
@@ -183,6 +183,7 @@ class DevicePort(DarwinPort):
             pin=self.get_option('pin', None),
             use_nfs=self.get_option('use_nfs', True),
             reboot=self.get_option('reboot', False),
+            udids=self.get_option('udids', None)
         )
 
         if not self.devices():


### PR DESCRIPTION
#### c6e2256db28c86d38e380e29bb8d12a69c79dfdf
<pre>
[webkitpy] Add --udids option to run-webkit-tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282198">https://bugs.webkit.org/show_bug.cgi?id=282198</a>
<a href="https://rdar.apple.com/138779069">rdar://138779069</a>

Reviewed by Jonathan Bedard.

This change adds a method of specifying the desired simulator to use to run
layout tests.

The new flow of simulated_device.py:
1. Try to find/boot simulators matching the specified UDID(s) (specify more
    than one by separating with a comma).
2. If device requests remain after handling the devices specified by UDID, try
    to attach to other booted simulators.
3. If we still have device requests after utilizing all available and matching
    existing simulators, create and boot simulators to match the requests.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py: Add --udids option to `parse_args`.
* Tools/Scripts/webkitpy/port/device_port.py: Pass specified UDIDs to the device manager.
* Tools/Scripts/webkitpy/xcode/simulated_device.py: SimulatedDeviceManager changes to accept and handle new data.
    -&gt; (initialize_devices): Change flow to above.
    -&gt; (_does_fulfill_request): Add option to include non-booted simulators.
    -&gt; (_validate_running_device_against_requests): Move requests validation from `initialize_devices`.

Canonical link: <a href="https://commits.webkit.org/285830@main">https://commits.webkit.org/285830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28ac23b18c1eae60a65c12473b994f723d0b4860

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25129 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38497 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/73399 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23462 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63580 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65704 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7773 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1172 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->