### PR TITLE
Finish off smart pointer adoption in WebCore/Modules/WebGPU/Implementation

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
@@ -61,6 +61,8 @@ private:
     RefPtr<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) final;
     RefPtr<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) final;
 
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const { return m_convertToBackingContext; }
+
     void copyBufferToBuffer(
         const Buffer& source,
         Size64 sourceOffset,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
@@ -50,7 +50,7 @@ ComputePassEncoderImpl::~ComputePassEncoderImpl() = default;
 
 void ComputePassEncoderImpl::setPipeline(const ComputePipeline& computePipeline)
 {
-    wgpuComputePassEncoderSetPipeline(m_backing.get(), m_convertToBackingContext->convertToBacking(computePipeline));
+    wgpuComputePassEncoderSetPipeline(m_backing.get(), protectedCnvertToBackingContext()->convertToBacking(computePipeline));
 }
 
 void ComputePassEncoderImpl::dispatch(Size32 workgroupCountX, Size32 workgroupCountY, Size32 workgroupCountZ)
@@ -60,7 +60,7 @@ void ComputePassEncoderImpl::dispatch(Size32 workgroupCountX, Size32 workgroupCo
 
 void ComputePassEncoderImpl::dispatchIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)
 {
-    wgpuComputePassEncoderDispatchWorkgroupsIndirect(m_backing.get(), m_convertToBackingContext->convertToBacking(indirectBuffer), indirectOffset);
+    wgpuComputePassEncoderDispatchWorkgroupsIndirect(m_backing.get(), protectedCnvertToBackingContext()->convertToBacking(indirectBuffer), indirectOffset);
 }
 
 void ComputePassEncoderImpl::end()
@@ -72,7 +72,7 @@ void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGr
     std::optional<Vector<BufferDynamicOffset>>&& offsets)
 {
     auto backingOffsets = valueOrDefault(offsets);
-    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), static_cast<uint32_t>(backingOffsets.size()), backingOffsets.data());
+    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, protectedCnvertToBackingContext()->convertToBacking(bindGroup), static_cast<uint32_t>(backingOffsets.size()), backingOffsets.data());
 }
 
 void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
@@ -81,7 +81,7 @@ void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGr
     Size32 dynamicOffsetsDataLength)
 {
     // FIXME: Use checked algebra.
-    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
+    wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, protectedCnvertToBackingContext()->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
 }
 
 void ComputePassEncoderImpl::pushDebugGroup(String&& groupLabel)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
@@ -78,6 +78,8 @@ private:
 
     void setLabelInternal(const String&) final;
 
+    Ref<ConvertToBackingContext> protectedCnvertToBackingContext() const { return m_convertToBackingContext; }
+
     WebGPUPtr<WGPUComputePassEncoder> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
@@ -61,20 +61,22 @@ static void requestAdapterCallback(WGPURequestAdapterStatus status, WGPUAdapter 
 
 void GPUImpl::requestAdapter(const RequestAdapterOptions& options, CompletionHandler<void(RefPtr<Adapter>&&)>&& callback)
 {
+    Ref convertToBackingContext = m_convertToBackingContext;
+
     WGPURequestAdapterOptions backingOptions {
         .nextInChain = nullptr,
         .compatibleSurface = nullptr,
 #if CPU(X86_64)
         .powerPreference = WGPUPowerPreference_HighPerformance,
 #else
-        .powerPreference = options.powerPreference ? m_convertToBackingContext->convertToBacking(*options.powerPreference) : static_cast<WGPUPowerPreference>(WGPUPowerPreference_Undefined),
+        .powerPreference = options.powerPreference ? convertToBackingContext->convertToBacking(*options.powerPreference) : static_cast<WGPUPowerPreference>(WGPUPowerPreference_Undefined),
 #endif
         .backendType = WGPUBackendType_Metal,
         .forceFallbackAdapter = options.forceFallbackAdapter,
         .xrCompatible = options.xrCompatible,
     };
 
-    auto blockPtr = makeBlockPtr([convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTFMove(callback)](WGPURequestAdapterStatus status, WGPUAdapter adapter, const char*) mutable {
+    auto blockPtr = makeBlockPtr([convertToBackingContext = convertToBackingContext.copyRef(), callback = WTFMove(callback)](WGPURequestAdapterStatus status, WGPUAdapter adapter, const char*) mutable {
         if (status == WGPURequestAdapterStatus_Success)
             callback(AdapterImpl::create(adoptWebGPU(adapter), convertToBackingContext));
         else

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -90,16 +90,18 @@ bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
 
     m_format = canvasConfiguration.format;
 
+    Ref convertToBackingContext = m_convertToBackingContext;
+
     WGPUSwapChainDescriptor backingDescriptor {
         .nextInChain = nullptr,
         .label = nullptr,
-        .usage = m_convertToBackingContext->convertTextureUsageFlagsToBacking(canvasConfiguration.usage),
-        .format = m_convertToBackingContext->convertToBacking(canvasConfiguration.format),
+        .usage = convertToBackingContext->convertTextureUsageFlagsToBacking(canvasConfiguration.usage),
+        .format = convertToBackingContext->convertToBacking(canvasConfiguration.format),
         .width = m_width,
         .height = m_height,
         .presentMode = WGPUPresentMode_Immediate,
-        .viewFormats = canvasConfiguration.viewFormats.map([&convertToBackingContext = m_convertToBackingContext.get()](auto colorFormat) {
-            return convertToBackingContext.convertToBacking(colorFormat);
+        .viewFormats = canvasConfiguration.viewFormats.map([&](auto colorFormat) {
+            return convertToBackingContext->convertToBacking(colorFormat);
         }),
         .colorSpace = canvasConfiguration.colorSpace == WebCore::WebGPU::PredefinedColorSpace::SRGB ? WGPUColorSpace::SRGB : WGPUColorSpace::DisplayP3,
         .toneMappingMode = convertToToneMappingMode(canvasConfiguration.toneMappingMode),
@@ -107,7 +109,7 @@ bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
         .reportValidationErrors = canvasConfiguration.reportValidationErrors
     };
 
-    m_swapChain = adoptWebGPU(wgpuDeviceCreateSwapChain(m_convertToBackingContext->convertToBacking(canvasConfiguration.device), m_backing.get(), &backingDescriptor));
+    m_swapChain = adoptWebGPU(wgpuDeviceCreateSwapChain(convertToBackingContext->convertToBacking(canvasConfiguration.protectedDevice().get()), m_backing.get(), &backingDescriptor));
     return true;
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
@@ -50,17 +50,17 @@ RenderBundleEncoderImpl::~RenderBundleEncoderImpl() = default;
 
 void RenderBundleEncoderImpl::setPipeline(const RenderPipeline& renderPipeline)
 {
-    wgpuRenderBundleEncoderSetPipeline(m_backing.get(), m_convertToBackingContext->convertToBacking(renderPipeline));
+    wgpuRenderBundleEncoderSetPipeline(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(renderPipeline));
 }
 
 void RenderBundleEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderBundleEncoderSetIndexBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderBundleEncoderSetIndexBuffer(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(buffer), protectedConvertToBackingContext()->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
 void RenderBundleEncoderImpl::setVertexBuffer(Index32 slot, const Buffer* buffer, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderBundleEncoderSetVertexBuffer(m_backing.get(), slot, buffer ? m_convertToBackingContext->convertToBacking(*buffer) : nullptr, offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderBundleEncoderSetVertexBuffer(m_backing.get(), slot, buffer ? protectedConvertToBackingContext()->convertToBacking(*buffer) : nullptr, offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
 void RenderBundleEncoderImpl::draw(Size32 vertexCount, std::optional<Size32> instanceCount,
@@ -79,19 +79,19 @@ void RenderBundleEncoderImpl::drawIndexed(Size32 indexCount, std::optional<Size3
 
 void RenderBundleEncoderImpl::drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)
 {
-    wgpuRenderBundleEncoderDrawIndirect(m_backing.get(), m_convertToBackingContext->convertToBacking(indirectBuffer), indirectOffset);
+    wgpuRenderBundleEncoderDrawIndirect(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(indirectBuffer), indirectOffset);
 }
 
 void RenderBundleEncoderImpl::drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)
 {
-    wgpuRenderBundleEncoderDrawIndexedIndirect(m_backing.get(), m_convertToBackingContext->convertToBacking(indirectBuffer), indirectOffset);
+    wgpuRenderBundleEncoderDrawIndexedIndirect(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(indirectBuffer), indirectOffset);
 }
 
 void RenderBundleEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
     std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets)
 {
     auto backingOffsets = valueOrDefault(dynamicOffsets);
-    wgpuRenderBundleEncoderSetBindGroupWithDynamicOffsets(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), WTFMove(dynamicOffsets));
+    wgpuRenderBundleEncoderSetBindGroupWithDynamicOffsets(m_backing.get(), index, protectedConvertToBackingContext()->convertToBacking(bindGroup), WTFMove(dynamicOffsets));
 }
 
 void RenderBundleEncoderImpl::setBindGroup(Index32, const BindGroup&,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
@@ -89,6 +89,8 @@ private:
 
     void setLabelInternal(const String&) final;
 
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const { return m_convertToBackingContext; }
+
     WebGPUPtr<WGPURenderBundleEncoder> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
@@ -51,17 +51,17 @@ RenderPassEncoderImpl::~RenderPassEncoderImpl() = default;
 
 void RenderPassEncoderImpl::setPipeline(const RenderPipeline& renderPipeline)
 {
-    wgpuRenderPassEncoderSetPipeline(m_backing.get(), m_convertToBackingContext->convertToBacking(renderPipeline));
+    wgpuRenderPassEncoderSetPipeline(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(renderPipeline));
 }
 
 void RenderPassEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderPassEncoderSetIndexBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderPassEncoderSetIndexBuffer(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(buffer), protectedConvertToBackingContext()->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
 void RenderPassEncoderImpl::setVertexBuffer(Index32 slot, const Buffer* buffer, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderPassEncoderSetVertexBuffer(m_backing.get(), slot, buffer ? m_convertToBackingContext->convertToBacking(*buffer) : nullptr, offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderPassEncoderSetVertexBuffer(m_backing.get(), slot, buffer ? protectedConvertToBackingContext()->convertToBacking(*buffer) : nullptr, offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
 void RenderPassEncoderImpl::draw(Size32 vertexCount, std::optional<Size32> instanceCount,
@@ -80,19 +80,19 @@ void RenderPassEncoderImpl::drawIndexed(Size32 indexCount, std::optional<Size32>
 
 void RenderPassEncoderImpl::drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)
 {
-    wgpuRenderPassEncoderDrawIndirect(m_backing.get(), m_convertToBackingContext->convertToBacking(indirectBuffer), indirectOffset);
+    wgpuRenderPassEncoderDrawIndirect(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(indirectBuffer), indirectOffset);
 }
 
 void RenderPassEncoderImpl::drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)
 {
-    wgpuRenderPassEncoderDrawIndexedIndirect(m_backing.get(), m_convertToBackingContext->convertToBacking(indirectBuffer), indirectOffset);
+    wgpuRenderPassEncoderDrawIndexedIndirect(m_backing.get(), protectedConvertToBackingContext()->convertToBacking(indirectBuffer), indirectOffset);
 }
 
 void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
     std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets)
 {
     auto backingOffsets = valueOrDefault(dynamicOffsets);
-    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), backingOffsets.size(), backingOffsets.data());
+    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, protectedConvertToBackingContext()->convertToBacking(bindGroup), backingOffsets.size(), backingOffsets.data());
 }
 
 void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGroup,
@@ -101,7 +101,7 @@ void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup& bindGro
     Size32 dynamicOffsetsDataLength)
 {
     // FIXME: Use checked algebra.
-    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, m_convertToBackingContext->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
+    wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, protectedConvertToBackingContext()->convertToBacking(bindGroup), dynamicOffsetsDataLength, dynamicOffsetsArrayBuffer.subspan(dynamicOffsetsDataStart).data());
 }
 
 void RenderPassEncoderImpl::pushDebugGroup(String&& groupLabel)
@@ -134,7 +134,7 @@ void RenderPassEncoderImpl::setScissorRect(IntegerCoordinate x, IntegerCoordinat
 
 void RenderPassEncoderImpl::setBlendConstant(Color color)
 {
-    auto backingColor = m_convertToBackingContext->convertToBacking(color);
+    auto backingColor = protectedConvertToBackingContext()->convertToBacking(color);
 
     wgpuRenderPassEncoderSetBlendConstant(m_backing.get(), &backingColor);
 }
@@ -156,8 +156,8 @@ void RenderPassEncoderImpl::endOcclusionQuery()
 
 void RenderPassEncoderImpl::executeBundles(Vector<Ref<RenderBundle>>&& renderBundles)
 {
-    auto backingBundles = renderBundles.map([&convertToBackingContext = m_convertToBackingContext.get()](auto renderBundle) {
-        return convertToBackingContext.convertToBacking(renderBundle.get());
+    auto backingBundles = renderBundles.map([&](auto renderBundle) {
+        return protectedConvertToBackingContext()->convertToBacking(renderBundle.get());
     });
 
     wgpuRenderPassEncoderExecuteBundles(m_backing.get(), backingBundles.size(), backingBundles.data());

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
@@ -103,6 +103,8 @@ private:
 
     void setLabelInternal(const String&) final;
 
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const { return m_convertToBackingContext; }
+
     WebGPUPtr<WGPURenderPassEncoder> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -53,19 +53,21 @@ RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescr
 {
     CString label = descriptor ? descriptor->label.utf8() : CString("");
 
+    Ref convertToBackingContext = m_convertToBackingContext;
+
     WGPUTextureViewDescriptor backingDescriptor {
         .nextInChain = nullptr,
         .label = label.data(),
-        .format = descriptor && descriptor->format ? m_convertToBackingContext->convertToBacking(*descriptor->format) : WGPUTextureFormat_Undefined,
-        .dimension = descriptor && descriptor->dimension ? m_convertToBackingContext->convertToBacking(*descriptor->dimension) : WGPUTextureViewDimension_Undefined,
+        .format = descriptor && descriptor->format ? convertToBackingContext->convertToBacking(*descriptor->format) : WGPUTextureFormat_Undefined,
+        .dimension = descriptor && descriptor->dimension ? convertToBackingContext->convertToBacking(*descriptor->dimension) : WGPUTextureViewDimension_Undefined,
         .baseMipLevel = descriptor ? descriptor->baseMipLevel : 0,
         .mipLevelCount = descriptor && descriptor->mipLevelCount ? *descriptor->mipLevelCount : static_cast<uint32_t>(WGPU_MIP_LEVEL_COUNT_UNDEFINED),
         .baseArrayLayer = descriptor ? descriptor->baseArrayLayer : 0,
         .arrayLayerCount = descriptor && descriptor->arrayLayerCount ? *descriptor->arrayLayerCount : static_cast<uint32_t>(WGPU_ARRAY_LAYER_COUNT_UNDEFINED),
-        .aspect = descriptor ? m_convertToBackingContext->convertToBacking(descriptor->aspect) : WGPUTextureAspect_All,
+        .aspect = descriptor ? convertToBackingContext->convertToBacking(descriptor->aspect) : WGPUTextureAspect_All,
     };
 
-    return TextureViewImpl::create(adoptWebGPU(wgpuTextureCreateView(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
+    return TextureViewImpl::create(adoptWebGPU(wgpuTextureCreateView(m_backing.get(), &backingDescriptor)), convertToBackingContext);
 }
 
 void TextureImpl::destroy()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
@@ -46,12 +46,14 @@ XRBindingImpl::~XRBindingImpl() = default;
 
 RefPtr<XRProjectionLayer> XRBindingImpl::createProjectionLayer(const XRProjectionLayerInit& init)
 {
-    WGPUTextureFormat colorFormat = m_convertToBackingContext->convertToBacking(init.colorFormat);
+    Ref convertToBackingContext = m_convertToBackingContext;
+
+    WGPUTextureFormat colorFormat = convertToBackingContext->convertToBacking(init.colorFormat);
     WGPUTextureFormat optionalDepthStencilFormat;
     if (init.depthStencilFormat)
-        optionalDepthStencilFormat = m_convertToBackingContext->convertToBacking(*init.depthStencilFormat);
-    WGPUTextureUsageFlags flags = m_convertToBackingContext->convertTextureUsageFlagsToBacking(init.textureUsage);
-    return XRProjectionLayerImpl::create(adoptWebGPU(wgpuBindingCreateXRProjectionLayer(m_backing.get(), colorFormat, init.depthStencilFormat ? &optionalDepthStencilFormat : nullptr, flags, init.scaleFactor)), m_convertToBackingContext);
+        optionalDepthStencilFormat = convertToBackingContext->convertToBacking(*init.depthStencilFormat);
+    WGPUTextureUsageFlags flags = convertToBackingContext->convertTextureUsageFlagsToBacking(init.textureUsage);
+    return XRProjectionLayerImpl::create(adoptWebGPU(wgpuBindingCreateXRProjectionLayer(m_backing.get(), colorFormat, init.depthStencilFormat ? &optionalDepthStencilFormat : nullptr, flags, init.scaleFactor)), convertToBackingContext);
 }
 
 RefPtr<XRSubImage> XRBindingImpl::getSubImage(XRProjectionLayer&, WebCore::WebXRFrame&, std::optional<XREye>/* = "none"*/)
@@ -63,7 +65,7 @@ RefPtr<XRSubImage> XRBindingImpl::getSubImage(XRProjectionLayer&, WebCore::WebXR
 RefPtr<XRSubImage> XRBindingImpl::getViewSubImage(XRProjectionLayer& projectionLayer)
 {
     auto& projectionLayerImpl = static_cast<XRProjectionLayerImpl&>(projectionLayer);
-    return XRSubImageImpl::create(adoptWebGPU(wgpuBindingGetViewSubImage(m_backing.get(), projectionLayerImpl.backing())), m_convertToBackingContext);
+    return XRSubImageImpl::create(adoptWebGPU(wgpuBindingGetViewSubImage(m_backing.get(), projectionLayerImpl.backing())), Ref { m_convertToBackingContext });
 }
 
 TextureFormat XRBindingImpl::getPreferredColorFormat()

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
@@ -37,6 +37,8 @@ class BindGroupLayout;
 struct BindGroupDescriptor : public ObjectDescriptorBase {
     WeakRef<BindGroupLayout> layout;
     Vector<BindGroupEntry> entries;
+
+    Ref<BindGroupLayout> protectedLayout() const { return layout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
@@ -37,6 +37,8 @@ struct BufferBinding {
     WeakRef<Buffer> buffer;
     Size64 offset { 0 };
     std::optional<Size64> size;
+
+    Ref<Buffer> protectedBuffer() const { return buffer.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
@@ -45,6 +45,8 @@ struct CanvasConfiguration {
     CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
     CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
     bool reportValidationErrors { true };
+
+    Ref<Device> protectedDevice() const { return device.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
@@ -38,6 +38,8 @@ struct ComputePassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
     Size32 endOfPassWriteIndex { 0 };
+
+    RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WebGPUBuffer.h"
 #include "WebGPUImageDataLayout.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakRef.h>
@@ -35,6 +36,8 @@ class Buffer;
 
 struct ImageCopyBuffer : public ImageDataLayout {
     WeakRef<Buffer> buffer;
+
+    Ref<Buffer> protectedBuffer() const { return buffer.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
@@ -42,6 +42,8 @@ struct ImageCopyTexture {
     IntegerCoordinate mipLevel { 0 };
     std::optional<Origin3D> origin;
     TextureAspect aspect { TextureAspect::All };
+
+    Ref<Texture> protectedTexture() const { return texture.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
@@ -33,6 +33,8 @@ namespace WebCore::WebGPU {
 
 struct PipelineDescriptorBase : public ObjectDescriptorBase {
     WeakPtr<PipelineLayout> layout;
+
+    RefPtr<PipelineLayout> protectedLayout() const { return layout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
@@ -39,6 +39,8 @@ struct ProgrammableStage {
     WeakRef<ShaderModule> module;
     std::optional<String> entryPoint;
     Vector<KeyValuePair<String, PipelineConstantValue>> constants;
+
+    Ref<ShaderModule> protectedModule() const { return module.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
@@ -47,6 +47,9 @@ struct RenderPassColorAttachment {
     std::optional<Color> clearValue;
     LoadOp loadOp { LoadOp::Load };
     StoreOp storeOp { StoreOp::Store };
+
+    Ref<TextureView> protectedView() const { return view.get(); }
+    RefPtr<TextureView> protectedResolveTarget() const { return resolveTarget.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
@@ -49,6 +49,8 @@ struct RenderPassDepthStencilAttachment {
     std::optional<LoadOp> stencilLoadOp;
     std::optional<StoreOp> stencilStoreOp;
     bool stencilReadOnly { false };
+
+    Ref<TextureView> protectedView() const { return view.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
@@ -42,6 +42,8 @@ struct RenderPassDescriptor : public ObjectDescriptorBase {
     WeakPtr<QuerySet> occlusionQuerySet;
     std::optional<RenderPassTimestampWrites> timestampWrites;
     std::optional<uint64_t> maxDrawCount;
+
+    RefPtr<QuerySet> protectedOcclusionQuerySet() const { return occlusionQuerySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebGPUIntegralTypes.h"
+#include "WebGPUQuerySet.h"
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -38,6 +39,8 @@ struct RenderPassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
     Size32 endOfPassWriteIndex { 0 };
+
+    RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -71,6 +71,8 @@ private:
     ExternalTexture(CVPixelBufferRef, WGPUColorSpace, Device&);
     ExternalTexture(Device&);
 
+    Ref<Device> protectedDevice() const { return m_device; }
+
     RetainPtr<CVPixelBufferRef> m_pixelBuffer;
     WGPUColorSpace m_colorSpace;
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -98,7 +98,7 @@ void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
     if (IOSurfaceRef ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
-        if (auto optionalWebProcessID = m_device->webProcessID()) {
+        if (auto optionalWebProcessID = protectedDevice()->webProcessID()) {
             if (auto webProcessID = optionalWebProcessID->sendRight())
                 IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
         }

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -46,7 +46,7 @@
 
 static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
 {
-    buffer.setCommandEncoder(renderPassEncoder->parentEncoder());
+    buffer.setCommandEncoder(renderPassEncoder->protectedParentEncoder().get());
     return !!renderPassEncoder->renderCommandEncoder();
 }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -97,7 +97,8 @@ public:
     bool colorDepthStencilTargetsMatch(const RenderPipeline&) const;
     id<MTLRenderCommandEncoder> renderCommandEncoder() const;
     void makeInvalid(NSString* = nil);
-    CommandEncoder& parentEncoder() { return m_parentEncoder; }
+    CommandEncoder& parentEncoder() const { return m_parentEncoder; }
+    Ref<CommandEncoder> protectedParentEncoder() const { return m_parentEncoder; }
 
     bool setCommandEncoder(const BindGroupEntryUsageData::Resource&);
     void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, id<MTLResource>, OptionSet<BindGroupEntryUsage>);

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
@@ -41,7 +41,7 @@ std::optional<BindGroupDescriptor> ConvertToBackingContext::convertToBacking(con
     if (!base)
         return std::nullopt;
 
-    auto identifier = convertToBacking(bindGroupDescriptor.layout);
+    auto identifier = convertToBacking(bindGroupDescriptor.protectedLayout().get());
 
     Vector<BindGroupEntry> entries;
     entries.reserveInitialCapacity(bindGroupDescriptor.entries.size());

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp
@@ -40,11 +40,11 @@ namespace WebKit::WebGPU {
 std::optional<BindGroupEntry> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BindGroupEntry& bindGroupEntry)
 {
     return WTF::switchOn(bindGroupEntry.resource, [&] (std::reference_wrapper<WebCore::WebGPU::Sampler> sampler) -> std::optional<BindGroupEntry> {
-        auto identifier = convertToBacking(sampler);
+        auto identifier = convertToBacking(Ref { sampler.get() }.get());
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::Sampler } };
     }, [&] (std::reference_wrapper<WebCore::WebGPU::TextureView> textureView) -> std::optional<BindGroupEntry> {
-        auto identifier = convertToBacking(textureView);
+        auto identifier = convertToBacking(Ref { textureView.get() }.get());
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::TextureView } };
     }, [&] (const auto& bufferBinding) -> std::optional<BindGroupEntry> {
@@ -54,7 +54,7 @@ std::optional<BindGroupEntry> ConvertToBackingContext::convertToBacking(const We
 
         return { { bindGroupEntry.binding, WTFMove(*convertedBufferBinding), convertedBufferBinding->buffer, BindingResourceType::BufferBinding } };
     }, [&] (std::reference_wrapper<WebCore::WebGPU::ExternalTexture> externalTexture) -> std::optional<BindGroupEntry> {
-        auto identifier = convertToBacking(externalTexture);
+        auto identifier = convertToBacking(Ref { externalTexture.get() }.get());
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::ExternalTexture } };
     });

--- a/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<BufferBinding> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BufferBinding& bufferBinding)
 {
-    auto buffer = convertToBacking(bufferBinding.buffer);
+    auto buffer = convertToBacking(bufferBinding.protectedBuffer().get());
 
     return { { buffer, bufferBinding.offset, bufferBinding.size } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
@@ -37,7 +37,8 @@ namespace WebKit::WebGPU {
 
 std::optional<CanvasConfiguration> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::CanvasConfiguration& canvasConfiguration)
 {
-    auto device = convertToBacking(canvasConfiguration.device);
+    Ref protectedDevice = canvasConfiguration.device.get();
+    auto device = convertToBacking(protectedDevice.get());
 
     return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.toneMappingMode, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
@@ -41,7 +41,7 @@ std::optional<ComputePassTimestampWrites> ConvertToBackingContext::convertToBack
     if (!computePassTimestampWrite.querySet)
         return std::nullopt;
 
-    auto querySet = convertToBacking(*computePassTimestampWrite.querySet);
+    auto querySet = convertToBacking(*computePassTimestampWrite.protectedQuerySet());
 
     return { { querySet, computePassTimestampWrite.beginningOfPassWriteIndex, computePassTimestampWrite.endOfPassWriteIndex } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
@@ -38,7 +38,7 @@ namespace WebKit::WebGPU {
 std::optional<ImageCopyBuffer> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyBuffer& imageCopyBuffer)
 {
     auto base = convertToBacking(static_cast<const WebCore::WebGPU::ImageDataLayout&>(imageCopyBuffer));
-    auto buffer = convertToBacking(imageCopyBuffer.buffer);
+    auto buffer = convertToBacking(imageCopyBuffer.protectedBuffer().get());
 
     return { { WTFMove(*base), buffer } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ImageCopyTexture> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyTexture& imageCopyTexture)
 {
-    auto texture = convertToBacking(imageCopyTexture.texture);
+    auto texture = convertToBacking(imageCopyTexture.protectedTexture().get());
 
     std::optional<Origin3D> origin;
     if (imageCopyTexture.origin) {

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
@@ -43,7 +43,7 @@ std::optional<PipelineDescriptorBase> ConvertToBackingContext::convertToBacking(
 
     std::optional<WebGPUIdentifier> layout;
     if (pipelineDescriptorBase.layout) {
-        layout = convertToBacking(*pipelineDescriptorBase.layout);
+        layout = convertToBacking(*pipelineDescriptorBase.protectedLayout().get());
         if (!layout)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ProgrammableStage> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ProgrammableStage& programmableStage)
 {
-    auto module = convertToBacking(programmableStage.module);
+    auto module = convertToBacking(programmableStage.protectedModule().get());
 
     return { { module, programmableStage.entryPoint, programmableStage.constants } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
@@ -37,11 +37,11 @@ namespace WebKit::WebGPU {
 
 std::optional<RenderPassColorAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassColorAttachment& renderPassColorAttachment)
 {
-    auto view = convertToBacking(renderPassColorAttachment.view);
+    auto view = convertToBacking(renderPassColorAttachment.protectedView().get());
 
     std::optional<WebGPUIdentifier> resolveTarget;
     if (renderPassColorAttachment.resolveTarget) {
-        resolveTarget = convertToBacking(*renderPassColorAttachment.resolveTarget);
+        resolveTarget = convertToBacking(*renderPassColorAttachment.protectedResolveTarget());
         if (!resolveTarget)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<RenderPassDepthStencilAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassDepthStencilAttachment& renderPassDepthStencilAttachment)
 {
-    auto view = convertToBacking(renderPassDepthStencilAttachment.view);
+    auto view = convertToBacking(renderPassDepthStencilAttachment.protectedView().get());
 
     return { { view, renderPassDepthStencilAttachment.depthClearValue, renderPassDepthStencilAttachment.depthLoadOp, renderPassDepthStencilAttachment.depthStoreOp, renderPassDepthStencilAttachment.depthReadOnly, renderPassDepthStencilAttachment.stencilClearValue, renderPassDepthStencilAttachment.stencilLoadOp, renderPassDepthStencilAttachment.stencilStoreOp, renderPassDepthStencilAttachment.stencilReadOnly } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp
@@ -61,7 +61,7 @@ std::optional<RenderPassDescriptor> ConvertToBackingContext::convertToBacking(co
 
     std::optional<WebGPUIdentifier> occlusionQuerySet;
     if (renderPassDescriptor.occlusionQuerySet) {
-        occlusionQuerySet = convertToBacking(*renderPassDescriptor.occlusionQuerySet);
+        occlusionQuerySet = convertToBacking(*renderPassDescriptor.protectedOcclusionQuerySet());
         if (!occlusionQuerySet)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
@@ -40,7 +40,7 @@ std::optional<RenderPassTimestampWrites> ConvertToBackingContext::convertToBacki
     if (!renderPassTimestampWrite.querySet)
         return std::nullopt;
 
-    auto querySet = convertToBacking(*renderPassTimestampWrite.querySet);
+    auto querySet = convertToBacking(*renderPassTimestampWrite.protectedQuerySet());
 
     return { { querySet, renderPassTimestampWrite.beginningOfPassWriteIndex, renderPassTimestampWrite.endOfPassWriteIndex } };
 }


### PR DESCRIPTION
#### 7b4e2500f1524427c59dddd6d5362ee5008dba8a
<pre>
Finish off smart pointer adoption in WebCore/Modules/WebGPU/Implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=282207">https://bugs.webkit.org/show_bug.cgi?id=282207</a>
<a href="https://rdar.apple.com/138794979">rdar://138794979</a>

Reviewed by Mike Wyrzykowski.

Static analysis told me to.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
(WebCore::WebGPU::CommandEncoderImpl::beginComputePass):
(WebCore::WebGPU::CommandEncoderImpl::copyBufferToBuffer):
(WebCore::WebGPU::CommandEncoderImpl::copyBufferToTexture):
(WebCore::WebGPU::CommandEncoderImpl::copyTextureToBuffer):
(WebCore::WebGPU::CommandEncoderImpl::copyTextureToTexture):
(WebCore::WebGPU::CommandEncoderImpl::clearBuffer):
(WebCore::WebGPU::CommandEncoderImpl::writeTimestamp):
(WebCore::WebGPU::CommandEncoderImpl::resolveQuerySet):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp:
(WebCore::WebGPU::ComputePassEncoderImpl::setPipeline):
(WebCore::WebGPU::ComputePassEncoderImpl::dispatchIndirect):
(WebCore::WebGPU::ComputePassEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createBuffer):
(WebCore::WebGPU::DeviceImpl::createTexture):
(WebCore::WebGPU::DeviceImpl::createSampler):
(WebCore::WebGPU::DeviceImpl::createBindGroup):
(WebCore::WebGPU::DeviceImpl::createShaderModule):
(WebCore::WebGPU::convertToBacking):
(WebCore::WebGPU::DeviceImpl::createRenderBundleEncoder):
(WebCore::WebGPU::DeviceImpl::createQuerySet):
(WebCore::WebGPU::DeviceImpl::pushErrorScope):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp:
(WebCore::WebGPU::GPUImpl::requestAdapter):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::configure):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::submit):
(WebCore::WebGPU::QueueImpl::writeBufferNoCopy):
(WebCore::WebGPU::QueueImpl::writeTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp:
(WebCore::WebGPU::RenderBundleEncoderImpl::setPipeline):
(WebCore::WebGPU::RenderBundleEncoderImpl::setIndexBuffer):
(WebCore::WebGPU::RenderBundleEncoderImpl::setVertexBuffer):
(WebCore::WebGPU::RenderBundleEncoderImpl::drawIndirect):
(WebCore::WebGPU::RenderBundleEncoderImpl::drawIndexedIndirect):
(WebCore::WebGPU::RenderBundleEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp:
(WebCore::WebGPU::RenderPassEncoderImpl::setPipeline):
(WebCore::WebGPU::RenderPassEncoderImpl::setIndexBuffer):
(WebCore::WebGPU::RenderPassEncoderImpl::setVertexBuffer):
(WebCore::WebGPU::RenderPassEncoderImpl::drawIndirect):
(WebCore::WebGPU::RenderPassEncoderImpl::drawIndexedIndirect):
(WebCore::WebGPU::RenderPassEncoderImpl::setBindGroup):
(WebCore::WebGPU::RenderPassEncoderImpl::setBlendConstant):
(WebCore::WebGPU::RenderPassEncoderImpl::executeBundles):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp:
(WebCore::WebGPU::XRBindingImpl::createProjectionLayer):
(WebCore::WebGPU::XRBindingImpl::getViewSubImage):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h:
(WebCore::WebGPU::BindGroupDescriptor::protectedLayout const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h:
(WebCore::WebGPU::BufferBinding::protectedBuffer const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h:
(WebCore::WebGPU::CanvasConfiguration::protectedDevice const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h:
(WebCore::WebGPU::ComputePassTimestampWrites::protectedQuerySet const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h:
(WebCore::WebGPU::ImageCopyBuffer::protectedBuffer const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h:
(WebCore::WebGPU::ImageCopyTexture::protectedTexture const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h:
(WebCore::WebGPU::PipelineDescriptorBase::protectedLayout const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h:
(WebCore::WebGPU::ProgrammableStage::protectedModule const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
(WebCore::WebGPU::RenderPassColorAttachment::protectedView const):
(WebCore::WebGPU::RenderPassColorAttachment::protectedResolveTarget const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h:
(WebCore::WebGPU::RenderPassDepthStencilAttachment::protectedView const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h:
(WebCore::WebGPU::RenderPassDescriptor::protectedOcclusionQuerySet const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h:
(WebCore::WebGPU::RenderPassTimestampWrites::protectedQuerySet const):
* Source/WebGPU/WebGPU/ExternalTexture.h:
(WebGPU::ExternalTexture::protectedDevice const):
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::update):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(setCommandEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::parentEncoder const):
(WebGPU::RenderPassEncoder::protectedParentEncoder const):
(WebGPU::RenderPassEncoder::parentEncoder): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):

Canonical link: <a href="https://commits.webkit.org/285817@main">https://commits.webkit.org/285817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2defd5eceb8eb6e6b4dc1de319c72fc5a9f5e11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16454 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66414 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9587 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1159 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->