### PR TITLE
Properly support es-419 in Web Extensions.

### DIFF
--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -32,6 +32,7 @@
 #include <wtf/Logging.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
@@ -177,16 +178,28 @@ LocaleComponents parseLocale(const String& localeIdentifier)
     LocaleComponents result;
 
     auto components = canonicalLanguageIdentifier(localeIdentifier).split('-');
-    if (components.size() >= 1)
-        result.languageCode = components[0];
+    if (components.isEmpty())
+        return result;
 
-    if (components.size() >= 2 && components[1].length() == 4)
+    // First component is always the language code.
+    result.languageCode = components[0].convertToASCIILowercase();
+
+    // If only a language code is present, return it.
+    if (components.size() <= 1)
+        return result;
+
+    // If the second component is four characters, interpret it as a script code.
+    if (components[1].length() == 4)
         result.scriptCode = makeString(components[1].left(1).convertToASCIIUppercase(), components[1].substring(1));
 
-    if (components.size() >= 3 && !result.scriptCode)
-        result.countryCode = components[1].convertToASCIIUppercase();
-    else if (components.size() >= 3)
-        result.countryCode = components[2].convertToASCIIUppercase();
+    // Determine region code component based on presence of script code.
+    auto regionCodeCandidate = components.size() >= 3 && !result.scriptCode.isEmpty() ? components[2] : components[1];
+
+    // 2 character codes (e.g., "US") are ISO 3166-1 alpha-2; 3 character codes (e.g., "001") are ISO 3166-1 numeric.
+    if (regionCodeCandidate.length() == 2)
+        result.regionCode = regionCodeCandidate.convertToASCIIUppercase();
+    else if (regionCodeCandidate.length() == 3 && parseInteger<uint16_t>(regionCodeCandidate, 10))
+        result.regionCode = regionCodeCandidate;
 
     return result;
 }
@@ -214,11 +227,11 @@ size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<St
         auto componentsFromList = parseLocale(canonicalizedLanguageFromList);
         if (components.languageCode == componentsFromList.languageCode) {
             // If it's a language-only match, store the first occurrence.
-            if (languageOnlyMatchIndex == notFound && componentsFromList.scriptCode.isEmpty() && componentsFromList.countryCode.isEmpty())
+            if (languageOnlyMatchIndex == notFound && componentsFromList.scriptCode.isEmpty() && componentsFromList.regionCode.isEmpty())
                 languageOnlyMatchIndex = i;
 
             // If it's a partial match (language and script), store the first occurrence.
-            if (partialMatchIndex == notFound && components.scriptCode == componentsFromList.scriptCode && !componentsFromList.countryCode.isEmpty())
+            if (partialMatchIndex == notFound && components.scriptCode == componentsFromList.scriptCode && !componentsFromList.regionCode.isEmpty())
                 partialMatchIndex = i;
         }
     }

--- a/Source/WTF/wtf/Language.h
+++ b/Source/WTF/wtf/Language.h
@@ -41,7 +41,7 @@ enum class ShouldMinimizeLanguages : bool { No, Yes };
 struct LocaleComponents {
     String languageCode;
     String scriptCode;
-    String countryCode;
+    String regionCode;
 };
 
 WTF_EXPORT_PRIVATE String defaultLanguage(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe.

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -371,9 +371,12 @@ NSString *toWebAPI(NSLocale *locale)
     if (!locale.languageCode.length)
         return @"und";
 
+    NSMutableString *result = [locale.languageCode mutableCopy];
+    if (locale.scriptCode.length)
+        [result appendFormat:@"-%@", locale.scriptCode];
     if (locale.countryCode.length)
-        return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
-    return locale.languageCode;
+        [result appendFormat:@"-%@", locale.countryCode];
+    return [result copy];
 }
 
 size_t storageSizeOf(NSString *keyOrValue)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
@@ -1394,6 +1394,145 @@ TEST(WKWebExtensionAPILocalization, i18nPortugueseLanguageFallback)
     [manager loadAndRun];
 }
 
+TEST(WKWebExtensionAPILocalization, i18nSpanishLatinAmerica)
+{
+    // Temporarily set the current locale to Latin American Spanish.
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"es-419" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensión en español')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *latinAmericanSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en español",
+            @"description": @"The name of the extension in Latin American Spanish."
+        }
+    };
+
+    auto *castilianSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en castellano",
+            @"description": @"The name of the extension in Castilian Spanish."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/es_419/messages.json": latinAmericanSpanishMessages,
+        @"_locales/es_ES/messages.json": castilianSpanishMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+
+TEST(WKWebExtensionAPILocalization, i18nSpanishMexico)
+{
+    // Temporarily set the current locale to Spanish (Mexico).
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"es-MX" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensión en español')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *latinAmericanSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en español",
+            @"description": @"The name of the extension in Latin American Spanish."
+        }
+    };
+
+    auto *castilianSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en castellano",
+            @"description": @"The name of the extension in Castilian Spanish."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/es_419/messages.json": latinAmericanSpanishMessages,
+        @"_locales/es_ES/messages.json": castilianSpanishMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18nSpanishSpain)
+{
+    // Temporarily set the current locale to Spanish (Spain).
+    [NSUserDefaults.standardUserDefaults setVolatileDomain:@{ @"AppleLanguages": @[ @"es-ES" ] } forName:NSArgumentDomain];
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Extensión en castellano')",
+        @"browser.test.assertEq(browser.i18n.getMessage('default_name'), 'Default English String')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default English String",
+            @"description": @"The default name in English."
+        }
+    };
+
+    auto *castilianSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en castellano",
+            @"description": @"The name of the extension in Castilian Spanish."
+        }
+    };
+
+    auto *latinAmericanSpanishMessages = @{
+        @"extension_name": @{
+            @"message": @"Extensión en español",
+            @"description": @"The name of the extension in Latin American Spanish."
+        }
+    };
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/es_ES/messages.json": castilianSpanishMessages,
+        @"_locales/es_419/messages.json": latinAmericanSpanishMessages,
+    };
+
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 2ec032a3571230b5921e6403f84b3a4828980838
<pre>
Properly support es-419 in Web Extensions.
<a href="https://webkit.org/b/282262">https://webkit.org/b/282262</a>
<a href="https://rdar.apple.com/problem/138857112">rdar://problem/138857112</a>

Reviewed by Brian Weinstein.

Apply some feedback to `parseLocale` to properly handle locales with numeric region
codes and better handling of components. And adopt `regionCode` instead of `countryCode`
to match the BCP47 spec.

Add tests to verify Mexico and Spain pick the right locales.

* Source/WTF/wtf/Language.cpp:
(WTF::parseLocale): Improve parsing to handle 3 digit region codes.
(WTF::indexOfBestMatchingLanguageInList): Use regionCode.
* Source/WTF/wtf/Language.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toWebAPI): Include scriptCode.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nSpanishLatinAmerica)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nSpanishMexico)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nSpanishSpain)): Added.

Canonical link: <a href="https://commits.webkit.org/285875@main">https://commits.webkit.org/285875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a705484d7ca05f7424edffc0268887f75ca72423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58200 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77109 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48364 "Found 1 new test failure: fast/events/ios/contenteditable-autocapitalize.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23613 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67179 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79934 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73300 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65800 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7894 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95081 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1323 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20890 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->