### PR TITLE
[css-values] Fix CSSAttrValue Fallback comparation

### DIFF
--- a/Source/WebCore/css/CSSAttrValue.cpp
+++ b/Source/WebCore/css/CSSAttrValue.cpp
@@ -44,6 +44,8 @@ bool CSSAttrValue::equals(const CSSAttrValue& other) const
 
     if (fallback && otherFallback)
         return m_attributeName == other.m_attributeName && fallback->stringValue() == otherFallback->stringValue();
+    if (fallback || otherFallback)
+        return false;
     return m_attributeName == other.m_attributeName;
 }
 


### PR DESCRIPTION
#### ffa340ae3dee5148462db2ec0e2b8fc00a981bb0
<pre>
[css-values] Fix CSSAttrValue Fallback comparation
<a href="https://bugs.webkit.org/show_bug.cgi?id=282316">https://bugs.webkit.org/show_bug.cgi?id=282316</a>

Reviewed by NOBODY (OOPS!).

When comparing two CSSAttrValue instances in the equals function for example, attr(foo) and attr(foo, &quot;fallback&quot;), the result incorrectly returns true.
This happens because the check was only validating cases where both instances have fallback values
but missed handling the scenario where only one instance has a fallback value.

* Source/WebCore/css/CSSAttrValue.cpp:
(WebCore::CSSAttrValue::equals const):
</pre>