### PR TITLE
[webkitpy][WTR] Allow passing all environment variables that start with specific prefixes like 'WEBKIT'

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -725,6 +725,11 @@ class Port(object):
         if name in os.environ:
             clean_env[name] = os.environ[name]
 
+    def _copy_values_from_environ_with_prefix(self, clean_env, prefix):
+        for name in os.environ:
+            if name.startswith(prefix):
+                clean_env[name] = os.environ[name]
+
     def port_adjust_environment_for_test_driver(self, env):
         return env
 
@@ -756,13 +761,12 @@ class Port(object):
 
             # Most ports (?):
             'HOME',
-            'PATH',
-            'WEBKIT_TESTFONTS',
-            'WEBKIT_OUTPUTDIR',
-
+            'PATH'
         ]
+
         for variable in variables_to_copy:
             self._copy_value_from_environ_if_set(clean_env, variable)
+        self._copy_values_from_environ_with_prefix(clean_env, 'WEBKIT')
 
         for string_variable in self.get_option('additional_env_var', []):
             [name, value] = string_variable.split('=', 1)

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -358,6 +358,22 @@ class DriverTest(unittest.TestCase):
             self.assertIn('WEBKIT_OUTPUTDIR', environment_driver_test)
             self.assertEqual(environment_user['WEBKIT_OUTPUTDIR'], environment_driver_test['WEBKIT_OUTPUTDIR'])
 
+    def test_setup_environ_for_test_webkit_prefix(self):
+        environment_user = {}
+        environment_user['WEBKIT2_PAUSE_WEB_PROCESS_ON_LAUNCH'] = '1'
+        environment_user['WEBKIT_ENABLE_RANDOM_FEATURE'] = '1'
+        environment_user['WEBKIT_DISABLE_ANOTHER_RANDOM_FEATURE'] = '1'
+        environment_user['WEBKIT_SET_RANDOM_VALUE'] = 'rand0m'
+        environment_user['WEBKIT_GST_USE_PLAYBIN3'] = '0'
+        environment_user['WEBKIT_DISABLE_MEMORY_PRESSURE_MONITOR'] = '0'
+        with patch('os.environ', environment_user):
+            port = self.make_port()
+            driver = Driver(port, None, pixel_tests=False)
+            environment_driver_test = driver._setup_environ_for_test()
+            for var in environment_user:
+                self.assertIn(var, environment_driver_test)
+                self.assertEqual(environment_user[var], environment_driver_test[var])
+
     def test_setup_environ_base_vars(self):
         # This are essential environment variables that should be copied
         # as part of base:setup_environ_for_server for all drivers

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -87,28 +87,16 @@ class GLibPort(Port):
         environment['WEBKIT_EXEC_PATH'] = self._build_path('bin')
         environment['LD_LIBRARY_PATH'] = self._prepend_to_env_value(self._build_path('lib'), environment.get('LD_LIBRARY_PATH', ''))
         self._copy_value_from_environ_if_set(environment, 'LIBGL_ALWAYS_SOFTWARE')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DISABLE_GL_SINK')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DMABUF_SINK_DISABLED')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HARNESS_DUMP_DIR')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HOLE_PUNCH_QUIRK')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_QUIRKS')
         self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
-        for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',
-                             'PLUGIN_SCANNER', 'PLUGIN_PATH', 'PLUGIN_SYSTEM_PATH', 'REGISTRY',
-                             'PLUGIN_PATH_1_0', 'TRACERS'):
-            self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
+
+        # Copy all GStreamer related env vars
+        self._copy_values_from_environ_with_prefix(environment, 'GST_')
 
         gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
         # Disable hardware-accelerated encoders and decoders. Depending on the underlying platform
         # they might be selected and decrease tests reproducibility. They can still be re-enabled by
         # setting the GST_PLUGIN_FEATURE_RANK variable accordingly when calling run-webkit-tests.
         downranked_elements = ['vah264dec', 'vah264enc', 'vah265dec', 'vah265enc', 'vaav1dec', 'vaav1enc', 'vajpegdec','vavp9dec']
-
         environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max,' + ','.join(['%s:0' % element for element in downranked_elements])
         if gst_feature_rank_override:
             environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -35,8 +35,8 @@ import unittest
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.port.gtk import GtkPort
-from webkitpy.port import port_testcase
-from webkitpy.thirdparty.mock import Mock
+from webkitpy.port import Driver, port_testcase
+from webkitpy.thirdparty.mock import Mock, patch
 from webkitpy.tool.mocktool import MockOptions
 
 from webkitcorepy import OutputCapture
@@ -137,3 +137,20 @@ class GtkPortTest(port_testcase.PortTestCase):
                                '/mock-checkout/LayoutTests/platform/glib/TestExpectations',
                                '/mock-checkout/LayoutTests/platform/gtk/TestExpectations'])
             self.assertEqual(captured.root.log.getvalue(), 'Multiple WebKit2GTK libraries found. Skipping GTK4 detection.\n')
+
+    def test_setup_environ_for_test_gstreamer_prefix(self):
+        environment_user = {}
+        environment_user['GST_DEBUG'] = '99'
+        environment_user['GST_PLUGIN_PATH'] = '/opt/gst/lib'
+        environment_user['GST_DEBUG_DUMP_DOT_DIR'] = '/tmp'
+        environment_user['GST_DEBUG_NO_COLOR'] = '1'
+        environment_user['GST_PLUGIN_SCANNER'] = '/opt/gst/bin/scanner'
+        environment_user['GST_TRACERS'] = 'meminfo;dbus'
+
+        with patch('os.environ', environment_user), patch('sys.platform', 'linux2'):
+            port = self.make_port()
+            driver = Driver(port, None, pixel_tests=False)
+            environment_driver_test = driver._setup_environ_for_test()
+            for var in environment_user:
+                self.assertIn(var, environment_driver_test)
+                self.assertEqual(environment_user[var], environment_driver_test[var])


### PR DESCRIPTION
#### 3bae70608191fdbd9ca4633117c9eb726484d3d8
<pre>
[webkitpy][WTR] Allow passing all environment variables that start with specific prefixes like &apos;WEBKIT&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282265">https://bugs.webkit.org/show_bug.cgi?id=282265</a>

Reviewed by Philippe Normand.

Instead of specifiying a big list of environment variables that should pass
from the user environment to the test one, allow to pass all the variables
that start with specific prefixes like &apos;WEBKIT&apos; (or &apos;GST_&apos; for GTK/WPE ports).

This are all variables that are specific to tunning different features of WebKit
(or gstreamer in the GTK/WPE case) and should not be set on the environment unless
the developer manually sets them.
So not allowing them to pass by default makes confusing the difference of behaviour
when the developer runs WTR vs the MiniBrowser.

* Tools/Scripts/webkitpy/port/base.py:
(Port._copy_values_from_environ_with_prefix):
(Port.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/driver_unittest.py:
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_gtk_expectations_both_binaries):
(GtkPortTest):
(GtkPortTest.test_setup_environ_for_test_gstreamer_prefix):

Canonical link: <a href="https://commits.webkit.org/286430@main">https://commits.webkit.org/286430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1461529053072bd1fabb5e7103a4e2bbf9e31bb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75712 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77828 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59383 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78779 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39744 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/75219 "Passed tests") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22517 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25305 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81671 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66922 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9007 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->