### PR TITLE
Make `FontProxy` RefCounted.

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -49,6 +49,7 @@
 #include "Path.h"
 #include "PlatformLayer.h"
 #include "Timer.h"
+#include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -247,11 +248,14 @@ public:
     using Direction = CanvasDirection;
     void setDirection(Direction);
 
-    class FontProxy final : public FontSelectorClient {
-    public:
-        FontProxy() = default;
+    class FontProxy final : public RefCounted<FontProxy>, public FontSelectorClient {
+
+        public:
+        static RefPtr<FontProxy> create() { return adoptRef(*new FontProxy()); }
         virtual ~FontProxy();
         FontProxy(const FontProxy&);
+
+        FontProxy();
         FontProxy& operator=(const FontProxy&);
 
         bool realized() const { return m_font.fontSelector(); }
@@ -304,7 +308,6 @@ public:
 
         String unparsedFont;
         FontProxy font;
-
         RefPtr<CanvasLayerContextSwitcher> targetSwitcher;
 
         CanvasLineCap canvasLineCap() const;


### PR DESCRIPTION
#### 115ced0751512a4fa57d12174320032de8765f71
<pre>
Make `FontProxy` RefCounted.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279478">https://bugs.webkit.org/show_bug.cgi?id=279478</a>
<a href="https://rdar.apple.com/problem/136185867">rdar://problem/136185867</a>

Reviewed by NOBODY (OOPS!).

Making `FontProxy` reference counted to avoid dangling pointer issues.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/115ced0751512a4fa57d12174320032de8765f71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1111 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58131 "Failure limit exceed. At least found 212 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-ImageData-cache.html fast/canvas/canvas-backing-store-reuse.html fast/canvas/canvas-blending-clipping.html fast/canvas/canvas-blending-color-over-color.html fast/canvas/canvas-blending-color-over-gradient.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16457 "Found 60 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html fast/canvas/canvas-filter-text-drawing.html fast/canvas/canvas-incremental-repaint.html fast/canvas/canvas-layer-filter-text-drawing.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76964 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48248 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63574 "4 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38530 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45062 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/html/canvas/element/2d.conformance.requirements.basics.html imported/w3c/web-platform-tests/html/canvas/element/2d.text-outside-of-the-flat-tree.html imported/w3c/web-platform-tests/html/canvas/element/conformance-requirements/2d.conformance.requirements.basics.html imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.disconnected.html imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.fontStretch.normal.html imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas_text_font_001.htm imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.text.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21063 "Found 60 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html fast/canvas/canvas-filter-text-drawing.html fast/canvas/canvas-incremental-repaint.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23468 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66615 "Found 4 new API test failures: TestWebKitAPI.AdvancedPrivacyProtections.Canvas2DQuirks, TestWebKitAPI.AdvancedPrivacyProtections.VerifyHashFromNoisyCanvas2DAPI, TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.AdvancedPrivacyProtections.VerifyPixelsFromNoisyCanvas2DAPI (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21411 "Found 60 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html fast/canvas/canvas-filter-text-drawing.html fast/canvas/canvas-incremental-repaint.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1214 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/627 "Found 60 new test failures: accessibility/parent-delete.html animations/stacking-context-unchanged-while-running.html compositing/canvas/accelerated-canvas-compositing.html compositing/layer-creation/deep-tree.html compositing/layer-creation/translatez-overlap.html compositing/masks/mask-layer-size.html compositing/tiling/huge-layer-with-layer-children-resize.html css1/cascade/cascade_order.html css3/blending/blend-mode-isolated-group-2.html css3/filters/clipping-overflow-scroll-with-pixel-moving-effect-on-parent.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66429 "Failure limit exceed. At least found 274 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html fast/canvas/canvas-incremental-repaint.html fast/canvas/canvas-overloads-fillText.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9598 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7780 "Found 60 new test failures: fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/canvas-blending-text.html fast/canvas/canvas-composite-text-alpha.html fast/canvas/canvas-direction.html fast/canvas/canvas-filter-bounding-rect.html fast/canvas/canvas-filter-text-drawing.html fast/canvas/canvas-incremental-repaint.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1178 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3928 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->