### PR TITLE
Update length check in appendQuotedJSONString to align with String's max length.

### DIFF
--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,8 +107,9 @@ class JS_EXPORT_PRIVATE HeapSnapshotBuilder final : public HeapAnalyzer {
     WTF_MAKE_TZONE_ALLOCATED(HeapSnapshotBuilder);
 public:
     enum SnapshotType { InspectorSnapshot, GCDebuggingSnapshot };
+    enum class OverflowAction : uint8_t { CrashOnOverflow, RecordOverflow };
 
-    HeapSnapshotBuilder(HeapProfiler&, SnapshotType = SnapshotType::InspectorSnapshot);
+    HeapSnapshotBuilder(HeapProfiler&, SnapshotType = SnapshotType::InspectorSnapshot, OverflowAction = OverflowAction::CrashOnOverflow);
     ~HeapSnapshotBuilder() final;
 
     static void resetNextAvailableObjectIdentifier();
@@ -132,6 +133,8 @@ public:
     String json();
     String json(Function<bool (const HeapSnapshotNode&)> allowNodeCallback);
 
+    bool hasOverflowed() const { return m_hasOverflowed; }
+
 private:
     static NodeIdentifier nextAvailableObjectIdentifier;
     static NodeIdentifier getNextObjectIdentifier();
@@ -148,6 +151,8 @@ private:
     };
     
     HeapProfiler& m_profiler;
+    OverflowAction m_overflowAction;
+    bool m_hasOverflowed { false };
 
     // SlotVisitors run in parallel.
     Lock m_buildingNodeMutex;

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
  * Copyright (C) 2017 Mozilla Foundation. All rights reserved.
@@ -27,7 +27,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
     // Make sure we have enough buffer space to append this string for worst case without reallocating.
     // The 2 is for the '"' quotes on each end.
     // The 6 is the worst case for a single code unit that could be encoded as \uNNNN.
-    CheckedUint32 stringLength = string.length();
+    CheckedInt32 stringLength = string.length();
     stringLength *= 6;
     stringLength += 2;
     if (stringLength.hasOverflowed()) {
@@ -38,7 +38,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
     auto stringLengthValue = stringLength.value();
 
     if (is8Bit() && string.is8Bit()) {
-        if (auto* output = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, stringLengthValue))) {
+        if (auto* output = extendBufferForAppending<LChar>(saturatedSum<int32_t>(m_length, stringLengthValue))) {
             auto* end = output + stringLengthValue;
             *output++ = '"';
             appendEscapedJSONStringContent(output, string.span8());
@@ -47,7 +47,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
                 shrink(m_length - (end - output));
         }
     } else {
-        if (auto* output = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, stringLengthValue))) {
+        if (auto* output = extendBufferForAppendingWithUpconvert(saturatedSum<int32_t>(m_length, stringLengthValue))) {
             auto* end = output + stringLengthValue;
             *output++ = '"';
             if (string.is8Bit())


### PR DESCRIPTION
#### 0aa654672af463701ce4b6c7abcecfab18009058
<pre>
Update length check in appendQuotedJSONString to align with String&apos;s max length.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281873">https://bugs.webkit.org/show_bug.cgi?id=281873</a>
<a href="https://rdar.apple.com/138178439">rdar://138178439</a>

Reviewed by Keith Miller and Michael Saboff.

`appendQuotedJSONString` currently utilizes a `CheckedUint32`. However, String&apos;s
maximum length is MAX_INT, which is the bounds of an `Int32`. Thus, we should
use `CheckedInt32` so that we don&apos;t try to create a String that is too long.

Also enhanced HeapSnapshotBuilder to allow customization of how it reacts when it
encounters an imminent overflow by specifying an OverflowAction at construction
time.  We then apply OverflowAction::RecordOverflow to the jsc shell&apos;s use of
HeapSnapshotBuilder so that it can throw an OOME instead of crashing when imminent
overflow is detected while constructing the HeapSnapshot.

This will unblock fuzzers that fuzzes with the jsc shell&apos;s HeapSnapshot functions
though they shouldn&apos;t, and thereby, avoids a crash.

The appendQuotedJSONString change was original provided by Daniel Liu.

* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::HeapSnapshotBuilder):
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.h:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::StringBuilder::appendQuotedJSONString):

Canonical link: <a href="https://commits.webkit.org/285840@main">https://commits.webkit.org/285840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559661166b7093abaa961de52859bca40b9d926e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26783 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77039 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67109 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79864 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73230 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1432 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/9659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95011 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1253 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/20875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1282 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->