### PR TITLE
[scroll-animations] Connect anonymous scroll and view timelines to originating element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-events-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timelime generates animationstart and animationend events assert_equals: scrollstart event received after scrolling into view. expected 1 but got 0
+PASS View timelime generates animationstart and animationend events
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scroll nearest on pseudo-element attaches to parent scroll container assert_equals: expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL scroll nearest on pseudo-element attaches to parent scroll container assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-document-scroller-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-document-scroller-quirks-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tests the document scroller in quirks mode assert_equals: expected "100" but got "auto"
+PASS Tests the document scroller in quirks mode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Resolving scroll(nearest) for an absolutely positioned element assert_equals: expected "300px" but got "100px"
+PASS Resolving scroll(nearest) for an absolutely positioned element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test that the scroll animation is paused promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+PASS Test that the scroll animation is paused
 FAIL Test that the scroll animation is paused by updating animation-play-state promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-with-percent-delay.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-with-percent-delay.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ScrollTimeline with animation delays as percentages promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL ScrollTimeline with animation delays as percentages promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "2"
+FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "3"
 FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "-1"
 FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "-1"
 FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "-1"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline use untransformed box for range calculations promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 50% expected 0.5 +/- 0.000001 but got 0.5744000244140625
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
@@ -2,5 +2,5 @@
 
 
 
-FAIL Stability of animated elements aligned to the bounds of a contain region promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.effect')"
+FAIL Stability of animated elements aligned to the bounds of a contain region assert_approx_equals: a: Unexpected progress expected 1 +/- 0.001 but got 0.6206896209716797
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline attached to SVG graphics element promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL View timeline attached to SVG graphics element assert_equals: expected "rgb(0, 64, 127)" but got "rgb(0, 128, 0)"
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -129,6 +129,10 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
                 if (RefPtr timeline = timelinesController->timelineForName(name, target))
                     setTimeline(WTFMove(timeline));
             }, [&] (Ref<ScrollTimeline> anonymousTimeline) {
+                if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(anonymousTimeline))
+                    viewTimeline->setSubject(target.ptr());
+                else
+                    anonymousTimeline->setSource(target.ptr());
                 setTimeline(RefPtr { anonymousTimeline.ptr() });
             }
         );

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -48,6 +48,7 @@ public:
     static Ref<ScrollTimeline> createFromCSSValue(const CSSScrollValue&);
 
     virtual Element* source() const { return m_source.get(); }
+    Element* sourceElementForProgressCalculation() const;
     void setSource(const Element*);
 
     ScrollAxis axis() const { return m_axis; }
@@ -89,7 +90,7 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_source;
     ScrollAxis m_axis { ScrollAxis::Block };
     AtomString m_name;
-    Scroller m_scroller { Scroller::Nearest };
+    Scroller m_scroller { Scroller::Self };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1e357f1dcd1b62dd39bc7c071304c092568722ef
<pre>
[scroll-animations] Connect anonymous scroll and view timelines to originating element
<a href="https://bugs.webkit.org/show_bug.cgi?id=282290">https://bugs.webkit.org/show_bug.cgi?id=282290</a>
<a href="https://rdar.apple.com/138873145">rdar://138873145</a>

Reviewed by Simon Fraser.

Connect created anonymous timelines to the source/subject element, and ensure that
scroll timelines find the proper source element based on the provided argument.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::sourceElementForProgressCalculation const):
(WebCore::ScrollTimeline::computeTimelineData const):
* Source/WebCore/animation/ScrollTimeline.h:

Canonical link: <a href="https://commits.webkit.org/286176@main">https://commits.webkit.org/286176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c8b2c40c95579b03ec1fc6cb51dc52af0b12711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58821 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17090 "2 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21852 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67081 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66384 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4967 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->