### PR TITLE
[css-flexbox] incorrect layout with max-height and flex-direction column and justify-content center

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1806,6 +1806,21 @@ bool RenderFlexibleBox::resolveFlexibleLengths(FlexSign flexSign, FlexLayoutItem
             flexItemSize += LayoutUnit::fromFloatRound(extraSpace);
 
         LayoutUnit adjustedFlexItemSize = flexLayoutItem.constrainSizeByMinMax(flexItemSize);
+
+        // Adjust flex item size with the specified container max size.
+        auto maximumSize = isHorizontalFlow() ? style().maxWidth() : style().maxHeight();
+        const auto minimumSize = isHorizontalFlow() ? style().minWidth() : style().minHeight();
+        if (maximumSize.isFixed()) {
+            // The fixed min height/width should be considered as maximum size if it is bigger than fixed max height/width.
+            if (minimumSize.isFixed() && minimumSize.value() > maximumSize.value())
+                maximumSize = minimumSize;
+
+            // If the size of flex item adjusted to its min/max size is bigger than the maximum size of the container, then
+            // we use flext item size calculated before adjusting the min/max size of the flex item.
+            if (adjustedFlexItemSize > LayoutUnit { maximumSize.value() })
+                adjustedFlexItemSize = std::max(LayoutUnit { }, flexItemSize);
+        }
+
         ASSERT(adjustedFlexItemSize >= 0);
         flexLayoutItem.flexedContentSize = adjustedFlexItemSize;
         usedFreeSpace += adjustedFlexItemSize - flexLayoutItem.flexBaseContentSize;


### PR DESCRIPTION
#### ebca6b1bdd254c8a39d39ad9e651345b623fbc92
<pre>
[css-flexbox] incorrect layout with max-height and flex-direction column and justify-content center
<a href="https://bugs.webkit.org/show_bug.cgi?id=282036">https://bugs.webkit.org/show_bug.cgi?id=282036</a>

Reviewed by NOBODY (OOPS!).

After calculation of the flex item size and adjusting it to min/max size
of the flex item we should also check how the calculated size
corresponds to specified max size of the whole container. In case the
adjusted flex item size is bigger than the max size of the whole
container we should use the flex item size calculated before adjusting
to flex item min/max size.

There is new layout test which tests the problem.

* LayoutTests/css3/flexbox/nested-flexbox-max-height-expected.txt: Added.
* LayoutTests/css3/flexbox/nested-flexbox-max-height.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a22738d4a612f90999cff6c3659a44c1c68017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72786 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81801 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81172 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25748 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15790 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27584 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->