### PR TITLE
[Cocoa] Modern media controls should have accessibility identifiers

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -83,6 +83,7 @@ class Button extends LayoutItem
 
         this._loadImage(iconName);
         this.element.setAttribute("aria-label", iconName.label);
+        this.element.setAttribute("id", iconName.name);
     }
 
     get on()

--- a/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
@@ -32,8 +32,8 @@ class MetadataContainer extends LayoutNode
         this._title = "";
         this._artist = "";
         
-        this._titleNode = new LayoutNode(`<div class="title-label"></div>`);
-        this._artistNode = new LayoutNode(`<div class="artist-label"></div>`);
+        this._titleNode = new LayoutNode(`<div id="title-label" class="title-label"></div>`);
+        this._artistNode = new LayoutNode(`<div id="artist-label" class="artist-label"></div>`);
         this.children = [this._titleNode, this._artistNode];
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
@@ -46,6 +46,20 @@ class TimeLabel extends LayoutNode
 
         this._type = type;
         this.setValueWithNumberOfDigits(0, 4);
+        
+        switch (this._type) {
+        case TimeLabel.Type.Elapsed:
+            this.element.setAttribute("id", "time-label-elapsed");
+            break;
+
+        case TimeLabel.Type.Remaining:
+            this.element.setAttribute("id", "time-label-remaining");
+            break;
+
+        case TimeLabel.Type.Duration:
+            this.element.setAttribute("id", "time-label-duration");
+            break;
+        }
     }
 
     // Public


### PR DESCRIPTION
#### 35b22b2be73b71b8dc5da677b8880696b9ce0dd2
<pre>
[Cocoa] Modern media controls should have accessibility identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=282022">https://bugs.webkit.org/show_bug.cgi?id=282022</a>
<a href="https://rdar.apple.com/138526033">rdar://138526033</a>

Reviewed by Antoine Quint.

Assigned id attributes to buttons and labels in modern media controls that also have aria-labels.
In a future change, WebKit will use these attributes to assign accessibility identifiers to these
elements.

* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype.set iconName):
* Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js:
* Source/WebCore/Modules/modern-media-controls/controls/time-label.js:
(TimeLabel.prototype.switch):

Canonical link: <a href="https://commits.webkit.org/285913@main">https://commits.webkit.org/285913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d557518dab14eefa0fc3024674f903ac87e479b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16545 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79920 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1345 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66517 "Found 1 new test failure: webanimations/accelerated-translate-animation-underlying-value-changed-in-flight.html (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/73706 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7876 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4090 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->