### PR TITLE
Crash under NetworkCache::SpeculativeLoadManager::~SpeculativeLoadManager()

### DIFF
--- a/Source/WebCore/platform/LowPowerModeNotifier.h
+++ b/Source/WebCore/platform/LowPowerModeNotifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -40,8 +41,9 @@ typedef struct _GPowerProfileMonitor GPowerProfileMonitor;
 
 namespace WebCore {
 
-class LowPowerModeNotifier {
+class LowPowerModeNotifier : public CanMakeCheckedPtr<LowPowerModeNotifier> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(LowPowerModeNotifier, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LowPowerModeNotifier);
 public:
     using LowPowerModeChangeCallback = Function<void(bool isLowPowerModeEnabled)>;
     WEBCORE_EXPORT explicit LowPowerModeNotifier(LowPowerModeChangeCallback&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -111,17 +111,21 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
 {
 #if ENABLE(NETWORK_CACHE_SPECULATIVE_REVALIDATION)
     if (options.contains(CacheOption::SpeculativeRevalidation)) {
-        m_lowPowerModeNotifier = makeUnique<WebCore::LowPowerModeNotifier>([this](bool isLowPowerModeEnabled) {
+        m_lowPowerModeNotifier = makeUnique<WebCore::LowPowerModeNotifier>([weakThis = WeakPtr { *this }](bool isLowPowerModeEnabled) {
             ASSERT(WTF::RunLoop::isMain());
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
             if (isLowPowerModeEnabled)
-                m_speculativeLoadManager = nullptr;
+                protectedThis->m_speculativeLoadManager = nullptr;
             else {
-                ASSERT(!m_speculativeLoadManager);
-                m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, m_storage.get());
+                ASSERT(!protectedThis->m_speculativeLoadManager);
+                protectedThis->m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*protectedThis, protectedThis->protectedStorage());
             }
         });
         if (!m_lowPowerModeNotifier->isLowPowerModeEnabled())
-            m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, m_storage.get());
+            m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protectedStorage());
     }
 #endif
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -226,6 +226,8 @@ private:
 
     std::optional<Seconds> maxAgeCap(Entry&, const WebCore::ResourceRequest&, PAL::SessionID);
 
+    Ref<Storage> protectedStorage() const { return m_storage; }
+
     Ref<Storage> m_storage;
     Ref<NetworkProcess> m_networkProcess;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -90,7 +90,7 @@ private:
     Ref<Storage> protectedStorage() const;
 
     WeakRef<Cache> m_cache;
-    CheckedRef<Storage> m_storage;
+    ThreadSafeWeakPtr<Storage> m_storage; // Not expected to be null.
 
     class PendingFrameLoad;
     HashMap<GlobalFrameID, RefPtr<PendingFrameLoad>> m_pendingFrameLoads;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -46,9 +46,8 @@ namespace NetworkCache {
 
 class IOChannel;
 
-class Storage : public ThreadSafeRefCounted<Storage, WTF::DestructionThread::Main>, public CanMakeThreadSafeCheckedPtr<Storage> {
+class Storage : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Storage, WTF::DestructionThread::MainRunLoop> {
     WTF_MAKE_FAST_ALLOCATED;
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Storage);
 public:
     enum class Mode { Normal, AvoidRandomness };
     static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity);


### PR DESCRIPTION
#### 33be0a4c0f11a4b4f19ada2a91d0d1ec1cc350e3
<pre>
Crash under NetworkCache::SpeculativeLoadManager::~SpeculativeLoadManager()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282297">https://bugs.webkit.org/show_bug.cgi?id=282297</a>
<a href="https://rdar.apple.com/138800566">rdar://138800566</a>

Reviewed by Ryosuke Niwa.

Made several fixes / hardening to hopefully resolve the crash:
1. The LowPowerModeNotifier destructor now makes sure to unregister the
   notification handler from NSNotificationCenter in addition to clear
   the notifier pointer. This guards against potential races.
2. Made WebLowPowerModeObserver.notifier a CheckedPtr instead of a raw
   pointer for extra safety.
3. In the NetworkCache constructor, capture `weakThis` instead of `this`
   in the lambda we pass to the LowPowerModeNotifier. We also convert
   `weakThis` to a `protectedThis` inside the lambda to guarantee
   lifetime.
4. Update SpeculativeLoadManager::m_storage to be a ThreadSafeWeakPtr
   instead of a CheckedRef since m_storage is already ThreadSafeRefCounted.
5. Add some threading assertions to help catch potential multi-threading
   issues.

* Source/WebCore/platform/LowPowerModeNotifier.h:
* Source/WebCore/platform/cocoa/LowPowerModeNotifier.mm:
(-[WebLowPowerModeObserver dealloc]):
(-[WebLowPowerModeObserver detach]):
(-[WebLowPowerModeObserver _didReceiveLowPowerModeChange]):
(WebCore::LowPowerModeNotifier::LowPowerModeNotifier):
(WebCore::LowPowerModeNotifier::~LowPowerModeNotifier):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::Cache):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
(WebKit::NetworkCache::Cache::protectedStorage const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::protectedStorage const):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveSubresourcesEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::~SpeculativeLoadManager): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:

Canonical link: <a href="https://commits.webkit.org/285883@main">https://commits.webkit.org/285883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7475b3b5236213abef0acd463a354ee94e35ef7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21227 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79980 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66549 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65824 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7918 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11437 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->