### PR TITLE
[GTK] Remove some WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN/END in SystemSettingsManagerProxyGtk.cpp

### DIFF
--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -56,18 +56,19 @@ bool SystemSettingsManagerProxy::darkMode() const
         return true;
 
     // FIXME: These are just heuristics, we should get the dark mode from libhandy/libadwaita, falling back to the settings portal.
-
-    if (auto* themeNameEnv = g_getenv("GTK_THEME"))
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return g_str_has_suffix(themeNameEnv, "-dark") || g_str_has_suffix(themeNameEnv, "-Dark") || g_str_has_suffix(themeNameEnv, ":dark");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    // Or maybe just use the settings portal, because we don't want to depend on libhandy, and maybe don't want to depend on libadwaita?
+    if (const char* themeNameEnv = g_getenv("GTK_THEME")) {
+        StringView themeNameEnvString = String::fromUTF8(themeNameEnv);
+        return themeNameEnvString.endsWith("-dark"_s) || themeNameEnvString.endsWith("-Dark"_s) || themeNameEnvString.endsWith(":dark"_s);
+    }
 
     GUniqueOutPtr<char> themeName;
     g_object_get(m_settings, "gtk-theme-name", &themeName.outPtr(), nullptr);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (g_str_has_suffix(themeName.get(), "-dark") || (g_str_has_suffix(themeName.get(), "-Dark")))
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        return true;
+    if (themeName) {
+        StringView themeNameString = String::fromUTF8(themeName.get());
+        if (themeNameString.endsWith("-dark"_s) || themeNameString.endsWith("-Dark"_s))
+            return true;
+    }
 
     return false;
 }
@@ -192,3 +193,4 @@ SystemSettingsManagerProxy::SystemSettingsManagerProxy()
 }
 
 } // namespace WebKit
+


### PR DESCRIPTION
#### 6267581a00987c4443a232cf111be743eddc89d0
<pre>
[GTK] Remove some WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN/END in SystemSettingsManagerProxyGtk.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282205">https://bugs.webkit.org/show_bug.cgi?id=282205</a>

Reviewed by Philippe Normand.

Let&apos;s use WTF::String rather than the GLib macros that trip this
warning.

* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::darkMode const):

Canonical link: <a href="https://commits.webkit.org/285852@main">https://commits.webkit.org/285852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f20da74cf69a109a34cbe652a0c7f7af20e06e93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58166 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16511 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45158 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66478 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63646 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65758 "Found 2 new API test failures: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback, /TestWebKit:WebKit.AboutBlankLoad (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7835 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1250 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->