### PR TITLE
[GLib] Provide and use helper functions to convert GBytes to std::span

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -32,6 +32,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h
+    glib/GSpanExtras.h
     glib/GThreadSafeWeakPtr.h
     glib/GTypedefs.h
     glib/GUniquePtr.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -35,6 +35,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h
+    glib/GSpanExtras.h
     glib/GThreadSafeWeakPtr.h
     glib/GTypedefs.h
     glib/GUniquePtr.h

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <wtf/StdLibExtras.h>
+#include <wtf/glib/GRefPtr.h>
+
+namespace WTF {
+
+inline std::span<const uint8_t> span(GBytes* bytes)
+{
+    size_t size = 0;
+    const auto* ptr = static_cast<const uint8_t*>(g_bytes_get_data(bytes, &size));
+    return unsafeForgeSpan<const uint8_t>(ptr, size);
+}
+
+inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes)
+{
+    return span(bytes.get());
+}
+
+} // namespace WTF
+
+using WTF::span;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -39,6 +39,8 @@
 #include <gio/gfiledescriptorbased.h>
 #endif
 
+#include <wtf/glib/GSpanExtras.h>
+
 namespace WebKit {
 namespace NetworkCache {
 
@@ -65,9 +67,7 @@ std::span<const uint8_t> Data::span() const
 {
     if (!m_buffer)
         return { };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return { reinterpret_cast<const uint8_t*>(g_bytes_get_data(m_buffer.get(), nullptr)), g_bytes_get_size(m_buffer.get()) };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return WTF::span(m_buffer);
 }
 
 size_t Data::size() const
@@ -85,11 +85,7 @@ bool Data::apply(const Function<bool(std::span<const uint8_t>)>& applier) const
     if (!size())
         return false;
 
-    gsize length;
-    const auto* data = g_bytes_get_data(m_buffer.get(), &length);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return applier({ reinterpret_cast<const uint8_t*>(data), length });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return applier(span());
 }
 
 Data Data::subrange(size_t offset, size_t size) const

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -83,7 +83,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
-#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
@@ -3451,14 +3451,11 @@ void webkit_web_view_load_bytes(WebKitWebView* webView, GBytes* bytes, const cha
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(bytes);
 
-    gsize bytesDataSize;
-    gconstpointer bytesData = g_bytes_get_data(bytes, &bytesDataSize);
-    g_return_if_fail(bytesDataSize);
+    auto bytesData = span(bytes);
+    g_return_if_fail(bytesData.size());
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    getPage(webView).loadData(WebCore::SharedBuffer::create(std::span { reinterpret_cast<const uint8_t*>(bytesData), bytesDataSize }), mimeType ? String::fromUTF8(mimeType) : String::fromUTF8("text/html"),
+    getPage(webView).loadData(WebCore::SharedBuffer::create(bytesData), mimeType ? String::fromUTF8(mimeType) : String::fromUTF8("text/html"),
         encoding ? String::fromUTF8(encoding) : String::fromUTF8("UTF-8"), String::fromUTF8(baseURI));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/GtkUtilities.h>
 #include <WebCore/GtkVersioning.h>
 #include <WebCore/Scrollbar.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/Base64.h>
 
 namespace WebKit {
@@ -345,12 +346,7 @@ static std::optional<String> base64EncodedPNGData(GdkTexture* texture)
         return std::nullopt;
 
     GRefPtr<GBytes> pngBytes = adoptGRef(gdk_texture_save_to_png_bytes(texture));
-    size_t pngSize;
-    auto* pngData = static_cast<const uint8_t*>(g_bytes_get_data(pngBytes.get(), &pngSize));
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return base64EncodeToString(std::span<const uint8_t>(pngData, pngSize));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return base64EncodeToString(span(pngBytes));
 }
 #else
 static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
@@ -361,7 +357,7 @@ static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
     Vector<uint8_t> pngData;
     cairo_surface_write_to_png_stream(surface, [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
         auto* pngData = static_cast<Vector<uint8_t>*>(userData);
-        pngData->append(std::span { reinterpret_cast<const uint8_t*>(data), length });
+        pngData->append(unsafeForgeSpan<const uint8_t>(data, length));
         return CAIRO_STATUS_SUCCESS;
     }, &pngData);
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/SoupVersioning.h>
 #include <wtf/FileSystem.h>
 #include <wtf/URL.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebKit {
@@ -132,11 +133,7 @@ void RemoteInspectorHTTPServer::handleWebSocket(const char* path, SoupWebsocketC
     m_webSocketConnectionToTargetMap.set(connection, std::make_pair(connectionID, targetID));
     g_signal_connect(connection, "message", G_CALLBACK(+[](SoupWebsocketConnection* connection, SoupWebsocketDataType messageType, GBytes* message, gpointer userData) {
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);
-        gsize dataSize;
-        const auto* data = static_cast<const char*>(g_bytes_get_data(message, &dataSize));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        httpServer.sendMessageToBackend(connection, String::fromUTF8(std::span(data, dataSize)));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        httpServer.sendMessageToBackend(connection, String::fromUTF8(span(message)));
     }), this);
     g_signal_connect(connection, "closed", G_CALLBACK(+[](SoupWebsocketConnection* connection, gpointer userData) {
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);


### PR DESCRIPTION
#### bdeb007fd6c1fe75bfc58afdf501ce0ddb5f465f
<pre>
[GLib] Provide and use helper functions to convert GBytes to std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=282210">https://bugs.webkit.org/show_bug.cgi?id=282210</a>

Reviewed by Geoffrey Garen and Michael Catanzaro.

Add a new span(GBytes*) utility function, and a span(GRefPtr&lt;GBytes&gt;&amp;)
overload. These localize the unsafe creation of a std::span&lt;const uint8_t&gt;
that represents the GBytes data in a single location, allowing to remove
WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} macros which were sprinkled
around. For item types other than uint8_t it is recommended to use
WTF::spanReinterpretCast&lt;T&gt; afterwards.

* Source/WTF/wtf/PlatformGTK.cmake: List new SpanHelpers.h header.
* Source/WTF/wtf/PlatformWPE.cmake: Ditto.
* Source/WTF/wtf/glib/GSpanExtras.h: Added.
(WTF::span): New function to make a std::span out of a GBytes.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::span const): Use WTF::span() helper.
(WebKit::NetworkCache::Data::apply const): Use the Data::span() method.
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp:
(webkitUserContentFilterStoreSaveBytes): Use WTF::span() helper.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_load_bytes): Ditto.
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept): Ditto.
* Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp:
(WebKit::base64EncodedPNGData): Ditto.
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp:

Canonical link: <a href="https://commits.webkit.org/285855@main">https://commits.webkit.org/285855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7565e5eb50e69226318ab99565fad3e1f0ac4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26837 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21166 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67163 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79918 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73284 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1343 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63689 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16298 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/9701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95065 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1307 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20886 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->