### PR TITLE
Don't unset m_tailCallClobbersInstance if it was previously set

### DIFF
--- a/JSTests/wasm/stress/tail-call-across-modules.js
+++ b/JSTests/wasm/stress/tail-call-across-modules.js
@@ -1,0 +1,73 @@
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat1 = `
+(module
+    (table 1 funcref)
+    (table 2 funcref)
+    (table 3 funcref)
+    (table 4 funcref)
+
+    (func (export "cross_module_callee")
+        (table.size 2)
+        (drop)
+        (return)
+    )
+)
+`
+
+let wat2 = `
+(module
+    (import "o" "cross_module_callee" (func $cross_module_callee))
+
+    (table 10 funcref)
+    (table 11 funcref)
+    (table 12 funcref)
+    (table 13 funcref)
+    (table 14 funcref)
+    (table 15 funcref)
+    (table 16 funcref)
+    (table 17 funcref)
+    (table 18 funcref)
+    (table 19 funcref)
+
+    (func $local_callee
+        (table.size 6)
+        (drop)
+        (return)
+    )
+
+    (func $foo (export "foo") (param $x i32)
+        (table.size 7)
+        (drop)
+        (if (local.get $x)
+            (then 
+                (return_call $cross_module_callee)
+            )
+            (else
+                (return_call $local_callee)
+            )
+        )
+    )
+
+    (func (export "main") (param $x i32) (result i32)
+        (call $foo (local.get $x))
+        (table.size 8)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat1, {}, { simd: true })
+    const { cross_module_callee } = instance.exports
+    const instance2 = await instantiate(wat2, { o : { cross_module_callee } }, { simd: true, tail_call: true })
+    const { main } = instance2.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(main(0), 18)
+        assert.eq(main(1), 18)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
@@ -77,7 +77,8 @@ unsigned FunctionCodeBlockGenerator::numberOfJumpTables() const
 void FunctionCodeBlockGenerator::setTailCall(uint32_t functionIndex, bool isImportedFunctionFromFunctionIndexSpace)
 {
     m_tailCallSuccessors.set(functionIndex);
-    setTailCallClobbersInstance(isImportedFunctionFromFunctionIndexSpace);
+    if (isImportedFunctionFromFunctionIndexSpace)
+        setTailCallClobbersInstance();
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -90,7 +90,7 @@ public:
     FixedBitVector&& takeCallees() { return WTFMove(m_callees); }
     bool tailCallClobbersInstance() const { return m_tailCallClobbersInstance ; }
     void setTailCall(uint32_t, bool);
-    void setTailCallClobbersInstance(bool value) { m_tailCallClobbersInstance  = value; }
+    void setTailCallClobbersInstance() { m_tailCallClobbersInstance = true; }
 
     void setNumVars(unsigned numVars) { m_numVars = numVars; }
     void setNumCalleeLocals(unsigned numCalleeLocals) { m_numCalleeLocals = numCalleeLocals; }

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1696,7 +1696,7 @@ auto LLIntGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& 
     unifyValuesWithBlock(calleeInfo.arguments, args);
 
     if (isTailCall) {
-        m_codeBlock->setTailCallClobbersInstance(true);
+        m_codeBlock->setTailCallClobbersInstance();
 
         const auto& callingConvention = wasmCallingConvention();
         const TypeIndex callerTypeIndex = m_info.internalFunctionTypeIndices[m_functionIndex];
@@ -1722,7 +1722,7 @@ auto LLIntGenerator::addCallRef(const TypeDefinition& signature, ArgumentList& a
     LLIntCallInformation info = callInformationForCaller(functionSignature);
     unifyValuesWithBlock(info.arguments, args);
     if (isTailCall) {
-        m_codeBlock->setTailCallClobbersInstance(true);
+        m_codeBlock->setTailCallClobbersInstance();
 
         const auto& callingConvention = wasmCallingConvention();
         const TypeIndex callerTypeIndex = m_info.internalFunctionTypeIndices[m_functionIndex];


### PR DESCRIPTION
#### 1972367d6b5a00b9312d261ebcf97721d235bd17
<pre>
Don&apos;t unset m_tailCallClobbersInstance if it was previously set
<a href="https://bugs.webkit.org/show_bug.cgi?id=282273">https://bugs.webkit.org/show_bug.cgi?id=282273</a>
<a href="https://rdar.apple.com/138177426">rdar://138177426</a>

Reviewed by Yusuke Suzuki.

When we determine what functions may transitively call across instances, we
utilize `setTailCallClobbersInstance`. However, this sets the value, without
checking if it was set previously. Thus, a later function that does not call
across instances may reset this flag, and lead to the callee&apos;s instance being
used.

* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp:
(JSC::Wasm::FunctionCodeBlockGenerator::setTailCall):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
(JSC::Wasm::FunctionCodeBlockGenerator::setTailCallClobbersInstance):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addCallIndirect):
(JSC::Wasm::LLIntGenerator::addCallRef):

Canonical link: <a href="https://commits.webkit.org/285981@main">https://commits.webkit.org/285981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f830c66206c889691f86dff608d64419addd7f1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1453 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58373 "Found 84 new test failures: fast/block/positioning/fixed-container-with-relative-parent.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/canvas-video-to-canvas.html fast/mediastream/captureStream/canvas3d.html fast/multicol/table-vertical-align.html fast/ruby/annotation-with-line-gap.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23810 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80133 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73497 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65927 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95278 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1520 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20922 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->