### PR TITLE
[Navigation] Initial implementation of focusReset

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7495,9 +7495,6 @@ imported/w3c/web-platform-tests/navigation-api/ [ Timeout Pass ]
 imported/w3c/web-platform-tests/navigation-api/commit-behavior/ [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-before-after-transition-commit.html [ Skip ]
 
-# Not yet implemented so just full of timeouts and flakes.
-imported/w3c/web-platform-tests/navigation-api/focus-reset/ [ Skip ]
-
 # Tests for sourceElement is not yet part of the HTML spec.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requestSubmit.html [ Skip ]
 
@@ -7522,6 +7519,11 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/n
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-beforeunload.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload.html [ Skip ]
+
+# These are likely fixed with https://bugs.webkit.org/show_bug.cgi?id=282137
+imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept.html [ Pass Failure ]
+# Single flakey test case ("Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)")
+imported/w3c/web-platform-tests/navigation-api/focus-reset/basic.html [ Pass Failure ]
 
 # -- View Transitions -- #
 # Reftest failures:

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
@@ -1,12 +1,18 @@
 
+FAIL An element with autofocus, present before navigation, gets focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
+FAIL Two elements with autofocus, present before navigation; the first gets focused assert_equals: Focus stays on the initially-focused button during the transition expected Element node <button autofocus=""></button> but got Element node <button autofocus=""></button>
+FAIL An element with autofocus, present before navigation but disabled before finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
+FAIL An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
+FAIL Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused assert_equals: Disabling the initially-focused button temporarily resets focus to the body expected Element node <body>
 
-Harness Error (TIMEOUT), message = null
+<script type="module">
+promise_setup(async () => ... but got Element node <button autofocus="" disabled=""></button>
+FAIL An element with autofocus, introduced between committed and finished, gets focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <body>
 
-TIMEOUT An element with autofocus, present before navigation, gets focused Test timed out
-NOTRUN Two elements with autofocus, present before navigation; the first gets focused
-NOTRUN An element with autofocus, present before navigation but disabled before finished, does not get focused
-NOTRUN An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused
-NOTRUN Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused
-NOTRUN An element with autofocus, introduced between committed and finished, gets focused
-NOTRUN An element with autofocus, introduced after finished, does not get focused
+<script type="module">
+promise_setup(async () => ...
+FAIL An element with autofocus, introduced after finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <body>
+
+<script type="module">
+promise_setup(async () => ...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
@@ -1,13 +1,10 @@
 
-
-Harness Error (TIMEOUT), message = null
-
 PASS Invalid values for focusReset throw
-TIMEOUT Does not reset the focus when no navigate handler is present Test timed out
-NOTRUN Resets the focus when no focusReset option is provided
-NOTRUN Resets the focus when focusReset is explicitly set to undefined
-NOTRUN Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)
-NOTRUN Resets the focus when no focusReset option is provided (rejected promise)
-NOTRUN Resets the focus when focusReset is explicitly set to 'after-transition'
-NOTRUN Does not reset the focus when focusReset is set to 'manual'
+PASS Does not reset the focus when no navigate handler is present
+FAIL Resets the focus when no focusReset option is provided assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+FAIL Resets the focus when focusReset is explicitly set to undefined assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)
+FAIL Resets the focus when no focusReset option is provided (rejected promise) assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+FAIL Resets the focus when focusReset is explicitly set to 'after-transition' assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS Does not reset the focus when focusReset is set to 'manual'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
@@ -1,8 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
 
-FAIL Focus should be reset before navigatesuccess assert_equals: Focus must be reset before navigatesuccess expected Element node <body>
-<script>
-promise_test(async t => {
-  navigation.ad... but got Element node <button></button>
-FAIL Focus should be reset before navigateerror assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Focus should be reset before navigatesuccess
+PASS Focus should be reset before navigateerror
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt
@@ -1,11 +1,8 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT (not provided) + after-transition Test timed out
-NOTRUN (not provided) + manual
-NOTRUN after-transition + manual
-NOTRUN after-transition + (not provided)
-NOTRUN manual + after-transition
-NOTRUN manual + (not provided)
+FAIL (not provided) + after-transition assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS (not provided) + manual
+PASS after-transition + manual
+FAIL after-transition + (not provided) assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+FAIL manual + after-transition assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS manual + (not provided)
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -170,6 +170,7 @@
 #include "MouseEventWithHitTestResults.h"
 #include "MutationEvent.h"
 #include "NameNodeList.h"
+#include "Navigation.h"
 #include "NavigationActivation.h"
 #include "NavigationDisabler.h"
 #include "NavigationScheduler.h"
@@ -5567,6 +5568,9 @@ void Document::adjustFocusedNodeOnNodeRemoval(Node& node, NodeRemoval nodeRemova
         // Also we need to call removeFocusNavigationNodeOfSubtree after this function because
         // setFocusedElement(nullptr) will reset m_focusNavigationStartingNode.
         setFocusNavigationStartingNode(focusedElement.get());
+
+        if (settings().navigationAPIEnabled())
+            domWindow()->navigation().setFocusChanged(FocusDidChange::No);
     }
 }
 
@@ -5899,6 +5903,10 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     }
 
     if (m_focusedElement) {
+
+        if (settings().navigationAPIEnabled())
+            domWindow()->navigation().setFocusChanged(FocusDidChange::Yes);
+
 #if PLATFORM(GTK)
         // GTK relies on creating the AXObjectCache when a focus change happens.
         if (CheckedPtr cache = axObjectCache())

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -50,6 +50,11 @@ enum class InterceptionHandlersDidFulfill : bool {
     Yes
 };
 
+enum class FocusDidChange : bool {
+    No,
+    Yes
+};
+
 class NavigateEvent final : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigateEvent);
 public:
@@ -104,7 +109,7 @@ public:
     void setCanIntercept(bool canIntercept) { m_canIntercept = canIntercept; }
     void setInterceptionState(InterceptionState interceptionState) { m_interceptionState = interceptionState; }
 
-    void finish(Document&, InterceptionHandlersDidFulfill);
+    void finish(Document&, InterceptionHandlersDidFulfill, FocusDidChange);
 
     Vector<Ref<NavigationInterceptHandler>>& handlers() { return m_handlers; }
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -702,7 +702,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     if (!globalObject)
         return;
 
-    m_focusChangedDuringOnoingNavigation = false;
+    m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
 
     if (event.isBeingDispatched())
@@ -850,7 +850,7 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
 
     Ref event = NavigateEvent::create(eventNames().navigateEvent, init, abortController.get());
     m_ongoingNavigateEvent = event.ptr();
-    m_focusChangedDuringOnoingNavigation = false;
+    m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
 
     dispatchEvent(event);
@@ -926,7 +926,8 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
 
             RefPtr strongThis = weakThis.get();
 
-            m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::Yes);
+            auto focusChanged = std::exchange(m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+            m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::Yes, focusChanged);
             m_ongoingNavigateEvent = nullptr;
 
             dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
@@ -945,7 +946,8 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
 
             RefPtr strongThis = weakThis.get();
 
-            m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::No);
+            auto focusChanged = std::exchange(m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+            m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::No, focusChanged);
             m_ongoingNavigateEvent = nullptr;
 
             ErrorInformation errorInformation;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -28,6 +28,7 @@
 #include "EventTarget.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindowProperty.h"
+#include "NavigateEvent.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
 #include "NavigationTransition.h"
@@ -153,6 +154,8 @@ public:
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
     bool suppressNormalScrollRestoration() const { return m_suppressNormalScrollRestorationDuringOngoingNavigation; }
 
+    void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
+
 private:
     explicit Navigation(LocalDOMWindow&);
 
@@ -183,7 +186,7 @@ private:
     Vector<Ref<NavigationHistoryEntry>> m_entries;
 
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;
-    bool m_focusChangedDuringOnoingNavigation { false };
+    FocusDidChange m_focusChangedDuringOngoingNavigation { FocusDidChange::No };
     bool m_suppressNormalScrollRestorationDuringOngoingNavigation { false };
     RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker;
     RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker;


### PR DESCRIPTION
#### 000b0b9319cb19a386bd1a7cbe0c445b8e390aa9
<pre>
[Navigation] Initial implementation of focusReset
<a href="https://bugs.webkit.org/show_bug.cgi?id=282250">https://bugs.webkit.org/show_bug.cgi?id=282250</a>

Reviewed by Alex Christensen.

This implements the focusReset property of NavigateEvent.intercept().

The test coverage here is misleading due to <a href="https://bugs.webkit.org/show_bug.cgi?id=282137">https://bugs.webkit.org/show_bug.cgi?id=282137</a>

If a workaround for that bug is applied the results are:

        multiple-intercept:

        PASS (not provided) + after-transition
        PASS (not provided) + manual
        PASS after-transition + manual
        PASS after-transition + (not provided)
        PASS manual + after-transition
        PASS manual + (not provided)

        basic:

        PASS Invalid values for focusReset throw
        PASS Does not reset the focus when no navigate handler is present
        PASS Resets the focus when no focusReset option is provided
        PASS Resets the focus when focusReset is explicitly set to undefined
        PASS Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)
        PASS Resets the focus when no focusReset option is provided (rejected promise)
        PASS Resets the focus when focusReset is explicitly set to &apos;after-transition&apos;
        PASS Does not reset the focus when focusReset is set to &apos;manual&apos;

        autofocus:

        PASS An element with autofocus, present before navigation, gets focused
        PASS Two elements with autofocus, present before navigation; the first gets focused
        PASS An element with autofocus, present before navigation but disabled before finished, does not get focused
        PASS An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused
        FAIL Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused
        PASS An element with autofocus, introduced between committed and finished, gets focused
        PASS An element with autofocus, introduced after finished, does not get focused

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::adjustFocusedNodeOnNodeRemoval):
(WebCore::Document::setFocusedElement):
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::finish):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/285882@main">https://commits.webkit.org/285882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/184ce64b7dc526b263c0f42d0616c5ac53473278

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16583 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23646 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66541 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65817 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7909 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1356 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->