### PR TITLE
Add assertion in CacheStorageRecordInformation to ensure URL does not have AtomString

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -101,7 +101,7 @@ void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
         uint64_t size = 0;
         for (auto& urlRecords : m_records.values()) {
             for (auto& record : urlRecords)
-                size += record.size;
+                size += record.size();
         }
         return callback(size);
     }
@@ -109,7 +109,7 @@ void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
     m_store->readAllRecordInfos([callback = WTFMove(callback)](auto&& recordInfos) mutable {
         uint64_t size = 0;
         for (auto& recordInfo : recordInfos)
-            size += recordInfo.size;
+            size += recordInfo.size();
 
         callback(size);
     });
@@ -133,13 +133,13 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
         assertIsOnCorrectQueue();
 
         std::sort(recordInfos.begin(), recordInfos.end(), [](auto& a, auto& b) {
-            return a.insertionTime < b.insertionTime;
+            return a.insertionTime() < b.insertionTime();
         });
 
         for (auto&& recordInfo : recordInfos) {
-            RELEASE_ASSERT(!recordInfo.url.string().impl()->isAtom());
-            recordInfo.identifier = nextRecordIdentifier();
-            m_records.ensure(computeKeyURL(recordInfo.url), [] {
+            RELEASE_ASSERT(!recordInfo.url().string().impl()->isAtom());
+            recordInfo.setIdentifier(nextRecordIdentifier());
+            m_records.ensure(computeKeyURL(recordInfo.url()), [] {
                 return Vector<CacheStorageRecordInformation> { };
             }).iterator->value.append(WTFMove(recordInfo));
         }
@@ -154,7 +154,8 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
 static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::CrossThreadRecord&& record, FileSystem::Salt salt, const String& uniqueName)
 {
     NetworkCache::Key key { "record"_s, uniqueName, { }, createVersion4UUIDString(), salt };
-    CacheStorageRecordInformation recordInfo { WTFMove(key), MonotonicTime::now().secondsSinceEpoch().milliseconds(), record.identifier, 0 , record.responseBodySize, record.request.url(), false, { } };
+    auto requestURL = record.request.url();
+    CacheStorageRecordInformation recordInfo { WTFMove(key), MonotonicTime::now().secondsSinceEpoch().milliseconds(), record.identifier, 0 , record.responseBodySize, WTFMove(requestURL), false, HashMap<String, String> { } };
     recordInfo.updateVaryHeaders(record.request, record.response);
 
     return CacheStorageRecord { WTFMove(recordInfo), record.requestHeadersGuard, WTFMove(record.request), record.options, WTFMove(record.referrer), record.responseHeadersGuard, WTFMove(record.response), record.responseBodySize, WTFMove(record.responseBody) };
@@ -184,8 +185,8 @@ void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& option
 
         WebCore::CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary };
         for (auto& record : iterator->value) {
-            RELEASE_ASSERT(!record.url.string().impl()->isAtom());
-            if (WebCore::DOMCacheEngine::queryCacheMatch(options.request, record.url, record.hasVaryStar, record.varyHeaders, queryOptions))
+            RELEASE_ASSERT(!record.url().string().impl()->isAtom());
+            if (WebCore::DOMCacheEngine::queryCacheMatch(options.request, record.url(), record.hasVaryStar(), record.varyHeaders(), queryOptions))
                 targetRecordInfos.append(record);
         }
     }
@@ -200,7 +201,7 @@ void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& option
             if (!cacheStorageRecord)
                 continue;
     
-            WebCore::DOMCacheEngine::CrossThreadRecord record { cacheStorageRecord->info.identifier, 0, cacheStorageRecord->requestHeadersGuard, WTFMove(cacheStorageRecord->request), cacheStorageRecord->options, WTFMove(cacheStorageRecord->referrer), cacheStorageRecord->responseHeadersGuard, { }, nullptr, 0 };
+            WebCore::DOMCacheEngine::CrossThreadRecord record { cacheStorageRecord->info.identifier(), 0, cacheStorageRecord->requestHeadersGuard, WTFMove(cacheStorageRecord->request), cacheStorageRecord->options, WTFMove(cacheStorageRecord->referrer), cacheStorageRecord->responseHeadersGuard, { }, nullptr, 0 };
             if (options.shouldProvideResponse) {
                 record.response = WTFMove(cacheStorageRecord->responseData);
                 record.responseBody = WTFMove(cacheStorageRecord->responseBody);
@@ -239,12 +240,12 @@ void CacheStorageCache::removeRecords(WebCore::ResourceRequest&& request, WebCor
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     uint64_t sizeDecreased = 0;
     iterator->value.removeAllMatching([&](auto& record) {
-        if (!WebCore::DOMCacheEngine::queryCacheMatch(request, record.url, record.hasVaryStar, record.varyHeaders, options))
+        if (!WebCore::DOMCacheEngine::queryCacheMatch(request, record.url(), record.hasVaryStar(), record.varyHeaders(), options))
             return false;
 
-        targetRecordIdentifiers.append(record.identifier);
+        targetRecordIdentifiers.append(record.identifier());
         targetRecordInfos.append(record);
-        sizeDecreased += record.size;
+        sizeDecreased += record.size();
         return true;
     });
     if (iterator->value.isEmpty())
@@ -269,9 +270,9 @@ CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCo
 
     WebCore::CacheQueryOptions options;
     auto index = iterator->value.findIf([&] (auto& record) {
-        RELEASE_ASSERT(!record.url.string().impl()->isAtom());
-        bool hasMatchedIdentifier = !identifier || identifier == record.identifier;
-        return hasMatchedIdentifier && WebCore::DOMCacheEngine::queryCacheMatch(request, record.url, record.hasVaryStar, record.varyHeaders, options);
+        RELEASE_ASSERT(!record.url().string().impl()->isAtom());
+        bool hasMatchedIdentifier = !identifier || identifier == record.identifier();
+        return hasMatchedIdentifier && WebCore::DOMCacheEngine::queryCacheMatch(request, record.url(), record.hasVaryStar(), record.varyHeaders(), options);
     });
     if (index == notFound)
         return nullptr;
@@ -292,7 +293,7 @@ void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRe
     auto cacheStorageRecords = WTF::map(WTFMove(records), [&](WebCore::DOMCacheEngine::CrossThreadRecord&& record) {
         spaceRequested += record.responseBodySize;
         if (auto* existingRecord = findExistingRecord(record.request))
-            spaceRequested -= existingRecord->size;
+            spaceRequested -= existingRecord->size();
         return toCacheStorageRecord(WTFMove(record), manager->salt(), m_uniqueName);
     });
 
@@ -318,9 +319,9 @@ void CacheStorageCache::putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&& r
 
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     for (auto& record : records) {
-        RELEASE_ASSERT(!record.info.url.string().impl()->isAtom());
+        RELEASE_ASSERT(!record.info.url().string().impl()->isAtom());
         if (auto* existingRecord = findExistingRecord(record.request)) {
-            record.info.identifier = existingRecord->identifier;
+            record.info.setIdentifier(existingRecord->identifier());
             targetRecordInfos.append(*existingRecord);
         }
     }
@@ -340,49 +341,50 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
     Vector<uint64_t> targetIdentifiers;
     uint64_t sizeIncreased = 0, sizeDecreased = 0;
     for (auto& record : records) {
-        if (!record.info.identifier) {
-            record.info.identifier = nextRecordIdentifier();
-            sizeIncreased += record.info.size;
-            m_records.ensure(computeKeyURL(record.info.url), [] {
+        if (!record.info.identifier()) {
+            record.info.setIdentifier(nextRecordIdentifier());
+            sizeIncreased += record.info.size();
+            m_records.ensure(computeKeyURL(record.info.url()), [] {
                 return Vector<CacheStorageRecordInformation> { };
             }).iterator->value.append(record.info);
         } else {
             auto index = existingRecords.findIf([&](auto& existingRecord) {
-                return existingRecord && existingRecord->info.identifier == record.info.identifier;
+                return existingRecord && existingRecord->info.identifier() == record.info.identifier();
             });
             // Ensure record still exists.
             if (index == notFound) {
-                record.info.identifier = 0;
+                record.info.setIdentifier(0);
                 continue;
             }
 
             auto& existingRecord = existingRecords[index];
             // Ensure identifier still exists.
-            auto* existingRecordInfo = findExistingRecord(record.request, record.info.identifier);
+            auto* existingRecordInfo = findExistingRecord(record.request, record.info.identifier());
             if (!existingRecordInfo) {
-                record.info.identifier = 0;
+                record.info.setIdentifier(0);
                 continue;
             }
 
-            record.info.key = existingRecordInfo->key;
-            record.info.insertionTime = existingRecordInfo->insertionTime;
+            auto existingKey = existingRecordInfo->key();
+            record.info.setKey(WTFMove(existingKey));
+            record.info.setInsertionTime(existingRecordInfo->insertionTime());
             // FIXME: Remove isolatedCopy() when rdar://105122133 is resolved.
-            record.info.url = existingRecordInfo->url.isolatedCopy();
+            record.info.setURL(existingRecordInfo->url().isolatedCopy());
             record.requestHeadersGuard = existingRecord->requestHeadersGuard;
             record.request = WTFMove(existingRecord->request);
             record.options = WTFMove(existingRecord->options);
             record.referrer = WTFMove(existingRecord->referrer);
             record.info.updateVaryHeaders(record.request, record.responseData);
-            sizeIncreased += record.info.size;
-            sizeDecreased += existingRecordInfo->size;
-            existingRecordInfo->size = record.info.size;
+            sizeIncreased += record.info.size();
+            sizeDecreased += existingRecordInfo->size();
+            existingRecordInfo->setSize(record.info.size());
         }
 
-        targetIdentifiers.append(record.info.identifier);
+        targetIdentifiers.append(record.info.identifier());
     }
 
     records.removeAllMatching([&](auto& record) {
-        return !record.info.identifier;
+        return !record.info.identifier();
     });
 
     if (RefPtr manager = m_manager.get()) {
@@ -409,7 +411,7 @@ void CacheStorageCache::removeAllRecords()
     for (auto& urlRecords : m_records.values()) {
         for (auto& record : urlRecords) {
             targetRecordInfos.append(record);
-            sizeDecreased += record.size;
+            sizeDecreased += record.size();
         }
     }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -301,7 +301,9 @@ static std::optional<StoredRecordInformation> readRecordInfoFromFileData(const F
     if (!header)
         return std::nullopt;
 
-    CacheStorageRecordInformation info { metaData->key, header->insertionTime, 0, 0, header->responseBodySize, header->request.url(), false, { } };
+    auto key = metaData->key;
+    auto url = header->request.url();
+    CacheStorageRecordInformation info { WTFMove(key), header->insertionTime, 0, 0, header->responseBodySize, WTFMove(url), false, { } };
     info.updateVaryHeaders(header->request, header->responseData);
     return StoredRecordInformation { info, WTFMove(*metaData), WTFMove(*header) };
 }
@@ -380,7 +382,7 @@ void CacheStorageDiskStore::readRecordsInternal(const Vector<CacheStorageRecordI
     m_ioQueue->dispatch([this, protectedThis = Ref { *this }, directory = crossThreadCopy(recordsDirectoryPath()), recordInfos = crossThreadCopy(recordInfos), callback = WTFMove(callback)]() mutable {
         Vector<std::optional<CacheStorageRecord>> records;
         for (auto& recordInfo : recordInfos) {
-            auto recordFile = recordFilePathWithDirectory(directory, recordInfo.key);
+            auto recordFile = recordFilePathWithDirectory(directory, recordInfo.key());
             auto fileData = valueOrDefault(FileSystem::MappedFileData::create(recordFile, FileSystem::MappedFileMode::Private));
             auto blobData = !fileData.size() ? FileSystem::MappedFileData { } : valueOrDefault(FileSystem::MappedFileData::create(recordBlobFilePath(recordFile), FileSystem::MappedFileMode::Private));
             auto record = readRecordFromFileData(fileData.span(), WTFMove(blobData));
@@ -390,18 +392,18 @@ void CacheStorageDiskStore::readRecordsInternal(const Vector<CacheStorageRecordI
                 continue;
             }
 
-            if (recordInfo.insertionTime != record->info.insertionTime || recordInfo.size != record->info.size || recordInfo.url != record->info.url) {
+            if (recordInfo.insertionTime() != record->info.insertionTime() || recordInfo.size() != record->info.size() || recordInfo.url() != record->info.url()) {
                 records.append(std::nullopt);
                 continue;
             }
 
-            if (recordFilePath(recordInfo.key) != recordFilePath(record->info.key)) {
+            if (recordFilePath(recordInfo.key()) != recordFilePath(record->info.key())) {
                 records.append(std::nullopt);
                 continue;
             }
 
-            record->info.identifier = recordInfo.identifier;
-            record->info.updateResponseCounter = recordInfo.updateResponseCounter;
+            record->info.setIdentifier(recordInfo.identifier());
+            record->info.setUpdateResponseCounter(recordInfo.updateResponseCounter());
             records.append(WTFMove(record));
         }
 
@@ -419,7 +421,7 @@ void CacheStorageDiskStore::readRecords(const Vector<CacheStorageRecordInformati
 void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
 {
     auto recordFiles = WTF::map(recordInfos, [&](auto recordInfo) {
-        return recordFilePath(recordInfo.key);
+        return recordFilePath(recordInfo.key());
     });
 
     m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), callback = WTFMove(callback)]() mutable {
@@ -441,8 +443,8 @@ void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInforma
 static Vector<uint8_t> encodeRecordHeader(CacheStorageRecord&& record)
 {
     WTF::Persistence::Encoder encoder;
-    encoder << record.info.insertionTime;
-    encoder << record.info.size;
+    encoder << record.info.insertionTime();
+    encoder << record.info.size();
     encoder << record.requestHeadersGuard;
     encoder << record.request;
     record.options.encodePersistent(encoder);
@@ -501,11 +503,11 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
     Vector<Vector<uint8_t>> recordDatas;
     Vector<Vector<uint8_t>> recordBlobDatas;
     for (auto&& record : records) {
-        recordFiles.append(recordFilePath(record.info.key));
+        recordFiles.append(recordFilePath(record.info.key()));
         auto bodyData = encodeRecordBody(record);
         auto bodyHash = computeSHA1(bodyData.span(), m_salt);
         bool shouldCreateBlob = shouldStoreBodyAsBlob(bodyData);
-        auto recordInfoKey = record.info.key;
+        auto recordInfoKey = record.info.key();
         auto headerData = encodeRecordHeader(WTFMove(record));
         auto recordData = encodeRecord(recordInfoKey, headerData, !shouldCreateBlob, bodyData, bodyHash, m_salt);
         recordDatas.append(WTFMove(recordData));

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -40,10 +40,10 @@ struct ClientOrigin;
 
 namespace WebKit {
 class CacheStorageCache;
+class CacheStorageRecordInformation;
 class CacheStorageRegistry;
 class CacheStorageStore;
 struct CacheStorageRecord;
-struct CacheStorageRecordInformation;
 
 
 class CacheStorageManager : public RefCountedAndCanMakeWeakPtr<CacheStorageManager> {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -51,7 +51,7 @@ void CacheStorageMemoryStore::readAllRecordInfos(ReadAllRecordInfosCallback&& ca
 void CacheStorageMemoryStore::readRecords(const Vector<CacheStorageRecordInformation>& recordInfos, ReadRecordsCallback&& callback)
 {
     auto result = WTF::map(recordInfos, [&](auto& recordInfo) -> std::optional<CacheStorageRecord> {
-        auto iterator = m_records.find(recordInfo.identifier);
+        auto iterator = m_records.find(recordInfo.identifier());
         if (iterator == m_records.end())
             return std::nullopt;
         return copyCacheStorageRecord(*iterator->value);
@@ -62,7 +62,7 @@ void CacheStorageMemoryStore::readRecords(const Vector<CacheStorageRecordInforma
 void CacheStorageMemoryStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
 {
     for (auto& recordInfo : recordInfos)
-        m_records.remove(recordInfo.identifier);
+        m_records.remove(recordInfo.identifier());
 
     callback(true);
 }
@@ -70,7 +70,7 @@ void CacheStorageMemoryStore::deleteRecords(const Vector<CacheStorageRecordInfor
 void CacheStorageMemoryStore::writeRecords(Vector<CacheStorageRecord>&& records, WriteRecordsCallback&& callback)
 {
     for (auto&& record : records)
-        m_records.set(record.info.identifier, makeUnique<CacheStorageRecord>(WTFMove(record)));
+        m_records.set(record.info.identifier(), makeUnique<CacheStorageRecord>(WTFMove(record)));
 
     callback(true);
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageRecord.h"
+
+namespace WebKit {
+
+CacheStorageRecordInformation::CacheStorageRecordInformation(NetworkCache::Key&& key, double insertionTime, uint64_t identifier, uint64_t updateResponseCounter, uint64_t size, URL&& url, bool hasVaryStar, HashMap<String, String>&& varyHeaders)
+    : m_key(WTFMove(key))
+    , m_insertionTime(insertionTime)
+    , m_identifier(identifier)
+    , m_updateResponseCounter(updateResponseCounter)
+    , m_size(size)
+    , m_url(WTFMove(url))
+    , m_hasVaryStar(hasVaryStar)
+    , m_varyHeaders(WTFMove(varyHeaders))
+{
+    RELEASE_ASSERT(!m_url.string().impl()->isAtom());
+}
+
+void CacheStorageRecordInformation::updateVaryHeaders(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse::CrossThreadData& response)
+{
+    auto varyValue = response.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary);
+    if (varyValue.isNull() || response.tainting == WebCore::ResourceResponse::Tainting::Opaque || response.tainting == WebCore::ResourceResponse::Tainting::Opaqueredirect) {
+        m_hasVaryStar = false;
+        m_varyHeaders = { };
+        return;
+    }
+
+    varyValue.split(',', [&](StringView view) {
+        if (!m_hasVaryStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
+            m_hasVaryStar = true;
+        m_varyHeaders.add(view.toString(), request.httpHeaderField(view));
+    });
+
+    if (m_hasVaryStar)
+        m_varyHeaders = { };
+}
+
+CacheStorageRecordInformation CacheStorageRecordInformation::isolatedCopy() && {
+    return {
+        crossThreadCopy(WTFMove(m_key)),
+        m_insertionTime,
+        m_identifier,
+        m_updateResponseCounter,
+        m_size,
+        crossThreadCopy(WTFMove(m_url)),
+        m_hasVaryStar,
+        crossThreadCopy(WTFMove(m_varyHeaders))
+    };
+}
+
+void CacheStorageRecordInformation::setURL(URL&& url)
+{
+    RELEASE_ASSERT(!url.string().impl()->isAtom());
+    m_url = WTFMove(url);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
@@ -30,8 +30,8 @@
 
 namespace WebKit {
 
+class CacheStorageRecordInformation;
 struct CacheStorageRecord;
-struct CacheStorageRecordInformation;
 
 class CacheStorageStore : public ThreadSafeRefCounted<CacheStorageStore> {
 public:

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -169,6 +169,7 @@ NetworkProcess/storage/CacheStorageCache.cpp
 NetworkProcess/storage/CacheStorageMemoryStore.cpp
 NetworkProcess/storage/CacheStorageManager.cpp
 NetworkProcess/storage/CacheStorageDiskStore.cpp
+NetworkProcess/storage/CacheStorageRecord.cpp
 NetworkProcess/storage/CacheStorageRegistry.cpp
 NetworkProcess/storage/FileSystemStorageManager.cpp
 NetworkProcess/storage/FileSystemStorageHandle.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5159,6 +5159,7 @@
 		3AC6E5242A1C59AE0059F092 /* RemoteGraphicsContextGLInitializationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLInitializationState.h; sourceTree = "<group>"; };
 		3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginQuotaManager.cpp; sourceTree = "<group>"; };
 		3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginQuotaManager.h; sourceTree = "<group>"; };
+		3AE26CB62CD1B10B00836AB7 /* CacheStorageRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageRecord.cpp; sourceTree = "<group>"; };
 		3AEE89912AA595AC00D4DF44 /* PlatformXRARKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformXRARKit.mm; sourceTree = "<group>"; };
 		3AEE89922AA595AC00D4DF44 /* PlatformXRARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformXRARKit.h; sourceTree = "<group>"; };
 		3AEE89932AA5966A00D4DF44 /* PlatformXRSystemIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformXRSystemIOS.mm; sourceTree = "<group>"; };
@@ -13472,6 +13473,7 @@
 				935BF7F62936BF1800B41326 /* CacheStorageManager.h */,
 				934CF812294B884B00304F7D /* CacheStorageMemoryStore.cpp */,
 				934CF811294B884A00304F7D /* CacheStorageMemoryStore.h */,
+				3AE26CB62CD1B10B00836AB7 /* CacheStorageRecord.cpp */,
 				935BF7FA2936BF1900B41326 /* CacheStorageRecord.h */,
 				935BF8082936CA2F00B41326 /* CacheStorageRegistry.cpp */,
 				935BF8062936C9FC00B41326 /* CacheStorageRegistry.h */,


### PR DESCRIPTION
#### 981e412577e1141c506393efe25669b78a6819d5
<pre>
Add assertion in CacheStorageRecordInformation to ensure URL does not have AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=282307">https://bugs.webkit.org/show_bug.cgi?id=282307</a>
<a href="https://rdar.apple.com/138880442">rdar://138880442</a>

Reviewed by Youenn Fablet.

CrashTracer indicates the assertion in CacheStorageCache::findExistingRecord is hit, which means url in stored records
contains AtomString. This is unexpected because CacheStorageRecordInformation (and its members) stored in
CacheStorageCache::m_records should be created with isolatedCopy(). To figure out how CacheStorageRecordInformation
gets an AtomString URL, this patch makes CacheStorageRecordInformation a class and adds assertions in constructor and
URL setter.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::getSize):
(WebKit::CacheStorageCache::open):
(WebKit::toCacheStorageRecord):
(WebKit::CacheStorageCache::retrieveRecords):
(WebKit::CacheStorageCache::removeRecords):
(WebKit::CacheStorageCache::findExistingRecord):
(WebKit::CacheStorageCache::putRecords):
(WebKit::CacheStorageCache::putRecordsAfterQuotaCheck):
(WebKit::CacheStorageCache::putRecordsInStore):
(WebKit::CacheStorageCache::removeAllRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::readRecordInfoFromFileData):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
(WebKit::CacheStorageDiskStore::deleteRecords):
(WebKit::encodeRecordHeader):
(WebKit::CacheStorageDiskStore::writeRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp:
(WebKit::CacheStorageMemoryStore::readRecords):
(WebKit::CacheStorageMemoryStore::deleteRecords):
(WebKit::CacheStorageMemoryStore::writeRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp: Added.
(WebKit::CacheStorageRecordInformation::CacheStorageRecordInformation):
(WebKit::CacheStorageRecordInformation::updateVaryHeaders):
(WebKit::CacheStorageRecordInformation::isolatedCopy):
(WebKit::CacheStorageRecordInformation::setURL):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecordInformation::key const):
(WebKit::CacheStorageRecordInformation::insertionTime const):
(WebKit::CacheStorageRecordInformation::identifier const):
(WebKit::CacheStorageRecordInformation::updateResponseCounter const):
(WebKit::CacheStorageRecordInformation::size const):
(WebKit::CacheStorageRecordInformation::url const):
(WebKit::CacheStorageRecordInformation::hasVaryStar const):
(WebKit::CacheStorageRecordInformation::varyHeaders const):
(WebKit::CacheStorageRecordInformation::setKey):
(WebKit::CacheStorageRecordInformation::setSize):
(WebKit::CacheStorageRecordInformation::setIdentifier):
(WebKit::CacheStorageRecordInformation::setUpdateResponseCounter):
(WebKit::CacheStorageRecordInformation::setInsertionTime):
(WebKit::CacheStorageRecordInformation::updateVaryHeaders): Deleted.
(WebKit::CacheStorageRecordInformation::isolatedCopy): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageStore.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285908@main">https://commits.webkit.org/285908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3153b1c69b81eb0aecee44aacb963cc357e8051

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25332 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58268 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45274 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23665 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79986 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9756 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7917 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4163 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->