### PR TITLE
Make asByteSpan() / asMutableByteSpan() work with input spans

### DIFF
--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -116,7 +116,7 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t 
 
     std::span<CharacterType> buffer;
     String string = String::createUninitialized(length, buffer);
-    if (!decoder.decodeFixedLengthData(spanReinterpretCast<uint8_t>(buffer)))
+    if (!decoder.decodeFixedLengthData(asMutableByteSpan(buffer)))
         return std::nullopt;
     
     return string;

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -161,7 +161,7 @@ template<> struct Coder<WTF::String> {
 
         std::span<CharacterType> buffer;
         String string = String::createUninitialized(length, buffer);
-        if (!decoder.decodeFixedLengthData(spanReinterpretCast<uint8_t>(buffer)))
+        if (!decoder.decodeFixedLengthData(asMutableByteSpan(buffer)))
             return std::nullopt;
 
         return string;

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -608,7 +608,7 @@ public:
 
         std::span<UChar> buffer;
         auto string = String::createUninitialized(length, buffer);
-        decodeFixedLengthData(spanReinterpretCast<uint8_t>(buffer), alignof(UChar));
+        decodeFixedLengthData(asMutableByteSpan(buffer), alignof(UChar));
 
         value = string;
         return *this;

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -214,7 +214,7 @@ TEST(WTF_StdLibExtras, SpanReinterpretCast_DynamicExtent)
     static_assert(std::same_as<std::span<const int32_t, std::dynamic_extent>, decltype(signedIntSpan)>);
 
     // Cast from 4 bytes to 1 byte per item.
-    auto unsignedIntByteSpan = spanReinterpretCast<const uint8_t>(signedIntSpan);
+    auto unsignedIntByteSpan = asByteSpan(signedIntSpan);
     static_assert(std::same_as<std::span<const uint8_t, std::dynamic_extent>, decltype(unsignedIntByteSpan)>);
     EXPECT_TRUE(!memcmp(signedIntSpan.data(), unsignedIntByteSpan.data(), unsignedIntByteSpan.size_bytes()));
 
@@ -257,8 +257,8 @@ TEST(WTF_StdLibExtras, SpanReinterpretCast_NonDynamicExtent)
     static_assert(std::same_as<std::span<const int32_t, 6>, decltype(signedIntSpan)>);
 
     // Cast from 4 bytes to 1 byte per item.
-    auto unsignedIntByteSpan = spanReinterpretCast<const uint8_t>(signedIntSpan);
-    static_assert(std::same_as<std::span<const uint8_t, 24>, decltype(unsignedIntByteSpan)>);
+    auto unsignedIntByteSpan = asByteSpan(signedIntSpan);
+    static_assert(std::same_as<std::span<const uint8_t>, decltype(unsignedIntByteSpan)>);
     EXPECT_TRUE(!memcmp(signedIntSpan.data(), unsignedIntByteSpan.data(), unsignedIntByteSpan.size_bytes()));
 
     // Cast from 4 bytes to 4 bytes per item.


### PR DESCRIPTION
#### 53d58fbd7acfa1b6976ba1ffebddf1d76e973673
<pre>
Make asByteSpan() / asMutableByteSpan() work with input spans
<a href="https://bugs.webkit.org/show_bug.cgi?id=282212">https://bugs.webkit.org/show_bug.cgi?id=282212</a>

Reviewed by Geoffrey Garen.

Make asByteSpan() / asMutableByteSpan() do what we&apos;d expect if passed in a span.
It is risky otherwise.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::unsafeForgeSpan):
(WTF::asByteSpan):
(WTF::asMutableByteSpan):
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::decodeStringText):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::String&gt;::decodeStringText):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataDecoder::operator&gt;&gt;):
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST(WTF_StdLibExtras, SpanReinterpretCast_DynamicExtent)):
(TestWebKitAPI::TEST(WTF_StdLibExtras, SpanReinterpretCast_NonDynamicExtent)):

Canonical link: <a href="https://commits.webkit.org/285902@main">https://commits.webkit.org/285902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff6fba4c684abfbeae188f05cea097a86fd6761

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25248 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23581 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67147 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79902 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73268 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65791 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7873 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95049 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11444 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4044 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20884 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->