### PR TITLE
[WPE] WPE Platform: add support for touch events in DRM

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
@@ -182,6 +182,18 @@ void Seat::processEvent(struct libinput_event* event)
     case LIBINPUT_EVENT_KEYBOARD_KEY:
         handleKeyEvent(libinput_event_get_keyboard_event(event));
         break;
+    case LIBINPUT_EVENT_TOUCH_DOWN:
+        handleTouchDownEvent(libinput_event_get_touch_event(event));
+        break;
+    case LIBINPUT_EVENT_TOUCH_UP:
+        handleTouchUpEvent(libinput_event_get_touch_event(event));
+        break;
+    case LIBINPUT_EVENT_TOUCH_MOTION:
+        handleTouchMotionEvent(libinput_event_get_touch_event(event));
+        break;
+    case LIBINPUT_EVENT_TOUCH_CANCEL:
+        handleTouchCancelEvent(libinput_event_get_touch_event(event));
+        break;
     default:
         break;
     }
@@ -423,6 +435,76 @@ void Seat::handleKey(uint32_t time, uint32_t key, bool pressed, bool fromRepeat)
         g_source_set_ready_time(m_keyboard.repeat.source.get(), readyTime);
     } else
         g_source_set_ready_time(m_keyboard.repeat.source.get(), 0);
+}
+
+void Seat::handleTouchDownEvent(struct libinput_event_touch* event)
+{
+    if (!m_view)
+        return;
+
+    m_touch.time = libinput_event_touch_get_time(event);
+
+    int id = libinput_event_touch_get_seat_slot(event);
+    double x = libinput_event_touch_get_x_transformed(event, wpe_view_get_width(m_view.get()));
+    double y = libinput_event_touch_get_y_transformed(event, wpe_view_get_height(m_view.get()));
+    m_touch.points.add(id, std::pair<double, double>(x, y));
+
+    auto* wpeEvent = wpe_event_touch_new(WPE_EVENT_TOUCH_DOWN, m_view.get(), m_touch.source, m_touch.time, modifiers(), id, x, y);
+    wpe_view_event(m_view.get(), wpeEvent);
+    wpe_event_unref(wpeEvent);
+}
+
+void Seat::handleTouchUpEvent(struct libinput_event_touch* event)
+{
+    if (!m_view)
+        return;
+
+    int id = libinput_event_touch_get_seat_slot(event);
+    const auto& iter = m_touch.points.find(id);
+    if (iter == m_touch.points.end())
+        return;
+
+    m_touch.time = libinput_event_touch_get_time(event);
+
+    auto* wpeEvent = wpe_event_touch_new(WPE_EVENT_TOUCH_UP, m_view.get(), m_touch.source, m_touch.time, modifiers(), id, iter->value.first, iter->value.second);
+    wpe_view_event(m_view.get(), wpeEvent);
+    wpe_event_unref(wpeEvent);
+
+    m_touch.points.remove(id);
+}
+
+void Seat::handleTouchMotionEvent(struct libinput_event_touch* event)
+{
+    if (!m_view)
+        return;
+
+    int id = libinput_event_touch_get_seat_slot(event);
+    const auto& iter = m_touch.points.find(id);
+    if (iter == m_touch.points.end())
+        return;
+
+    m_touch.time = libinput_event_touch_get_time(event);
+
+    double x = libinput_event_touch_get_x_transformed(event, wpe_view_get_width(m_view.get()));
+    double y = libinput_event_touch_get_y_transformed(event, wpe_view_get_height(m_view.get()));
+    iter->value = { x, y };
+
+    auto* wpeEvent = wpe_event_touch_new(WPE_EVENT_TOUCH_MOVE, m_view.get(), m_touch.source, m_touch.time, modifiers(), id, x, y);
+    wpe_view_event(m_view.get(), wpeEvent);
+    wpe_event_unref(wpeEvent);
+}
+
+void Seat::handleTouchCancelEvent(struct libinput_event_touch*)
+{
+    if (!m_view)
+        return;
+
+    for (const auto& iter : m_touch.points) {
+        auto* wpeEvent = wpe_event_touch_new(WPE_EVENT_TOUCH_CANCEL, m_view.get(), m_touch.source, 0, modifiers(), iter.key, iter.value.first, iter.value.second);
+        wpe_view_event(m_view.get(), wpeEvent);
+        wpe_event_unref(wpeEvent);
+    }
+    m_touch.points.clear();
 }
 
 } // namespace DRM

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
@@ -28,6 +28,7 @@
 #include "WPEKeymap.h"
 #include "WPEView.h"
 #include <libinput.h>
+#include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
@@ -60,6 +61,10 @@ private:
     void handlePointerScrollContinuousEvent(struct libinput_event_pointer*, WPEInputSource);
     void handleKeyEvent(struct libinput_event_keyboard*);
     void handleKey(uint32_t time, uint32_t key, bool pressed, bool fromRepeat);
+    void handleTouchDownEvent(struct libinput_event_touch*);
+    void handleTouchUpEvent(struct libinput_event_touch*);
+    void handleTouchMotionEvent(struct libinput_event_touch*);
+    void handleTouchCancelEvent(struct libinput_event_touch*);
 
     struct libinput* m_libinput { nullptr };
     GRefPtr<GSource> m_inputSource;
@@ -85,6 +90,12 @@ private:
             Seconds deadline;
         } repeat;
     } m_keyboard;
+
+    struct {
+        WPEInputSource source { WPE_INPUT_SOURCE_TOUCHSCREEN };
+        uint32_t time { 0 };
+        HashMap<int32_t, std::pair<double, double>, IntHash<int32_t>, WTF::SignedWithZeroKeyHashTraits<int32_t>> points;
+    } m_touch;
 };
 
 } // namespace DRM


### PR DESCRIPTION
#### eeca106abd6024f3aa93f7bf53a5edbf0b7d96a7
<pre>
[WPE] WPE Platform: add support for touch events in DRM
<a href="https://bugs.webkit.org/show_bug.cgi?id=282230">https://bugs.webkit.org/show_bug.cgi?id=282230</a>

Reviewed by Alejandro G. Castro and Adrian Perez de Castro.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp:
(WPE::DRM::Seat::processEvent):
(WPE::DRM::Seat::handleTouchDownEvent):
(WPE::DRM::Seat::handleTouchUpEvent):
(WPE::DRM::Seat::handleTouchMotionEvent):
(WPE::DRM::libinput_event_touch::for):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h:

Canonical link: <a href="https://commits.webkit.org/286075@main">https://commits.webkit.org/286075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d1e71206c7875081503f5e31de1b8e8a81aded

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25184 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16494 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45120 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66462 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65743 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7816 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1227 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4061 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->