### PR TITLE
WindowClient.matchAll resolves promise too early

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch-worker.js
@@ -1,0 +1,47 @@
+function doFetch(e)
+{
+    let resultsPromise;
+    if (self.location.href.includes("get")) {
+        resultsPromise = self.clients.get(e.resultingClientId).then(result => {
+            let text = "<html><body><script>window.result = '";
+            if (result)
+                text += result.url;
+            else
+                text += "none";
+            text += "';</script></body></html>";
+            return new Response(text, {  headers: [["Content-Type", "text/html; charset=utf-8"]] });
+        });
+    } else if (self.location.href.includes("matchall")) {
+        resultsPromise = self.clients.matchAll().then(results => {
+            let text = "<html><body><script>window.result = '";
+            if (!results.length)
+                text += "none";
+            else
+                results.forEach(result => text += result.url + ",");
+            text += "';</script></body></html>";
+            return new Response(text, {  headers: [["Content-Type", "text/html; charset=utf-8"]] });
+        });
+    } else if (self.location.href.includes("postmessage")) {
+       resultsPromise = Promise.any([
+           self.clients.get(e.resultingClientId).then(client => {
+               if (client)
+                   client.postMessage("got client " + client.url);
+           }),
+           new Promise(resolve => setTimeout(resolve, 1000))
+       ]);
+       resultsPromise = resultsPromise.then(() => {
+           const text = "<html><body><script>window.result = ''; navigator.serviceWorker.onmessage = e => window.result += e.data;</script></body></html>";
+           return new Response(text, {  headers: [["Content-Type", "text/html; charset=utf-8"]] });
+       });
+       setInterval(async () => {
+           const client = await self.clients.get(e.resultingClientId);
+           if (client)
+               client.postMessage("post fetch");
+       }, 100);
+    }
+
+    e.respondWith(resultsPromise);
+    return resultsPromise;
+}
+
+self.addEventListener("fetch", e => e.waitUntil(doFetch(e)));

--- a/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS List controlled clients via matchAll at fetch event time
+PASS Get resulting client id at fetch event time
+PASS Post message to resulting client at fetch event time
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+const script = "service-worker-match-during-fetch-worker.js"
+promise_test(async (test) => {
+    const scope = "test1";
+    const registration = await navigator.serviceWorker.register(script + "?matchall", { scope });
+    const worker = registration.installing;
+    if (worker)
+        await waitForState(worker, "activated");
+
+    const frame = await withIframe(scope);
+    assert_equals(frame.contentWindow.result, "none");
+}, "List controlled clients via matchAll at fetch event time");
+
+promise_test(async (test) => {
+    const scope = "test2";
+    const registration = await navigator.serviceWorker.register(script + "?get", { scope });
+    const worker = registration.installing;
+    if (worker)
+        await waitForState(worker, "activated");
+
+    const frame = await withIframe(scope);
+    assert_true(frame.contentWindow.result.includes(scope));
+}, "Get resulting client id at fetch event time");
+
+promise_test(async (test) => {
+    const scope = "test3";
+    const registration = await navigator.serviceWorker.register(script + "?postmessage", { scope });
+    const worker = registration.installing;
+    if (worker)
+        await waitForState(worker, "activated");
+
+    const frame = await withIframe(scope);
+    await new Promise((resolve, reject)  => {
+        frame.contentWindow.navigator.serviceWorker.addEventListener('message', resolve)
+        setTimeout(() => reject("message timed out"), 1000);
+    });
+    assert_true(frame.contentWindow.result.includes(scope));
+}, "Post message to resulting client at fetch event time");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -348,10 +348,11 @@ private:
         std::unique_ptr<Timer> terminateServiceWorkersTimer;
         String userAgent;
     };
+
     HashMap<ClientOrigin, Clients> m_clientIdentifiersPerOrigin;
     HashMap<ScriptExecutionContextIdentifier, WeakRef<SWServerRegistration>> m_serviceWorkerPageIdentifierToRegistrationMap;
     HashMap<ScriptExecutionContextIdentifier, UniqueRef<ServiceWorkerClientData>> m_clientsById;
-    HashMap<ScriptExecutionContextIdentifier, Vector<ServiceWorkerClientPendingMessage>> m_clientPendingMessagesById;
+    HashMap<ScriptExecutionContextIdentifier, Vector<ServiceWorkerClientPendingMessage>> m_clientsToBeCreatedById;
     HashMap<ScriptExecutionContextIdentifier, ServiceWorkerRegistrationIdentifier> m_clientToControllingRegistration;
     MemoryCompactRobinHoodHashMap<String, ScriptExecutionContextIdentifier> m_visibleClientIdToInternalClientIdMap;
 


### PR DESCRIPTION
#### 1c96accc39ab19374823137df0e4308f5788f94f
<pre>
WindowClient.matchAll resolves promise too early
<a href="https://rdar.apple.com/135742835">rdar://135742835</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279458">https://bugs.webkit.org/show_bug.cgi?id=279458</a>

Reviewed by Ben Nham.

matchAll was returning service worker clients that were not yet active, although <a href="https://w3c.github.io/ServiceWorker/#dom-clients-matchall">https://w3c.github.io/ServiceWorker/#dom-clients-matchall</a> says to not expose them through matchAll.
This patch aligns with the spec and with Chrome.
After the patch, matchAll promise will continue resolving with the same timing but will contain fewer clients.
This also ensures that clients exposed via matchAll can be focused/navigated as they are backed by a Document object in a WebContent process.

We rename m_clientPendingMessagesById to m_clientsToBeCreatedById to make it clearer this map is about clients that are not yet created.
We should further improve our compliance by waiting for the document to become active (<a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag).">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag).</a>
This can be done in a follow-up. Ditto for ServiceWorkerClients.get.

* LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch-worker.js: Added.
* LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https.html: Added.
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::matchAll):
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::unregisterServiceWorkerClient):
(WebCore::SWServer::postMessageToServiceWorkerClient):
(WebCore::SWServer::releaseServiceWorkerClientPendingMessage):
* Source/WebCore/workers/service/server/SWServer.h:

Canonical link: <a href="https://commits.webkit.org/285953@main">https://commits.webkit.org/285953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e3a7ab18897fe95266a1f8098e338d6dc06b92c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58228 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16510 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79856 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7831 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4069 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->