### PR TITLE
Web Extensions do not replace @@extension_id in content scripts.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -83,16 +83,18 @@ Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *currentNode, std
     return matchingFrames;
 }
 
-std::optional<SourcePair> sourcePairForResource(String path, WebExtensionContext& extensionContext)
+std::optional<SourcePair> sourcePairForResource(const String& path, WebExtensionContext& extensionContext)
 {
     RefPtr<API::Error> error;
-    RefPtr scriptData = extensionContext.protectedExtension()->resourceDataForPath(path, error);
-    if (!scriptData || error) {
+    auto scriptString = extensionContext.protectedExtension()->resourceStringForPath(path, error);
+    if (!scriptString || error) {
         extensionContext.recordError(wrapper(error));
         return std::nullopt;
     }
 
-    return SourcePair { String::fromUTF8(scriptData->span()), { extensionContext.baseURL(), path } };
+    scriptString = extensionContext.localizedResourceString(scriptString, extensionContext.extension().resourceMIMETypeForPath(path));
+
+    return SourcePair { scriptString, { extensionContext.baseURL(), path } };
 }
 
 SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters& parameters, WebExtensionContext& extensionContext)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -291,6 +291,19 @@ URL WebExtension::resourceFileURLForPath(const String& originalPath)
     return result;
 }
 
+String WebExtension::resourceMIMETypeForPath(const String& path)
+{
+    auto dataPrefix = "data:"_s;
+    if (path.startsWith(dataPrefix)) {
+        auto mimeTypePosition = path.find(';');
+        if (mimeTypePosition != notFound)
+            return path.substring(dataPrefix.length(), mimeTypePosition - dataPrefix.length());
+        return defaultMIMEType();
+    }
+
+    return MIMETypeRegistry::mimeTypeForPath(path);
+}
+
 String WebExtension::resourceStringForPath(const String& originalPath, RefPtr<API::Error>& outError, CacheResult cacheResult, SuppressNotFoundErrors suppressErrors)
 {
     ASSERT(originalPath);

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -50,7 +50,6 @@ OBJC_CLASS NSLocale;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
-OBJC_CLASS UTType;
 OBJC_CLASS WKWebExtension;
 OBJC_CLASS _WKWebExtensionLocalization;
 
@@ -233,7 +232,7 @@ public:
 
     bool isWebAccessibleResource(const URL& resourceURL, const URL& pageURL);
 
-    UTType *resourceTypeForPath(NSString *);
+    String resourceMIMETypeForPath(const String&);
 
     String resourceStringForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
     RefPtr<API::Data> resourceDataForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -311,6 +311,9 @@ public:
 
     _WKWebExtensionLocalization *localization();
 
+    RefPtr<API::Data> localizedResourceData(const RefPtr<API::Data>&, const String& mimeType);
+    String localizedResourceString(const String&, const String& mimeType);
+
     bool isInspectable() const { return m_inspectable; }
     void setInspectable(bool);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -105,7 +105,7 @@ private:
     void removeUserScripts(const String& identifier);
 };
 
-std::optional<SourcePair> sourcePairForResource(String path, WebExtensionContext&);
+std::optional<SourcePair> sourcePairForResource(const String& path, WebExtensionContext&);
 SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters&, WebExtensionContext&);
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
@@ -32,6 +32,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "HTTPServer.h"
 #import "WebExtensionUtilities.h"
 
 @interface NSLocale ()
@@ -530,6 +531,159 @@ TEST(WKWebExtensionAPILocalization, CSSLocalization)
     auto *testPageURL = [NSURL URLWithString:@"test.html" relativeToURL:manager.get().context.baseURL];
     [manager.get().defaultTab changeWebViewIfNeededForURL:testPageURL forExtensionContext:manager.get().context];
     [manager.get().defaultTab.webView loadRequest:[NSURLRequest requestWithURL:testPageURL]];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPILocalization, CSSLocalizationInContentScript)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"default_locale": @"en",
+
+        @"name": @"Localization Test",
+        @"description": @"Localization Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module"
+        },
+
+        @"content_scripts": @[@{
+            @"matches": @[ @"<all_urls>" ],
+            @"css": @[ @"content.css" ],
+            @"js": @[ @"content.js" ]
+        }]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto *contentStyleSheet = Util::constructScript(@[
+        @"body {",
+        @"  content: '__MSG_@@extension_id__';",
+        @"  direction: '__MSG_@@bidi_dir__';",
+        @"  text-align: '__MSG_@@bidi_start_edge__';",
+        @"}"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"window.addEventListener('load', () => {",
+        @"  const bodyStyle = getComputedStyle(document.body)",
+        @"  browser.test.assertEq(bodyStyle.content, '\"76C788B8-3374-400D-8259-40E5B9DF79D3\"', 'CSS content should be')",
+        @"  browser.test.assertEq(bodyStyle.direction, 'ltr', 'CSS direction should be')",
+        @"  browser.test.assertEq(bodyStyle.textAlign, 'start', 'CSS text-align should be')",
+
+        @"  browser.test.notifyPass()",
+        @"})"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"content.js": contentScript,
+        @"content.css": contentStyleSheet,
+        @"_locales/en/messages.json": messages
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    // Set a base URL so it is a known value and not the default random one.
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-extension"];
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPILocalization, CSSLocalizationInRegisteredContentScript)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    static auto *localizationManifest = @{
+        @"manifest_version": @3,
+        @"default_locale": @"en",
+
+        @"name": @"Localization Test",
+        @"description": @"Localization Test",
+        @"version": @"1.0",
+
+        @"permissions": @[ @"scripting" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module"
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.scripting.registerContentScripts([{",
+        @"  id: 'test',",
+        @"  matches: ['<all_urls>'],",
+        @"  css: ['content.css'],",
+        @"  js: ['content.js']",
+        @"}])",
+
+        @"browser.test.yield('Load Tab')"
+    ]);
+
+    auto *contentStyleSheet = Util::constructScript(@[
+        @"body {",
+        @"  content: '__MSG_@@extension_id__';",
+        @"  direction: '__MSG_@@bidi_dir__';",
+        @"  text-align: '__MSG_@@bidi_start_edge__';",
+        @"}"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"window.addEventListener('load', () => {",
+        @"  const bodyStyle = getComputedStyle(document.body)",
+        @"  browser.test.assertEq(bodyStyle.content, '\"76C788B8-3374-400D-8259-40E5B9DF79D3\"', 'CSS content should be')",
+        @"  browser.test.assertEq(bodyStyle.direction, 'ltr', 'CSS direction should be')",
+        @"  browser.test.assertEq(bodyStyle.textAlign, 'start', 'CSS text-align should be')",
+
+        @"  browser.test.notifyPass()",
+        @"})"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"content.js": contentScript,
+        @"content.css": contentStyleSheet,
+        @"_locales/en/messages.json": messages
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    // Set a base URL so it is a known value and not the default random one.
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-extension"];
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }


### PR DESCRIPTION
#### 563ab233542f103f19dd5ecf8ede65fe62925d86
<pre>
Web Extensions do not replace @@extension_id in content scripts.
<a href="https://webkit.org/b/282259">https://webkit.org/b/282259</a>
<a href="https://rdar.apple.com/138779942">rdar://138779942</a>

Reviewed by Brian Weinstein.

We were localizing CSS resources loaded in web views, but not the content scripts injected
via `API::UserScript`. Do the same localizing for those content scripts.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::imageForPath): Check MIME type.
(WebKit::WebExtension::resourceTypeForPath): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::localizedResourceData): Added.
(WebKit::WebExtensionContext::localizedResourceString): Added.
(WebKit::WebExtensionContext::addInjectedContent): Localize string.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::sourcePairForResource): Localize string.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::resourceMIMETypeForPath): Added.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, CSSLocalizationInContentScript)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, CSSLocalizationInRegisteredContentScript)): Added.

Canonical link: <a href="https://commits.webkit.org/285858@main">https://commits.webkit.org/285858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1806ba98a76f9a422101d1761ae7d6910711fe2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16531 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23573 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/707 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65778 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7868 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1283 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->