### PR TITLE
[Cocoa] Move UIIntelligenceSupport integration from WebKitSwift to the WebKit framework

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -336,6 +336,8 @@ EXCLUDED_MACOS_PLUGIN_FILE_NAMES[sdk=iphone*] = SecItemShim.dylib WebProcessShim
 // platforms, preventing any Swift compilation. (https://bugs.webkit.org/show_bug.cgi?id=280912)
 EXCLUDED_SWIFT_FILE_NAMES[sdk=appletv*] = *.swift;
 EXCLUDED_SWIFT_FILE_NAMES[sdk=watch*] = *.swift;
+EXCLUDED_SWIFT_FILE_NAMES[sdk=appletv*internal] = ;
+EXCLUDED_SWIFT_FILE_NAMES[sdk=watch*internal] = ;
 
 INSTALLHDRS_SCRIPT_PHASE = YES;
 INSTALLHDRS_COPY_PHASE = YES;

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.swift
@@ -23,8 +23,7 @@
 
 import Foundation
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionItem) public class WKTextExtractionItem: NSObject {
+@objc(WKTextExtractionItem) class WKTextExtractionItem: NSObject {
     @objc public let rectInWebView: CGRect
     @objc public let children: [WKTextExtractionItem]
 
@@ -34,8 +33,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc public enum WKTextExtractionContainer: Int {
+@objc enum WKTextExtractionContainer: Int {
     case root
     case viewportConstrained
     case list
@@ -47,8 +45,7 @@ import Foundation
     case button
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionContainerItem) public class WKTextExtractionContainerItem: WKTextExtractionItem {
+@objc(WKTextExtractionContainerItem) class WKTextExtractionContainerItem: WKTextExtractionItem {
     @objc public let container: WKTextExtractionContainer
 
     @objc public init(container: WKTextExtractionContainer, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
@@ -57,8 +54,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionEditable) public class WKTextExtractionEditable: NSObject {
+@objc(WKTextExtractionEditable) class WKTextExtractionEditable: NSObject {
     @objc public let label: String
     @objc public let placeholder: String
     @objc public let isSecure: Bool
@@ -72,8 +68,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionLink) public class WKTextExtractionLink: NSObject {
+@objc(WKTextExtractionLink) class WKTextExtractionLink: NSObject {
     @objc public let url: NSURL
     @objc public let range: NSRange
 
@@ -83,8 +78,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionTextItem) public class WKTextExtractionTextItem: WKTextExtractionItem {
+@objc(WKTextExtractionTextItem) class WKTextExtractionTextItem: WKTextExtractionItem {
     @objc public let content: String
     @objc public let selectedRange: NSRange
     @objc public let links: [WKTextExtractionLink]
@@ -99,8 +93,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionScrollableItem) public class WKTextExtractionScrollableItem: WKTextExtractionItem {
+@objc(WKTextExtractionScrollableItem) class WKTextExtractionScrollableItem: WKTextExtractionItem {
     @objc public let contentSize: CGSize
 
     @objc public init(contentSize: CGSize, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
@@ -109,8 +102,7 @@ import Foundation
     }
 }
 
-@available(iOS 17.0, macOS 12.0, *)
-@objc(WKTextExtractionImageItem) public class WKTextExtractionImageItem: WKTextExtractionItem {
+@objc(WKTextExtractionImageItem) class WKTextExtractionImageItem: WKTextExtractionItem {
     @objc public let name: String
     @objc public let altText: String
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
@@ -40,8 +40,6 @@ struct Item;
 
 namespace WebKit {
 
-void prepareTextExtractionSupportIfNeeded();
-
 using RootViewToWebViewConverter = Function<WebCore::FloatRect(const WebCore::FloatRect&)>;
 RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&, RootViewToWebViewConverter&&);
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -35,13 +35,6 @@
 namespace WebKit {
 using namespace WebCore;
 
-void prepareTextExtractionSupportIfNeeded()
-{
-    // Preemptively soft link libWebKitSwift if it exists, so that the corresponding Swift extension
-    // on WKWebView will be loaded.
-    WebKitSwiftLibrary(true);
-}
-
 inline static WKTextExtractionContainer containerType(TextExtraction::ContainerType type)
 {
     switch (type) {

--- a/Source/WebKit/UIProcess/Cocoa/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebView+TextExtraction.swift
@@ -23,8 +23,7 @@
 
 #if canImport(UIIntelligenceSupport)
 
-@_spiOnly import WebKit
-@_spiOnly import UIIntelligenceSupport
+@_weakLinked @_spiOnly import UIIntelligenceSupport
 
 #if canImport(UIKit)
 @_spi(UIIntelligenceSupport) import UIKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6964,11 +6964,6 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame())
         resetMediaCapability();
 #endif
-
-#if PLATFORM(COCOA)
-    if (frame->isMainFrame() && preferences().textExtractionEnabled())
-        prepareTextExtractionSupportIfNeeded();
-#endif
 }
 
 void WebPageProxy::didFinishDocumentLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData, WallTime timestamp)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2541,6 +2541,8 @@
 		F433C0A72958C22F00E771C2 /* NetworkIssueReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F433C0A52958C22F00E771C2 /* NetworkIssueReporter.h */; };
 		F4351B9E25EEC84C00D63892 /* ImageAnalysisUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F4351B9D25EEC84C00D63892 /* ImageAnalysisUtilities.h */; };
 		F43548382AB7C41E00150894 /* WKTapHighlightView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */; };
+		F438467D2CD14B3000EF0447 /* WKWebView+TextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438467C2CD14B3000EF0447 /* WKWebView+TextExtraction.swift */; };
+		F438467E2CD14B3000EF0447 /* WKTextExtractionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438467B2CD14B3000EF0447 /* WKTextExtractionItem.swift */; };
 		F438CD1C2241421400DE6DDA /* WKWebpagePreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD1B224140A600DE6DDA /* WKWebpagePreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F438CD1F22414D4000DE6DDA /* WKWebpagePreferencesInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD1E22414D4000DE6DDA /* WKWebpagePreferencesInternal.h */; };
 		F438CD212241F69500DE6DDA /* WKWebpagePreferencesPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD202241F69500DE6DDA /* WKWebpagePreferencesPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2562,13 +2564,11 @@
 		F4648E92296E81FA00744170 /* WebPrivacyHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F4648E90296E81F500744170 /* WebPrivacyHelpers.h */; };
 		F4660BC225DEF08100E86598 /* PasteboardAccessIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */; };
 		F468770B2C6402650068A20C /* CocoaWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = F468770A2C6402650068A20C /* CocoaWindow.h */; };
-		F47AA6CA2B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47AA6C92B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift */; };
 		F48523B62C76962C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm in Sources */ = {isa = PBXBuildFile; fileRef = F48523B52C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm */; };
 		F48523B72C769D8700C71FC2 /* CoreIPCNSURLProtectionSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = F48523B42C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.h */; };
 		F48570A32644BEC500C05F71 /* Timeout.h in Headers */ = {isa = PBXBuildFile; fileRef = F48570A22644BEC400C05F71 /* Timeout.h */; };
 		F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */ = {isa = PBXBuildFile; fileRef = F48C81E32AE0BA6E00073850 /* CoreIPCData.h */; };
 		F48D2A8521583A7E00C6752B /* AppKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F48D2A8421583A0200C6752B /* AppKitSPI.h */; };
-		F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */; };
 		F48EC3582B75895800D1B886 /* WKTextExtractionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */; };
 		F496A4311F58A272004C1757 /* DragDropInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = F496A42F1F58A272004C1757 /* DragDropInteractionState.h */; };
 		F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F446EDEF265EB2B00031DA8F /* WKRevealItemPresenter.h */; };
@@ -8196,6 +8196,8 @@
 		F433C0A62958C22F00E771C2 /* NetworkIssueReporter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkIssueReporter.mm; sourceTree = "<group>"; };
 		F4351B9D25EEC84C00D63892 /* ImageAnalysisUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageAnalysisUtilities.h; sourceTree = "<group>"; };
 		F4351B9F25EEC87800D63892 /* ImageAnalysisUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ImageAnalysisUtilities.mm; sourceTree = "<group>"; };
+		F438467B2CD14B3000EF0447 /* WKTextExtractionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKTextExtractionItem.swift; sourceTree = "<group>"; };
+		F438467C2CD14B3000EF0447 /* WKWebView+TextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+TextExtraction.swift"; sourceTree = "<group>"; };
 		F438CD1B224140A600DE6DDA /* WKWebpagePreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebpagePreferences.h; sourceTree = "<group>"; };
 		F438CD1D22414AD600DE6DDA /* WKWebpagePreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebpagePreferences.mm; sourceTree = "<group>"; };
 		F438CD1E22414D4000DE6DDA /* WKWebpagePreferencesInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebpagePreferencesInternal.h; sourceTree = "<group>"; };
@@ -8231,7 +8233,6 @@
 		F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasteboardAccessIntent.h; sourceTree = "<group>"; };
 		F468770A2C6402650068A20C /* CocoaWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CocoaWindow.h; sourceTree = "<group>"; };
 		F476894628D2B5CD00073641 /* LayerTreeContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = LayerTreeContext.serialization.in; sourceTree = "<group>"; };
-		F47AA6C92B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WKWebView+TextExtraction.swift"; path = "TextExtraction/WKWebView+TextExtraction.swift"; sourceTree = "<group>"; };
 		F48523B42C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSURLProtectionSpace.h; sourceTree = "<group>"; };
 		F48523B52C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSURLProtectionSpace.mm; sourceTree = "<group>"; };
 		F48570A22644BEC400C05F71 /* Timeout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timeout.h; sourceTree = "<group>"; };
@@ -8245,7 +8246,6 @@
 		F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCData.serialization.in; sourceTree = "<group>"; };
 		F48D2A8421583A0200C6752B /* AppKitSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitSPI.h; sourceTree = "<group>"; };
 		F48D2F452BDAEC7F0057BB0E /* CoreIPCNSURLRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCNSURLRequest.serialization.in; sourceTree = "<group>"; };
-		F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WKTextExtractionItem.swift; path = TextExtraction/WKTextExtractionItem.swift; sourceTree = "<group>"; };
 		F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextExtractionUtilities.mm; sourceTree = "<group>"; };
 		F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextExtractionUtilities.h; sourceTree = "<group>"; };
 		F496A42F1F58A272004C1757 /* DragDropInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DragDropInteractionState.h; path = ios/DragDropInteractionState.h; sourceTree = "<group>"; };
@@ -9695,12 +9695,14 @@
 				7A78FF2F224191760096483E /* WKStorageAccessAlert.mm */,
 				4447F01F2BC833F0006988E9 /* WKTextAnimationType.h */,
 				F49DC6FD2B76A88F00816E73 /* WKTextExtractionItem.h */,
+				F438467B2CD14B3000EF0447 /* WKTextExtractionItem.swift */,
 				F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */,
 				F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */,
 				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
 				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
 				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
 				CE45945B240F85B90078019F /* WKTextSelectionRect.mm */,
+				F438467C2CD14B3000EF0447 /* WKWebView+TextExtraction.swift */,
 				2D7AAFD218C8640600A7ACD4 /* WKWebViewContentProvider.h */,
 				2DC6D9C118C44A610043BAD4 /* WKWebViewContentProviderRegistry.h */,
 				2DC6D9C218C44A610043BAD4 /* WKWebViewContentProviderRegistry.mm */,
@@ -13636,7 +13638,6 @@
 				B66F88BE2B6D1D6000FB1734 /* Preview */,
 				5260053F2C707686005D813A /* RealityKit */,
 				449A79EE2BAE299C0033BF53 /* TextAnimation */,
-				F48EC3512B75837200D1B886 /* TextExtraction */,
 				0785E7FE2CBCDFDD00F68126 /* WritingTools */,
 				A14F9B652B686E0200AD9C56 /* module.modulemap */,
 				A14F9B662B686E0200AD9C56 /* WebKitSwift.h */,
@@ -15975,15 +15976,6 @@
 				EBF4E32F2C2E105A00FAC85C /* NotificationAllowLists.xcfilelist */,
 			);
 			path = NotificationAllowList;
-			sourceTree = "<group>";
-		};
-		F48EC3512B75837200D1B886 /* TextExtraction */ = {
-			isa = PBXGroup;
-			children = (
-				F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */,
-				F47AA6C92B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift */,
-			);
-			name = TextExtraction;
 			sourceTree = "<group>";
 		};
 		F638955A133BF57D008941D5 /* mac */ = {
@@ -20171,6 +20163,7 @@
 				E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */,
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
+				F438467E2CD14B3000EF0447 /* WKTextExtractionItem.swift in Sources */,
 				1C627479288B2F7400CED3A2 /* WKWebExtension.mm in Sources */,
 				1CF0C9482AC37FAD00EC82F2 /* WKWebExtensionAction.mm in Sources */,
 				1C974FDF2AFABD03009DE8FC /* WKWebExtensionCommand.mm in Sources */,
@@ -20184,6 +20177,7 @@
 				1C049838289AF5AD0010308B /* WKWebExtensionPermission.mm in Sources */,
 				1C5ACF902A955CB000C041C0 /* WKWebExtensionTabConfiguration.mm in Sources */,
 				1C5ACF8D2A955CA700C041C0 /* WKWebExtensionWindowConfiguration.mm in Sources */,
+				F438467D2CD14B3000EF0447 /* WKWebView+TextExtraction.swift in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,
 				C14D306A24B79BE400480387 /* XPCEndpointClient.mm in Sources */,
 			);
@@ -20223,8 +20217,6 @@
 				528952812C70797900D0357E /* RKEntity.swift in Sources */,
 				440DB5B72C1914DC0021639B /* TextAnimationManager.swift in Sources */,
 				077FD1A02CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift in Sources */,
-				F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */,
-				F47AA6CA2B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### 8daaa373de2bab87e557aba179b85d5eb7f82fcd
<pre>
[Cocoa] Move UIIntelligenceSupport integration from WebKitSwift to the WebKit framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=282266">https://bugs.webkit.org/show_bug.cgi?id=282266</a>

Reviewed by Aditya Keerthi, Richard Robinson, and Elliott Williams.

Move UIIntelligenceSupport integration in WebKit out of WebKitSwift, and into the WebKit framework.
No change in behavior.

* Source/WebKit/Configurations/WebKit.xcconfig:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.swift: Renamed from Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift.
(WKTextExtractionRequest.completionHandler):
(WKTextExtractionRequest.fulfill(_:)):
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::prepareTextExtractionSupportIfNeeded): Deleted.
* Source/WebKit/UIProcess/Cocoa/WKWebView+TextExtraction.swift: Renamed from Source/WebKit/WebKitSwift/TextExtraction/WKWebView+TextExtraction.swift.
(createEditable(for:)):
(createElementContent(for:)):
(createIntelligenceElement(_:)):
(WKWebView._intelligenceBaseClass):
(WKWebView._intelligenceCollectContent(in:collector:)):
(WKWebView._intelligenceCollectRemoteContent(in:remoteContextWrapper:)):
(WKWebView._requestTextExtraction(in:completionHandler:)):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):

Remove this logic for preemptively loading `libWebKitSwift`, now that we no longer require the
`WebKitSwift` library in order to access these Swift objects.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8daaa373de2bab87e557aba179b85d5eb7f82fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16564 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77118 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23622 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79943 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/1368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1512 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/9718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1332 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->