### PR TITLE
Add a site-specific quirk to return 0 for `navigator.maxTouchPoints`

### DIFF
--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -398,9 +398,15 @@ RefPtr<Page> Navigator::protectedPage()
     return page();
 }
 
+const Document* Navigator::document() const
+{
+    RefPtr frame = this->frame();
+    return frame ? frame->document() : nullptr;
+}
+
 Document* Navigator::document()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     return frame ? frame->document() : nullptr;
 }
 
@@ -534,5 +540,16 @@ void Navigator::getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPer
 }
 
 #endif // #if ENABLE(DECLARATIVE_WEB_PUSH)
+
+int Navigator::maxTouchPoints() const
+{
+#if ENABLE(IOS_TOUCH_EVENTS) && !PLATFORM(MACCATALYST)
+    RefPtr document = this->document();
+    if (!document || !document->quirks().needsZeroMaxTouchPointsQuirk())
+        return 5;
+#endif
+
+    return 0;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -75,17 +75,14 @@ public:
     bool standalone() const;
 #endif
 
-#if ENABLE(IOS_TOUCH_EVENTS) && !PLATFORM(MACCATALYST)
-    int maxTouchPoints() const { return 5; }
-#else
-    int maxTouchPoints() const { return 0; }
-#endif
+    int maxTouchPoints() const;
 
     GPU* gpu();
 
     Page* page();
     RefPtr<Page> protectedPage();
 
+    const Document* document() const;
     Document* document();
     RefPtr<Document> protectedDocument();
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1905,4 +1905,19 @@ bool Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(const URL& reque
 
 #endif
 
+bool Quirks::needsZeroMaxTouchPointsQuirk() const
+{
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+    if (!needsQuirks())
+        return false;
+
+    if (!m_needsZeroMaxTouchPointsQuirk)
+        m_needsZeroMaxTouchPointsQuirk = isDomain("max.com"_s);
+
+    return *m_needsZeroMaxTouchPointsQuirk;
+#endif
+
+    return false;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -212,6 +212,8 @@ public:
 
     bool implicitMuteWhenVolumeSetToZero() const;
 
+    bool needsZeroMaxTouchPointsQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -285,6 +287,9 @@ private:
     mutable std::optional<bool> m_needsScrollbarWidthThinDisabledQuirk;
     mutable std::optional<bool> m_needsPrimeVideoUserSelectNoneQuirk;
     mutable std::optional<bool> m_implicitMuteWhenVolumeSetToZero;
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+    mutable std::optional<bool> m_needsZeroMaxTouchPointsQuirk;
+#endif
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };


### PR DESCRIPTION
#### 3a183fd2fdc9f68df1f0e7d3754d2428e394023e
<pre>
Add a site-specific quirk to return 0 for `navigator.maxTouchPoints`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282218">https://bugs.webkit.org/show_bug.cgi?id=282218</a>
<a href="https://rdar.apple.com/138424489">rdar://138424489</a>

Reviewed by Abrar Rahman Protyasha.

Add a quirk to force `maxTouchPoints` to return 0 on `max.com`, and related subdomains.

* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::document const):

Add a const version of `document()`, so that we can invoke it from const methods on `Navigator`.

(WebCore::Navigator::maxTouchPoints const):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsZeroMaxTouchPointsQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/285815@main">https://commits.webkit.org/285815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8a20e98cf758665ff5ed63ceac01decef2a0402

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1134 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76987 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21078 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63602 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9610 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1201 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->