### PR TITLE
media/media-vp8-webm-with-poster.html is an intermittent failure

### DIFF
--- a/LayoutTests/media/media-vp8-webm-with-poster-expected.html
+++ b/LayoutTests/media/media-vp8-webm-with-poster-expected.html
@@ -27,6 +27,6 @@
 </head>
 <body onload="init();">
     <div>This tests that a video with a poster set when playing fullscreen isn't blanked.</div>
-    <video/>
+    <video disableRemotePlayback />
 </body>
 </html>

--- a/LayoutTests/media/media-vp8-webm-with-poster.html
+++ b/LayoutTests/media/media-vp8-webm-with-poster.html
@@ -27,6 +27,6 @@
 </head>
 <body onload="init();">
     <div>This tests that a video with a poster set when playing fullscreen isn't blanked.</div>
-    <video poster="content/test-vp8.webm.png" />
+    <video poster="content/test-vp8.webm.png" disableRemotePlayback />
 </body>
 </html>


### PR DESCRIPTION
#### 444231f855e5e6e62482efdc954183546701a7ad
<pre>
media/media-vp8-webm-with-poster.html is an intermittent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=282224">https://bugs.webkit.org/show_bug.cgi?id=282224</a>
<a href="https://rdar.apple.com/138815872">rdar://138815872</a>

Reviewed by Eric Carlson.

Failure indicates that AirPlay was started on the video playing the reference image.
So as workaround we disable remote playback on the video element.

* LayoutTests/media/media-vp8-webm-with-poster-expected.html:
* LayoutTests/media/media-vp8-webm-with-poster.html:

Canonical link: <a href="https://commits.webkit.org/285827@main">https://commits.webkit.org/285827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/766341dfbf79ea4c28c3d6320250c6e5112491b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25168 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58142 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16477 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66639 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79820 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65734 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7801 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1211 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->