### PR TITLE
Asynchronously delete small DOM nodes

### DIFF
--- a/LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit-expected.txt
+++ b/LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit-expected.txt
@@ -1,0 +1,6 @@
+PASS window.internals.numberOfLiveNodes() < startingNodeCount + asyncNodeDeletionLimit is true
+PASS window.internals.numberOfLiveNodes() < startingNodeCount + asyncNodeDeletionLimit is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit.html
+++ b/LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    const asyncNodeDeletionLimit = 100000;
+    const startingNodeCount = window.internals.numberOfLiveNodes();
+    let rootDiv = document.createElement("div");
+    for (let i = 0; i < asyncNodeDeletionLimit + 1; ++i)
+        rootDiv.appendChild(document.createElement('div'));
+    rootDiv.innerHTML = "";
+    gc();
+    shouldBeTrue("window.internals.numberOfLiveNodes() < startingNodeCount + asyncNodeDeletionLimit");
+
+    let nodeWithManyChildren = document.createElement("div");
+    for (let i = 0; i < asyncNodeDeletionLimit + 1; ++i)
+        nodeWithManyChildren.appendChild(document.createElement("p"));
+    let hostNode = document.createElement("div");
+    shadowRoot = hostNode.attachShadow({mode: 'closed'});
+    shadowRoot.appendChild(nodeWithManyChildren);
+    rootDiv.appendChild(hostNode);
+    rootDiv.innerHTML = "";
+    shadowRoot = null;
+    hostNode = null;
+    rootDiv = null;
+    nodeWithManyChildren = null;
+    gc();
+    shouldBeTrue("window.internals.numberOfLiveNodes() < startingNodeCount + asyncNodeDeletionLimit");
+
+var successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree-expected.txt
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree-expected.txt
@@ -1,0 +1,202 @@
+=== Initial state ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+=== Initial state ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+=== Initial state ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+=== Initial state ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+=== Initial state ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+=== Initial state ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML ===
+PASS globalDiv.id is "div2"
+PASS globalDiv.parentNode.id is "div2-parent"
+PASS globalDiv.firstChild.id is "div2-child"
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML and divX ===
+PASS globalDiv.id is "div1"
+PASS globalDiv.parentNode.id is "div1-parent"
+PASS globalDiv.firstChild.id is "div1-child"
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML, divX and divY ===
+PASS globalDiv.id is "div0"
+PASS globalDiv.parentNode.id is "div0-parent"
+PASS globalDiv.firstChild.id is "div0-child"
+=== After clearing innerHTML, divX, divY and divZ ===
+PASS All <div> objects in a DOM tree are successfully destructed.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+var testCases = [["div0", "div1", "div2"],
+                 ["div0", "div2", "div1"],
+                 ["div1", "div0", "div2"],
+                 ["div1", "div2", "div0"],
+                 ["div2", "div0", "div1"],
+                 ["div2", "div1", "div0"]];
+
+var rootDiv = document.createElement("div");
+document.body.appendChild(rootDiv);
+var testHtml = "<div id='div0-parent'><div id='div0'><div id='div0-child'></div></div><div id='div1-parent'><div id='div1'><div id='div1-child'></div></div><div id='div2-parent'><div id='div2'><div id='div2-child'></div></div></div></div></div>";
+
+testCases.forEach(function (test) {
+    var divX, divY, divZ, hostNode, shadowRoot;
+    debug("=== Initial state ===");
+    shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
+    rootDiv.innerHTML = "";
+    divX = shadowRoot.getElementById(test[0]);
+    divY = shadowRoot.getElementById(test[1]);
+    divZ = shadowRoot.getElementById(test[2]);
+    checkParentAndChildAlive(divX, test[0]);
+    checkParentAndChildAlive(divY, test[1]);
+    checkParentAndChildAlive(divZ, test[2]);
+
+    debug("=== After clearing innerHTML ===");
+    shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
+    divX = shadowRoot.getElementById(test[0]);
+    divY = shadowRoot.getElementById(test[1]);
+    divZ = shadowRoot.getElementById(test[2]);
+    rootDiv.innerHTML = "";
+    checkParentAndChildAlive(divX, test[0]);
+    checkParentAndChildAlive(divY, test[1]);
+    checkParentAndChildAlive(divZ, test[2]);
+
+    debug("=== After clearing innerHTML and divX ===");
+    shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
+    divX = shadowRoot.getElementById(test[0]);
+    divY = shadowRoot.getElementById(test[1]);
+    divZ = shadowRoot.getElementById(test[2]);
+    rootDiv.innerHTML = "";
+    divX = null;
+    gc();
+    checkParentAndChildAlive(divY, test[1]);
+    checkParentAndChildAlive(divZ, test[2]);
+
+    debug("=== After clearing innerHTML, divX and divY ===");
+    shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
+    divX = shadowRoot.getElementById(test[0]);
+    divY = shadowRoot.getElementById(test[1]);
+    divZ = shadowRoot.getElementById(test[2]);
+    rootDiv.innerHTML = "";
+    divX = null;
+    divY = null;
+    gc();
+    checkParentAndChildAlive(divZ, test[2]);
+
+    debug("=== After clearing innerHTML, divX, divY and divZ ===");
+    shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
+    divX = shadowRoot.getElementById(test[0]);
+    divY = shadowRoot.getElementById(test[1]);
+    divZ = shadowRoot.getElementById(test[2]);
+    if (window.internals)
+        prevNodes = window.internals.numberOfLiveNodes();
+    rootDiv.innerHTML = "";
+    divX = null;
+    divY = null;
+    divZ = null;
+    gc();
+    if (window.internals) {
+        // DOM nodes can be destructed asynchronously during idle time. Force delete the nodes
+        internals.executeOpportunisticallyScheduledTasks();
+        // If all the Node objects in testHtml are successfully destructed,
+        // at least 9 <div>s objects will be removed.
+        // (Actually, since testHtml rendering requires more than 9 Node objects.)
+        if (window.internals.numberOfLiveNodes() <= prevNodes - 9)
+            testPassed("All <div> objects in a DOM tree are successfully destructed.");
+        else
+            testFailed("<div> objects in a DOM tree are not destructed.");
+    }
+});
+
+function checkParentAndChildAlive(div, name) {
+    globalDiv = div;
+    shouldBeEqualToString('globalDiv.id', name);
+    shouldBeEqualToString('globalDiv.parentNode.id', name + "-parent");
+    shouldBeEqualToString('globalDiv.firstChild.id', name + "-child");
+    globalDiv = null;
+    gc();
+}
+
+function setUpShadowTree(rootDiv, hostNode, testHtml) {
+    hostNode = document.createElement("div");
+    shadowRoot = hostNode.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = testHtml;
+    rootDiv.appendChild(hostNode);
+    return shadowRoot;
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime.html
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime.html
@@ -72,6 +72,8 @@ testCases.forEach(function (test) {
     divZ = null;
     gc();
     if (window.internals) {
+        // DOM nodes can be destructed asynchronously during idle time. Force delete the nodes.
+        internals.executeOpportunisticallyScheduledTasks();
         // If all the Node objects in testHtml are successfully destructed,
         // at least 9 <div>s objects will be removed.
         // (Actually, since testHtml rendering requires more than 9 Node objects.)

--- a/LayoutTests/intersection-observer/root-element-deleted.html
+++ b/LayoutTests/intersection-observer/root-element-deleted.html
@@ -50,7 +50,8 @@ function runTest(testNumber) {
     root.remove();
     root = null;
     target = null;
-    requestAnimationFrame(function () {
+    // add a timeout between requestAnimationFrame calls to allow opportunistic node deletion to occur
+    setTimeout(() => { requestAnimationFrame(function () {
         observer.takeRecords();
         gc();
 
@@ -71,6 +72,7 @@ function runTest(testNumber) {
         else
             setTimeout(() => finish(testNumber), 0);
     });
+    }, 5);
 }
 
 function testFailed(testNumber, error)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -360,6 +360,10 @@ platform/ios/ios/fast/forms/range-input-touches.html [ Skip ]
 platform/ios/ios/touch [ Skip ]
 media/modern-media-controls/css/pointer-events-none.html [ Skip ]
 
+# Calls into the Opportunistic Task Scheduler which is currently disabled on IOS
+fast/dom/gc-dom-tree-lifetime.html
+fast/dom/gc-dom-tree-lifetime-shadow-tree.html
+
 platform/ipad/fast/forms [ Skip ]
 
 media/media-sources-selection.html [ ImageOnlyFailure ] # Sources selection on iOS will select a different source.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2822,6 +2822,9 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nestin
 #test uses test helper functions not implemented on WK1
 fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]
 
+# Deletes nodes asynchronously using OpportunisticTaskScheduler, which is disabled on WK1
+intersection-observer/root-element-deleted.html [ Skip ]
+
 # webkit.org/b/267799 [ Ventura wk1 ] 2 tests in media/track are constant crash
 [ Ventura ] media/track/track-in-band-layout.html [ Crash ]
 [ Ventura ] media/track/track-paint-on-captions.html [ Crash ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1024,6 +1024,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ActiveDOMCallback.h
     dom/ActiveDOMObject.h
     dom/AddEventListenerOptions.h
+    dom/AsyncNodeDeletionQueue.h
     dom/Attr.h
     dom/Attribute.h
     dom/BoundaryPoint.h

--- a/Source/WebCore/dom/AsyncNodeDeletionQueue.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueue.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ContainerNode.h"
+#include "Element.h"
+#include "HTMLElement.h"
+#include "HTMLNames.h"
+#include "NodeName.h"
+
+namespace WebCore {
+
+class AsyncNodeDeletionQueue {
+public:
+    ALWAYS_INLINE void addIfSubtreeSizeIsUnderLimit(NodeVector&& children, unsigned subTreeSize)
+    {
+        if (m_nodeCount + subTreeSize > s_maxSizeAsyncNodeDeletionQueue)
+            return;
+        m_nodeCount += subTreeSize;
+        m_queue.appendVector(WTFMove(children));
+    }
+
+    ALWAYS_INLINE void deleteNodesNow()
+    {
+        m_queue.clear();
+        m_nodeCount = 0;
+    }
+
+    ALWAYS_INLINE static ContainerNode::CanDelayNodeDeletion canNodeBeDeletedAsync(const Node& node)
+    {
+        if (!dynamicDowncast<HTMLElement>(node))
+            return ContainerNode::CanDelayNodeDeletion::Yes;
+        if (isNodeLikelyLarge(node))
+            return ContainerNode::CanDelayNodeDeletion::No;
+        return ContainerNode::CanDelayNodeDeletion::Yes;
+    }
+
+    ALWAYS_INLINE static bool isNodeLikelyLarge(const Node& node)
+    {
+        ASSERT(node.isElementNode());
+
+        switch (downcast<Element>(node).elementName()) {
+        case NodeName::HTML_audio:
+        case NodeName::HTML_body:
+        case NodeName::HTML_canvas:
+        case NodeName::HTML_iframe:
+        case NodeName::HTML_img:
+        case NodeName::HTML_object:
+        case NodeName::HTML_source:
+        case NodeName::HTML_track:
+        case NodeName::HTML_video:
+        case NodeName::SVG_svg:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+private:
+    Vector<Ref<Node>> m_queue;
+    unsigned m_nodeCount { 0 };
+    static constexpr unsigned s_maxSizeAsyncNodeDeletionQueue = 100000;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -79,6 +79,7 @@ public:
 
     void cloneChildNodes(TreeScope&, ContainerNode& clone);
 
+    enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {
         enum class Type : uint8_t { ElementInserted, ElementRemoved, TextInserted, TextRemoved, TextChanged, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, AllChildrenReplaced };
         enum class Source : uint8_t { Parser, API, Clone };
@@ -161,7 +162,13 @@ private:
     void executePreparedChildrenRemoval();
     enum class DeferChildrenChanged : bool { No, Yes };
     enum class DidRemoveElements : bool { No, Yes };
-    DidRemoveElements removeAllChildrenWithScriptAssertion(ChildChange::Source, NodeVector& children, DeferChildrenChanged = DeferChildrenChanged::No);
+    struct RemoveAllChildrenResult {
+        unsigned subTreeSize;
+        DidRemoveElements didRemoveElements;
+        CanDelayNodeDeletion canBeDelayed;
+    };
+    RemoveAllChildrenResult removeAllChildrenWithScriptAssertionMaybeAsync(ChildChange::Source, NodeVector& children, DeferChildrenChanged = DeferChildrenChanged::No);
+    RemoveAllChildrenResult removeAllChildrenWithScriptAssertion(ChildChange::Source, NodeVector& children, DeferChildrenChanged = DeferChildrenChanged::No);
     bool removeNodeWithScriptAssertion(Node&, ChildChange::Source);
     ExceptionOr<void> removeSelfOrChildNodesForInsertion(Node&, NodeVector&);
 

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -101,38 +101,59 @@ inline void updateObservability(RemovedSubtreeObservability& currentObservabilit
         currentObservability = newStatus;
 }
 
-static RemovedSubtreeObservability notifyNodeRemovedFromDocument(ContainerNode& oldParentOfRemovedTree, TreeScopeChange treeScopeChange, Node& node)
+inline void updateCanDelayNodeDeletion(ContainerNode::CanDelayNodeDeletion& currentCanDelayDeletion, ContainerNode::CanDelayNodeDeletion newStatus)
+{
+    if (newStatus == ContainerNode::CanDelayNodeDeletion::No)
+        currentCanDelayDeletion = ContainerNode::CanDelayNodeDeletion::No;
+}
+
+static RemovedSubtreeResult notifyNodeRemovedFromDocument(ContainerNode& oldParentOfRemovedTree, TreeScopeChange treeScopeChange, Node& node)
 {
     ASSERT(!node.parentNode());
     ASSERT(oldParentOfRemovedTree.isConnected());
     ASSERT(node.isConnected());
 
     RemovedSubtreeObservability observability = RemovedSubtreeObservability::NotObservable;
+    auto canDelayNodeDeletion = ContainerNode::CanDelayNodeDeletion::Yes;
+    unsigned subTreeSize = 0;
     for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
+        ++subTreeSize;
         currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ true, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
+        updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));
         updateObservability(observability, observabilityOfRemovedNode(*currentNode));
-        if (RefPtr root = currentNode->shadowRoot())
-            updateObservability(observability, notifyNodeRemovedFromDocument(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root));
+        if (RefPtr root = currentNode->shadowRoot()) {
+            auto [shadowTreeSize, newObservability, canBeDelayed] = notifyNodeRemovedFromDocument(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root);
+            subTreeSize += shadowTreeSize;
+            updateCanDelayNodeDeletion(canDelayNodeDeletion, canBeDelayed);
+            updateObservability(observability, newObservability);
+        }
     }
-    return observability;
+    return { subTreeSize, observability, canDelayNodeDeletion };
 }
 
-static RemovedSubtreeObservability notifyNodeRemovedFromTree(ContainerNode& oldParentOfRemovedTree, TreeScopeChange treeScopeChange, Node& node)
+static RemovedSubtreeResult notifyNodeRemovedFromTree(ContainerNode& oldParentOfRemovedTree, TreeScopeChange treeScopeChange, Node& node)
 {
     ASSERT(!node.parentNode());
     ASSERT(!oldParentOfRemovedTree.isConnected());
-
+    unsigned subTreeSize = 0;
+    auto canDelayNodeDeletion = ContainerNode::CanDelayNodeDeletion::Yes;
     RemovedSubtreeObservability observability = RemovedSubtreeObservability::NotObservable;
     for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
+        ++subTreeSize;
         currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ false, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
+        updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));
         updateObservability(observability, observabilityOfRemovedNode(*currentNode));
-        if (RefPtr root = currentNode->shadowRoot())
-            updateObservability(observability, notifyNodeRemovedFromTree(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root));
+        if (RefPtr root = currentNode->shadowRoot()) {
+            auto [shadowTreeSize, newObservability, canBeDelayed] = notifyNodeRemovedFromTree(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root);
+            subTreeSize += shadowTreeSize;
+            updateCanDelayNodeDeletion(canDelayNodeDeletion, canBeDelayed);
+            updateObservability(observability, newObservability);
+        }
     }
-    return observability;
+    return { subTreeSize, observability, canDelayNodeDeletion };
 }
 
-RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node& child)
+RemovedSubtreeResult notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node& child)
 {
     // Assert that the caller of this function has an instance of ScriptDisallowedScope.
     ASSERT(!isMainThread() || ScriptDisallowedScope::InMainThread::hasDisallowedScope());

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.h
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.h
@@ -62,12 +62,20 @@ public:
 #endif // not ASSERT_ENABLED
 
 void notifyChildNodeInserted(ContainerNode& parentOfInsertedTree, Node&, NodeVector& postInsertionNotificationTargets);
+inline void updateCanDelayNodeDeletion(ContainerNode::CanDelayNodeDeletion& currentCanDelayDeletion, ContainerNode::CanDelayNodeDeletion newStatus);
 
 enum class RemovedSubtreeObservability : bool {
     NotObservable,
     MaybeObservableByRefPtr,
 };
-RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node&);
+
+struct RemovedSubtreeResult {
+    unsigned subTreeSize;
+    RemovedSubtreeObservability removedSubtreeObservability;
+    ContainerNode::CanDelayNodeDeletion canBeDelayed;
+};
+
+RemovedSubtreeResult notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node&);
 void removeDetachedChildrenInContainer(ContainerNode&);
 
 enum class SubframeDisconnectPolicy : bool {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -850,6 +850,7 @@ void Document::removedLastRef()
         m_documentElement = nullptr;
         m_focusNavigationStartingNode = nullptr;
         m_userActionElements.clear();
+        m_asyncNodeDeletionQueue.deleteNodesNow();
 #if ENABLE(FULLSCREEN_API)
         if (CheckedPtr fullscreenManager = m_fullscreenManager.get())
             m_fullscreenManager->clear();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "AsyncNodeDeletionQueue.h"
 #include "Color.h"
 #include "ContainerNode.h"
 #include "ContextDestructionObserverInlines.h"
@@ -517,6 +518,7 @@ public:
     WEBCORE_EXPORT DOMImplementation& implementation();
     
     Element* documentElement() const { return m_documentElement.get(); }
+    AsyncNodeDeletionQueue& asyncNodeDeletionQueue() { return m_asyncNodeDeletionQueue; };
     inline RefPtr<Element> protectedDocumentElement() const; // Defined in DocumentInlines.h.
     static constexpr ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
@@ -2153,6 +2155,7 @@ private:
     RefPtr<LocalDOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     OptionSet<ParserContentPolicy> m_parserContentPolicy;
+    AsyncNodeDeletionQueue m_asyncNodeDeletionQueue;
 
     RefPtr<CachedResourceLoader> m_cachedResourceLoader;
     RefPtr<DocumentParser> m_parser;

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -85,6 +85,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     SelectorQueryCache::singleton().clear();
 
     for (auto& document : Document::allDocuments()) {
+        document->asyncNodeDeletionQueue().deleteNodesNow();
         if (CheckedPtr renderView = document->renderView()) {
             LayoutIntegration::LineLayout::releaseCaches(*renderView);
             Layout::TextBreakingPositionCache::singleton().clear();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5067,6 +5067,24 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
         options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
     commonVM().performOpportunisticallyScheduledTasks(deadline, options);
+
+    deleteRemovedNodes();
+}
+
+void Page::deleteRemovedNodes()
+{
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    if (!localMainFrame)
+        return;
+    RefPtr document = localMainFrame->document();
+    if (!document)
+        return;
+    forEachLocalFrame([] (LocalFrame& frame) {
+        RefPtr document = frame.document();
+        if (!document)
+            return;
+        document->asyncNodeDeletionQueue().deleteNodesNow();
+    });
 }
 
 CheckedRef<ProgressTracker> Page::checkedProgress()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1185,7 +1185,8 @@ public:
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
     void opportunisticallyRunIdleCallbacks(MonotonicTime deadline);
-    void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    WEBCORE_EXPORT void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    void deleteRemovedNodes();
     String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&);
     WEBCORE_EXPORT void setMediaKeysStorageDirectory(const String&);
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3108,6 +3108,15 @@ unsigned Internals::referencingNodeCount(const Document& document) const
     return document.referencingNodeCount();
 }
 
+ExceptionOr<void> Internals::executeOpportunisticallyScheduledTasks() const
+{
+    Document* document = contextDocument();
+    if (!document || !document->page())
+        return Exception { ExceptionCode::InvalidAccessError };
+    document->page()->performOpportunisticallyScheduledTasks(MonotonicTime::now());
+    return { };
+}
+
 #if ENABLE(WEB_AUDIO)
 uint64_t Internals::baseAudioContextIdentifier(const BaseAudioContext& context)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -587,6 +587,7 @@ public:
     unsigned numberOfLiveNodes() const;
     unsigned numberOfLiveDocuments() const;
     unsigned referencingNodeCount(const Document&) const;
+    ExceptionOr<void> executeOpportunisticallyScheduledTasks() const;
 
 #if ENABLE(WEB_AUDIO)
     // BaseAudioContext lifetime testing.

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -815,6 +815,7 @@ enum RenderingMode {
     unsigned long numberOfLiveNodes();
     unsigned long numberOfLiveDocuments();
     unsigned long referencingNodeCount(Document document);
+    undefined executeOpportunisticallyScheduledTasks();
     unsigned long numberOfIntersectionObservers(Document document);
     unsigned long numberOfResizeObservers(Document document);
     WindowProxy? openDummyInspectorFrontend(DOMString url);


### PR DESCRIPTION
#### ef070161a369956d0787ffa9e4ae9904e27ee3cf
<pre>
Asynchronously delete small DOM nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=282249">https://bugs.webkit.org/show_bug.cgi?id=282249</a>
<a href="https://rdar.apple.com/137026148">rdar://137026148</a>

Reviewed by Matthieu Dubet and Ryosuke Niwa.

Make removedChildren DOM nodes get deleted using the Opportunistic Task
Scheduler.
Instead of synchronously deleting removed child nodes upon each call
to removeChildren, keep a strong reference to each child that has been
removed from the DOM tree but has not been deallocated. Remove the
last reference using the Opportunistic Task Scheduler which will call
each node&apos;s destructor.
This is an optimization. We see roughly a
.30% - .55% performance improvement.

* LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit-expected.txt: Added.
* LayoutTests/fast/dom/gc-dom-tree-async-node-deletion-queue-limit.html: Added.
* LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree-expected.txt: Added.
* LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html: Copied from LayoutTests/fast/dom/gc-dom-tree-lifetime.html.
* LayoutTests/fast/dom/gc-dom-tree-lifetime.html:
* LayoutTests/intersection-observer/root-element-deleted.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/AsyncNodeDeletionQueue.h: Added.
(WebCore::AsyncNodeDeletionQueue::addIfSubtreeSizeIsUnderLimit):
(WebCore::AsyncNodeDeletionQueue::deleteNodesNow):
(WebCore::AsyncNodeDeletionQueue::canNodeBeDeletedAsync):
(WebCore::AsyncNodeDeletionQueue::isNodeLikelyLarge):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertionMaybeAsync):
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::removeNodeWithScriptAssertion):
(WebCore::ContainerNode::replaceAll):
(WebCore::ContainerNode::removeChildren):
(WebCore::ContainerNode::replaceChildren):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::updateCanDelayNodeDeletion):
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyNodeRemovedFromTree):
(WebCore::notifyChildNodeRemoved):
* Source/WebCore/dom/ContainerNodeAlgorithms.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/dom/Document.h:
(WebCore::Document::asyncNodeDeletionQueue):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::performOpportunisticallyScheduledTasks):
(WebCore::Page::deleteRemovedNodes):
* Source/WebCore/page/Page.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::executeOpportunisticallyScheduledTasks const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/288944@main">https://commits.webkit.org/288944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67bbefcdf1787ff5382fd684f757abbd6b8db261

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65960 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34893 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12106 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8835 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/connect-src-websocket-allowed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74435 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16384 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3554 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17498 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->