### PR TITLE
REGRESSION(282990@main) LegacyEME fails when appending media segment before completing key exchange

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait-expected.txt
@@ -1,0 +1,18 @@
+
+Created mediaSource
+EVENT(sourceopen)
+-
+Appending Encrypted Video Header
+FETCH: content/elementary-stream-video-header-keyid-1.m4v OK
+EVENT(webkitneedkey)
+EVENT(updateend)
+FETCH: content/elementary-stream-video-payload.m4v OK
+EVENT(updateend)
+EVENT(webkitkeymessage)
+EXPECTED (uInt8ArrayToString(event.message) == 'certificate') OK
+FETCH: resources/cert.der OK
+EVENT(webkitkeymessage)
+PROMISE: licenseResponse resolved
+EVENT(canplay)
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait.html
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>legacy-fairplay-mse-muxed-nowait</title>
+    <script src="../../../media-resources/video-test.js"></script>
+    <script src="support.js"></script>
+    <script src="legacy-eme.js"></script>
+    <script src="eme2016.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    var event;
+
+    async function startTest() {
+        let video = document.querySelector('video');
+        waitFor(video, 'error').then(failTest);
+
+        let keys = await startLegacyEME({
+            video: video,
+            protocolVersion: 2,
+            mimeType: 'video/mp4'
+        });
+
+        let mediaSource = new MediaSource;
+        video.srcObject = mediaSource;
+        consoleWrite('Created mediaSource');
+        await waitFor(mediaSource, 'sourceopen');
+
+        consoleWrite('-');
+        consoleWrite('Appending Encrypted Video Header');
+
+        let sourceBuffer = mediaSource.addSourceBuffer('video/mp4');
+        let needkeyPromise = waitFor(video, 'webkitneedkey');
+        let canPlayPromise = waitFor(video, 'canplay');
+
+        await fetchAndAppend(sourceBuffer, 'content/elementary-stream-video-header-keyid-1.m4v');
+        await fetchAndAppend(sourceBuffer, 'content/elementary-stream-video-payload.m4v');
+
+        event = await needkeyPromise;
+
+        let initDataArray = stringToUInt8Array('skd://twelve');
+        let keySession = keys.createSession('video/mp4', initDataArray);
+        waitFor(keySession, 'webkitkeyerror').then(event => {
+            consoleWrite(`FAIL: update() failed with code: ${ event.code }, systemCode: ${ event.systemCode }`);
+            endTest();
+        });
+        event = await waitFor(keySession, 'webkitkeymessage');
+        testExpected('uInt8ArrayToString(event.message)', 'certificate')
+
+        let buffer = await fetchBuffer('resources/cert.der');
+        let certificate = new Uint8Array(buffer);
+        keySession.update(certificate);
+
+        event = await waitFor(keySession, 'webkitkeymessage');
+        let response = await getResponse(event);
+        keySession.update(response);
+
+        await canPlayPromise;
+    }
+    </script>
+</head>
+<body>
+    <video controls width="480"></video>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2415,6 +2415,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-init-data-cenc.html [ Failure ]
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-init-data-sinf.html [ Failure ]
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-init-data-skd.html [ Failure ]
+[ Sequoia arm64 ] http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait.html [ Failure ]
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-mse-play-while-not-in-dom.html [ Failure ]
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html [ Failure ]
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-mse-unmuxed-key-renewal.html [ Failure ]
@@ -2446,3 +2447,6 @@ webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html
 
 # webkit.org/b/281765 PROGRESSION (285251@main): [ macOS iOS ] imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html is a constant failure. 
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html [ Skip ]
+
+# Modern AVContentKeySession is only available on Sonoma
+[ Ventura Sonoma ] http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait.html [ Skip ]

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -80,6 +80,7 @@ void WebKitMediaKeySession::close()
     ALWAYS_LOG(LOGIDENTIFIER);
     if (m_session) {
         m_session->releaseKeys();
+        m_session->invalidate();
         m_session = nullptr;
     }
 }

--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -80,6 +80,7 @@ enum LegacyCDMSessionType {
 class WEBCORE_EXPORT LegacyCDMSession : public AbstractRefCounted {
 public:
     virtual ~LegacyCDMSession() = default;
+    virtual void invalidate() { }
 
     virtual LegacyCDMSessionType type() { return CDMSessionTypeUnknown; }
     virtual const String& sessionId() const = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -43,6 +43,15 @@ class WorkQueue;
 }
 
 namespace WebCore {
+class CDMSessionAVContentKeySession;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
+template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMSessionAVContentKeySession> : std::true_type { };
+}
+
+namespace WebCore {
 
 class CDMPrivateMediaSourceAVFObjC;
 
@@ -76,16 +85,16 @@ public:
 
     void didProvideContentKeyRequest(AVContentKeyRequest *);
 
-protected:
-    CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, CDMPrivateMediaSourceAVFObjC&, LegacyCDMSessionClient&);
-
-    RefPtr<Uint8Array> generateKeyReleaseMessage(unsigned short& errorCode, uint32_t& systemCode);
-
     bool hasContentKeySession() const { return m_contentKeySession; }
     AVContentKeySession* contentKeySession();
 
     bool hasContentKeyRequest() const;
     RetainPtr<AVContentKeyRequest> contentKeyRequest() const;
+
+protected:
+    CDMSessionAVContentKeySession(Vector<int>&& protocolVersions, int cdmVersion, CDMPrivateMediaSourceAVFObjC&, LegacyCDMSessionClient&);
+
+    RefPtr<Uint8Array> generateKeyReleaseMessage(unsigned short& errorCode, uint32_t& systemCode);
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const { return "CDMSessionAVContentKeySession"_s; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
@@ -91,8 +91,6 @@ void CDMSessionMediaSourceAVFObjC::addSourceBuffer(SourceBufferPrivateAVFObjC* s
     ASSERT(!m_sourceBuffers.contains(sourceBuffer));
     ASSERT(sourceBuffer);
 
-    addParser(sourceBuffer->streamDataParser());
-
     m_sourceBuffers.append(sourceBuffer);
     sourceBuffer->registerForErrorNotifications(this);
 }
@@ -101,8 +99,6 @@ void CDMSessionMediaSourceAVFObjC::removeSourceBuffer(SourceBufferPrivateAVFObjC
 {
     ASSERT(m_sourceBuffers.contains(sourceBuffer));
     ASSERT(sourceBuffer);
-
-    removeParser(sourceBuffer->streamDataParser());
 
     sourceBuffer->unregisterForErrorNotifications(this);
     m_sourceBuffers.remove(m_sourceBuffers.find(sourceBuffer));

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -54,7 +54,7 @@ typedef struct OpaqueFigVideoTarget *FigVideoTargetRef;
 namespace WebCore {
 
 class AudioTrackPrivate;
-class CDMSessionMediaSourceAVFObjC;
+class CDMSessionAVContentKeySession;
 class EffectiveRateChangedListener;
 class InbandTextTrackPrivate;
 class MediaSourcePrivateAVFObjC;
@@ -134,7 +134,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void setCDMSession(LegacyCDMSession*) override;
-    CDMSessionMediaSourceAVFObjC* cdmSession() const;
+    CDMSessionAVContentKeySession* cdmSession() const;
+    void keyAdded() final;
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -372,7 +373,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Deque<RetainPtr<id>> m_sizeChangeObservers;
     Timer m_seekTimer;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    WeakPtr<CDMSessionMediaSourceAVFObjC> m_session;
+    WeakPtr<CDMSessionAVContentKeySession> m_session;
 #endif
     MediaPlayer::NetworkState m_networkState;
     MediaPlayer::ReadyState m_readyState;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -31,7 +31,7 @@
 #import "AVAssetMIMETypeCache.h"
 #import "AVAssetTrackUtilities.h"
 #import "AVStreamDataParserMIMETypeCache.h"
-#import "CDMSessionMediaSourceAVFObjC.h"
+#import "CDMSessionAVContentKeySession.h"
 #import "ContentTypeUtilities.h"
 #import "GraphicsContext.h"
 #import "IOSurface.h"
@@ -1346,7 +1346,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::flushPendingSizeChanges()
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-CDMSessionMediaSourceAVFObjC* MediaPlayerPrivateMediaSourceAVFObjC::cdmSession() const
+CDMSessionAVContentKeySession* MediaPlayerPrivateMediaSourceAVFObjC::cdmSession() const
 {
     return m_session.get();
 }
@@ -1358,13 +1358,20 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setCDMSession(LegacyCDMSession* sessi
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_session = toCDMSessionMediaSourceAVFObjC(session);
+    m_session = toCDMSessionAVContentKeySession(session);
 
     if (!m_mediaSourcePrivate)
         return;
 
     m_mediaSourcePrivate->setCDMSession(session);
 }
+
+void MediaPlayerPrivateMediaSourceAVFObjC::keyAdded()
+{
+    if (m_mediaSourcePrivate)
+        m_mediaSourcePrivate->keyAdded();
+}
+
 #endif // ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -114,6 +114,10 @@ public:
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    void keyAdded();
+#endif
+
 private:
     friend class SourceBufferPrivateAVFObjC;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -163,6 +163,12 @@ void MediaSourcePrivateAVFObjC::sourceBufferKeyNeeded(SourceBufferPrivateAVFObjC
     if (auto player = platformPlayer())
         player->keyNeeded(initData);
 }
+
+void MediaSourcePrivateAVFObjC::keyAdded()
+{
+    for (auto& sourceBuffer : m_sourceBuffers)
+        sourceBuffer->attemptToDecrypt();
+}
 #endif
 
 bool MediaSourcePrivateAVFObjC::hasSelectedVideo() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -65,7 +65,7 @@ namespace WebCore {
 
 class CDMInstance;
 class CDMInstanceFairPlayStreamingAVFObjC;
-class CDMSessionMediaSourceAVFObjC;
+class CDMSessionAVContentKeySession;
 class MediaPlayerPrivateMediaSourceAVFObjC;
 class MediaSourcePrivateAVFObjC;
 class TimeRanges;
@@ -239,7 +239,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RefPtr<SharedBuffer> m_initData;
-    WeakPtr<CDMSessionMediaSourceAVFObjC> m_session { nullptr };
+    WeakPtr<CDMSessionAVContentKeySession> m_session { nullptr };
 #endif
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     using KeyIDs = Vector<Ref<SharedBuffer>>;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -638,10 +638,15 @@ void SourceBufferPrivateAVFObjC::setCDMSession(LegacyCDMSession* session)
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    if (m_session)
+    if (m_session) {
         m_session->removeSourceBuffer(this);
 
-    m_session = toCDMSessionMediaSourceAVFObjC(session);
+        auto parser = this->streamDataParser();
+        if (parser && shouldAddContentKeyRecipients())
+            [m_session->contentKeySession() removeContentKeyRecipient:parser];
+    }
+
+    m_session = toCDMSessionAVContentKeySession(session);
 
     if (m_session) {
         m_session->addSourceBuffer(this);
@@ -649,6 +654,10 @@ void SourceBufferPrivateAVFObjC::setCDMSession(LegacyCDMSession* session)
             m_hasSessionSemaphore->signal();
             m_hasSessionSemaphore = nullptr;
         }
+
+        auto parser = this->streamDataParser();
+        if (parser && shouldAddContentKeyRecipients())
+            [m_session->contentKeySession() addContentKeyRecipient:parser];
 
         if (m_hdcpError) {
             callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
@@ -707,17 +716,21 @@ void SourceBufferPrivateAVFObjC::setCDMInstance(CDMInstance* instance)
 void SourceBufferPrivateAVFObjC::attemptToDecrypt()
 {
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    if (!m_cdmInstance || m_keyIDs.isEmpty() || !m_waitingForKey)
+    if (m_keyIDs.isEmpty() || !m_waitingForKey)
         return;
 
-    auto instanceSession = m_cdmInstance->sessionForKeyIDs(m_keyIDs);
-    if (!instanceSession)
+    if (m_cdmInstance) {
+        RefPtr instanceSession = m_cdmInstance->sessionForKeyIDs(m_keyIDs);
+        if (!instanceSession)
+            return;
+
+        if (!MediaSessionManagerCocoa::shouldUseModernAVContentKeySession()) {
+            if (auto parser = this->streamDataParser())
+                [instanceSession->contentKeySession() addContentKeyRecipient:parser];
+        }
+    } else if (!m_session)
         return;
 
-    if (!MediaSessionManagerCocoa::shouldUseModernAVContentKeySession()) {
-        if (auto parser = this->streamDataParser())
-            [instanceSession->contentKeySession() addContentKeyRecipient:parser];
-    }
     if (m_hasSessionSemaphore) {
         m_hasSessionSemaphore->signal();
         m_hasSessionSemaphore = nullptr;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -66,7 +66,7 @@ public:
     void removeProxy(RemoteLegacyCDMIdentifier);
 
     void addSession(RemoteLegacyCDMSessionIdentifier, std::unique_ptr<RemoteLegacyCDMSessionProxy>&&);
-    void removeSession(RemoteLegacyCDMSessionIdentifier);
+    void removeSession(RemoteLegacyCDMSessionIdentifier, CompletionHandler<void()>&&);
     RemoteLegacyCDMSessionProxy* getSession(const RemoteLegacyCDMSessionIdentifier&) const;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
@@ -27,7 +27,7 @@
 messages -> RemoteLegacyCDMFactoryProxy NotRefCounted {
     CreateCDM(String keySystem, std::optional<WebCore::MediaPlayerIdentifier> playerId) -> (std::optional<WebKit::RemoteLegacyCDMIdentifier> identifier) Synchronous
     SupportsKeySystem(String keySystem, std::optional<String> mimeType) -> (bool result) Synchronous
-    RemoveSession(WebKit::RemoteLegacyCDMSessionIdentifier identifier)
+    RemoveSession(WebKit::RemoteLegacyCDMSessionIdentifier identifier) -> ()
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -62,6 +62,11 @@ RemoteLegacyCDMSessionProxy::RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryP
 
 RemoteLegacyCDMSessionProxy::~RemoteLegacyCDMSessionProxy() = default;
 
+void RemoteLegacyCDMSessionProxy::invalidate()
+{
+    m_factory = nullptr;
+}
+
 static RefPtr<Uint8Array> convertToUint8Array(RefPtr<SharedBuffer>&& buffer)
 {
     if (!buffer)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -52,6 +52,8 @@ public:
     static std::unique_ptr<RemoteLegacyCDMSessionProxy> create(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
     ~RemoteLegacyCDMSessionProxy();
 
+    void invalidate();
+
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
     WebCore::LegacyCDMSession* session() const { return m_session.get(); }
     RefPtr<WebCore::LegacyCDMSession> protectedSession() const;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -82,8 +82,15 @@ RemoteLegacyCDMSession::RemoteLegacyCDMSession(RemoteLegacyCDMFactory& factory, 
 
 RemoteLegacyCDMSession::~RemoteLegacyCDMSession()
 {
-    if (m_factory)
-        m_factory->removeSession(m_identifier);
+    ASSERT(!m_factory);
+}
+
+void RemoteLegacyCDMSession::invalidate()
+{
+    if (RefPtr factory = m_factory.get()) {
+        factory->removeSession(m_identifier);
+        m_factory = nullptr;
+    }
 }
 
 RefPtr<Uint8Array> RemoteLegacyCDMSession::generateKeyRequest(const String& mimeType, Uint8Array* initData, String& destinationURL, unsigned short& errorCode, uint32_t& systemCode)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
@@ -61,6 +61,7 @@ private:
     RemoteLegacyCDMSession(RemoteLegacyCDMFactory&, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
 
     // LegacyCDMSession
+    void invalidate() final;
     WebCore::LegacyCDMSessionType type() final { return WebCore::CDMSessionTypeRemote; }
     const String& sessionId() const final { return m_sessionId; }
     RefPtr<Uint8Array> generateKeyRequest(const String& mimeType, Uint8Array* initData, String& destinationURL, unsigned short& errorCode, uint32_t& systemCode) final;


### PR DESCRIPTION
#### 710c98ac50e2a103b0f5fea4cbb2c1179a25d986
<pre>
REGRESSION(282990@main) LegacyEME fails when appending media segment before completing key exchange
<a href="https://bugs.webkit.org/show_bug.cgi?id=282252">https://bugs.webkit.org/show_bug.cgi?id=282252</a>
<a href="https://rdar.apple.com/138002160">rdar://138002160</a>

Reviewed by Andy Estes.

When enabling the &quot;modern AVContentKey support&quot; path, we updated the modern EME implementation
but neglected to update the LegacyEME implementation with similar changes. To support the new
AVContentKeySession path, we must _not_ add the AVStreamDataParser to the AVContentKeySession.
Additionally, when keys are added through the LegacyEME path, we must explicitly signal the
SourceBufferPrivate to attempt to enqueue the protected samples for decode and display.

* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-muxed-nowait.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm:
(WebCore::CDMSessionMediaSourceAVFObjC::addSourceBuffer):
(WebCore::CDMSessionMediaSourceAVFObjC::removeSourceBuffer):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::keyAdded):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::keyAdded):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::attemptToDecrypt):

Canonical link: <a href="https://commits.webkit.org/286068@main">https://commits.webkit.org/286068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c4230148af67e34b716f922b7a71e039345cb8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74736 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16990 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80649 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66252 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8352 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4806 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->