### PR TITLE
Rename "Shape" to "LayoutShape"

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2483,7 +2483,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/line/LineWidth.h
     rendering/line/TrailingObjects.h
 
-    rendering/shapes/Shape.h
+    rendering/shapes/LayoutShape.h
     rendering/shapes/ShapeOutsideInfo.h
 
     rendering/style/BasicShapes.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2859,11 +2859,11 @@ rendering/mathml/RenderMathMLScripts.cpp
 rendering/mathml/RenderMathMLSpace.cpp
 rendering/mathml/RenderMathMLToken.cpp
 rendering/mathml/RenderMathMLUnderOver.cpp
-rendering/shapes/BoxShape.cpp
-rendering/shapes/PolygonShape.cpp
-rendering/shapes/RasterShape.cpp
-rendering/shapes/RectangleShape.cpp
-rendering/shapes/Shape.cpp
+rendering/shapes/BoxLayoutShape.cpp
+rendering/shapes/PolygonLayoutShape.cpp
+rendering/shapes/RasterLayoutShape.cpp
+rendering/shapes/RectangleLayoutShape.cpp
+rendering/shapes/LayoutShape.cpp
 rendering/shapes/ShapeOutsideInfo.cpp
 rendering/style/BasicShapes.cpp
 rendering/style/BasicShapesShape.cpp

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -326,7 +326,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
 
     static constexpr auto shapeHighlightColor = SRGBA<uint8_t> { 96, 82, 127, 204 };
 
-    Shape::DisplayPaths paths;
+    LayoutShape::DisplayPaths paths;
     shapeOutsideInfo->computedShape().buildDisplayPaths(paths);
 
     if (paths.shape.isEmpty()) {

--- a/Source/WebCore/layout/floats/FloatingContext.cpp
+++ b/Source/WebCore/layout/floats/FloatingContext.cpp
@@ -33,8 +33,8 @@
 #include "LayoutBoxGeometry.h"
 #include "LayoutContainingBlockChainIterator.h"
 #include "LayoutElementBox.h"
+#include "LayoutShape.h"
 #include "RenderStyleInlines.h"
-#include "Shape.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/floats/PlacedFloats.cpp
+++ b/Source/WebCore/layout/floats/PlacedFloats.cpp
@@ -28,8 +28,8 @@
 
 #include "LayoutContainingBlockChainIterator.h"
 #include "LayoutInitialContainingBlock.h"
+#include "LayoutShape.h"
 #include "RenderStyleInlines.h"
-#include "Shape.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -47,7 +47,7 @@ PlacedFloats::Item::Item(const Box& layoutBox, Position position, const BoxGeome
 {
 }
 
-PlacedFloats::Item::Item(Position position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, const Shape* shape)
+PlacedFloats::Item::Item(Position position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, const LayoutShape* shape)
     : m_position(position)
     , m_absoluteBoxGeometry(absoluteBoxGeometry)
     , m_localTopLeft(localTopLeft)

--- a/Source/WebCore/layout/floats/PlacedFloats.h
+++ b/Source/WebCore/layout/floats/PlacedFloats.h
@@ -27,7 +27,7 @@
 
 #include "LayoutBoxGeometry.h"
 #include "LayoutElementBox.h"
-#include "Shape.h"
+#include "LayoutShape.h"
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -52,7 +52,7 @@ public:
     public:
         // FIXME: This c'tor is only used by the render tree integation codepath.
         enum class Position { Left, Right };
-        Item(Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, const Shape*);
+        Item(Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, const LayoutShape*);
         Item(const Box&, Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, std::optional<size_t> line);
 
         ~Item();
@@ -68,7 +68,7 @@ public:
         BoxGeometry::HorizontalEdges horizontalMargin() const { return m_absoluteBoxGeometry.horizontalMargin(); }
         PositionInContextRoot absoluteBottom() const { return { absoluteRectWithMargin().bottom() }; }
 
-        const Shape* shape() const { return m_shape.get(); }
+        const LayoutShape* shape() const { return m_shape.get(); }
         std::optional<size_t> placedByLine() const { return m_placedByLine; }
 
         const Box* layoutBox() const { return m_layoutBox.get(); }
@@ -78,7 +78,7 @@ public:
         Position m_position;
         BoxGeometry m_absoluteBoxGeometry;
         LayoutPoint m_localTopLeft;
-        RefPtr<const Shape> m_shape;
+        RefPtr<const LayoutShape> m_shape;
         std::optional<size_t> m_placedByLine;
     };
     using List = Vector<Item>;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -33,9 +33,9 @@
 #include "InlineQuirks.h"
 #include "LayoutBox.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutShape.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"
-#include "Shape.h"
 #include "TextUtil.h"
 #include "UnicodeBidi.h"
 #include <wtf/unicode/CharacterNames.h>

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -31,10 +31,10 @@
 #include "LayoutElementBox.h"
 #include "LayoutInitialContainingBlock.h"
 #include "LayoutPhase.h"
+#include "LayoutShape.h"
 #include "LayoutState.h"
 #include "RenderObject.h"
 #include "RenderStyleInlines.h"
-#include "Shape.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -495,14 +495,14 @@ std::optional<LayoutUnit> Box::columnWidth() const
     return rareData().columnWidth;
 }
 
-const Shape* Box::shape() const
+const LayoutShape* Box::shape() const
 {
     if (!hasRareData())
         return nullptr;
     return rareData().shape.get();
 }
 
-void Box::setShape(RefPtr<const Shape> shape)
+void Box::setShape(RefPtr<const LayoutShape> shape)
 {
     ensureRareData().shape = WTFMove(shape);
 }

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class Shape;
+class LayoutShape;
 class RenderObject;
 
 namespace Layout {
@@ -192,8 +192,8 @@ public:
     void setIsInlineIntegrationRoot() { m_isInlineIntegrationRoot = true; }
     void setIsFirstChildForIntegration(bool value) { m_isFirstChildForIntegration = value; }
 
-    const Shape* shape() const;
-    void setShape(RefPtr<const Shape>);
+    const LayoutShape* shape() const;
+    void setShape(RefPtr<const LayoutShape>);
 
     const ElementBox* associatedRubyAnnotationBox() const;
 
@@ -217,7 +217,7 @@ private:
         CellSpan tableCellSpan;
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
-        RefPtr<const Shape> shape;
+        RefPtr<const LayoutShape> shape;
     };
 
     bool hasRareData() const { return m_hasRareData; }

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -41,6 +41,7 @@
 #include "HTMLInputElement.h"
 #include "HTMLLabelElement.h"
 #include "HitTestResult.h"
+#include "LayoutShape.h"
 #include "LegacyRenderSVGShape.h"
 #include "LegacyRenderSVGShapeInlines.h"
 #include "LocalFrame.h"
@@ -55,7 +56,6 @@
 #include "RenderLayerBacking.h"
 #include "RenderVideo.h"
 #include "SVGSVGElement.h"
-#include "Shape.h"
 #include "SimpleRange.h"
 #include "SliderThumbElement.h"
 #include "StyleResolver.h"
@@ -501,8 +501,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     } else if (iconImage && originalElement) {
         auto size = boundingSize(regionRenderer, transform);
         LayoutRect imageRect(FloatPoint(), size);
-        Ref shape = Shape::createRasterShape(iconImage.get(), 0, imageRect, imageRect, WritingMode(), 0);
-        Shape::DisplayPaths paths;
+        Ref shape = LayoutShape::createRasterShape(iconImage.get(), 0, imageRect, imageRect, WritingMode(), 0);
+        LayoutShape::DisplayPaths paths;
         shape->buildDisplayPaths(paths);
         auto path = paths.shape;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -50,7 +50,7 @@
 #include "AccessibilityRegionContext.h"
 #include "BitmapImage.h"
 #include "BorderShape.h"
-#include "BoxShape.h"
+#include "BoxLayoutShape.h"
 #include "CSSFilter.h"
 #include "CSSPropertyNames.h"
 #include "Chrome.h"

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "config.h"
-#include "BoxShape.h"
+#include "BoxLayoutShape.h"
 
 #include "BorderShape.h"
 #include "RenderBoxInlines.h"
@@ -97,7 +97,7 @@ RoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox& rende
     return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).deprecatedRoundedRect();
 }
 
-LayoutRect BoxShape::shapeMarginLogicalBoundingBox() const
+LayoutRect BoxLayoutShape::shapeMarginLogicalBoundingBox() const
 {
     FloatRect marginBounds(m_bounds.rect());
     if (shapeMargin() > 0)
@@ -105,7 +105,7 @@ LayoutRect BoxShape::shapeMarginLogicalBoundingBox() const
     return static_cast<LayoutRect>(marginBounds);
 }
 
-FloatRoundedRect BoxShape::shapeMarginBounds() const
+FloatRoundedRect BoxLayoutShape::shapeMarginBounds() const
 {
     FloatRoundedRect marginBounds(m_bounds);
     if (shapeMargin() > 0) {
@@ -115,7 +115,7 @@ FloatRoundedRect BoxShape::shapeMarginBounds() const
     return marginBounds;
 }
 
-LineSegment BoxShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
+LineSegment BoxLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
 {
     const FloatRoundedRect& marginBounds = shapeMarginBounds();
     if (marginBounds.isEmpty() || !lineOverlapsShapeMarginBounds(logicalTop, logicalHeight))
@@ -159,7 +159,7 @@ LineSegment BoxShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logi
     return LineSegment(x1, x2);
 }
 
-void BoxShape::buildDisplayPaths(DisplayPaths& paths) const
+void BoxLayoutShape::buildDisplayPaths(DisplayPaths& paths) const
 {
     paths.shape.addRoundedRect(m_bounds, PathRoundedRect::Strategy::PreferBezier);
     if (shapeMargin())

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,49 +29,33 @@
 
 #pragma once
 
-#include "FloatPolygon.h"
-#include "Shape.h"
-#include "ShapeInterval.h"
+#include "FloatRoundedRect.h"
+#include "LayoutShape.h"
+#include "RenderStyleConstants.h"
 
 namespace WebCore {
 
-class OffsetPolygonEdge final : public VertexPair {
+class RenderBox;
+
+RoundedRect computeRoundedRectForBoxShape(CSSBoxType, const RenderBox&);
+
+class BoxLayoutShape final : public LayoutShape {
 public:
-    OffsetPolygonEdge(const FloatPolygonEdge& edge, const FloatSize& offset)
-        : m_vertex1(edge.vertex1() + offset)
-        , m_vertex2(edge.vertex2() + offset)
-    {
-    }
-
-    const FloatPoint& vertex1() const override { return m_vertex1; }
-    const FloatPoint& vertex2() const override { return m_vertex2; }
-
-    bool isWithinYRange(float y1, float y2) const { return y1 <= minY() && y2 >= maxY(); }
-    bool overlapsYRange(float y1, float y2) const { return y2 >= minY() && y1 <= maxY(); }
-    float xIntercept(float y) const;
-    FloatShapeInterval clippedEdgeXRange(float y1, float y2) const;
-
-private:
-    FloatPoint m_vertex1;
-    FloatPoint m_vertex2;
-};
-
-class PolygonShape : public Shape {
-    WTF_MAKE_NONCOPYABLE(PolygonShape);
-public:
-    PolygonShape(Vector<FloatPoint>&& vertices, WindRule fillRule)
-        : m_polygon(WTFMove(vertices), fillRule)
+    BoxLayoutShape(const FloatRoundedRect& bounds)
+        : m_bounds(bounds)
     {
     }
 
     LayoutRect shapeMarginLogicalBoundingBox() const override;
-    bool isEmpty() const override { return m_polygon.isEmpty(); }
+    bool isEmpty() const override { return m_bounds.isEmpty(); }
     LineSegment getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const override;
 
     void buildDisplayPaths(DisplayPaths&) const override;
 
 private:
-    FloatPolygon m_polygon;
+    FloatRoundedRect shapeMarginBounds() const;
+
+    FloatRoundedRect m_bounds;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/shapes/LayoutShape.h
+++ b/Source/WebCore/rendering/shapes/LayoutShape.h
@@ -65,18 +65,18 @@ class RoundedRect;
 // computed segments are returned as pairs of logical X coordinates. The BasicShape itself is defined in
 // physical coordinates.
 
-class Shape : public RefCounted<Shape> {
+class LayoutShape : public RefCounted<LayoutShape> {
 public:
     struct DisplayPaths {
         Path shape;
         Path marginShape;
     };
 
-    static Ref<const Shape> createShape(const BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float margin);
-    static Ref<const Shape> createRasterShape(Image*, float threshold, const LayoutRect& imageRect, const LayoutRect& marginRect, WritingMode, float margin);
-    static Ref<const Shape> createBoxShape(const RoundedRect&, WritingMode, float margin);
+    static Ref<const LayoutShape> createShape(const BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float margin);
+    static Ref<const LayoutShape> createRasterShape(Image*, float threshold, const LayoutRect& imageRect, const LayoutRect& marginRect, WritingMode, float margin);
+    static Ref<const LayoutShape> createBoxShape(const RoundedRect&, WritingMode, float margin);
 
-    virtual ~Shape() = default;
+    virtual ~LayoutShape() = default;
 
     virtual LayoutRect shapeMarginLogicalBoundingBox() const = 0;
     virtual bool isEmpty() const = 0;

--- a/Source/WebCore/rendering/shapes/PolygonLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/PolygonLayoutShape.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "config.h"
-#include "PolygonShape.h"
+#include "PolygonLayoutShape.h"
 
 #include <wtf/MathExtras.h>
 
@@ -110,14 +110,14 @@ static FloatShapeInterval clippedCircleXRange(const FloatPoint& center, float ra
     return FloatShapeInterval(center.x() - xi, center.x() + xi);
 }
 
-LayoutRect PolygonShape::shapeMarginLogicalBoundingBox() const
+LayoutRect PolygonLayoutShape::shapeMarginLogicalBoundingBox() const
 {
     FloatRect box = m_polygon.boundingBox();
     box.inflate(shapeMargin());
     return LayoutRect(box);
 }
 
-LineSegment PolygonShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
+LineSegment PolygonLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
 {
     float y1 = logicalTop;
     float y2 = logicalTop + logicalHeight;
@@ -145,7 +145,7 @@ LineSegment PolygonShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit 
     return LineSegment(excludedInterval.x1(), excludedInterval.x2());
 }
 
-void PolygonShape::buildDisplayPaths(DisplayPaths& paths) const
+void PolygonLayoutShape::buildDisplayPaths(DisplayPaths& paths) const
 {
     if (m_polygon.isEmpty())
         return;

--- a/Source/WebCore/rendering/shapes/RasterLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/RasterLayoutShape.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "config.h"
-#include "RasterShape.h"
+#include "RasterLayoutShape.h"
 
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -138,7 +138,7 @@ void RasterShapeIntervals::buildBoundsPath(Path& path) const
     }
 }
 
-const RasterShapeIntervals& RasterShape::marginIntervals() const
+const RasterShapeIntervals& RasterLayoutShape::marginIntervals() const
 {
     ASSERT(shapeMargin() >= 0);
     if (!shapeMargin())
@@ -152,7 +152,7 @@ const RasterShapeIntervals& RasterShape::marginIntervals() const
     return *m_marginIntervals;
 }
 
-LineSegment RasterShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
+LineSegment RasterLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
 {
     const RasterShapeIntervals& intervals = marginIntervals();
     if (intervals.isEmpty())

--- a/Source/WebCore/rendering/shapes/RasterLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/RasterLayoutShape.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include "FloatRect.h"
-#include "Shape.h"
+#include "LayoutShape.h"
 #include "ShapeInterval.h"
 #include <wtf/Assertions.h>
 #include <wtf/TZoneMalloc.h>
@@ -77,10 +77,10 @@ private:
     int m_offset;
 };
 
-class RasterShape final : public Shape {
-    WTF_MAKE_NONCOPYABLE(RasterShape);
+class RasterLayoutShape final : public LayoutShape {
+    WTF_MAKE_NONCOPYABLE(RasterLayoutShape);
 public:
-    RasterShape(std::unique_ptr<RasterShapeIntervals> intervals, const IntSize& marginRectSize)
+    RasterLayoutShape(std::unique_ptr<RasterShapeIntervals> intervals, const IntSize& marginRectSize)
         : m_intervals(WTFMove(intervals))
         , m_marginRectSize(marginRectSize)
     {

--- a/Source/WebCore/rendering/shapes/RectangleLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/RectangleLayoutShape.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "config.h"
-#include "RectangleShape.h"
+#include "RectangleLayoutShape.h"
 
 #include <wtf/MathExtras.h>
 
@@ -40,7 +40,7 @@ static inline float ellipseXIntercept(float y, float rx, float ry)
     return rx * sqrt(1 - (y * y) / (ry * ry));
 }
 
-FloatRect RectangleShape::shapeMarginBounds() const
+FloatRect RectangleLayoutShape::shapeMarginBounds() const
 {
     ASSERT(shapeMargin() >= 0);
     if (!shapeMargin())
@@ -53,7 +53,7 @@ FloatRect RectangleShape::shapeMarginBounds() const
     return FloatRect(boundsX, boundsY, boundsWidth, boundsHeight);
 }
 
-LineSegment RectangleShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
+LineSegment RectangleLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
 {
     const FloatRect& bounds = shapeMarginBounds();
     if (bounds.isEmpty())
@@ -88,7 +88,7 @@ LineSegment RectangleShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUni
     return LineSegment(x1, x2);
 }
 
-void RectangleShape::buildDisplayPaths(DisplayPaths& paths) const
+void RectangleLayoutShape::buildDisplayPaths(DisplayPaths& paths) const
 {
     paths.shape.addRoundedRect(m_bounds, FloatSize(m_radii.width(), m_radii.height()), PathRoundedRect::Strategy::PreferBezier);
     if (shapeMargin())

--- a/Source/WebCore/rendering/shapes/RectangleLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/RectangleLayoutShape.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,33 +29,39 @@
 
 #pragma once
 
-#include "FloatRoundedRect.h"
-#include "RenderStyleConstants.h"
-#include "Shape.h"
+#include "FloatRect.h"
+#include "FloatSize.h"
+#include "LayoutShape.h"
+#include <wtf/Assertions.h>
 
 namespace WebCore {
 
-class RenderBox;
-
-RoundedRect computeRoundedRectForBoxShape(CSSBoxType, const RenderBox&);
-
-class BoxShape final : public Shape {
+class RectangleLayoutShape final : public LayoutShape {
 public:
-    BoxShape(const FloatRoundedRect& bounds)
+    RectangleLayoutShape(const FloatRect& bounds, const FloatSize& radii)
         : m_bounds(bounds)
+        , m_radii(radii)
     {
     }
 
-    LayoutRect shapeMarginLogicalBoundingBox() const override;
+    LayoutRect shapeMarginLogicalBoundingBox() const override { return static_cast<LayoutRect>(shapeMarginBounds()); }
     bool isEmpty() const override { return m_bounds.isEmpty(); }
     LineSegment getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const override;
 
     void buildDisplayPaths(DisplayPaths&) const override;
 
 private:
-    FloatRoundedRect shapeMarginBounds() const;
+    FloatRect shapeMarginBounds() const;
 
-    FloatRoundedRect m_bounds;
+    float rx() const { return m_radii.width(); }
+    float ry() const { return m_radii.height(); }
+    float x() const { return m_bounds.x(); }
+    float y() const { return m_bounds.y(); }
+    float width() const { return m_bounds.width(); }
+    float height() const { return m_bounds.height(); }
+
+    FloatRect m_bounds;
+    FloatSize m_radii;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -30,7 +30,6 @@
 #include "config.h"
 #include "ShapeOutsideInfo.h"
 
-#include "BoxShape.h"
 #include "FloatingObjects.h"
 #include "LengthFunctions.h"
 #include "RenderBlockFlow.h"
@@ -124,7 +123,7 @@ static LayoutRect getShapeImageMarginRect(const RenderBox& renderBox, const Layo
     return LayoutRect(marginBoxOrigin, marginRectSize);
 }
 
-Ref<const Shape> makeShapeForShapeOutside(const RenderBox& renderer)
+Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
 {
     auto& style = renderer.style();
     auto& containingBlock = *renderer.containingBlock();
@@ -145,7 +144,7 @@ Ref<const Shape> makeShapeForShapeOutside(const RenderBox& renderer)
     case ShapeValue::Type::Shape: {
         ASSERT(shapeValue.shape());
         auto offset = LayoutPoint { logicalLeftOffset(renderer), logicalTopOffset(renderer) };
-        return Shape::createShape(*shapeValue.shape(), offset, boxSize, writingMode, margin);
+        return LayoutShape::createShape(*shapeValue.shape(), offset, boxSize, writingMode, margin);
     }
     case ShapeValue::Type::Image: {
         ASSERT(shapeValue.isImageValid());
@@ -159,17 +158,17 @@ Ref<const Shape> makeShapeForShapeOutside(const RenderBox& renderer)
 
         ASSERT(!styleImage->isPending());
         RefPtr<Image> image = styleImage->image(const_cast<RenderBox*>(&renderer), imageSize);
-        return Shape::createRasterShape(image.get(), shapeImageThreshold, imageRect, marginRect, writingMode, margin);
+        return LayoutShape::createRasterShape(image.get(), shapeImageThreshold, imageRect, marginRect, writingMode, margin);
     }
     case ShapeValue::Type::Box: {
         auto shapeRect = computeRoundedRectForBoxShape(shapeValue.effectiveCSSBox(), renderer);
         if (!isHorizontalWritingMode)
             shapeRect = shapeRect.transposedRect();
-        return Shape::createBoxShape(shapeRect, writingMode, margin);
+        return LayoutShape::createBoxShape(shapeRect, writingMode, margin);
     }
     }
     ASSERT_NOT_REACHED();
-    return Shape::createBoxShape(RoundedRect { { } }, writingMode, 0);
+    return LayoutShape::createBoxShape(RoundedRect { { } }, writingMode, 0);
 }
 
 static inline bool checkShapeImageOrigin(Document& document, const StyleImage& styleImage)
@@ -189,7 +188,7 @@ static inline bool checkShapeImageOrigin(Document& document, const StyleImage& s
     return false;
 }
 
-const Shape& ShapeOutsideInfo::computedShape() const
+const LayoutShape& ShapeOutsideInfo::computedShape() const
 {
     if (!m_shape)
         m_shape = makeShapeForShapeOutside(m_renderer);

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -29,8 +29,8 @@
 
 #pragma once
 
+#include "LayoutShape.h"
 #include "LayoutSize.h"
-#include "Shape.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMalloc.h>
@@ -42,7 +42,7 @@ class RenderBox;
 class StyleImage;
 class FloatingObject;
 
-Ref<const Shape> makeShapeForShapeOutside(const RenderBox&);
+Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox&);
 
 class ShapeOutsideDeltas final {
     WTF_MAKE_TZONE_ALLOCATED(ShapeOutsideDeltas);
@@ -104,7 +104,7 @@ public:
     LayoutRect computedShapePhysicalBoundingBox() const;
     FloatPoint shapeToRendererPoint(const FloatPoint&) const;
 
-    const Shape& computedShape() const;
+    const LayoutShape& computedShape() const;
 
 private:
     LayoutUnit logicalTopOffset() const;
@@ -112,7 +112,7 @@ private:
 
     const RenderBox& m_renderer;
 
-    mutable RefPtr<const Shape> m_shape;
+    mutable RefPtr<const LayoutShape> m_shape;
     LayoutSize m_cachedShapeLogicalSize;
 
     ShapeOutsideDeltas m_shapeOutsideDeltas;


### PR DESCRIPTION
#### 8fbb39e35ffb6435b5c00b1fd5b48d947f6986d6
<pre>
Rename &quot;Shape&quot; to &quot;LayoutShape&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282263">https://bugs.webkit.org/show_bug.cgi?id=282263</a>
<a href="https://rdar.apple.com/138857418">rdar://138857418</a>

Reviewed by Alan Baradlay.

There are lots of things called &quot;Shape&quot;: classes at the CSSValue level (ShapeValue), classes at the
style level (BasicShape), classes at the rendering level (BorderShape).

Using &quot;Shape&quot; for something that is only used at layout time is confusing, so rename it &quot;LayoutShape&quot;,
and rename the subclasses accordingly.

No behavior change.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::drawShapeHighlight):
* Source/WebCore/layout/floats/FloatingContext.cpp:
* Source/WebCore/layout/floats/PlacedFloats.cpp:
(WebCore::Layout::PlacedFloats::Item::Item):
* Source/WebCore/layout/floats/PlacedFloats.h:
(WebCore::Layout::PlacedFloats::Item::shape const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::shape const):
(WebCore::Layout::Box::setShape):
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/shapes/BoxLayoutShape.cpp: Renamed from Source/WebCore/rendering/shapes/BoxShape.cpp.
(WebCore::adjustRadiusForMarginBoxShape):
(WebCore::computeMarginBoxShapeRadius):
(WebCore::computeMarginBoxShapeRadii):
(WebCore::computeRoundedRectForBoxShape):
(WebCore::BoxLayoutShape::shapeMarginLogicalBoundingBox const):
(WebCore::BoxLayoutShape::shapeMarginBounds const):
(WebCore::BoxLayoutShape::getExcludedInterval const):
(WebCore::BoxLayoutShape::buildDisplayPaths const):
* Source/WebCore/rendering/shapes/BoxLayoutShape.h: Renamed from Source/WebCore/rendering/shapes/BoxShape.h.
* Source/WebCore/rendering/shapes/LayoutShape.cpp: Renamed from Source/WebCore/rendering/shapes/Shape.cpp.
(WebCore::createInsetShape):
(WebCore::createCircleShape):
(WebCore::createEllipseShape):
(WebCore::createPolygonShape):
(WebCore::physicalRectToLogical):
(WebCore::physicalPointToLogical):
(WebCore::physicalSizeToLogical):
(WebCore::LayoutShape::createShape):
(WebCore::LayoutShape::createRasterShape):
(WebCore::LayoutShape::createBoxShape):
* Source/WebCore/rendering/shapes/LayoutShape.h: Renamed from Source/WebCore/rendering/shapes/Shape.h.
(WebCore::LineSegment::LineSegment):
(WebCore::LayoutShape::lineOverlapsShapeMarginBounds const):
(WebCore::LayoutShape::shapeMargin const):
(WebCore::LayoutShape::lineOverlapsBoundingBox const):
* Source/WebCore/rendering/shapes/PolygonLayoutShape.cpp: Renamed from Source/WebCore/rendering/shapes/PolygonShape.cpp.
(WebCore::inwardEdgeNormal):
(WebCore::outwardEdgeNormal):
(WebCore::OffsetPolygonEdge::xIntercept const):
(WebCore::OffsetPolygonEdge::clippedEdgeXRange const):
(WebCore::circleXIntercept):
(WebCore::clippedCircleXRange):
(WebCore::PolygonLayoutShape::shapeMarginLogicalBoundingBox const):
(WebCore::PolygonLayoutShape::getExcludedInterval const):
(WebCore::PolygonLayoutShape::buildDisplayPaths const):
* Source/WebCore/rendering/shapes/PolygonLayoutShape.h: Renamed from Source/WebCore/rendering/shapes/PolygonShape.h.
(WebCore::PolygonLayoutShape::PolygonLayoutShape):
* Source/WebCore/rendering/shapes/RasterLayoutShape.cpp: Renamed from Source/WebCore/rendering/shapes/RasterShape.cpp.
(WebCore::MarginIntervalGenerator::MarginIntervalGenerator):
(WebCore::MarginIntervalGenerator::set):
(WebCore::MarginIntervalGenerator::intervalAt const):
(WebCore::RasterShapeIntervals::computeShapeMarginIntervals const):
(WebCore::RasterShapeIntervals::initializeBounds):
(WebCore::RasterShapeIntervals::buildBoundsPath const):
(WebCore::RasterLayoutShape::marginIntervals const):
(WebCore::RasterLayoutShape::getExcludedInterval const):
* Source/WebCore/rendering/shapes/RasterLayoutShape.h: Renamed from Source/WebCore/rendering/shapes/RasterShape.h.
(WebCore::RasterShapeIntervals::RasterShapeIntervals):
(WebCore::RasterShapeIntervals::bounds const):
(WebCore::RasterShapeIntervals::isEmpty const):
(WebCore::RasterShapeIntervals::intervalAt):
(WebCore::RasterShapeIntervals::intervalAt const):
(WebCore::RasterShapeIntervals::size const):
(WebCore::RasterShapeIntervals::offset const):
(WebCore::RasterShapeIntervals::minY const):
(WebCore::RasterShapeIntervals::maxY const):
* Source/WebCore/rendering/shapes/RectangleLayoutShape.cpp: Renamed from Source/WebCore/rendering/shapes/RectangleShape.cpp.
(WebCore::ellipseXIntercept):
(WebCore::RectangleLayoutShape::shapeMarginBounds const):
(WebCore::RectangleLayoutShape::getExcludedInterval const):
(WebCore::RectangleLayoutShape::buildDisplayPaths const):
* Source/WebCore/rendering/shapes/RectangleLayoutShape.h: Renamed from Source/WebCore/rendering/shapes/RectangleShape.h.
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
(WebCore::ShapeOutsideInfo::computedShape const):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:

Canonical link: <a href="https://commits.webkit.org/285863@main">https://commits.webkit.org/285863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0dea14e4fc95e0c3168f3688d86f3a76cc521b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25262 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1238 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16547 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23595 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/725 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63687 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7872 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1305 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->