### PR TITLE
Regression(284311@main): When `getTotalLength` path is empty, the maze don't work on 'pudding.cool'

### DIFF
--- a/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html
+++ b/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html
@@ -14,7 +14,8 @@ test(function() {
   assert_equals(getTotalLength('M0,20 L400,20 L640,20'), 640);
   assert_equals(getTotalLength('M0,20 L400,20 L640,20 z'), 1280);
   assert_equals(getTotalLength('M0,20 L400,20 z M 320,20 L640,20'), 1120);
-  assert_throws_dom("InvalidStateError", function() { getTotalLength('') });
+  assert_equals(getTotalLength(''), 0);
+  assert_equals(getTotalLength('M0,20'), 0);
 }, document.title + " with SVGPathElement");
 
 test(function() {

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -182,9 +182,6 @@ ExceptionOr<float> SVGPathElement::getTotalLength() const
 {
     protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    if (pathByteStream().isEmpty())
-        return Exception { ExceptionCode::InvalidStateError, "The element's path is empty."_s };
-
     return getTotalLengthOfSVGPathByteStream(pathByteStream());
 }
 


### PR DESCRIPTION
#### c0113e9dc8ad398f5a59e75c70798ed290afa0cf
<pre>
Regression(284311@main): When `getTotalLength` path is empty, the maze don&apos;t work on &apos;pudding.cool&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=282253">https://bugs.webkit.org/show_bug.cgi?id=282253</a>
<a href="https://rdar.apple.com/138845454">rdar://138845454</a>

Reviewed by NOBODY (OOPS!).

In 284311@main, we aligned with web specification [1] but our fix was
not web compatible behavior completely.

So this is to do partial revert of `SVGPathElement` change to fix web compatibility issue.

[1] <a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength">https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength</a>

* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::getTotalLength const):
* LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0113e9dc8ad398f5a59e75c70798ed290afa0cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1220 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58181 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-transforms/huge-length-tiny-scale.html imported/w3c/web-platform-tests/scroll-to-text-fragment/find-range-from-text-directive.html media/media-vp8-webm-seek-to-start.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16534 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65787 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7860 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4038 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->