### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -79,6 +79,12 @@ public:
         memcpy(&m_data, span.data(), 16);
     }
 
+    explicit UUID(std::span<const uint8_t> span)
+    {
+        RELEASE_ASSERT(span.size() == 16);
+        memcpy(&m_data, span.data(), 16);
+    }
+
     explicit constexpr UUID(UInt128 data)
         : m_data(data)
     {

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -27,175 +27,175 @@
 
 namespace IPC::Detail {
 
-const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1] = {
+const MessageDescriptionsArray messageDescriptions {
 #if USE(AVFOUNDATION)
-    { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
-    { "TestWithCVPixelBuffer_SendCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
+    MessageDescription { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
+    MessageDescription { "TestWithCVPixelBuffer_SendCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
 #endif
-    { "TestWithEnabledByAndConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByAndConjunction, false, false },
-    { "TestWithEnabledByOrConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByOrConjunction, false, false },
-    { "TestWithEnabledBy_AlwaysEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
-    { "TestWithEnabledBy_ConditionallyEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
-    { "TestWithEnabledBy_ConditionallyEnabledAnd"_s, ReceiverName::TestWithEnabledBy, false, false },
-    { "TestWithEnabledBy_ConditionallyEnabledOr"_s, ReceiverName::TestWithEnabledBy, false, false },
-    { "TestWithEnabledIf_AlwaysEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
-    { "TestWithEnabledIf_OnlyEnabledIfFeatureEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
+    MessageDescription { "TestWithEnabledByAndConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByAndConjunction, false, false },
+    MessageDescription { "TestWithEnabledByOrConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByOrConjunction, false, false },
+    MessageDescription { "TestWithEnabledBy_AlwaysEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
+    MessageDescription { "TestWithEnabledBy_ConditionallyEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
+    MessageDescription { "TestWithEnabledBy_ConditionallyEnabledAnd"_s, ReceiverName::TestWithEnabledBy, false, false },
+    MessageDescription { "TestWithEnabledBy_ConditionallyEnabledOr"_s, ReceiverName::TestWithEnabledBy, false, false },
+    MessageDescription { "TestWithEnabledIf_AlwaysEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
+    MessageDescription { "TestWithEnabledIf_OnlyEnabledIfFeatureEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
 #if PLATFORM(COCOA) || PLATFORM(GTK)
-    { "TestWithIfMessage_LoadURL"_s, ReceiverName::TestWithIfMessage, false, false },
+    MessageDescription { "TestWithIfMessage_LoadURL"_s, ReceiverName::TestWithIfMessage, false, false },
 #endif
-    { "TestWithImageData_ReceiveImageData"_s, ReceiverName::TestWithImageData, false, false },
-    { "TestWithImageData_SendImageData"_s, ReceiverName::TestWithImageData, false, false },
+    MessageDescription { "TestWithImageData_ReceiveImageData"_s, ReceiverName::TestWithImageData, false, false },
+    MessageDescription { "TestWithImageData_SendImageData"_s, ReceiverName::TestWithImageData, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithLegacyReceiver_AddEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_AddEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_Close"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_CreatePlugin"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_Close"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_CreatePlugin"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    { "TestWithLegacyReceiver_DeprecatedOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_DeprecatedOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_DidCreateWebProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_DidCreateWebProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_DidReceivePolicyDecision"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_DidReceivePolicyDecision"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    { "TestWithLegacyReceiver_ExperimentalOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_ExperimentalOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_GetPlugins"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_GetPlugins"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_InterpretKeyEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_InterpretKeyEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    { "TestWithLegacyReceiver_LoadSomething"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_LoadSomethingElse"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_LoadSomething"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_LoadSomethingElse"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_LoadURL"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_PreferencesDidChange"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SendDoubleAndFloat"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SendInts"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SetVideoLayerID"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_TemplateTest"_s, ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_TestParameterAttributes"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_LoadURL"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_PreferencesDidChange"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_SendDoubleAndFloat"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_SendInts"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_SetVideoLayerID"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_TemplateTest"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_TestParameterAttributes"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithLegacyReceiver_TouchEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    MessageDescription { "TestWithLegacyReceiver_TouchEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
-    { "TestWithSemaphore_SendSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
-    { "TestWithStreamBatched_SendString"_s, ReceiverName::TestWithStreamBatched, true, false },
-    { "TestWithStreamBuffer_SendStreamBuffer"_s, ReceiverName::TestWithStreamBuffer, false, false },
-    { "TestWithStreamServerConnectionHandle_SendStreamServerConnection"_s, ReceiverName::TestWithStreamServerConnectionHandle, false, false },
-    { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
+    MessageDescription { "TestWithSemaphore_SendSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
+    MessageDescription { "TestWithStreamBatched_SendString"_s, ReceiverName::TestWithStreamBatched, true, false },
+    MessageDescription { "TestWithStreamBuffer_SendStreamBuffer"_s, ReceiverName::TestWithStreamBuffer, false, false },
+    MessageDescription { "TestWithStreamServerConnectionHandle_SendStreamServerConnection"_s, ReceiverName::TestWithStreamServerConnectionHandle, false, false },
+    MessageDescription { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false },
 #if PLATFORM(COCOA)
-    { "TestWithStream_SendMachSendRight"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithStream_SendMachSendRight"_s, ReceiverName::TestWithStream, true, false },
 #endif
-    { "TestWithStream_SendString"_s, ReceiverName::TestWithStream, true, false },
-    { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false },
-    { "TestWithSuperclassAndWantsAsyncDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, false, false },
-    { "TestWithSuperclassAndWantsDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, false, false },
-    { "TestWithSuperclass_LoadURL"_s, ReceiverName::TestWithSuperclass, false, false },
+    MessageDescription { "TestWithStream_SendString"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithSuperclassAndWantsAsyncDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, false, false },
+    MessageDescription { "TestWithSuperclassAndWantsDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, false, false },
+    MessageDescription { "TestWithSuperclass_LoadURL"_s, ReceiverName::TestWithSuperclass, false, false },
 #if ENABLE(TEST_FEATURE)
-    { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithConnection"_s, ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithConnection"_s, ReceiverName::TestWithSuperclass, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false },
 #endif
-    { "TestWithWantsAsyncDispatch_TestMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, false, false },
-    { "TestWithWantsDispatchNoSyncMessages_TestMessage"_s, ReceiverName::TestWithWantsDispatchNoSyncMessages, false, false },
-    { "TestWithWantsDispatch_TestMessage"_s, ReceiverName::TestWithWantsDispatch, false, false },
+    MessageDescription { "TestWithWantsAsyncDispatch_TestMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, false, false },
+    MessageDescription { "TestWithWantsDispatchNoSyncMessages_TestMessage"_s, ReceiverName::TestWithWantsDispatchNoSyncMessages, false, false },
+    MessageDescription { "TestWithWantsDispatch_TestMessage"_s, ReceiverName::TestWithWantsDispatch, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithoutAttributes_AddEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_AddEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_Close"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_CreatePlugin"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_Close"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_CreatePlugin"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    { "TestWithoutAttributes_DeprecatedOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_DeprecatedOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_DidCreateWebProcessConnection"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_DidCreateWebProcessConnection"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_DidReceivePolicyDecision"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_DidReceivePolicyDecision"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    { "TestWithoutAttributes_ExperimentalOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_ExperimentalOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_GetPlugins"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_GetPlugins"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_InterpretKeyEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_InterpretKeyEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    { "TestWithoutAttributes_LoadSomething"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_LoadSomethingElse"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_LoadSomething"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_LoadSomethingElse"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_LoadURL"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_PreferencesDidChange"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SendDoubleAndFloat"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SendInts"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SetVideoLayerID"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_TemplateTest"_s, ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_TestParameterAttributes"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_LoadURL"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_PreferencesDidChange"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_SendDoubleAndFloat"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_SendInts"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_SetVideoLayerID"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_TemplateTest"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_TestParameterAttributes"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithoutAttributes_TouchEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
+    MessageDescription { "TestWithoutAttributes_TouchEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutUsingIPCConnection_MessageWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "CancelSyncMessageReply"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    MessageDescription { "CancelSyncMessageReply"_s, ReceiverName::IPC, false, false },
 #if PLATFORM(COCOA)
-    { "InitializeConnection"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "InitializeConnection"_s, ReceiverName::IPC, false, false },
 #endif
-    { "LegacySessionState"_s, ReceiverName::IPC, false, false },
-    { "ProcessOutOfStreamMessage"_s, ReceiverName::IPC, false, false },
-    { "SetStreamDestinationID"_s, ReceiverName::IPC, false, false },
-    { "SyncMessageReply"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "LegacySessionState"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "ProcessOutOfStreamMessage"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "SetStreamDestinationID"_s, ReceiverName::IPC, false, false },
+    MessageDescription { "SyncMessageReply"_s, ReceiverName::IPC, false, false },
 #if USE(AVFOUNDATION)
-    { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithImageData_ReceiveImageDataReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithImageData_ReceiveImageDataReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithLegacyReceiver_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithLegacyReceiver_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithLegacyReceiver_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithLegacyReceiver_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithSemaphore_ReceiveSemaphoreReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithStream_CallWithIdentifierReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithStream_SendStringAsyncReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithSemaphore_ReceiveSemaphoreReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithStream_CallWithIdentifierReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithStream_SendStringAsyncReply"_s, ReceiverName::AsyncReply, false, false },
 #if ENABLE(TEST_FEATURE)
-    { "TestWithSuperclass_TestAsyncMessageReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithConnectionReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithConnectionReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithoutAttributes_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithoutAttributes_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutAttributes_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutAttributes_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutAttributes_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithoutAttributes_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_GetPluginProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, true, false },
-    { "TestWithLegacyReceiver_TestMultipleAttributes"_s, ReceiverName::TestWithLegacyReceiver, true, false },
+    MessageDescription { "TestWithoutAttributes_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
+    MessageDescription { "TestWithLegacyReceiver_GetPluginProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, true, false },
+    MessageDescription { "TestWithLegacyReceiver_TestMultipleAttributes"_s, ReceiverName::TestWithLegacyReceiver, true, false },
 #if PLATFORM(COCOA)
-    { "TestWithStream_ReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
-    { "TestWithStream_SendAndReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithStream_ReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithStream_SendAndReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
 #endif
-    { "TestWithStream_SendStringSync"_s, ReceiverName::TestWithStream, true, false },
-    { "TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, true, false },
-    { "TestWithSuperclassAndWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, true, false },
-    { "TestWithSuperclass_TestSyncMessage"_s, ReceiverName::TestWithSuperclass, true, false },
-    { "TestWithSuperclass_TestSynchronousMessage"_s, ReceiverName::TestWithSuperclass, true, false },
-    { "TestWithWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, true, false },
-    { "TestWithWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsDispatch, true, false },
-    { "TestWithoutAttributes_GetPluginProcessConnection"_s, ReceiverName::TestWithoutAttributes, true, false },
-    { "TestWithoutAttributes_TestMultipleAttributes"_s, ReceiverName::TestWithoutAttributes, true, false },
-    { "WrappedAsyncMessageForTesting"_s, ReceiverName::IPC, true, false },
-    { "<invalid message name>"_s, ReceiverName::Invalid, false, false }
+    MessageDescription { "TestWithStream_SendStringSync"_s, ReceiverName::TestWithStream, true, false },
+    MessageDescription { "TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, true, false },
+    MessageDescription { "TestWithSuperclassAndWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, true, false },
+    MessageDescription { "TestWithSuperclass_TestSyncMessage"_s, ReceiverName::TestWithSuperclass, true, false },
+    MessageDescription { "TestWithSuperclass_TestSynchronousMessage"_s, ReceiverName::TestWithSuperclass, true, false },
+    MessageDescription { "TestWithWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, true, false },
+    MessageDescription { "TestWithWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsDispatch, true, false },
+    MessageDescription { "TestWithoutAttributes_GetPluginProcessConnection"_s, ReceiverName::TestWithoutAttributes, true, false },
+    MessageDescription { "TestWithoutAttributes_TestMultipleAttributes"_s, ReceiverName::TestWithoutAttributes, true, false },
+    MessageDescription { "WrappedAsyncMessageForTesting"_s, ReceiverName::IPC, true, false },
+    MessageDescription { "<invalid message name>"_s, ReceiverName::Invalid, false, false }
 };
 
 } // namespace IPC::Detail

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -28,8 +28,6 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/text/ASCIILiteral.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace IPC {
 
 enum class ReceiverName : uint8_t {
@@ -242,7 +240,9 @@ struct MessageDescription {
     bool messageAllowedWhenWaitingForUnboundedSyncReply : 1;
 };
 
-extern const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1];
+using MessageDescriptionsArray = std::array<MessageDescription, static_cast<size_t>(MessageName::Count) + 1>;
+extern const MessageDescriptionsArray messageDescriptions;
+
 }
 
 inline ReceiverName receiverName(MessageName messageName)
@@ -284,5 +284,3 @@ template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_ty
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -43,8 +43,6 @@
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/CString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 @interface NSURLError : NSError
 @end
 
@@ -600,7 +598,7 @@ static NSString *escapeKey(NSString *key)
 
 - (void)encodeBytes:(const uint8_t *)bytes length:(NSUInteger)length forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Data::create({ bytes, length }));
+    _currentDictionary->set(escapeKey(key), API::Data::create(unsafeForgeSpan(bytes, length)));
 }
 
 - (void)encodeBool:(BOOL)value forKey:(NSString *)key
@@ -1179,5 +1177,3 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 }
 
 @end
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -28,24 +28,25 @@
 
 #include "APIArray.h"
 #include "WKAPICast.h"
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 WKTypeID WKArrayGetTypeID()
 {
     return WebKit::toAPI(API::Array::APIType);
 }
 
-WKArrayRef WKArrayCreate(WKTypeRef* values, size_t numberOfValues)
+WKArrayRef WKArrayCreate(WKTypeRef* rawValues, size_t numberOfValues)
 {
+    auto values = unsafeForgeSpan(rawValues, numberOfValues);
     Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) -> RefPtr<API::Object> {
         return WebKit::toImpl(values[i]);
     });
     return WebKit::toAPI(&API::Array::create(WTFMove(elements)).leakRef());
 }
 
-WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* values, size_t numberOfValues)
+WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* rawValues, size_t numberOfValues)
 {
+    auto values = unsafeForgeSpan(rawValues, numberOfValues);
     Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) {
         return adoptRef(WebKit::toImpl(values[i]));
     });
@@ -61,5 +62,3 @@ size_t WKArrayGetSize(WKArrayRef arrayRef)
 {
     return WebKit::toImpl(arrayRef)->size();
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKData.cpp
+++ b/Source/WebKit/Shared/API/c/WKData.cpp
@@ -28,8 +28,7 @@
 
 #include "APIData.h"
 #include "WKAPICast.h"
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 WKTypeID WKDataGetTypeID()
 {
@@ -38,7 +37,7 @@ WKTypeID WKDataGetTypeID()
 
 WKDataRef WKDataCreate(const unsigned char* bytes, size_t size)
 {
-    return WebKit::toAPI(&API::Data::create({ bytes, size }).leakRef());
+    return WebKit::toAPI(&API::Data::create(unsafeForgeSpan(bytes, size)).leakRef());
 }
 
 const unsigned char* WKDataGetBytes(WKDataRef dataRef)
@@ -51,4 +50,7 @@ size_t WKDataGetSize(WKDataRef dataRef)
     return WebKit::toImpl(dataRef)->size();
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+std::span<const uint8_t> WKDataGetSpan(WKDataRef dataRef)
+{
+    return unsafeForgeSpan(byteCast<uint8_t>(WKDataGetBytes(dataRef)), WKDataGetSize(dataRef));
+}

--- a/Source/WebKit/Shared/API/c/WKData.h
+++ b/Source/WebKit/Shared/API/c/WKData.h
@@ -31,6 +31,8 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
+#include <span>
+
 extern "C" {
 #endif
 
@@ -43,6 +45,9 @@ WK_EXPORT size_t WKDataGetSize(WKDataRef data);
 
 #ifdef __cplusplus
 }
+
+WK_EXPORT std::span<const uint8_t> WKDataGetSpan(WKDataRef data);
+
 #endif
 
 #endif // WKData_h

--- a/Source/WebKit/Shared/API/c/WKDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKDictionary.cpp
@@ -30,15 +30,16 @@
 #include "APIDictionary.h"
 #include "WKAPICast.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 WKTypeID WKDictionaryGetTypeID()
 {
     return WebKit::toAPI(API::Dictionary::APIType);
 }
 
-WK_EXPORT WKDictionaryRef WKDictionaryCreate(const WKStringRef* keys, const WKTypeRef* values, size_t numberOfValues)
+WK_EXPORT WKDictionaryRef WKDictionaryCreate(const WKStringRef* rawKeys, const WKTypeRef* rawValues, size_t numberOfValues)
 {
+    auto keys = unsafeForgeSpan(rawKeys, numberOfValues);
+    auto values = unsafeForgeSpan(rawValues, numberOfValues);
+
     API::Dictionary::MapType map;
     map.reserveInitialCapacity(numberOfValues);
     for (size_t i = 0; i < numberOfValues; ++i)
@@ -61,5 +62,3 @@ WKArrayRef WKDictionaryCopyKeys(WKDictionaryRef dictionaryRef)
 {
     return WebKit::toAPI(&WebKit::toImpl(dictionaryRef)->keys().leakRef());
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -36,6 +36,7 @@
 #include "SameDocumentNavigationType.h"
 #include "WKBase.h"
 #include "WKContextMenuItemTypes.h"
+#include "WKData.h"
 #include "WKDiagnosticLoggingResultType.h"
 #include "WKEvent.h"
 #include "WKFindOptions.h"

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -31,9 +31,8 @@
 #include <JavaScriptCore/InitializeThreading.h>
 #include <JavaScriptCore/OpaqueJSString.h>
 #include <WebCore/WebCoreJITOperations.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/unicode/UTF8Conversion.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 WKTypeID WKStringGetTypeID()
 {
@@ -47,7 +46,7 @@ WKStringRef WKStringCreateWithUTF8CString(const char* string)
 
 WKStringRef WKStringCreateWithUTF8CStringWithLength(const char* string, size_t stringLength)
 {
-    return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8({ string, stringLength })).leakRef());
+    return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8(unsafeForgeSpan(string, stringLength))).leakRef());
 }
 
 bool WKStringIsEmpty(WKStringRef stringRef)
@@ -86,21 +85,21 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
 
     auto string = WebKit::toImpl(stringRef)->stringView();
 
-    std::span<char8_t> target { byteCast<char8_t>(buffer), bufferSize - 1 };
+    auto target = unsafeForgeSpan(byteCast<char8_t>(buffer), bufferSize);
     WTF::Unicode::ConversionResult<char8_t> result;
     if (string.is8Bit())
-        result = WTF::Unicode::convert(string.span8(), target);
+        result = WTF::Unicode::convert(string.span8(), target.first(bufferSize - 1));
     else {
         if constexpr (strict == NonStrict)
-            result = WTF::Unicode::convertReplacingInvalidSequences(string.span16(), target);
+            result = WTF::Unicode::convertReplacingInvalidSequences(string.span16(), target.first(bufferSize - 1));
         else {
-            result = WTF::Unicode::convert(string.span16(), target);
+            result = WTF::Unicode::convert(string.span16(), target.first(bufferSize - 1));
             if (result.code == WTF::Unicode::ConversionResultCode::SourceInvalid)
                 return 0;
         }
     }
 
-    buffer[result.buffer.size()] = '\0';
+    target[result.buffer.size()] = '\0';
     return result.buffer.size() + 1;
 }
 
@@ -146,5 +145,3 @@ JSStringRef WKStringCopyJSString(WKStringRef stringRef)
     WebCore::populateJITOperations();
     return OpaqueJSString::tryCreate(WebKit::toImpl(stringRef)->string()).leakRef();
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKURLRequest.cpp
+++ b/Source/WebKit/Shared/API/c/WKURLRequest.cpp
@@ -29,9 +29,8 @@
 #include "APIURLRequest.h"
 #include "WKAPICast.h"
 #include "WKData.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 WKTypeID WKURLRequestGetTypeID()
 {
@@ -61,7 +60,7 @@ WKStringRef WKURLRequestCopyHTTPMethod(WKURLRequestRef requestRef)
 WKURLRequestRef WKURLRequestCopySettingHTTPBody(WKURLRequestRef requestRef, WKDataRef body)
 {
     WebCore::ResourceRequest requestCopy(WebKit::toImpl(requestRef)->resourceRequest());
-    requestCopy.setHTTPBody(WebCore::FormData::create(std::span { WKDataGetBytes(body), WKDataGetSize(body) }));
+    requestCopy.setHTTPBody(WebCore::FormData::create(WKDataGetSpan(body)));
     return WebKit::toAPI(&API::URLRequest::create(requestCopy).leakRef());
 }
 
@@ -69,5 +68,3 @@ void WKURLRequestSetDefaultTimeoutInterval(double timeoutInterval)
 {
     API::URLRequest::setDefaultTimeoutInterval(timeoutInterval);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h
@@ -29,8 +29,7 @@
 
 #include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/cf/VectorCF.h>
 
 namespace WebKit {
 
@@ -61,9 +60,7 @@ public:
     std::span<const uint8_t> dataReference() const
     {
         ASSERT(m_cfCharacterSetData);
-        CFDataRef data = m_cfCharacterSetData.get();
-        ASSERT(data);
-        return { CFDataGetBytePtr(data), static_cast<size_t>(CFDataGetLength(data)) };
+        return span(m_cfCharacterSetData.get());
     }
 
 private:
@@ -79,7 +76,5 @@ private:
 };
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
@@ -26,11 +26,9 @@
 #import "config.h"
 #import "CoreIPCDateComponents.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
-NSUInteger calendarUnitForComponentIndex[] = {
+std::array calendarUnitForComponentIndex {
     NSCalendarUnitEra,
     NSCalendarUnitYear,
     NSCalendarUnitYearForWeekOfYear,
@@ -81,5 +79,3 @@ bool CoreIPCDateComponents::hasCorrectNumberOfComponentValues(const Vector<NSInt
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -35,8 +35,6 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/CString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
@@ -314,7 +312,7 @@ auto SandboxExtension::createHandlesForMachLookup(std::span<const ASCIILiteral> 
 
 auto SandboxExtension::createHandlesForMachLookup(std::initializer_list<const ASCIILiteral> services, std::optional<audit_token_t> auditToken, MachBootstrapOptions machBootstrapOptions, OptionSet<Flags> flags) -> Vector<Handle>
 {
-    return createHandlesForMachLookup(std::span(services.begin(), services.size()), auditToken, machBootstrapOptions, flags);
+    return createHandlesForMachLookup(std::span { services }, auditToken, machBootstrapOptions, flags);
 }
 
 auto SandboxExtension::createHandleForReadByAuditToken(StringView path, audit_token_t auditToken) -> std::optional<Handle>
@@ -429,7 +427,5 @@ bool SandboxExtension::consumePermanently(const Vector<Handle>& handleArray)
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(SANDBOX_EXTENSIONS)

--- a/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
@@ -26,8 +26,6 @@
 #import "config.h"
 #import "SandboxInitializationParameters.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 SandboxInitializationParameters::SandboxInitializationParameters()
@@ -39,21 +37,21 @@ SandboxInitializationParameters::~SandboxInitializationParameters() = default;
 
 void SandboxInitializationParameters::appendPathInternal(ASCIILiteral name, const char* path)
 {
-    char normalizedPath[PATH_MAX];
-    if (!realpath(path, normalizedPath))
+    std::array<char, PATH_MAX> normalizedPath;
+    if (!realpath(path, normalizedPath.data()))
         normalizedPath[0] = '\0';
 
     m_parameterNames.append(name);
-    m_parameterValues.append(normalizedPath);
+    m_parameterValues.append(normalizedPath.data());
 }
 
 void SandboxInitializationParameters::addConfDirectoryParameter(ASCIILiteral name, int confID)
 {
-    char path[PATH_MAX];
-    if (confstr(confID, path, PATH_MAX) <= 0)
+    std::array<char, PATH_MAX> path;
+    if (confstr(confID, path.data(), PATH_MAX) <= 0)
         path[0] = '\0';
 
-    appendPathInternal(name, path);
+    appendPathInternal(name, path.data());
 }
 
 void SandboxInitializationParameters::addPathParameter(ASCIILiteral name, NSString *path)
@@ -101,5 +99,3 @@ const char* SandboxInitializationParameters::value(size_t index) const
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -501,9 +501,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
             return false;
         memcpy(profile.builtin, sandboxBuiltin.data(), cachedSandboxHeader.builtinSize);
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(sandboxData.subspan(profile.size).data() <= (cachedSandboxContents.data() + cachedSandboxContents.size()));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    ASSERT(sandboxData.subspan(profile.size).data() <= std::to_address(cachedSandboxContents.end()));
     profile.data = sandboxData.data();
 
     if (sandbox_apply(&profile)) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -553,9 +553,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         uuid_t proxyIdentifier;
         nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
 
-        configDataVector.append({ makeVector(agentData.get()), WTF::UUID(proxyIdentifier) });
+        configDataVector.append({ makeVector(agentData.get()), WTF::UUID(std::span<const uint8_t, 16> { proxyIdentifier }) });
     }
-    
+
     _websiteDataStore->setProxyConfigData(WTFMove(configDataVector));
 }
 

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -806,9 +806,7 @@ private:
 
     inline bool alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, size_t size) const
     {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        auto* bufferEnd = m_buffer.data() + m_buffer.size();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto* bufferEnd = std::to_address(m_buffer.end());
         return bufferEnd >= alignedPosition && static_cast<size_t>(bufferEnd - alignedPosition) >= size;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
@@ -33,6 +33,7 @@
 #include <WebKit/WKURLCF.h>
 #include <WebKit/WKContextPrivate.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/cf/VectorCF.h>
 
 namespace TestWebKitAPI {
 
@@ -49,9 +50,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
     WKDataRef receivedData = static_cast<WKDataRef>(body);
         
     // Do basic sanity checks on the returned webarchive. We have more thorough checks in LayoutTests.
-    size_t size = WKDataGetSize(receivedData);
-    const unsigned char* bytes = WKDataGetBytes(receivedData);
-    RetainPtr<CFDataRef> data = adoptCF(CFDataCreate(0, bytes, size));
+    RetainPtr data = toCFData(WKDataGetSpan(receivedData));
     RetainPtr<CFPropertyListRef> propertyList = adoptCF(CFPropertyListCreateWithData(0, data.get(), kCFPropertyListImmutable, 0, 0));
     EXPECT_TRUE(propertyList);
     

--- a/Tools/WebKitTestRunner/DataFunctions.h
+++ b/Tools/WebKitTestRunner/DataFunctions.h
@@ -42,8 +42,7 @@ inline WKDataRef dataValue(WKTypeRef value)
 
 inline WTF::UUID dataToUUID(WKDataRef data)
 {
-    RELEASE_ASSERT(WKDataGetSize(data) == 16);
-    return WTF::UUID { std::span<const uint8_t, 16> { WKDataGetBytes(data), 16 } };
+    return WTF::UUID { WKDataGetSpan(data) };
 }
 
 inline WKRetainPtr<WKDataRef> uuidToData(const WTF::UUID& uuid)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -57,6 +57,7 @@
 
 #if USE(CF)
 #include "WebArchiveDumpSupport.h"
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/cf/StringConcatenateCF.h>
 #endif
 
@@ -694,7 +695,7 @@ void InjectedBundlePage::dumpDOMAsWebArchive(WKBundleFrameRef frame, StringBuild
 {
 #if USE(CF)
     auto wkData = adoptWK(WKBundleFrameCopyWebArchive(frame));
-    auto cfData = adoptCF(CFDataCreate(0, WKDataGetBytes(wkData.get()), WKDataGetSize(wkData.get())));
+    RetainPtr cfData = toCFData(WKDataGetSpan(wkData.get()));
     stringBuilder.append(WebCoreTestSupport::createXMLStringFromWebArchiveData(cfData.get()).get());
 #endif
 }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -317,16 +317,14 @@ void TestInvocation::dumpResults()
 
 void TestInvocation::dumpAudio(WKDataRef audioData)
 {
-    size_t length = WKDataGetSize(audioData);
-    if (!length)
+    auto span = WKDataGetSpan(audioData);
+    if (span.empty())
         return;
 
-    const unsigned char* data = WKDataGetBytes(audioData);
-
     printf("Content-Type: audio/wav\n");
-    printf("Content-Length: %lu\n", static_cast<unsigned long>(length));
+    printf("Content-Length: %lu\n", static_cast<unsigned long>(span.size()));
 
-    fwrite(data, 1, length, stdout);
+    fwrite(span.data(), 1, span.size(), stdout);
     printf("#EOF\n");
     fprintf(stderr, "#EOF\n");
 }


### PR DESCRIPTION
#### fb3e81759d213897ec6e7a3dd80a04c30b56f872
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=282221">https://bugs.webkit.org/show_bug.cgi?id=282221</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_names_header):
(generate_message_names_implementation):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::create):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectEncoder encodeBytes:length:forKey:]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
(initializeMethod):
(initializeMethods):
* Source/WebKit/Shared/API/c/WKArray.cpp:
(WKArrayCreate):
(WKArrayCreateAdoptingValues):
(WKArrayGetSize):
* Source/WebKit/Shared/API/c/WKData.cpp:
(WKDataCreate):
(WKDataGetSize):
* Source/WebKit/Shared/API/c/WKDictionary.cpp:
(WKDictionaryCreate):
(WKDictionaryCopyKeys):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringCreateWithUTF8CStringWithLength):
(WKStringGetUTF8CStringImpl):
(WKStringCopyJSString):
* Source/WebKit/Shared/API/c/WKURLRequest.cpp:
(WKURLRequestCopySettingHTTPBody):
(WKURLRequestSetDefaultTimeoutInterval):
* Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h:
(WebKit::CoreIPCCFCharacterSet::dataReference const):
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandlesForMachLookup):
* Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::tryApplyCachedSandbox):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataDecoder::alignedBufferIsLargeEnoughToContain const):

Canonical link: <a href="https://commits.webkit.org/285917@main">https://commits.webkit.org/285917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a97a0181fe1aecd588fcc68e6418225467ff30a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38705 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/73646 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23709 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67275 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80031 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73396 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/809 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65869 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7955 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95177 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4207 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->