### PR TITLE
Fix WebProcess crash when queueing microtask in ShadowRealm inside WorkletGlobalScope

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -43,6 +43,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // queueMicrotaskToEventLoop
+        nullptr, // queueMicrotaskToIncubatingRealm
         &shouldInterruptScriptBeforeTimeout,
         nullptr, // moduleLoaderImportModule
         nullptr, // moduleLoaderResolve

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -63,6 +63,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // queueMicrotaskToEventLoop
+        nullptr, // queueMicrotaskToIncubatingRealm
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -935,6 +935,7 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     &shouldInterruptScript,
     &javaScriptRuntimeFlags,
     nullptr, // queueMicrotaskToEventLoop
+    nullptr, // queueMicrotaskToIncubatingRealm
     &shouldInterruptScriptBeforeTimeout,
     &moduleLoaderImportModule,
     &moduleLoaderResolve,

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -51,6 +51,7 @@ struct GlobalObjectMethodTable {
     bool (*shouldInterruptScript)(const JSGlobalObject*);
     RuntimeFlags (*javaScriptRuntimeFlags)(const JSGlobalObject*);
     void (*queueMicrotaskToEventLoop)(JSGlobalObject&, Ref<Microtask>&&);
+    void (*queueMicrotaskToIncubatingRealm)(JSGlobalObject&, JSValue job, JSValue arg0, JSValue arg1, JSValue arg2, JSValue arg3);
     bool (*shouldInterruptScriptBeforeTimeout)(const JSGlobalObject*);
 
     JSInternalPromise* (*moduleLoaderImportModule)(JSGlobalObject*, JSModuleLoader*, JSString*, JSValue, const SourceOrigin&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -613,6 +613,7 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // queueMicrotaskToEventLoop
+        nullptr, // queueMicrotaskToIncubatingRealm
         &shouldInterruptScriptBeforeTimeout,
         nullptr, // moduleLoaderImportModule
         nullptr, // moduleLoaderResolve
@@ -3261,6 +3262,11 @@ void JSGlobalObject::queueMicrotask(Ref<Microtask>&& task)
 
 void JSGlobalObject::queueMicrotask(JSValue job, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
 {
+    if (globalObjectMethodTable()->queueMicrotaskToIncubatingRealm) {
+        globalObjectMethodTable()->queueMicrotaskToIncubatingRealm(*this, job, argument0, argument1, argument2, argument3);
+        return;
+    }
+
     if (globalObjectMethodTable()->queueMicrotaskToEventLoop) {
         queueMicrotask(createJSMicrotask(vm(), job, argument0, argument1, argument2, argument3));
         return;

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -87,6 +87,7 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
         shouldInterruptScript,
         javaScriptRuntimeFlags,
         queueMicrotaskToEventLoop,
+        nullptr, // queueMicrotaskToIncubatingRealm
         shouldInterruptScriptBeforeTimeout,
         moduleLoaderImportModule,
         moduleLoaderResolve,

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -50,7 +50,8 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
+        nullptr, // queueMicrotaskToEventLoop
+        &queueMicrotaskToIncubatingRealm,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,
@@ -165,10 +166,10 @@ bool JSShadowRealmGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* global
     return JSGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
-void JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)
+void JSShadowRealmGlobalScopeBase::queueMicrotaskToIncubatingRealm(JSC::JSGlobalObject& object, JSC::JSValue job, JSC::JSValue arg0, JSC::JSValue arg1, JSC::JSValue arg2, JSC::JSValue arg3)
 {
-    auto incubating = jsCast<JSShadowRealmGlobalScopeBase*>(&object)->incubatingRealm();
-    incubating->globalObjectMethodTable()->queueMicrotaskToEventLoop(*incubating, WTFMove(task));
+    auto* incubating = jsCast<JSShadowRealmGlobalScopeBase*>(&object)->incubatingRealm();
+    incubating->queueMicrotask(job, arg0, arg1, arg2, arg3);
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, ShadowRealmGlobalScope& realmGlobalScope)

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -53,6 +53,7 @@ private:
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
+    static void queueMicrotaskToIncubatingRealm(JSC::JSGlobalObject&, JSC::JSValue job, JSC::JSValue arg0, JSC::JSValue arg1, JSC::JSValue arg2, JSC::JSValue arg3);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -56,6 +56,7 @@ const GlobalObjectMethodTable* JSWorkerGlobalScopeBase::globalObjectMethodTable(
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         &queueMicrotaskToEventLoop,
+        nullptr, // queueMicrotaskToIncubatingRealm
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -49,6 +49,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // queueMicrotaskToEventLoop
+        nullptr, // queueMicrotaskToIncubatingRealm
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -57,7 +57,6 @@ public:
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
-    static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
     static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);


### PR DESCRIPTION
#### cbad6d6bdfcc39e8a63956068473d894ad9d4186
<pre>
Fix WebProcess crash when queueing microtask in ShadowRealm inside WorkletGlobalScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=282304">https://bugs.webkit.org/show_bug.cgi?id=282304</a>

Reviewed by NOBODY (OOPS!).

Adds a new method to the global object method table which allows
queueing a microtask in the ShadowRealm&apos;s incubating realm without
assuming that the incubating realm has an entry for
queueMicrotaskToEventLoop (which WorkletGlobalScope does not.)

* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable): Add null entry to
  table.
* Source/JavaScriptCore/jsc.cpp: Add null entry to table.
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h: Add entry to
  table.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable): Add null entry to
  base table.
(JSC::JSGlobalObject::queueMicrotask): Call the table method
  queueMicrotaskToIncubatingRealm if it is present.
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable): Add null entry to
  table.
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable): Add
  new queueMicrotaskToIncubatingRealm entry to table and null out old
  queueMicrotaskToEventLoop entry, which is no longer used.
(WebCore::JSShadowRealmGlobalScopeBase::queueMicrotaskToIncubatingRealm):
  Implement virtual method from table. Very similar to the deleted
  implementation of queueMicrotaskToEventLoop, but calls
  queueMicrotask() on the global object instead. (Extra cleanup: change
  auto to auto* for type safety.)
(WebCore::JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop): Deleted.
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h: Method
  declaration.
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable): Add null
  entry to table.
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable): Add null
  entry to table.
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h: Drive-by
  cleanup: This method doesn&apos;t exist, since this global scope has a null
  entry for queueMicrotaskToEventLoop in its method table. So remove the
  declaration.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbad6d6bdfcc39e8a63956068473d894ad9d4186

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58314 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16656 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77246 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48478 "Found 2 new test failures: fast/forms/call-text-did-change-in-text-field-when-typing.html fast/scrolling/ios/key-command-scroll-to-bottom.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45400 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21306 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_keyPath.any.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23750 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67316 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80072 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73437 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65886 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7985 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4248 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->