### PR TITLE
[Site isolation] Site isolated frames with css transform are not displayed correctly

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-with-transform-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-with-transform-expected.html
@@ -1,0 +1,17 @@
+<style>
+    .container {
+        width: 300px;
+        height: 150px;
+        background-color: green;
+    }
+    .box {
+        width: 50px;
+        height:50px;
+        background-color: blue;
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-with-transform.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-with-transform.html
@@ -1,0 +1,13 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<style>
+    iframe {
+        width: 600px;
+        height: 300px;
+        transform: scale(0.5);
+        transform-origin: 0 0;
+        background-color: red;
+    }
+</style>
+<body>
+    <iframe src="http://localhost:8000/site-isolation/resources/100x100-blue-box-green-background.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/100x100-blue-box-green-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/100x100-blue-box-green-background.html
@@ -1,0 +1,18 @@
+<style>
+    body {
+        background-color: green;
+        margin: 0;
+        padding: 0;
+    }
+    .box {
+        width: 100px;
+        height:100px;
+        background-color: blue;
+    }
+</style>
+<body>
+    <div class="box"></div>
+    <script>
+        onload = () => { window.parent.postMessage("onload", "*"); }
+    </script>
+</body>

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -162,7 +162,7 @@ bool RenderWidget::updateWidgetGeometry()
 
     LayoutRect contentBox = contentBoxRect();
     LayoutRect absoluteContentBox(localToAbsoluteQuad(FloatQuad(contentBox)).boundingBox());
-    if (m_widget->isLocalFrameView()) {
+    if (is<FrameView>(m_widget)) {
         contentBox.setLocation(absoluteContentBox.location());
         return setWidgetGeometry(contentBox);
     }


### PR DESCRIPTION
#### b27e4007cd73176eb33a572b3a245b850b225eb5
<pre>
[Site isolation] Site isolated frames with css transform are not displayed correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=282007">https://bugs.webkit.org/show_bug.cgi?id=282007</a>
<a href="https://rdar.apple.com/138513187">rdar://138513187</a>

Reviewed by Sihui Liu.

Similar to the local frame, the size of the remote frame should be set in logical
units.

* LayoutTests/http/tests/site-isolation/iframe-with-transform-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-with-transform.html: Added.
* LayoutTests/http/tests/site-isolation/resources/100x100-blue-box-green-background.html: Added.
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::updateWidgetGeometry):

Canonical link: <a href="https://commits.webkit.org/285842@main">https://commits.webkit.org/285842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e15b20068718433e2d05e2e7be6c817cda5f9f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7793 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1199 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->