### PR TITLE
Fix errors of platform/graphics/skia/PlatformDisplaySkia.cpp for Windows

### DIFF
--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -47,7 +47,7 @@ IGNORE_CLANG_WARNINGS_END
 #if USE(LIBEPOXY)
 #include <skia/gpu/ganesh/gl/epoxy/GrGLMakeEpoxyEGLInterface.h>
 #else
-#include <skia/gpu/gl/egl/GrGLMakeEGLInterface.h>
+#include <skia/gpu/ganesh/gl/egl/GrGLMakeEGLInterface.h>
 #endif
 
 namespace WebCore {
@@ -70,7 +70,7 @@ static const unsigned s_defaultSampleCount = 0;
 #if !(PLATFORM(PLAYSTATION) && USE(COORDINATED_GRAPHICS))
 static sk_sp<const GrGLInterface> skiaGLInterface()
 {
-    static NeverDestroyed<sk_sp<const GrGLInterface>> interface {
+    static NeverDestroyed<sk_sp<const GrGLInterface>> grGLInterface {
 #if USE(LIBEPOXY)
         GrGLInterfaces::MakeEpoxyEGL()
 #else
@@ -78,7 +78,7 @@ static sk_sp<const GrGLInterface> skiaGLInterface()
 #endif
     };
 
-    return interface.get();
+    return grGLInterface.get();
 }
 
 static thread_local RefPtr<SkiaGLContext> s_skiaGLContext;


### PR DESCRIPTION
#### a7cc63aa47ddcd39ec34f13e0338a14c9622c94d
<pre>
Fix errors of platform/graphics/skia/PlatformDisplaySkia.cpp for Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=282314">https://bugs.webkit.org/show_bug.cgi?id=282314</a>

Reviewed by Carlos Garcia Campos.

Windows has a macro `interface` defined. Renamed a variable name
`interface` to `grGLInterface`.

Fixed a wrong path of GrGLMakeEGLInterface.h.

* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::skiaGLInterface):

Canonical link: <a href="https://commits.webkit.org/285894@main">https://commits.webkit.org/285894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d00877ce0329ce4a0a7d77ff87c392e8ec2b74e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58256 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77173 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48413 "Too many flaky failures: editing/input/ios/typing-with-inline-predictions.html, fast/events/ios/command+shift+v-should-not-insert-v.html, fast/events/ios/contenteditable-autocapitalize.html, fast/events/ios/input-events-insert-replacement-text.html, fast/events/ios/input-value-after-oninput.html, fast/events/ios/keyboard-event-key-attribute.html, fast/events/ios/keypress-grave-accent.html, fast/events/ios/keyup.html, fast/forms/call-text-did-change-in-text-field-when-typing.html, fast/scrolling/ios/key-command-scroll-to-bottom.html, fast/scrolling/ios/key-command-scroll-to-top.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23677 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66788 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66566 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65840 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7927 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11442 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4175 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->