### PR TITLE
ImageDiff/skia/PlatformImageSkia.cpp: error: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned long long')

### DIFF
--- a/Tools/ImageDiff/skia/PlatformImageSkia.cpp
+++ b/Tools/ImageDiff/skia/PlatformImageSkia.cpp
@@ -132,7 +132,7 @@ void PlatformImage::writeAsPNGToStdout()
     if (!data)
         return;
 
-    fprintf(stdout, "Content-Length: %lu\n", data->size());
+    fprintf(stdout, "Content-Length: %zu\n", data->size());
     fwrite(data->data(), 1, data->size(), stdout);
 }
 


### PR DESCRIPTION
#### fdb86ab290e20acec5de779bbf455241404a738a
<pre>
ImageDiff/skia/PlatformImageSkia.cpp: error: format specifies type &apos;unsigned long&apos; but the argument has type &apos;size_t&apos; (aka &apos;unsigned long long&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=282313">https://bugs.webkit.org/show_bug.cgi?id=282313</a>

Reviewed by Carlos Garcia Campos.

Windows port couldn&apos;t compile PlatformImageSkia.cpp. Use %zu for
size_t instead of %lu.

* Tools/ImageDiff/skia/PlatformImageSkia.cpp:
(ImageDiff::PlatformImage::writeAsPNGToStdout):

Canonical link: <a href="https://commits.webkit.org/285893@main">https://commits.webkit.org/285893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d9c52efc7d7c9afc73ff9202f2db8588d77e15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58254 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77172 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48414 "Too many flaky failures: compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html, fast/events/ios/command+shift+v-should-not-insert-v.html, fast/events/ios/contenteditable-autocapitalize.html, fast/events/ios/input-events-insert-replacement-text.html, fast/events/ios/input-value-after-oninput.html, fast/events/ios/key-events-comprehensive/key-events-control-option.html, fast/events/ios/key-events-comprehensive/key-events-meta-control.html, fast/events/ios/key-events-comprehensive/key-events-meta-option.html, fast/events/ios/key-events-comprehensive/key-events-meta-shift.html, fast/events/ios/key-events-comprehensive/key-events-meta.html, fast/events/ios/key-events-comprehensive/key-events-option-shift.html, fast/events/ios/key-events-comprehensive/key-events-option.html, fast/events/ios/key-events-comprehensive/key-events-shift.html, fast/events/ios/keyboard-event-key-attribute.html, fast/events/ios/keypress-grave-accent.html, fast/events/ios/keypress-keys-in-non-editable-element.html, fast/events/ios/keyup.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65839 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7928 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1386 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->