### PR TITLE
REGRESSION(285775@main): [macOS wk2 Debug] swipe/pushState tests are flaky failing/timeout

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1916,7 +1916,3 @@ imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module-data
 
 # webkit.org/b/282126 NEW TEST [ Sequoia+ x86_64 ] 5 swipe layout tests are timing due to "Timed out waiting for notifyDone to be called"
 [ Debug ] swipe/main-frame-pinning-requirement.html [ Failure Timeout ]
-
-# webkit.org/b/282264 REGRESSION (285707@main): [macOS wk2 Debug] swipe/pushState tests are failing/timeout (EWS failure)
-[ Debug ] swipe/pushState-programmatic-back-while-swiping-crash.html [ Pass Failure ]
-[ Debug ] swipe/pushstate-with-manual-scrollrestoration.html [ Pass Timeout ]

--- a/LayoutTests/swipe/basic-cached-back-swipe.html
+++ b/LayoutTests/swipe/basic-cached-back-swipe.html
@@ -52,15 +52,15 @@ window.onload = async function () {
     document.body.innerHTML = isFirstPage() ? "first" : "second";
 
     if (isFirstPage()) {
-        initializeSwipeTest();
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+
+        await initializeSwipeTest();
 
         testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
         testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
         testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
         testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
-
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
 
         setTimeout(function () { 
             window.location.href = window.location.href + "?second";

--- a/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
+++ b/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
@@ -58,15 +58,15 @@ window.onload = async function () {
 
     updateContent();
 
-    initializeSwipeTest();
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    await initializeSwipeTest();
 
     testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
     testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
     testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
     testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
-
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
 
     await UIHelper.delayFor(0);
 

--- a/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html
+++ b/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html
@@ -58,15 +58,15 @@ window.onload = async function () {
 
     updateContent();
 
-    initializeSwipeTest();
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    await initializeSwipeTest();
 
     testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
     testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
     testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
     testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
-
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
 
     window.addEventListener("popstate", function(e) {
         log("hasUAVisualTransition " + e.hasUAVisualTransition);

--- a/LayoutTests/swipe/pushState-cached-back-swipe.html
+++ b/LayoutTests/swipe/pushState-cached-back-swipe.html
@@ -59,15 +59,15 @@ window.onload = async function () {
 
     updateContent();
 
-    initializeSwipeTest();
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    await initializeSwipeTest();
 
     testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
     testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
     testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
     testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
-
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
 
     window.addEventListener("popstate", function(e) {
         updateContent();

--- a/LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html
+++ b/LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html
@@ -98,12 +98,12 @@ window.onload = async function () {
 
     updateContent();
 
-    initializeSwipeTest();
-
-    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
+
+    await initializeSwipeTest();
+
+    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
 
     window.addEventListener("popstate", function(e) {
         updateContent();

--- a/LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html
+++ b/LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html
@@ -40,14 +40,14 @@ window.onload = async function () {
         return;
     }
 
-    initializeSwipeTest();
-
     testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
     testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
     testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
 
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
+
+    await initializeSwipeTest();
 
     await UIHelper.delayFor(0);
     history.pushState({page: "second"}, "second", "?second");

--- a/LayoutTests/swipe/resources/swipe-test.js
+++ b/LayoutTests/swipe/resources/swipe-test.js
@@ -22,11 +22,11 @@ function testComplete(logContainer)
     window.testRunner.notifyDone();
 }
 
-function initializeSwipeTest()
+async function initializeSwipeTest()
 {
     window.localStorage["swipeLogging"] = "";
     testRunner.setNavigationGesturesEnabled(true);
-    testRunner.clearBackForwardList();
+    await testRunner.clearBackForwardList();
 }
 
 function startMeasuringDuration(key)

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html
@@ -62,14 +62,14 @@
             if (!window.eventSender || !window.testRunner)
                 return;
 
-            initializeSwipeTest();
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            await initializeSwipeTest();
         
             testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
             testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
             testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
 
             return;
         }

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
@@ -52,14 +52,14 @@
             if (!window.eventSender || !window.testRunner)
                 return;
 
-            initializeSwipeTest();
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            await initializeSwipeTest();
         
             testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
             testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
             testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
 
             return;
         }

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html
@@ -61,15 +61,15 @@
 
             if (!window.eventSender || !window.testRunner)
                 return;
+            
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
 
-            initializeSwipeTest();
+            await initializeSwipeTest();
         
             testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
             testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
             testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
 
             return;
         }

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
@@ -52,14 +52,14 @@
             if (!window.eventSender || !window.testRunner)
                 return;
 
-            initializeSwipeTest();
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            await initializeSwipeTest();
         
             testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
             testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
             testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
 
             return;
         }

--- a/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back.html
+++ b/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back.html
@@ -49,7 +49,7 @@
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
 
-            initializeSwipeTest();
+            await initializeSwipeTest();
         
             testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
             testRunner.installWillEndSwipeCallback(willEndSwipeCallback);


### PR DESCRIPTION
#### a770474be5cfbc749e37758e501567807ef3e762
<pre>
REGRESSION(285775@main): [macOS wk2 Debug] swipe/pushState tests are flaky failing/timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=282264">https://bugs.webkit.org/show_bug.cgi?id=282264</a>
<a href="https://rdar.apple.com/138858231">rdar://138858231</a>

Reviewed by Alex Christensen.

These tests need to wait for the clearBackForwardList promise to resolve.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/swipe/basic-cached-back-swipe.html:
* LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html:
* LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html:
* LayoutTests/swipe/pushState-cached-back-swipe.html:
* LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html:
* LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html:
* LayoutTests/swipe/resources/swipe-test.js:
(async initializeSwipeTest):
(initializeSwipeTest): Deleted.
* LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html:
* LayoutTests/swipe/swipe-back-with-active-wheel-listener.html:
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html:
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html:
* LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back.html:

Canonical link: <a href="https://commits.webkit.org/285885@main">https://commits.webkit.org/285885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44725686920f602bec3ac2aaeb79da5b0896423a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25335 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58246 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16596 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38656 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21233 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23668 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79989 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63755 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9755 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7923 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11439 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1378 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->