### PR TITLE
Update MediaSource.cpp to comply with new CPP-safer rules.

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -77,8 +77,8 @@ void ManagedMediaSource::setStreaming(bool streaming)
         return;
     ALWAYS_LOG(LOGIDENTIFIER, streaming);
     m_streaming = streaming;
-    if (m_private)
-        m_private->setStreaming(streaming);
+    if (RefPtr msp = protectedPrivate())
+        msp->setStreaming(streaming);
     if (streaming) {
         scheduleEvent(eventNames().startstreamingEvent);
         if (m_streamingAllowed) {
@@ -140,8 +140,8 @@ void ManagedMediaSource::streamingTimerFired()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "Disabling streaming due to policy ", *m_highThreshold);
     m_streamingAllowed = false;
-    if (m_private)
-        m_private->setStreamingAllowed(false);
+    if (RefPtr msp = protectedPrivate())
+        msp->setStreamingAllowed(false);
     notifyElementUpdateMediaState();
 }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -134,8 +134,8 @@ private:
         , m_logger(parent.logger())
 #endif
         , m_private(parent.m_private)
-        {
-        }
+    {
+    }
 
     void setPrivateAndOpen(Ref<MediaSourcePrivate>&& mediaSourcePrivate) final
     {
@@ -283,7 +283,7 @@ void MediaSource::setPrivateAndOpen(Ref<MediaSourcePrivate>&& mediaSourcePrivate
     ASSERT(!m_private);
 
     setPrivate(WTFMove(mediaSourcePrivate));
-    m_private->setTimeFudgeFactor(currentTimeFudgeFactor());
+    protectedPrivate()->setTimeFudgeFactor(currentTimeFudgeFactor());
 
     open();
 }
@@ -296,7 +296,7 @@ void MediaSource::reOpen()
 
     open();
 
-    for (auto& sourceBuffer : m_sourceBuffers.get())
+    for (Ref sourceBuffer : m_sourceBuffers.get())
         sourceBuffer->attach();
 }
 
@@ -361,7 +361,9 @@ MediaTime MediaSource::duration() const
     // 1. If the readyState attribute is "closed" then return NaN and abort these steps.
     // 2. Return the current value of the attribute.
 
-    return m_private ? m_private->duration() : MediaTime::invalidTime();
+    if (RefPtr msp = protectedPrivate())
+        return msp->duration();
+    return MediaTime::invalidTime();
 }
 
 MediaTime MediaSource::currentTime() const
@@ -369,12 +371,14 @@ MediaTime MediaSource::currentTime() const
     if (m_pendingSeekTarget)
         return m_pendingSeekTarget->time;
 
-    return m_private ? m_private->currentTime() : MediaTime::zeroTime();
+    if (RefPtr msp = protectedPrivate())
+        return msp->currentTime();
+    return MediaTime::zeroTime();
 }
 
 PlatformTimeRanges MediaSource::buffered() const
 {
-    return isClosed() ? PlatformTimeRanges::emptyRanges() : m_private->buffered();
+    return isClosed() ? PlatformTimeRanges::emptyRanges() : protectedPrivate()->buffered();
 }
 
 Ref<MediaTimePromise> MediaSource::waitForTarget(const SeekTarget& target)
@@ -383,6 +387,10 @@ Ref<MediaTimePromise> MediaSource::waitForTarget(const SeekTarget& target)
 
     // 2.4.3 Seeking
     // https://rawgit.com/w3c/media-source/45627646344eea0170dd1cbc5a3d508ca751abb8/media-source-respec.html#mediasource-seeking
+
+    RefPtr msp = protectedPrivate();
+    if (!msp)
+        return MediaTimePromise::createAndReject(PlatformMediaError::SourceRemoved);
 
     if (m_seekTargetPromise) {
         ALWAYS_LOG(LOGIDENTIFIER, "Previous seeking to ", m_pendingSeekTarget->time, "pending, cancelling it");
@@ -399,7 +407,7 @@ Ref<MediaTimePromise> MediaSource::waitForTarget(const SeekTarget& target)
         ALWAYS_LOG(LOGIDENTIFIER, "No data at seeked time, waiting");
         // 1. If the HTMLMediaElement.readyState attribute is greater than HAVE_METADATA,
         // then set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
-        m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
+        msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
 
         // 2. The media element waits until an appendBuffer() or an appendStream() call causes the coded
         // frame processing algorithm to set the HTMLMediaElement.readyState attribute to a value greater
@@ -463,14 +471,16 @@ void MediaSource::completeSeek()
 
 Ref<MediaPromise> MediaSource::seekToTime(const MediaTime& time)
 {
-    for (auto& sourceBuffer : m_activeSourceBuffers.get())
+    for (Ref sourceBuffer : m_activeSourceBuffers.get())
         sourceBuffer->seekToTime(time);
     return MediaPromise::createAndResolve();
 }
 
 Ref<TimeRanges> MediaSource::seekable()
 {
-    return m_private ? TimeRanges::create(m_private->seekable()) : TimeRanges::create();
+    if (RefPtr msp = protectedPrivate())
+        return TimeRanges::create(msp->seekable());
+    return TimeRanges::create();
 }
 
 ExceptionOr<void> MediaSource::setLiveSeekableRange(double start, double end)
@@ -484,13 +494,15 @@ ExceptionOr<void> MediaSource::setLiveSeekableRange(double start, double end)
     if (!isOpen())
         return Exception { ExceptionCode::InvalidStateError };
 
+    Ref msp = protectedPrivate().releaseNonNull();
+
     // If start is negative or greater than end, then throw a TypeError exception and abort these steps.
     if (start < 0 || start > end)
         return Exception { ExceptionCode::TypeError };
 
     // Set live seekable range to be a new normalized TimeRanges object containing a single range
     // whose start position is start and end position is end.
-    m_private->setLiveSeekableRange({ MediaTime::createWithDouble(start), MediaTime::createWithDouble(end) });
+    msp->setLiveSeekableRange({ MediaTime::createWithDouble(start), MediaTime::createWithDouble(end) });
 
     return { };
 }
@@ -505,7 +517,8 @@ ExceptionOr<void> MediaSource::clearLiveSeekableRange()
     // If the readyState attribute is not "open" then throw an InvalidStateError exception and abort these steps.
     if (!isOpen())
         return Exception { ExceptionCode::InvalidStateError };
-    m_private->clearLiveSeekableRange();
+    Ref msp = protectedPrivate().releaseNonNull();
+    msp->clearLiveSeekableRange();
     return { };
 }
 
@@ -532,11 +545,12 @@ bool MediaSource::hasBufferedTime(const MediaTime& time)
     if (time > duration())
         return false;
 
-    auto ranges = m_private->buffered();
+    Ref msp = protectedPrivate().releaseNonNull();
+    auto ranges = msp->buffered();
     if (!ranges.length())
         return false;
 
-    return abs(ranges.nearest(time) - time) <= m_private->timeFudgeFactor();
+    return abs(ranges.nearest(time) - time) <= msp->timeFudgeFactor();
 }
 
 bool MediaSource::hasCurrentTime()
@@ -549,7 +563,9 @@ bool MediaSource::hasFutureTime()
     if (isClosed())
         return false;
 
-    return m_private->hasFutureTime(currentTime(), m_private->timeIsProgressing() ? MediaTime::zeroTime() : MediaSourcePrivate::futureDataThreshold());
+    Ref msp = protectedPrivate().releaseNonNull();
+
+    return msp->hasFutureTime(currentTime(), msp->timeIsProgressing() ? MediaTime::zeroTime() : MediaSourcePrivate::futureDataThreshold());
 }
 
 bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
@@ -559,7 +575,9 @@ bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 
     ASSERT(ranges.length() == 1);
 
-    auto bufferedRanges = m_private->buffered();
+    Ref msp = protectedPrivate().releaseNonNull();
+
+    auto bufferedRanges = msp->buffered();
     if (!bufferedRanges.length())
         return false;
     bufferedRanges.intersectWith(ranges);
@@ -568,7 +586,7 @@ bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
         return false;
 
     auto hasBufferedTime = [&] (const MediaTime& time) {
-        return abs(bufferedRanges.nearest(time) - time) <= m_private->timeFudgeFactor();
+        return abs(bufferedRanges.nearest(time) - time) <= msp->timeFudgeFactor();
     };
 
     if (!hasBufferedTime(ranges.minimumBufferedTime()) || !hasBufferedTime(ranges.maximumBufferedTime()))
@@ -579,7 +597,7 @@ bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 
     // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
     for (unsigned i = 1; i < bufferedRanges.length(); i++) {
-        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > m_private->timeFudgeFactor())
+        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > msp->timeFudgeFactor())
             return false;
     }
 
@@ -591,7 +609,7 @@ void MediaSource::monitorSourceBuffers()
     if (isClosed())
         return;
 
-    ASSERT(m_private);
+    Ref msp = protectedPrivate().releaseNonNull();
 
     // 2.4.4 SourceBuffer Monitoring
     // https://rawgit.com/w3c/media-source/45627646344eea0170dd1cbc5a3d508ca751abb8/media-source-respec.html#buffer-monitoring
@@ -599,7 +617,7 @@ void MediaSource::monitorSourceBuffers()
     // Note, the behavior if activeSourceBuffers is empty is undefined.
 
     // ↳ If the HTMLMediaElement.readyState attribute equals HAVE_NOTHING:
-    if (m_private->mediaPlayerReadyState() == MediaPlayer::ReadyState::HaveNothing) {
+    if (msp->mediaPlayerReadyState() == MediaPlayer::ReadyState::HaveNothing) {
         // 1. Abort these steps.
         return;
     }
@@ -609,7 +627,7 @@ void MediaSource::monitorSourceBuffers()
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
         // 2. If this is the first transition to HAVE_METADATA, then queue a task to fire a simple event
         // named loadedmetadata at the media element.
-        m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
+        msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
 
         // 3. Abort these steps.
         return;
@@ -631,7 +649,7 @@ void MediaSource::monitorSourceBuffers()
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_ENOUGH_DATA.
         // 2. Queue a task to fire a simple event named canplaythrough at the media element.
         // 3. Playback may resume at this point if it was previously suspended by a transition to HAVE_CURRENT_DATA.
-        m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveEnoughData);
+        msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveEnoughData);
 
         if (m_pendingSeekTarget)
             completeSeek();
@@ -646,7 +664,7 @@ void MediaSource::monitorSourceBuffers()
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_FUTURE_DATA.
         // 2. If the previous value of HTMLMediaElement.readyState was less than HAVE_FUTURE_DATA, then queue a task to fire a simple event named canplay at the media element.
         // 3. Playback may resume at this point if it was previously suspended by a transition to HAVE_CURRENT_DATA.
-        m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveFutureData);
+        msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveFutureData);
 
         if (m_pendingSeekTarget)
             completeSeek();
@@ -663,7 +681,7 @@ void MediaSource::monitorSourceBuffers()
     // event named loadeddata at the media element.
     // 3. Playback is suspended at this point since the media element doesn't have enough data to
     // advance the media timeline.
-    m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveCurrentData);
+    msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveCurrentData);
 
     if (m_pendingSeekTarget)
         completeSeek();
@@ -689,7 +707,7 @@ ExceptionOr<void> MediaSource::setDuration(double duration)
 
     // 3. If the updating attribute equals true on any SourceBuffer in sourceBuffers, then throw an InvalidStateError
     // exception and abort these steps.
-    for (auto& sourceBuffer : m_sourceBuffers.get()) {
+    for (Ref sourceBuffer : m_sourceBuffers.get()) {
         if (sourceBuffer->updating())
             return Exception { ExceptionCode::InvalidStateError };
     }
@@ -700,6 +718,9 @@ ExceptionOr<void> MediaSource::setDuration(double duration)
 
 ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& newDuration)
 {
+    if (isClosed())
+        return Exception { ExceptionCode::InvalidStateError };
+
     // 2.4.6 Duration Change
     // https://www.w3.org/TR/2016/REC-media-source-20161117/#duration-change-algorithm
 
@@ -714,7 +735,7 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& newDuration)
     // across all SourceBuffer objects in sourceBuffers.
     MediaTime highestPresentationTimestamp;
     MediaTime highestEndTime;
-    for (auto& sourceBuffer : m_sourceBuffers.get()) {
+    for (Ref sourceBuffer : m_sourceBuffers.get()) {
         highestPresentationTimestamp = std::max(highestPresentationTimestamp, sourceBuffer->highestPresentationTimestamp());
         highestEndTime = std::max(highestEndTime, sourceBuffer->bufferedInternal().maximumBufferedTime());
     }
@@ -729,7 +750,7 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& newDuration)
 
     // 5. Update duration to new duration.
     // 6. Update the media duration to new duration and run the HTMLMediaElement duration change algorithm.
-    m_private->durationChanged(duration);
+    protectedPrivate()->durationChanged(duration);
 
     // Changing the duration affects the buffered range.
     monitorSourceBuffers();
@@ -743,8 +764,8 @@ void MediaSource::setReadyState(ReadyState state)
     if (oldState == state)
         return;
 
-    if (m_private)
-        m_private->setReadyState(state);
+    if (RefPtr msp = protectedPrivate())
+        msp->setReadyState(state);
 
     onReadyStateChange(oldState, readyState());
 }
@@ -782,6 +803,8 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
     if (isClosed())
         return;
 
+    Ref msp = protectedPrivate().releaseNonNull();
+
     // 2.4.7 https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html#end-of-stream-algorithm
 
     // 1. Change the readyState attribute value to "ended".
@@ -794,14 +817,14 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
         // 1. Run the duration change algorithm with new duration set to the highest end time reported by
         // the buffered attribute across all SourceBuffer objects in sourceBuffers.
         MediaTime maxEndTime;
-        for (auto& sourceBuffer : m_sourceBuffers.get()) {
+        for (Ref sourceBuffer : m_sourceBuffers.get()) {
             if (auto length = sourceBuffer->bufferedInternal().length())
                 maxEndTime = std::max(sourceBuffer->bufferedInternal().end(length - 1), maxEndTime);
         }
         setDurationInternal(maxEndTime);
 
         // 2. Notify the media element that it now has all of the media data.
-        m_private->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::NoError);
+        msp->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::NoError);
         return;
     }
 
@@ -809,9 +832,9 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
     MediaPlayer::NetworkState mediaElementNextState = MediaPlayer::NetworkState::NetworkError;
 
     if (error == EndOfStreamError::Network) {
-        m_private->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::NetworkError);
+        msp->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::NetworkError);
         // ↳ If error is set to "network"
-        if (m_private->mediaPlayerReadyState() == MediaPlayerReadyState::HaveNothing) {
+        if (msp->mediaPlayerReadyState() == MediaPlayerReadyState::HaveNothing) {
             //  ↳ If the HTMLMediaElement.readyState attribute equals HAVE_NOTHING
             //    Run the "If the media data cannot be fetched at all, due to network errors, causing
             //    the user agent to give up trying to fetch the resource" steps of the resource fetch algorithm.
@@ -828,9 +851,9 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
     } else {
         // ↳ If error is set to "decode"
         ASSERT(error == EndOfStreamError::Decode);
-        m_private->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::DecodeError);
+        msp->markEndOfStream(MediaSourcePrivate::EndOfStreamStatus::DecodeError);
 
-        if (m_private->mediaPlayerReadyState() == MediaPlayerReadyState::HaveNothing) {
+        if (msp->mediaPlayerReadyState() == MediaPlayerReadyState::HaveNothing) {
             //  ↳ If the HTMLMediaElement.readyState attribute equals HAVE_NOTHING
             //    Run the "If the media data can be fetched but is found by inspection to be in an unsupported
             //    format, or can otherwise not be rendered at all" steps of the resource fetch algorithm.
@@ -1256,7 +1279,7 @@ void MediaSource::detachFromElement()
     // can be called from the destructor, where we may no longer have a scriptExecutionContext.
     if (scriptExecutionContext()) {
         while (m_activeSourceBuffers->length()) {
-            auto& buffer = *m_activeSourceBuffers->item(0);
+            Ref buffer = m_activeSourceBuffers->item(0).releaseNonNull();
             if (detachable()) {
                 removeSourceBufferWithOptionalDestruction(buffer, false);
                 m_activeSourceBuffers->remove(buffer);
@@ -1267,7 +1290,7 @@ void MediaSource::detachFromElement()
         m_activeSourceBuffers->replaceWith({ });
 
     if (detachable()) {
-        for (auto& sourceBuffer : m_sourceBuffers.get())
+        for (Ref sourceBuffer : m_sourceBuffers.get())
             sourceBuffer->detach();
 
         m_mediaElement = nullptr;
@@ -1288,11 +1311,10 @@ void MediaSource::detachFromElement()
     m_mediaElement = nullptr;
     m_isAttached = false;
 
-    if (!m_private)
-        return;
-
-    m_private->shutdown();
-    setPrivate(nullptr);
+    if (RefPtr msp = protectedPrivate()) {
+        msp->shutdown();
+        setPrivate(nullptr);
+    }
 }
 
 void MediaSource::sourceBufferDidChangeActiveState(SourceBuffer&, bool)
@@ -1321,8 +1343,8 @@ void MediaSource::openIfInEndedState()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setReadyState(ReadyState::Open);
-    m_private->unmarkEndOfStream();
-    for (auto& sourceBuffer : m_sourceBuffers.get())
+    protectedPrivate()->unmarkEndOfStream();
+    for (Ref sourceBuffer : m_sourceBuffers.get())
         sourceBuffer->setMediaSourceEnded(false);
 }
 
@@ -1371,7 +1393,7 @@ void MediaSource::stop()
 
 MediaSource::ReadyState MediaSource::readyState() const
 {
-    return (m_openDeferred || !m_private) ? ReadyState::Closed : m_private->readyState();
+    return (m_openDeferred || !m_private) ? ReadyState::Closed : protectedPrivate()->readyState();
 }
 
 void MediaSource::onReadyStateChange(ReadyState oldState, ReadyState newState)
@@ -1428,8 +1450,11 @@ ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(con
     if (document && document->quirks().needsVP9FullRangeFlagQuirk())
         type = addVP9FullRangeVideoFlagToContentType(incomingType);
 
+    ASSERT(isOpen());
+    Ref msp = protectedPrivate().releaseNonNull();
+
     RefPtr<SourceBufferPrivate> sourceBufferPrivate;
-    switch (m_private->addSourceBuffer(type, DeprecatedGlobalSettings::webMParserEnabled(), sourceBufferPrivate)) {
+    switch (msp->addSourceBuffer(type, DeprecatedGlobalSettings::webMParserEnabled(), sourceBufferPrivate)) {
     case MediaSourcePrivate::AddStatus::Ok:
         return sourceBufferPrivate.releaseNonNull();
     case MediaSourcePrivate::AddStatus::NotSupported:
@@ -1473,13 +1498,13 @@ URLRegistry& MediaSource::registry() const
 
 void MediaSource::regenerateActiveSourceBuffers()
 {
-    Vector<RefPtr<SourceBuffer>> newList;
-    for (auto& sourceBuffer : m_sourceBuffers.get()) {
+    Vector<Ref<SourceBuffer>> newList;
+    for (Ref sourceBuffer : m_sourceBuffers.get()) {
         if (sourceBuffer->active())
-            newList.append(sourceBuffer);
+            newList.append(WTFMove(sourceBuffer));
     }
     m_activeSourceBuffers->replaceWith(WTFMove(newList));
-    for (auto& sourceBuffer : m_activeSourceBuffers.get())
+    for (Ref sourceBuffer : m_activeSourceBuffers.get())
         sourceBuffer->setBufferedDirty(true);
 
     notifyElementUpdateMediaState();
@@ -1512,17 +1537,19 @@ void MediaSource::updateBufferedIfNeeded(bool force)
     if (isClosed())
         return;
 
+    Ref msp = protectedPrivate().releaseNonNull();
+
     if (!force && m_activeSourceBuffers->length() && std::all_of(m_activeSourceBuffers->begin(), m_activeSourceBuffers->end(), [](auto& buffer) { return !buffer->isBufferedDirty(); }))
         return;
 
-    for (auto& sourceBuffer : m_activeSourceBuffers.get())
+    for (Ref sourceBuffer : m_activeSourceBuffers.get())
         sourceBuffer->setBufferedDirty(false);
 
     PlatformTimeRanges buffered;
     auto updatePrivate = makeScopeExit([&] {
-        if (buffered == m_private->buffered())
+        if (buffered == msp->buffered())
             return;
-        m_private->bufferedChanged(buffered);
+        msp->bufferedChanged(buffered);
         monitorSourceBuffers();
     });
 
@@ -1585,7 +1612,9 @@ void MediaSource::failedToCreateRenderer(RendererType type)
 
 void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()
 {
-    if (m_private && m_private->mediaPlayerReadyState() == MediaPlayer::ReadyState::HaveNothing) {
+    RefPtr msp = protectedPrivate();
+
+    if (msp && msp->mediaPlayerReadyState() == MediaPlayer::ReadyState::HaveNothing) {
         // 6.1 If one or more objects in sourceBuffers have first initialization segment flag set to false, then abort these steps.
         for (auto& sourceBuffer : m_sourceBuffers.get()) {
             if (!sourceBuffer->receivedFirstInitializationSegment())
@@ -1593,23 +1622,22 @@ void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()
         }
         // 6.2 Set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
         // 6.3 Queue a task to fire a simple event named loadedmetadata at the media element.
-        m_private->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
+        msp->setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
     }
 }
 
 void MediaSource::sourceBufferActiveTrackFlagChanged(bool activeTrackFlag)
 {
-    if (!m_private)
-        return;
-    if (activeTrackFlag && m_private->mediaPlayerReadyState() > MediaPlayer::ReadyState::HaveCurrentData)
-        setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    if (RefPtr msp = protectedPrivate()) {
+        if (activeTrackFlag && msp->mediaPlayerReadyState() > MediaPlayer::ReadyState::HaveCurrentData)
+            setMediaPlayerReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    }
 }
 
 void MediaSource::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
-    if (!m_private)
-        return;
-    m_private->setMediaPlayerReadyState(readyState);
+    if (RefPtr msp = protectedPrivate())
+        msp->setMediaPlayerReadyState(readyState);
 }
 
 void MediaSource::incrementDroppedFrameCount()
@@ -1671,7 +1699,7 @@ void MediaSource::memoryPressure()
 {
     if (!isManaged())
         return;
-    for (auto& sourceBuffer : m_sourceBuffers.get())
+    for (Ref sourceBuffer : m_sourceBuffers.get())
         sourceBuffer->memoryPressure();
 }
 
@@ -1700,6 +1728,11 @@ Ref<SourceBufferList> MediaSource::sourceBuffers() const
 Ref<SourceBufferList> MediaSource::activeSourceBuffers() const
 {
     return m_activeSourceBuffers;
+}
+
+RefPtr<MediaSourcePrivate> MediaSource::protectedPrivate() const
+{
+    return m_private;
 }
 
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -184,7 +184,8 @@ protected:
 
     virtual void elementDetached() { }
 
-    RefPtr<MediaSourcePrivate> m_private;
+    RefPtr<MediaSourcePrivate> protectedPrivate() const;
+
     WeakPtr<HTMLMediaElement> m_mediaElement;
     bool m_detachable { false };
 
@@ -251,6 +252,7 @@ private:
 #endif
     std::atomic<uint64_t> m_associatedRegistryCount { 0 };
     Ref<MediaSourceClientImpl> m_client;
+    RefPtr<MediaSourcePrivate> m_private;
 };
 
 String convertEnumerationToString(MediaSource::EndOfStreamError);

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -67,9 +67,21 @@ void SourceBufferList::add(Ref<SourceBuffer>&& buffer)
     scheduleEvent(eventNames().addsourcebufferEvent);
 }
 
+bool SourceBufferList::contains(SourceBuffer& buffer) const
+{
+    return m_list.find(Ref { buffer } ) != notFound;
+}
+
+RefPtr<SourceBuffer> SourceBufferList::item(unsigned index) const
+{
+    if (index < m_list.size())
+        return m_list[index].copyRef();
+    return { };
+}
+
 void SourceBufferList::remove(SourceBuffer& buffer)
 {
-    size_t index = m_list.find(&buffer);
+    size_t index = m_list.find(Ref { buffer });
     if (index == notFound)
         return;
     m_list.remove(index);
@@ -82,7 +94,7 @@ void SourceBufferList::clear()
     scheduleEvent(eventNames().removesourcebufferEvent);
 }
 
-void SourceBufferList::replaceWith(Vector<RefPtr<SourceBuffer>>&& other)
+void SourceBufferList::replaceWith(Vector<Ref<SourceBuffer>>&& other)
 {
     int changeInSize = other.size() - m_list.size();
     int addedEntries = 0;

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -54,13 +54,13 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const { return m_list.size(); }
 
-    SourceBuffer* item(unsigned index) const { return (index < m_list.size()) ? m_list[index].get() : nullptr; }
+    RefPtr<SourceBuffer> item(unsigned index) const;
 
     void add(Ref<SourceBuffer>&&);
     void remove(SourceBuffer&);
-    bool contains(SourceBuffer& buffer) { return m_list.find(&buffer) != notFound; }
+    bool contains(SourceBuffer&) const;
     void clear();
-    void replaceWith(Vector<RefPtr<SourceBuffer>>&&);
+    void replaceWith(Vector<Ref<SourceBuffer>>&&);
 
     auto begin() { return m_list.begin(); }
     auto end() { return m_list.end(); }
@@ -80,7 +80,7 @@ private:
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 
-    Vector<RefPtr<SourceBuffer>> m_list;
+    Vector<Ref<SourceBuffer>> m_list;
 };
 
 WebCoreOpaqueRoot root(SourceBufferList*);

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -377,7 +377,6 @@ Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediasession/MediaSession.cpp
-Modules/mediasource/MediaSource.cpp
 Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
 Modules/mediastream/MediaDevices.cpp


### PR DESCRIPTION
#### 02f76ccb0345a51164a5f1e7a57a774cf7e445eb
<pre>
Update MediaSource.cpp to comply with new CPP-safer rules.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282303">https://bugs.webkit.org/show_bug.cgi?id=282303</a>
<a href="https://rdar.apple.com/138878642">rdar://138878642</a>

Reviewed by Youenn Fablet.

Make SourceBufferList use Vector&lt;Ref&lt;SourceBuffer&gt;&gt; as storage.
Adopt more smart pointers to access SourceBuffer and MediaSourcePrivate.

No observable change.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::setStreaming):
(WebCore::ManagedMediaSource::streamingTimerFired):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setPrivateAndOpen):
(WebCore::MediaSource::reOpen):
(WebCore::MediaSource::duration const):
(WebCore::MediaSource::currentTime const):
(WebCore::MediaSource::buffered const):
(WebCore::MediaSource::waitForTarget):
(WebCore::MediaSource::seekToTime):
(WebCore::MediaSource::seekable):
(WebCore::MediaSource::setLiveSeekableRange):
(WebCore::MediaSource::clearLiveSeekableRange):
(WebCore::MediaSource::hasBufferedTime):
(WebCore::MediaSource::hasFutureTime):
(WebCore::MediaSource::isBuffered const):
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::setDuration):
(WebCore::MediaSource::setDurationInternal):
(WebCore::MediaSource::setReadyState):
(WebCore::MediaSource::streamEndedWithError):
(WebCore::MediaSource::detachFromElement):
(WebCore::MediaSource::openIfInEndedState):
(WebCore::MediaSource::readyState const):
(WebCore::MediaSource::createSourceBufferPrivate):
(WebCore::MediaSource::regenerateActiveSourceBuffers):
(WebCore::MediaSource::updateBufferedIfNeeded):
(WebCore::MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged):
(WebCore::MediaSource::sourceBufferActiveTrackFlagChanged):
(WebCore::MediaSource::setMediaPlayerReadyState):
(WebCore::MediaSource::protectedPrivate const):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp:
(WebCore::SourceBufferList::contains const):
(WebCore::SourceBufferList::item const):
(WebCore::SourceBufferList::remove):
(WebCore::SourceBufferList::replaceWith):
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/285899@main">https://commits.webkit.org/285899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d787c97c4d0dfd87d64d7ded8c0d114e43ed2cc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58271 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1564 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9762 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4172 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->