### PR TITLE
Re-enable TestWebKitAPI.WebpagePreferences.WebsitePoliciesAutoplayQuirks on new macOS

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
@@ -215,8 +215,7 @@ TEST(AppPrivacyReport, AppInitiatedRequestWithSubFrame)
 
     [webView loadRequest:appInitiatedRequest];
 
-    [webView waitForMessage:@"MainFrame: B"];
-    [webView waitForMessage:@"Subframe: B"];
+    [webView waitForMessages:@[@"MainFrame: B", @"Subframe: B"]];
 
     [webView _appPrivacyReportTestingData: ^(struct WKAppPrivacyReportTestingData data) {
         EXPECT_TRUE(data.hasLoadedAppInitiatedRequestTesting);
@@ -239,8 +238,7 @@ TEST(AppPrivacyReport, NonAppInitiatedRequestWithSubFrame)
 
     [webView loadRequest:nonAppInitiatedRequest];
 
-    [webView waitForMessage:@"MainFrame: B"];
-    [webView waitForMessage:@"Subframe: B"];
+    [webView waitForMessages:@[@"MainFrame: B", @"Subframe: B"]];
 
     [webView _appPrivacyReportTestingData: ^(struct WKAppPrivacyReportTestingData data) {
         EXPECT_FALSE(data.hasLoadedAppInitiatedRequestTesting);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
@@ -32,7 +32,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
-TEST(WKWebView, DISABLED_SetOverrideContentSecurityPolicyWithEmptyStringForPageWithCSP)
+TEST(WKWebView, SetOverrideContentSecurityPolicyWithEmptyStringForPageWithCSP)
 {
     @autoreleasepool {
         RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -42,10 +42,7 @@ TEST(WKWebView, DISABLED_SetOverrideContentSecurityPolicyWithEmptyStringForPageW
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
-        [webView waitForMessage:@"MainFrame: A"];
-        [webView waitForMessage:@"MainFrame: B"];
-        [webView waitForMessage:@"Subframe: A"];
-        [webView waitForMessage:@"Subframe: B"];
+        [webView waitForMessages:@[@"MainFrame: A", @"MainFrame: B", @"Subframe: A", @"Subframe: B"]];
     }
 }
 
@@ -59,8 +56,7 @@ TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithCSP)
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
-        [webView waitForMessage:@"MainFrame: B"];
-        [webView waitForMessage:@"Subframe: B"];
+        [webView waitForMessages:@[@"MainFrame: B", @"Subframe: B"]];
     }
 }
 
@@ -74,8 +70,7 @@ TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithoutCSP)
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-without-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
-        [webView waitForMessage:@"MainFrame: B"];
-        [webView waitForMessage:@"Subframe: B"];
+        [webView waitForMessages:@[@"MainFrame: B", @"Subframe: B"]];
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1117,7 +1117,7 @@ public:
 
     void captureAllMessages()
     {
-        [m_testMessageHandler setWildcardMessageHandler:^(NSString *message){
+        [m_testMessageHandler setDidReceiveScriptMessage:^(NSString *message) {
             m_mostRecentMessage = message;
         }];
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -778,12 +778,7 @@ TEST(WebpagePreferences, WebsitePoliciesUpdates)
 }
 
 #if PLATFORM(MAC)
-// rdar://137267112
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
-TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirks)
-#else
 TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -801,9 +796,9 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyDeny;
     }];
+
     [webView loadRequest:requestWithAudio];
-    [webView waitForMessage:@"did-not-play"];
-    [webView waitForMessage:@"on-pause"];
+    [webView waitForMessages:@[@"did-not-play", @"on-pause"]];
 
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
@@ -820,8 +815,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
         return _WKWebsiteAutoplayPolicyDeny;
     }];
     [webView loadRequest:requestWithAudioInFrame];
-    [webView waitForMessage:@"did-not-play"];
-    [webView waitForMessage:@"on-pause"];
+    [webView waitForMessages:@[@"did-not-play", @"on-pause"]];
 
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
@@ -911,8 +905,7 @@ TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 }
 #endif
 
-// FIXME: Re-enable this test once webkit.org/b/230494 is resolved.
-TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelegate)
+TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirksAsyncPolicyDelegate)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
@@ -934,8 +927,8 @@ TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelega
         return _WKWebsiteAutoplayPolicyDeny;
     }];
     [webView loadRequest:requestWithAudio];
-    [webView waitForMessage:@"did-not-play"];
-    [webView waitForMessage:@"on-pause"];
+
+    [webView waitForMessages:@[@"did-not-play", @"on-pause"]];
 
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
@@ -952,8 +945,7 @@ TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelega
         return _WKWebsiteAutoplayPolicyDeny;
     }];
     [webView loadRequest:requestWithAudioInFrame];
-    [webView waitForMessage:@"did-not-play"];
-    [webView waitForMessage:@"on-pause"];
+    [webView waitForMessages:@[@"did-not-play", @"on-pause"]];
 }
 
 TEST(WebpagePreferences, InvalidCustomHeaders)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -132,7 +132,7 @@ struct AutocorrectionContext {
 
 @interface TestMessageHandler : NSObject <WKScriptMessageHandler>
 - (void)addMessage:(NSString *)message withHandler:(dispatch_block_t)handler;
-- (void)setWildcardMessageHandler:(void (^)(NSString *))handler;
+@property (nonatomic, copy) void (^didReceiveScriptMessage)(NSString *);
 @end
 
 @interface TestWKWebView : WKWebView
@@ -143,6 +143,7 @@ struct AutocorrectionContext {
 - (void)performAfterReceivingMessage:(NSString *)message action:(dispatch_block_t)action;
 - (void)performAfterReceivingAnyMessage:(void (^)(NSString *))action;
 - (void)waitForMessage:(NSString *)message;
+- (void)waitForMessages:(NSArray<NSString *> *)messages;
 
 // This function waits until a DOM load event is fired.
 // FIXME: Rename this function to better describe what "after loading" means.

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -45,6 +45,7 @@
 #import <objc/runtime.h>
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Deque.h>
 #import <wtf/RetainPtr.h>
 
 #if PLATFORM(MAC)
@@ -671,7 +672,6 @@ static WebEvent *unwrap(BEKeyEntry *event)
 
 @implementation TestMessageHandler {
     NSMutableDictionary<NSString *, dispatch_block_t> *_messageHandlers;
-    BlockPtr<void(NSString *)> _wildcardMessageHandler;
 }
 
 - (void)addMessage:(NSString *)message withHandler:(dispatch_block_t)handler
@@ -679,12 +679,7 @@ static WebEvent *unwrap(BEKeyEntry *event)
     if (!_messageHandlers)
         _messageHandlers = [NSMutableDictionary dictionary];
 
-    _messageHandlers[message] = [handler copy];
-}
-
-- (void)setWildcardMessageHandler:(void (^)(NSString *))handler
-{
-    _wildcardMessageHandler = handler;
+    _messageHandlers[message] = adoptNS([handler copy]).autorelease();
 }
 
 - (void)removeMessage:(NSString *)message
@@ -694,12 +689,10 @@ static WebEvent *unwrap(BEKeyEntry *event)
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    dispatch_block_t handler = _messageHandlers[message.body];
-    if (handler)
+    if (dispatch_block_t handler = _messageHandlers[message.body])
         handler();
-
-    if (_wildcardMessageHandler)
-        _wildcardMessageHandler(message.body);
+    if (_didReceiveScriptMessage)
+        _didReceiveScriptMessage(message.body);
 }
 
 @end
@@ -952,7 +945,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
         _testHandler = adoptNS([[TestMessageHandler alloc] init]);
         [[[self configuration] userContentController] addScriptMessageHandler:_testHandler.get() name:@"testHandler"];
     }
-    [_testHandler setWildcardMessageHandler:action];
+    [_testHandler setDidReceiveScriptMessage:action];
 }
 
 - (void)synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:(NSString *)html
@@ -972,6 +965,22 @@ static InputSessionChangeCount nextInputSessionChangeCount()
         isDoneWaiting = true;
     }];
     TestWebKitAPI::Util::run(&isDoneWaiting);
+}
+
+- (void)waitForMessages:(NSArray<NSString *> *)expectedMessages
+{
+    __block Deque<RetainPtr<NSString>> receivedMessages;
+    RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
+    [messageHandler setDidReceiveScriptMessage:^(NSString *message) {
+        receivedMessages.append(message);
+    }];
+    [self.configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+    for (NSString *expectedMessage in expectedMessages) {
+        while (receivedMessages.isEmpty())
+            TestWebKitAPI::Util::spinRunLoop();
+        EXPECT_WK_STREQ(receivedMessages.takeFirst().get(), expectedMessage);
+    }
+    [self.configuration.userContentController removeScriptMessageHandlerForName:@"testHandler"];
 }
 
 - (void)performAfterLoading:(dispatch_block_t)actions


### PR DESCRIPTION
#### 3857b6ae9b5240a9d2124501ac70c74b7d549cdf
<pre>
Re-enable TestWebKitAPI.WebpagePreferences.WebsitePoliciesAutoplayQuirks on new macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=282214">https://bugs.webkit.org/show_bug.cgi?id=282214</a>
<a href="https://rdar.apple.com/137267112">rdar://137267112</a>

Reviewed by Wenson Hsieh.

Sometimes the TestWebKitAPI::Util::run call in TestWKWebView.waitForMessage causes
the runloop to spin until multiple messages have been received.  This makes it so
if you have multiple calls to waitForMessage without anything being done between them,
it can sometimes be waiting for a message it has already received, causing the test
to time out.  To fix this, use a Deque to be more robust against receiving multiple
messages in one call to Util::run.

A quick audit of the uses of TestWKWebView.waitForMessage found several more places
this is an issue, some of which had resulted in disabled tests.  I fixed this everywhere.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestMessageHandler addMessage:withHandler:]):
(-[TestMessageHandler userContentController:didReceiveScriptMessage:]):
(-[TestWKWebView performAfterReceivingAnyMessage:]):
(-[TestMessageHandler setWildcardMessageHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/285843@main">https://commits.webkit.org/285843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1864ffdfa8d1db3bac40cbba656148606157c980

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63590 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65718 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7783 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->