### PR TITLE
Enable -Wunsafe-buffer-usage in WebCore/PAL

### DIFF
--- a/Source/WebCore/PAL/Configurations/Base.xcconfig
+++ b/Source/WebCore/PAL/Configurations/Base.xcconfig
@@ -84,7 +84,7 @@ GCC_WARN_SIGN_COMPARE = YES;
 GCC_WARN_UNINITIALIZED_AUTOS = YES;
 GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
-WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wno-unknown-warning-option -Wliteral-conversion -Wthread-safety;
+WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wno-unknown-warning-option -Wliteral-conversion -Wthread-safety -Wunsafe-buffer-usage;
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;

--- a/Source/WebCore/PAL/pal/PALSwift.h
+++ b/Source/WebCore/PAL/pal/PALSwift.h
@@ -61,5 +61,7 @@ struct CryptoOperationReturnValue {
 } // Cpp
 
 #ifndef __swift__
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "PALSwift-Generated.h"
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -36,6 +36,8 @@
 
 #include <pal/cocoa/AVFoundationSoftLink.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 OutputContext::OutputContext(RetainPtr<AVOutputContext>&& context)
@@ -104,5 +106,7 @@ Vector<OutputDevice> OutputContext::outputDevices() const
 
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/PAL/pal/cocoa/Gunzip.cpp
+++ b/Source/WebCore/PAL/pal/cocoa/Gunzip.cpp
@@ -28,6 +28,8 @@
 
 #include <compression.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 Vector<LChar> gunzip(const unsigned char* data, size_t length)
@@ -88,3 +90,5 @@ Vector<LChar> gunzip(const unsigned char* data, size_t length)
 }
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -33,6 +33,8 @@
 #include <optional>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 struct CryptoDigestContext {
@@ -231,3 +233,5 @@ String CryptoDigest::toHexString()
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -34,6 +34,8 @@
 #include <wtf/Assertions.h>
 #include <wtf/text/StringBuilder.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 // See <http://en.wikipedia.org/wiki/Percent-encoding#Non-standard_implementations>.
@@ -187,3 +189,4 @@ inline Vector<uint8_t> decodeURLEscapeSequencesAsData(StringView string)
 
 } // namespace PAL
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -30,6 +30,8 @@
 #include <mutex>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 #if ASSERT_ENABLED
@@ -8686,3 +8688,5 @@ void checkEncodingTableInvariants()
 #endif
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
@@ -28,6 +28,8 @@
 
 #include <wtf/text/ASCIIFastPath.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 template<size_t size> struct UCharByteFiller;
@@ -75,3 +77,5 @@ inline void copyASCIIMachineWord(UChar* destination, const uint8_t* source)
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -34,6 +34,8 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecCJK);
@@ -1206,3 +1208,5 @@ Vector<uint8_t> TextCodecCJK::encode(StringView string, UnencodableHandling hand
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -39,6 +39,8 @@
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecICU);
@@ -322,3 +324,5 @@ Vector<uint8_t> TextCodecICU::encode(StringView string, UnencodableHandling hand
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -31,6 +31,8 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 static const UChar latin1ConversionTable[256] = {
@@ -253,3 +255,5 @@ Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling h
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
@@ -34,6 +34,8 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecSingleByte);
@@ -463,3 +465,5 @@ void TextCodecSingleByte::registerCodecs(TextCodecRegistrar registrar)
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
@@ -32,6 +32,8 @@
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecUTF16);
@@ -168,3 +170,5 @@ Vector<uint8_t> TextCodecUTF16::encode(StringView string, UnencodableHandling) c
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -33,6 +33,8 @@
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecUTF8);
@@ -486,3 +488,5 @@ Vector<uint8_t> TextCodecUTF8::encode(StringView string, UnencodableHandling) co
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -32,6 +32,8 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecUserDefined);
@@ -97,3 +99,5 @@ Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandl
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
@@ -35,6 +35,8 @@
 #include <unicode/ucnv.h>
 #include <unicode/ucsdet.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingName, TextEncoding* detectedEncoding)
@@ -113,3 +115,5 @@ bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingN
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -48,6 +48,8 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/StringHash.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace PAL {
 
 const size_t maxEncodingNameLength = 63;
@@ -357,3 +359,5 @@ String defaultTextEncodingNameForSystemLanguage()
 }
 
 } // namespace PAL
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### db7b208cc2700705b099cc204deb64321368a13f
<pre>
Enable -Wunsafe-buffer-usage in WebCore/PAL
<a href="https://bugs.webkit.org/show_bug.cgi?id=282222">https://bugs.webkit.org/show_bug.cgi?id=282222</a>
<a href="https://rdar.apple.com/137810571">rdar://137810571</a>

Reviewed by Chris Dumez.

Added skip markers for non-conforming files.

* Source/WebCore/PAL/Configurations/Base.xcconfig:
* Source/WebCore/PAL/pal/avfoundation/OutputContext.mm:
* Source/WebCore/PAL/pal/cocoa/Gunzip.cpp:
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
* Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h:
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
* Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp:
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
* Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp:
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:

Canonical link: <a href="https://commits.webkit.org/285826@main">https://commits.webkit.org/285826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d5ae1ecccfa5124be2fdffca681258369b9edfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45097 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21088 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65730 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7804 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11403 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1214 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->