### PR TITLE
StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::RenderVTTCue::layout

### DIFF
--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -83,7 +83,11 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     if (!firstChild())
         return false;
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(cueBox()) ? InlineIterator::firstInlineBoxFor(cueBox()) : InlineIterator::firstRootInlineBoxFor(*this);
+    auto* box = cueBox();
+    if (!box)
+        return false;
+
+    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box) ? InlineIterator::firstInlineBoxFor(*box) : InlineIterator::firstRootInlineBoxFor(*this);
     if (!firstInlineBox)
         return false;
 
@@ -356,7 +360,11 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
     bool switched;
     placeBoxInDefaultPosition(position, switched);
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(cueBox()) ? InlineIterator::firstInlineBoxFor(cueBox()) : InlineIterator::firstRootInlineBoxFor(*this);
+    auto* box = cueBox();
+    if (!box)
+        return;
+
+    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box) ? InlineIterator::firstInlineBoxFor(*box) : InlineIterator::firstRootInlineBoxFor(*this);
     ASSERT(firstInlineBox);
     // 11. Step loop: If none of the boxes in boxes would overlap any of the boxes
     // in output and all the boxes in output are within the video's rendering area
@@ -383,7 +391,11 @@ void RenderVTTCue::repositionGenericCue()
     if (!firstChild())
         return;
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(cueBox());
+    auto* box = cueBox();
+    if (!box)
+        return;
+
+    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box);
     if (downcast<TextTrackCueGeneric>(*m_cue).useDefaultPosition() && firstInlineBox) {
         LayoutUnit parentWidth = containingBlock()->logicalWidth();
         LayoutUnit width { firstInlineBox->visualRectIgnoringBlockDirection().width() };
@@ -471,10 +483,12 @@ RenderBlockFlow& RenderVTTCue::backdropBox() const
     return downcast<RenderBlockFlow>(firstChild);
 }
 
-RenderInline& RenderVTTCue::cueBox() const
+RenderInline* RenderVTTCue::cueBox() const
 {
-    ASSERT(firstChild());
-    return downcast<RenderInline>(*backdropBox().firstChild());
+    auto* firstChild = backdropBox().firstChild();
+    ASSERT(firstChild);
+    ASSERT(is<RenderInline>(firstChild));
+    return dynamicDowncast<RenderInline>(firstChild);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -66,7 +66,7 @@ private:
     void repositionGenericCue();
 
     RenderBlockFlow& backdropBox() const;
-    RenderInline& cueBox() const;
+    RenderInline* cueBox() const;
 
     VTTCue* m_cue;
     FloatPoint m_fallbackPosition;


### PR DESCRIPTION
#### 8b4752a3262d75b4ac05762a5ebb9f5d3be673b3
<pre>
StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::RenderVTTCue::layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=282277">https://bugs.webkit.org/show_bug.cgi?id=282277</a>
<a href="https://rdar.apple.com/138798594">rdar://138798594</a>

Reviewed by Jer Noble.

This patch has RenderVTTCue::cueBox() call dynamicDowncast&lt;RenderInline&gt; instead of
downcast&lt;RenderInline&gt;, and return a pointer instead of a reference. This way, if
the downcasting fails, it does not result in a user-facing crash.

* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::initializeLayoutParameters):
(WebCore::RenderVTTCue::repositionCueSnapToLinesSet):
(WebCore::RenderVTTCue::repositionGenericCue):
(WebCore::RenderVTTCue::cueBox const):
* Source/WebCore/rendering/RenderVTTCue.h:

Canonical link: <a href="https://commits.webkit.org/285914@main">https://commits.webkit.org/285914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b76d7ad49a4efd3a737598fddccf94df11b780c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1249 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58196 "Found 84 new test failures: accessibility/w3c-svg-content-language-attribute.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/images/object-data-url-case-insensitivity.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/canvas-video-to-canvas.html fast/mediastream/captureStream/canvas3d.html fast/multicol/table-vertical-align.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77102 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38606 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21178 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23606 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66520 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65795 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9704 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11453 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4097 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->