### PR TITLE
[WPE][GTK] Remove various WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -36,6 +36,28 @@ inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes)
     return span(bytes.get());
 }
 
+inline std::span<const uint8_t> span(GByteArray* array)
+{
+    return unsafeForgeSpan<const uint8_t>(array->data, array->len);
+}
+
+inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array)
+{
+    return span(array.get());
+}
+
+inline std::span<const uint8_t> span(GVariant* variant)
+{
+    const auto* ptr = static_cast<const uint8_t*>(g_variant_get_data(variant));
+    size_t size = g_variant_get_size(variant);
+    return unsafeForgeSpan<const uint8_t>(ptr, size);
+}
+
+inline std::span<const uint8_t> span(const GRefPtr<GVariant>& variant)
+{
+    return span(variant.get());
+}
+
 } // namespace WTF
 
 using WTF::span;

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -30,6 +30,7 @@
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include <wtf/Vector.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
@@ -43,9 +44,7 @@ void ArgumentCoder<GRefPtr<GByteArray>>::encode(Encoder& encoder, const GRefPtr<
     }
 
     encoder << true;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    encoder << std::span(array->data, array->len);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    encoder << span(array);
 }
 
 std::optional<GRefPtr<GByteArray>> ArgumentCoder<GRefPtr<GByteArray>>::decode(Decoder& decoder)
@@ -75,9 +74,7 @@ void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, const GRefPtr<GV
     }
 
     encoder << CString(g_variant_get_type_string(variant.get()));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    encoder << std::span(static_cast<const uint8_t*>(g_variant_get_data(variant.get())), g_variant_get_size(variant.get()));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    encoder << span(variant);
 }
 
 std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decoder& decoder)

--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -118,9 +118,7 @@ static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType
             translator->addPendingEditorCommand("MoveToEndOfParagraph");
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* rawCommand = gtkDeleteCommands[deleteType][direction];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!rawCommand)
         return;
 
@@ -151,9 +149,7 @@ static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint cou
     if (static_cast<unsigned>(step) >= G_N_ELEMENTS(gtkMoveCommands))
         return;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* rawCommand = gtkMoveCommands[step][direction];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!rawCommand)
         return;
 


### PR DESCRIPTION
#### 513711162fa0cf24c5da27ffb75e9c83ad732af6
<pre>
[WPE][GTK] Remove various WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
<a href="https://bugs.webkit.org/show_bug.cgi?id=282239">https://bugs.webkit.org/show_bug.cgi?id=282239</a>

Reviewed by Adrian Perez de Castro.

Add helpers to convert GByteArray and GVariant to std::span, and use
them where appropriate.

Also, use the existing GBytes -&gt; std::span helper in
WebSocketTaskSoup.cpp.

Also, the suppressions in KeyBindingTranslator.cpp are no longer needed
since 285804@main.

* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::span):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::didReceiveMessageCallback):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::encode):
* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
(WebKit::deleteFromCursorCallback):
(WebKit::moveCursorCallback):

Canonical link: <a href="https://commits.webkit.org/285862@main">https://commits.webkit.org/285862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ff76d48542797cde8f8ca7ce8b1d4f6e3608ef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1263 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16562 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77116 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38615 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23620 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67186 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79941 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73307 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1366 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63711 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9715 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1330 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/20891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1359 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->