### PR TITLE
ASAN_TRAP | Yarr::CharacterClassConstructor::unicodeOpSorted due to out of order Unicode Case Folding

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -573,3 +573,5 @@ testRegExpSyntaxError("\\q{a}", "v", "SyntaxError: Invalid regular expression: i
 testRegExp(/[\&\-\!\#\%\,\:\;\<\=\>\@\`\~]*/v, "&-!#%,:;<=>@`~", ["&-!#%,:;<=>@`~"]);
 testRegExp(/[\q{\&\-\!\#\%\,\:\;\<\=\>\@\`\~}X]*/v, "X&-!#%,:;<=>@`~X", ["X&-!#%,:;<=>@`~X"]);
 testRegExp(/[\q{}]/v, "", [""]);
+testRegExp(/[\q{\u{0095}|k}]/vi, "k", ["k"]);
+testRegExp(/[\q{\u{0095}|s}]/vi, "s", ["s"]);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -404,8 +404,13 @@ public:
         if (m_compileMode != CompileMode::UnicodeSets)
             return;
 
-        asciiOpSorted(rhsMatches, rhsRanges);
-        unicodeOpSorted(rhsMatchesUnicode, rhsRangesUnicode);
+        asciiOp(rhsMatches, rhsRanges);
+        // Sort the incoming Unicode matches, since Unicode case folding canonicalization may cause
+        // characters to be added to rhsMatches out of code point order.
+        Vector<char32_t> rhsSortedMatchesUnicode(rhsMatchesUnicode);
+        std::sort(rhsSortedMatchesUnicode.begin(), rhsSortedMatchesUnicode.end());
+
+        unicodeOpSorted(rhsSortedMatchesUnicode, rhsRangesUnicode);
     }
 
     bool hasInverteStrings()
@@ -662,7 +667,7 @@ private:
         m_mayContainStrings = !m_strings.isEmpty();
     }
 
-    void asciiOpSorted(const Vector<char32_t>& rhsMatches, const Vector<CharacterRange>& rhsRanges)
+    void asciiOp(const Vector<char32_t>& rhsMatches, const Vector<CharacterRange>& rhsRanges)
     {
         Vector<char32_t> resultMatches;
         Vector<CharacterRange> resultRanges;


### PR DESCRIPTION
#### 548b60525e35dd2b448520b213a332b83d001e1e
<pre>
ASAN_TRAP | Yarr::CharacterClassConstructor::unicodeOpSorted due to out of order Unicode Case Folding
<a href="https://bugs.webkit.org/show_bug.cgi?id=282200">https://bugs.webkit.org/show_bug.cgi?id=282200</a>
<a href="https://rdar.apple.com/138178588">rdar://138178588</a>

Reviewed by Mark Lam.

Certain ASCII characters can introduce Unicode characters (and vice versa) when we add all the
case variations in a case insensitive regex.  This leads to incorrect behavior in performSetOpWithMatches,
since one function it calls, unicodeOpSorted(), assume that its matches argument is in sorted order.

Renamed asciiOpSorted() to asciiOp(), since it doesn&apos;t care that its matches vector is sorted.

Added two new tests added to regexp-vflag-property-of-strings.js.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::performSetOpWithMatches):
(JSC::Yarr::CharacterClassConstructor::asciiOp):
(JSC::Yarr::CharacterClassConstructor::asciiOpSorted): Deleted.

Canonical link: <a href="https://commits.webkit.org/285819@main">https://commits.webkit.org/285819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0944a5e495372ea04f8e5a2f4fd574e764b2f38b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58095 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16455 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23460 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67026 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79778 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73147 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16269 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9602 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1170 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20862 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->