### PR TITLE
Web Inspector: Remove empty divs from TabBar used for border decoration

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -58,30 +58,18 @@ body.window-inactive .tab-bar {
     --tab-bar-background: hsl(0, 0%, 92%);
 }
 
-.tab-bar > .border {
-    position: absolute;
-    left: 0;
-    right: 0;
-    z-index: var(--tab-bar-border-z-index);
-    background-color: var(--tab-item-medium-border-color);
-}
-
-.tab-bar > .border.top {
-    top: 0;
-    height: calc(1px / var(--zoom-factor));
-}
-
-.tab-bar > .border.bottom {
-    bottom: 0;
-    height: 1px;
-}
-
-body.window-inactive .tab-bar > .border {
-    background-color: var(--tab-item-light-border-color);
-}
-
 .tab-bar > .navigation-bar {
     height: var(--tab-bar-height);
+    border-top: var(--tab-item-medium-border-style);
+    border-bottom: var(--tab-item-medium-border-style);
+}
+
+body.window-inactive .tab-bar > .navigation-bar {
+    border-color: var(--tab-item-light-border-color);
+}
+
+.tab-bar > .navigation-bar > .item.group {
+    margin-top: -1px;
 }
 
 .tab-bar > .navigation-bar > .item.group > .item {

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.js
@@ -32,8 +32,6 @@ WI.TabBar = class TabBar extends WI.View
         this.element.classList.add("tab-bar");
         this.element.addEventListener("mousedown", this._handleMouseDown.bind(this));
 
-        this.element.createChild("div", "border top");
-
         const navigationBarBeforeElement = null;
         this._navigationBarBefore = new WI.NavigationBar(navigationBarBeforeElement, {sizesToFit: true});
         this.addSubview(this._navigationBarBefore);
@@ -48,8 +46,6 @@ WI.TabBar = class TabBar extends WI.View
         const navigationBarAfterElement = null;
         this._navigationBarAfter = new WI.NavigationBar(navigationBarAfterElement, {sizesToFit: true});
         this.addSubview(this._navigationBarAfter);
-
-        this.element.createChild("div", "border bottom");
 
         this._tabBarItems = [];
         this._hiddenTabBarItems = [];

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -434,7 +434,7 @@ body {
         }
     }
 
-    &:not(.docked) {
+    &.mac-platform:not(.docked) {
         --undocked-title-area-height: calc(27px / var(--zoom-factor));
     }
 }


### PR DESCRIPTION
#### c5e42ee6bfc4938b29912c10ff33369c5ffcf634
<pre>
Web Inspector: Remove empty divs from TabBar used for border decoration
<a href="https://bugs.webkit.org/show_bug.cgi?id=282237">https://bugs.webkit.org/show_bug.cgi?id=282237</a>
<a href="https://rdar.apple.com/138842085">rdar://138842085</a>

Reviewed by NOBODY (OOPS!).

There&apos;s no need for two empty absolutely-positioned divs to create
top and bottom border for WI.TabBar. Existing border styles for tab bar items
that can be copied over to the navigation bar which is nested within the tab bar
acheive the same visual result.

* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(.tab-bar &gt; .navigation-bar):
(body.window-inactive .tab-bar &gt; .navigation-bar):
(.tab-bar &gt; .border): Deleted.
(.tab-bar &gt; .border.top): Deleted.
(.tab-bar &gt; .border.bottom): Deleted.
(body.window-inactive .tab-bar &gt; .border): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TabBar.js:
(WI.TabBar):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(&amp;.mac-platform:not(.docked)):
(&amp;:not(.docked)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5e42ee6bfc4938b29912c10ff33369c5ffcf634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74180 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/53609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78553 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/62742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/1394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78553 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/62742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78553 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/62742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/62742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1497 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/1394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/80073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1642 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/26991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/1461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1478 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/1497 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->