### PR TITLE
WebCore's main thread scroll position is poorly synchronized with the UI-process scroll position

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -83,10 +83,11 @@ public:
     }
 
     // Inform the web process that the scroll position changed (called from the scrolling tree)
-    void scrollingTreeNodeDidScroll(WebCore::ScrollingNodeID, const WebCore::FloatPoint& newScrollPosition, const std::optional<WebCore::FloatPoint>& layoutViewportOrigin, WebCore::ScrollingLayerPositionAction);
     virtual bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&);
     virtual bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&);
     void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingNodeID);
+
+    void scrollingThreadAddedPendingUpdate();
 
     WebCore::TrackingType eventTrackingTypeForPoint(WebCore::EventTrackingRegions::EventType, WebCore::IntPoint) const;
 
@@ -120,8 +121,6 @@ public:
 
     WebCore::OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
     WebCore::OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
-
-    virtual bool propagatesMainFrameScrolls() const { return true; }
 
     virtual void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) { }
     virtual void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -81,7 +81,10 @@ void RemoteScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&
     if (auto* scrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(node))
         layoutViewportOrigin = scrollingNode->layoutViewport().location();
 
-    scrollingCoordinatorProxy->scrollingTreeNodeDidScroll(node.scrollingNodeID(), node.currentScrollPosition(), layoutViewportOrigin, scrollingLayerPositionAction);
+    auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), node.currentScrollPosition(), layoutViewportOrigin, ScrollUpdateType::PositionUpdate, scrollingLayerPositionAction };
+    addPendingScrollUpdate(WTFMove(scrollUpdate));
+
+    scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
 }
 
 void RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode& node)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -81,7 +81,6 @@ public:
 
 private:
     RemoteLayerTreeDrawingAreaProxyIOS& drawingAreaIOS() const;
-    bool propagatesMainFrameScrolls() const override { return false; }
 
     void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -53,6 +53,19 @@ RemoteScrollingTreeIOS::RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy& 
 
 RemoteScrollingTreeIOS::~RemoteScrollingTreeIOS() = default;
 
+void RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node, ScrollingLayerPositionAction scrollingLayerPositionAction)
+{
+    ASSERT(isMainRunLoop());
+
+    // Scroll updates for the main frame on iOS are sent via WebPageProxy::updateVisibleContentRects()
+    if (node.isRootNode()) {
+        ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
+        return;
+    }
+
+    RemoteScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
+}
+
 void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
 {
     if (m_scrollingCoordinatorProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
@@ -43,6 +43,7 @@ public:
 private:
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
 
+    void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction) final;
     void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
 };
 


### PR DESCRIPTION
#### 3056a40d3e2365131be19a444b3f25fe1b42a824
<pre>
WebCore&apos;s main thread scroll position is poorly synchronized with the UI-process scroll position
<a href="https://bugs.webkit.org/show_bug.cgi?id=282215">https://bugs.webkit.org/show_bug.cgi?id=282215</a>
<a href="https://rdar.apple.com/138804403">rdar://138804403</a>

Reviewed by Matt Woodrow.

When we adopted UI-side compositing on macOS, the synchronization between the UI-process scroll
position, and the web process scroll position became worse. This has consequences for things like
repainting non-root `background-attachment: fixed`, and for the scroll position exposed to JavaScript.
It&apos;s bad enough that even for a responsive web process (&lt;16ms frames), the web content scroll position
is often a frame stale for a given rendering update.

There are some race conditions that cause this. A rendering update is triggered in the UI
process by a displayLink callback off the main thread. This callback triggers two things:

1. It is bounced to the scrolling thread where it triggers the generation of synthetic momentum events,
   which are handled by the scrolling tree. This results in layer repositioning, the actual manifestation of scrolling,
   and in &quot;scrollingTreeNodeDidScroll&quot; messages, which bounce back to the main thread, and then result
   in IPC to web content. It&apos;s these messages that determine the web content notion of scroll position.

2. It triggers a `DisplayDidRefresh` IPC message from the UI process main thread to the web process. This
   bounces through a zero-delay time in the web process which then starts the rendering update.

The raciness is between these two series of steps:
  i) Display link thread -&gt; scrolling thread -&gt; main thread -&gt; IPC to web content (for scroll position)
 ii) Display link thread -&gt; main thread -&gt; IPC to web content -&gt; zero delay timer (for rendering update trigger)

`RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()` tries to address this by eagerly calling
`scrollingCoordinatorProxy()-&gt;sendScrollingTreeNodeDidScroll()` but this was ineffective because the &quot;node did scroll&quot;
message often hasn&apos;t got back to the main thread yet.

The fix is to do what we do already in ThreadedScrollingTree (older the web process scrolling code): instead of
using a callback to get the &quot;node did scroll&quot; message back to the UI process main thread, add a `ScrollUpdate`
to the ScrollingTree&apos;s pending updates directly from the scrolling thread (with a lock). With that,
`RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()` sees the update in time.

`RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll()` goes away, replaced with `scrollingThreadAddedPendingUpdate`,
and the iOS-specific behavior there about `propagatesMainFrameScrolls` moves into a `RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll()`
override.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingThreadAddedPendingUpdate):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::propagatesMainFrameScrolls const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):

Canonical link: <a href="https://commits.webkit.org/286095@main">https://commits.webkit.org/286095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/113e3bb6358f2e9f4999acebf0114e99bc173491

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25149 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1125 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58108 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45077 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79801 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65717 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7788 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4047 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->