### PR TITLE
[Navigation] Implement url censoring

### DIFF
--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -45,7 +45,7 @@ public:
     using RefCounted<NavigationHistoryEntry>::ref;
     using RefCounted<NavigationHistoryEntry>::deref;
 
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier())); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, context, WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier())); }
     static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, const NavigationHistoryEntry&);
 
     const String& url() const;
@@ -60,13 +60,14 @@ public:
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
 
 private:
-    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
+    NavigationHistoryEntry(ScriptExecutionContext*, ScriptExecutionContext*, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
+    RefPtr<ScriptExecutionContext> m_originalScriptExecutionContext;
     const String m_urlString;
     const WTF::UUID m_key;
     const WTF::UUID m_id;


### PR DESCRIPTION
#### 4dd969555be54ccfafb507a8ad069878a5005551
<pre>
[Navigation] Implement url censoring
<a href="https://bugs.webkit.org/show_bug.cgi?id=282236">https://bugs.webkit.org/show_bug.cgi?id=282236</a>

Reviewed by NOBODY (OOPS!).

WIP.
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::url const):
* Source/WebCore/page/NavigationHistoryEntry.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dd969555be54ccfafb507a8ad069878a5005551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1172 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58160 "Found 24 new test failures: animations/leak-document-with-css-animation.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/intersection-observer-document-leak.html fast/editing/document-leak-altered-text-field.html fast/html/request-video-frame-callback-does-not-leak.html fast/reporting/reporting-observer-callback-does-not-leak.html fast/workers/worker-document-leak.html highlight/highlight-world-leak.html http/tests/canvas/ctx.2d-canvas-style-color-no-document-leak.html http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16506 "Found 16 new test failures: animations/leak-document-with-css-animation.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/TreeWalker/TreeWalker-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/editing/document-leak-altered-text-field.html fast/reporting/reporting-observer-callback-does-not-leak.html fast/workers/worker-document-leak.html highlight/highlight-world-leak.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77025 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48299 "Found 26 new test failures: animations/leak-document-with-css-animation.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/TreeWalker/TreeWalker-leak-document.html fast/dom/intersection-observer-document-leak.html fast/editing/document-leak-altered-text-field.html fast/html/request-video-frame-callback-does-not-leak.html fast/reporting/reporting-observer-callback-does-not-leak.html fast/workers/worker-document-leak.html highlight/highlight-world-leak.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45143 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21114 "Found 60 new test failures: animations/leak-document-with-css-animation.html editing/mac/selection/word-thai-does-not-leak.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/TreeWalker/TreeWalker-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/editing/document-leak-altered-text-field.html fast/events/selectionchange-user-initiated.html fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23529 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66671 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21461 "Found 30 new test failures: animations/leak-document-with-css-animation.html editing/mac/selection/word-thai-does-not-leak.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/TreeWalker/TreeWalker-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/editing/document-leak-altered-text-field.html fast/html/request-video-frame-callback-does-not-leak.html fast/reporting/reporting-observer-callback-does-not-leak.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1275 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/675 "Found 60 new test failures: animations/leak-document-with-css-animation.html editing/mac/selection/word-thai-does-not-leak.html editing/selection/navigation-clears-editor-state.html fast/canvas/webgl/debug-messages-to-console.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/editing/document-leak-altered-text-field.html fast/forms/switch/click-animation-twice-fast.html fast/html/request-video-frame-callback-does-not-leak.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66473 "Found 23 new test failures: animations/leak-document-with-css-animation.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/reporting/reporting-observer-callback-does-not-leak.html fast/workers/worker-document-leak.html highlight/highlight-world-leak.html http/tests/canvas/ctx.2d-canvas-style-color-no-document-leak.html http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65753 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9647 "Found 1 new test failure: resize-observer/element-leak.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7826 "Found 30 new test failures: animations/leak-document-with-css-animation.html editing/mac/selection/word-thai-does-not-leak.html editing/selection/navigation-clears-editor-state.html fast/dom/NodeIterator/NodeIterator-leak-document.html fast/dom/TreeWalker/TreeWalker-leak-document.html fast/dom/intersection-observer-document-leak.html fast/dom/lazy-image-loading-document-leak.html fast/editing/document-leak-altered-text-field.html fast/html/request-video-frame-callback-does-not-leak.html fast/reporting/reporting-observer-callback-does-not-leak.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->