### PR TITLE
Nullptr crash under RenderTreeBuilder::Inline::splitInlines while transitioning to fullscreen

### DIFF
--- a/LayoutTests/fast/css/fullscreen-style-sharing-crash-expected.txt
+++ b/LayoutTests/fast/css/fullscreen-style-sharing-crash-expected.txt
@@ -1,0 +1,2 @@
+
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/fullscreen-style-sharing-crash.html
+++ b/LayoutTests/fast/css/fullscreen-style-sharing-crash.html
@@ -1,0 +1,26 @@
+<script>
+(async () => {
+ testRunner.dumpAsText();
+ internals.withUserGesture(() => {});
+ n1 = document.createElement('video');
+ document.documentElement.append(n1);
+ n2 = document.createElement('source');
+ n1.after(n2);
+ n14 = document.createElement('div');
+ n2.append(n14);
+ n18 = document.createElement('div');
+ n2.after(n18);
+ n46 = document.createElement('source');
+ n1.after(n46);
+ n59 = document.createElement('audio');
+ n59.src = 'data:application/vnd.apple.mpegURL;base64,x';
+ try {
+ await n2.requestFullscreen();
+ navigator.mediaSession.callActionHandler({ action: 'seekbackward', });
+ await new Promise(requestAnimationFrame);
+ await new Promise(requestAnimationFrame);
+ await n18.requestFullscreen();
+ } catch { }
+})();
+ </script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -296,8 +296,11 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
     if (!m_document->styleScope().anchorPositionedStates().isEmptyIgnoringNullReferences())
         return false;
 
+    if (candidateElement.isInTopLayer() || element.isInTopLayer())
+        return false;
+
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr fullscreenManager = m_document->fullscreenManagerIfExists(); fullscreenManager && (&candidateElement == fullscreenManager->currentFullscreenElement() || &element == fullscreenManager->currentFullscreenElement()))
+    if (candidateElement.hasFullscreenFlag() || element.hasFullscreenFlag())
         return false;
 #endif
 


### PR DESCRIPTION
#### 30fb035c257c54eb394f0d81ad75007915fa5b6c
<pre>
Nullptr crash under RenderTreeBuilder::Inline::splitInlines while transitioning to fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=282231">https://bugs.webkit.org/show_bug.cgi?id=282231</a>
<a href="https://rdar.apple.com/137177522">rdar://137177522</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/fullscreen-style-sharing-crash-expected.txt: Added.
* LayoutTests/fast/css/fullscreen-style-sharing-crash.html: Added.
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const):

We were improperly sharing style between elements that had different top layer status and fullscreen flags.
This led to illegal render tree structure.

Canonical link: <a href="https://commits.webkit.org/285832@main">https://commits.webkit.org/285832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67fa0f9ea61555d6c1de691016f20476e40cc90b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1164 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58150 "Found 81 new test failures: accessibility/w3c-svg-content-language-attribute.html fast/css/focus-ring-exists-for-search-field.html fast/events/domactivate-sets-underlying-click-event-as-handled.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/canvas-video-to-canvas.html fast/mediastream/captureStream/canvas3d.html fast/multicol/table-vertical-align.html fast/ruby/annotation-with-line-gap.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48291 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63616 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21107 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66467 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1410 "Failed to checkout and rebase branch from PR 35857") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16279 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7819 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1231 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3981 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->