### PR TITLE
[ARMv7] Fix OMG Int64 live value OSR restore

### DIFF
--- a/JSTests/wasm/stress/armv7-simple-loop-osr.js
+++ b/JSTests/wasm/stress/armv7-simple-loop-osr.js
@@ -1,0 +1,74 @@
+//@ requireOptions("--useOMGJIT=1", "--useOMGInlining=0", "--useConcurrentJIT=0", "--useDollarVM=1", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=50", "--thresholdForOMGOptimizeSoon=50")
+// jsc -m armv7-simple-loop-osr.js --useOMGJIT=1 --useOMGInlining=0 --useConcurrentJIT=0 --useDollarVM=1 --thresholdForBBQOptimizeAfterWarmUp=0 --thresholdForBBQOptimizeSoon=0 --thresholdForOMGOptimizeAfterWarmUp=50 --thresholdForOMGOptimizeSoon=50
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "m" "isOMG" (func $isOMG (result i32)))
+    (import "m" "logOMG" (func $logOMG (param i32)))
+
+    ;; Debugging
+    (import "m" "logi32" (func $logi32 (param i32)))
+    (import "m" "logi64" (func $logi64 (param i64)))
+
+    (func $test (export "test") (param $l i32) (result i32 i64 i64)
+        (local $a i32)
+        (local $b i64)
+        (local $c i64)
+        (local.set $b (i64.const 0x0EEFBAADDEADFEED))
+        (local.set $a (i32.const 0x0A00000A))
+        (local.set $c (i64.const 0x0B00B00000B))
+
+        (loop $L0
+            (local.set $a (i32.add (local.get $a) (i32.const 16)))
+            (local.set $b (i64.add (local.get $b) (i64.const 25600000000)))
+            (local.set $c (i64.add (local.get $c) (i64.const 3200000000)))
+            (call $logOMG (call $isOMG))
+            ;; Debugging
+            ;; (call $logi32 (i32.const 0xFFFFFFFF))
+            ;; (call $logi32 (local.get $a))
+            ;; (call $logi64 (local.get $b))
+            ;; (call $logi64 (local.get $c))
+            ;; (call $logi32 (i32.const 0x77777777))
+
+            (local.set $l (i32.sub (local.get $l) (i32.const 1)))
+            (br_if $L0 (i32.ne (local.get $l) (i32.const 0)))
+        )
+
+        (local.get $a)
+        (local.get $b)
+        (local.get $c)
+    )
+)
+`
+
+let hasTierdUp = false
+
+async function test() {
+    function log(x) {
+        x = BigInt(x)
+        // print(x.toString(16))
+    }
+    function logOMG(x) {
+        // print("OMG: " + x)
+        assert.truthy(x === 0 || x === 1)
+        if (x === 1)
+            hasTierdUp = true
+    }
+    const instance = await instantiate(wat, { m: { isOMG: $vm.omgTrue, logOMG, logi32: log, logi64: log } }, { simd: true, exceptions: true })
+    const { test, test_with_call, test_with_call_indirect } = instance.exports
+
+    const result = test(100)
+    // print("---")
+    log(result[0])
+    log(result[1])
+    log(result[2])
+    assert.eq(result[0], 0xa00064a)
+    assert.eq(result[1], 0xeefbd01ea91feedn)
+    assert.eq(result[2], 0xfa8c7c800bn)
+
+    assert.truthy(hasTierdUp, "We did not reach OMG")
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/armv7-simple-throw-restore-live.js
+++ b/JSTests/wasm/stress/armv7-simple-throw-restore-live.js
@@ -1,0 +1,54 @@
+//@ requireOptions("--useOMGInlining=1", "--useWasmOSR=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (tag $e)
+
+    (func $test (export "test") (param $a i32) (result i64)
+        (local $x i64)
+        (local.set $x (i64.add (i64.const 0x0EEFBAADDEADFEED) (i64.extend_i32_u (local.get $a))))
+        (try
+            (do
+                (local.set $x (i64.add (i64.const 0x100000000) (local.get $x)))
+                (call $fun (local.get $a))
+                (local.set $x (i64.add (i64.const 1) (local.get $x)))
+            )
+            (catch $e
+                (local.set $x (i64.add (i64.const 5) (local.get $x)))
+            )
+        )
+        (try
+            (do
+                (local.set $x (i64.add (i64.const 0x100000000) (local.get $x)))
+                (call $fun (local.get $a))
+                (local.set $x (i64.add (i64.const 1) (local.get $x)))
+            )
+            (catch $e
+                (local.set $x (i64.add (i64.const 5) (local.get $x)))
+            )
+        )
+        (return (local.get $x))
+    )
+
+    (func $fun (param $x i32)
+        (if
+            (i32.eq (local.get $x) (i32.const 42))
+            (then (throw $e))
+        )
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, exceptions: true })
+    const { test, test_with_call, test_with_call_indirect } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(41), 0x0EEFBAADDEADFEEDn + 41n + (0x100000000n + 1n) * 2n)
+        assert.eq(test(42), 0x0EEFBAADDEADFEEDn + 42n + (0x100000000n + 5n) * 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -1648,6 +1648,9 @@ private:
             case ValueRep::SomeEarlyRegister:
             case ValueRep::Stack:
             case ValueRep::Constant:
+#if USE(JSVALUE32_64)
+            case ValueRep::RegisterPair:
+#endif
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
@@ -4987,6 +4990,9 @@ private:
                     after.append(Inst(moveForType(type), m_value, arg, tmp));
                     return;
                 }
+#if USE(JSVALUE32_64)
+                case ValueRep::RegisterPair:
+#endif
                 default:
                     RELEASE_ASSERT_NOT_REACHED();
                     return;

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -130,6 +130,9 @@ bool PatchpointSpecial::admitsStack(Inst& inst, unsigned argIndex)
         case ValueRep::Register:
         case ValueRep::LateRegister:
             return false;
+#if USE(JSVALUE32_64)
+        case ValueRep::RegisterPair:
+#endif
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return false;

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -127,6 +127,9 @@ void StackmapSpecial::forEachArgImpl(
             case ValueRep::LateColdAny:
                 role = Arg::LateColdUse;
                 break;
+#if USE(JSVALUE32_64)
+            case ValueRep::RegisterPair:
+#endif
             case ValueRep::SomeEarlyRegister:
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
@@ -275,6 +278,9 @@ bool StackmapSpecial::isArgValidForRep(Air::Code& code, const Air::Arg& arg, con
                 return true;
         }
         return false;
+#if USE(JSVALUE32_64)
+    case ValueRep::RegisterPair:
+#endif
     case ValueRep::Stack:
     case ValueRep::Constant:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -929,6 +929,9 @@ private:
                     VALIDATE(value.value()->type().isFloat() || value.value()->type().isVector(), ("At ", *context, ": ", value));
             }
             break;
+#if USE(JSVALUE32_64)
+        case ValueRep::RegisterPair:
+#endif
         case ValueRep::Constant:
         case ValueRep::Stack:
             VALIDATE(false, ("At ", *context, ": ", value));

--- a/Source/JavaScriptCore/b3/B3ValueRep.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueRep.cpp
@@ -57,6 +57,10 @@ void ValueRep::addUsedRegistersTo(bool isSIMDContext, RegisterSetBuilder& set) c
         set.add(MacroAssembler::stackPointerRegister, IgnoreVectors);
         set.add(GPRInfo::callFrameRegister, IgnoreVectors);
         return;
+#if USE(JSVALUE32_64)
+    case RegisterPair:
+        break;
+#endif
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -84,6 +88,11 @@ void ValueRep::dump(PrintStream& out) const
     case Register:
         out.print("(", reg(), ")");
         return;
+#if USE(JSVALUE32_64)
+    case RegisterPair:
+        out.print("(", u.regPair.regLo, ", ", u.regPair.regHi, ")");
+        return;
+#endif
     case Stack:
         out.print("(", offsetFromFP(), ")");
         return;
@@ -191,6 +200,11 @@ void printInternal(PrintStream& out, ValueRep::Kind kind)
     case ValueRep::SomeRegister:
         out.print("SomeRegister");
         return;
+#if USE(JSVALUE32_64)
+    case ValueRep::RegisterPair:
+        out.print("SomeRegisterPair");
+        return;
+#endif
     case ValueRep::SomeRegisterWithClobber:
         out.print("SomeRegisterWithClobber");
         return;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -49,6 +49,7 @@
 #include "JSPromise.h"
 #include "JSString.h"
 #include "LinkBuffer.h"
+#include "NativeCallee.h"
 #include "OperationResult.h"
 #include "Options.h"
 #include "Parser.h"
@@ -2137,6 +2138,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionBreakpoint);
 static JSC_DECLARE_HOST_FUNCTION(functionExit);
 static JSC_DECLARE_HOST_FUNCTION(functionDFGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionFTLTrue);
+static JSC_DECLARE_HOST_FUNCTION(functionOMGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuMfence);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuRdtsc);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuCpuid);
@@ -2350,6 +2352,84 @@ JSC_DEFINE_HOST_FUNCTION(functionFTLTrue, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(false));
+}
+
+// Returns true if the calling frame is an OMG frame.
+// Usage: isOMG = $vm.omgTrue() (from WASM only)
+JSC_DEFINE_HOST_FUNCTION(functionOMGTrue, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+#if ENABLE(WEBASSEMBLY)
+    VM& vm = globalObject->vm();
+
+    bool allFramesAreValid = true;
+    bool seenOMGFrame = false;
+    bool seenOtherWasmFrame = false;
+
+    auto modeForWasm = [&](StackVisitor& visitor) {
+        if (visitor->codeType() != StackVisitor::Frame::Wasm
+            || !visitor->callee().isNativeCallee()) {
+            allFramesAreValid = false;
+            return Wasm::CompilationMode::LLIntMode;
+        }
+        return static_cast<Wasm::Callee*>(visitor->callee().asNativeCallee())->compilationMode();
+    };
+
+    auto expectWasmToJS = [&](StackVisitor& visitor) {
+        if (visitor->codeType() != StackVisitor::Frame::Wasm
+            || !visitor->callee().isNativeCallee()
+            || !isAnyWasmToJS(static_cast<Wasm::Callee*>(visitor->callee().asNativeCallee())->compilationMode())) {
+            allFramesAreValid = false;
+            return;
+        }
+    };
+
+    auto expectNative = [&](StackVisitor& visitor) {
+        if (visitor->codeType() != StackVisitor::Frame::Native
+            || !visitor->callee().isCell()) {
+            allFramesAreValid = false;
+            return;
+        }
+    };
+
+    unsigned frameIndex = 0;
+    StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
+        DollarVMAssertScope assertScope;
+
+        switch (frameIndex) {
+        case 0:
+            expectNative(visitor);
+            break;
+        case 1:
+            expectWasmToJS(visitor);
+            break;
+        case 2: {
+            auto mode = modeForWasm(visitor);
+            seenOMGFrame = isAnyOMG(mode);
+            seenOtherWasmFrame = isAnyBBQ(mode) || isAnyInterpreter(mode);
+            return IterationStatus::Done;
+        }
+        default:
+            return IterationStatus::Done;
+        }
+
+        ++frameIndex;
+        return IterationStatus::Continue;
+    });
+
+    if (allFramesAreValid && seenOMGFrame && !seenOtherWasmFrame)
+        return JSValue::encode(jsNumber(1));
+
+    if (allFramesAreValid && !seenOMGFrame && seenOtherWasmFrame)
+        return JSValue::encode(jsNumber(0));
+
+    dataLogLn("omgTrue INVALID FRAME: ", allFramesAreValid, " ", seenOMGFrame, " ", seenOtherWasmFrame);
+#else
+    UNUSED_PARAM(globalObject);
+    UNUSED_PARAM(callFrame);
+#endif // ENABLE(WEBASSEMBLY)
+
+    return JSValue::encode(jsNumber(2));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionCpuMfence, (JSGlobalObject*, CallFrame*))
@@ -4245,6 +4325,7 @@ void JSDollarVM::finishCreation(VM& vm)
 
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "dfgTrue"_s), 0, functionDFGTrue, ImplementationVisibility::Public, DFGTrueIntrinsic, jsDollarVMPropertyAttributes);
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "ftlTrue"_s), 0, functionFTLTrue, ImplementationVisibility::Public, FTLTrueIntrinsic, jsDollarVMPropertyAttributes);
+    putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "omgTrue"_s), 0, functionOMGTrue, ImplementationVisibility::Public, NoIntrinsic, jsDollarVMPropertyAttributes);
 
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "cpuMfence"_s), 0, functionCpuMfence, ImplementationVisibility::Public, CPUMfenceIntrinsic, jsDollarVMPropertyAttributes);
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "cpuRdtsc"_s), 0, functionCpuRdtsc, ImplementationVisibility::Public, CPURdtscIntrinsic, jsDollarVMPropertyAttributes);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3244,6 +3244,10 @@ B3::Type BBQJIT::toB3Type(TypeKind kind)
 
 B3::ValueRep BBQJIT::toB3Rep(Location location)
 {
+#if USE(JSVALUE32_64)
+    if (location.isGPR2())
+        return B3::ValueRep(B3::ValueRep::OSRValueRep, Reg(location.asGPRlo()), Reg(location.asGPRhi()));
+#endif
     if (location.isRegister())
         return B3::ValueRep(location.isGPR() ? Reg(location.asGPR()) : Reg(location.asFPR()));
     if (location.isStack())

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -40,6 +40,23 @@ enum class CompilationMode : uint8_t {
     WasmToJSMode,
 };
 
+constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
+{
+    switch (compilationMode) {
+    case CompilationMode::LLIntMode:
+    case CompilationMode::IPIntMode:
+        return true;
+    case CompilationMode::BBQMode:
+    case CompilationMode::OMGForOSREntryMode:
+    case CompilationMode::OMGMode:
+    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmICMode:
+    case CompilationMode::WasmToJSMode:
+        return false;
+    }
+    RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+}
+
 constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
 {
     switch (compilationMode) {
@@ -69,6 +86,23 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::JSToWasmEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
+        return false;
+    }
+    RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+}
+
+constexpr inline bool isAnyWasmToJS(CompilationMode compilationMode)
+{
+    switch (compilationMode) {
+    case CompilationMode::WasmToJSMode:
+        return true;
+    case CompilationMode::OMGMode:
+    case CompilationMode::OMGForOSREntryMode:
+    case CompilationMode::BBQMode:
+    case CompilationMode::LLIntMode:
+    case CompilationMode::IPIntMode:
+    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmICMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();


### PR DESCRIPTION
#### d2b0596d08f44b20f0a488e7b6ccb4c03af36ee3
<pre>
[ARMv7] Fix OMG Int64 live value OSR restore
<a href="https://bugs.webkit.org/show_bug.cgi?id=282309">https://bugs.webkit.org/show_bug.cgi?id=282309</a>

Reviewed by David Degazio.

Int64 patchpoints get lowered in a way that makes the indices too hard
to compute when filling live values from patchpoints during exception unwinding.

1) Handle patchpoint live-value saving directly in the generator by splitting Int64s.
2) Fix BBQ OSR, which needs a value rep for register pairs. That is, LLInt fills
Int64 values directly from the stack. BBQ may map them to/from a register pair,
but still saves them to the OMG OSR buffer as a 64-bit value. OMG does an Int64
load, which is agressively lowered to remove Int64 stitches / extracts.

We also add some tests to make debugging OSR very simple.

* JSTests/wasm/stress/armv7-simple-throw-restore-live.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.tag.e.func.test.export.string_appeared_here.param.a.i32.result.i64.local.x.i64.local.x.i64.const.0x0EEFBAADDEADFEED.try.local.x.i64.add.i64.const.1.local.x.call.fun.local.a.local.x.i64.add.i64.const.1.local.x.catch.e.local.x.i64.add.i64.const.5.local.x.return.local.x.return.local.x.func.fun.param.x.i32.i32.eq.local.x.i32.const.42.then.throw.e.async test):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::traceCF):
(JSC::Wasm::OMGIRGenerator::loadFromScratchBuffer):
(JSC::Wasm::OMGIRGenerator::preparePatchpointForExceptions):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::loadValuesIntoBuffer):

Canonical link: <a href="https://commits.webkit.org/286405@main">https://commits.webkit.org/286405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c605dd3580f298c504cbc2fed5f7f5c40010bc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17642 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46757 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22634 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25452 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69036 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81820 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75135 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3228 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2028 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9086 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3178 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21293 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->