### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from RemoteLegacyCDMSession

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
@@ -135,9 +135,9 @@ RefPtr<CDMPrivateInterface> LegacyCDM::protectedCDMPrivate() const
     return cdmPrivate();
 }
 
-std::unique_ptr<LegacyCDMSession> LegacyCDM::createSession(LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> LegacyCDM::createSession(LegacyCDMSessionClient& client)
 {
-    auto session = protectedCDMPrivate()->createSession(client);
+    RefPtr session = protectedCDMPrivate()->createSession(client);
     if (mediaPlayer())
         mediaPlayer()->setCDMSession(session.get());
     return session;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
@@ -68,7 +68,7 @@ public:
     static void clearFactories();
 
     bool supportsMIMEType(const String&) const;
-    std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&);
+    RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&);
 
     const String& keySystem() const { return m_keySystem; }
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h
@@ -44,7 +44,7 @@ public:
 
     virtual bool supportsMIMEType(const String&) const = 0;
 
-    virtual std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) = 0;
+    virtual RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp
@@ -62,9 +62,9 @@ bool LegacyCDMPrivateClearKey::supportsMIMEType(const String& mimeType) const
     return MediaPlayer::supportsKeySystem(m_cdm->keySystem(), mimeType);
 }
 
-std::unique_ptr<LegacyCDMSession> LegacyCDMPrivateClearKey::createSession(LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> LegacyCDMPrivateClearKey::createSession(LegacyCDMSessionClient& client)
 {
-    return makeUnique<CDMSessionClearKey>(client);
+    return CDMSessionClearKey::create(client);
 }
 
 void LegacyCDMPrivateClearKey::ref() const

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h
@@ -48,7 +48,7 @@ public:
     static bool supportsKeySystemAndMimeType(const String& keySystem, const String& mimeType);
 
     bool supportsMIMEType(const String& mimeType) const override;
-    std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
+    RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
     void ref() const final;
     void deref() const final;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp
@@ -57,7 +57,7 @@ bool CDMPrivateMediaPlayer::supportsMIMEType(const String& mimeType) const
     return MediaPlayer::supportsKeySystem(m_cdm->keySystem(), mimeType);
 }
 
-std::unique_ptr<LegacyCDMSession> CDMPrivateMediaPlayer::createSession(LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> CDMPrivateMediaPlayer::createSession(LegacyCDMSessionClient& client)
 {
     Ref cdm = m_cdm.get();
     auto mediaPlayer = cdm->mediaPlayer();

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h
@@ -49,7 +49,7 @@ public:
     virtual ~CDMPrivateMediaPlayer() = default;
 
     bool supportsMIMEType(const String& mimeType) const override;
-    std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
+    RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
     LegacyCDM& cdm() const { return m_cdm; }
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LegacyCDMSession.h"
+#include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
@@ -34,11 +35,18 @@
 
 namespace WebCore {
 
-class CDMSessionClearKey final : public LegacyCDMSession {
+class CDMSessionClearKey final : public LegacyCDMSession, public RefCounted<CDMSessionClearKey> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionClearKey);
 public:
-    CDMSessionClearKey(LegacyCDMSessionClient&);
+    static Ref<CDMSessionClearKey> create(LegacyCDMSessionClient& client)
+    {
+        return adoptRef(*new CDMSessionClearKey(client));
+    }
+
     virtual ~CDMSessionClearKey();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     // CDMSessionPrivate
     LegacyCDMSessionType type() override { return CDMSessionTypeClearKey; }
@@ -49,6 +57,8 @@ public:
     RefPtr<ArrayBuffer> cachedKeyForKeyID(const String&) const override;
 
 private:
+    CDMSessionClearKey(LegacyCDMSessionClient&);
+
     WeakPtr<LegacyCDMSessionClient> m_client;
     RefPtr<Uint8Array> m_initData;
     MemoryCompactRobinHoodHashMap<String, Vector<uint8_t>> m_cachedKeys;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -96,7 +96,7 @@ private:
     String m_keySystem;
     String m_sessionId;
     RefPtr<WebKitMediaKeyError> m_error;
-    std::unique_ptr<LegacyCDMSession> m_session;
+    RefPtr<LegacyCDMSession> m_session;
 
     struct PendingKeyRequest {
         String mimeType;

--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -28,6 +28,7 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include <JavaScriptCore/Forward.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
@@ -76,7 +77,7 @@ enum LegacyCDMSessionType {
     CDMSessionTypeRemote,
 };
 
-class WEBCORE_EXPORT LegacyCDMSession {
+class WEBCORE_EXPORT LegacyCDMSession : public AbstractRefCounted {
 public:
     virtual ~LegacyCDMSession() = default;
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -735,7 +735,7 @@ void MediaPlayer::setBufferingPolicy(BufferingPolicy policy)
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
-std::unique_ptr<LegacyCDMSession> MediaPlayer::createSession(const String& keySystem, LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> MediaPlayer::createSession(const String& keySystem, LegacyCDMSessionClient& client)
 {
     return m_private->createSession(keySystem, client);
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -443,7 +443,7 @@ public:
     // This is different from the asynchronous MediaKeyError.
     enum MediaKeyException { NoError, InvalidPlayerState, KeySystemNotSupported };
 
-    std::unique_ptr<LegacyCDMSession> createSession(const String& keySystem, LegacyCDMSessionClient&);
+    RefPtr<LegacyCDMSession> createSession(const String& keySystem, LegacyCDMSessionClient&);
     void setCDM(LegacyCDM*);
     void setCDMSession(LegacyCDMSession*);
     void keyAdded();

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -262,7 +262,7 @@ public:
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    virtual std::unique_ptr<LegacyCDMSession> createSession(const String&, LegacyCDMSessionClient&) { return nullptr; }
+    virtual RefPtr<LegacyCDMSession> createSession(const String&, LegacyCDMSessionClient&) { return nullptr; }
     virtual void setCDM(LegacyCDM*) { }
     virtual void setCDMSession(LegacyCDMSession*) { }
     virtual void keyAdded() { }

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
@@ -50,7 +50,7 @@ public:
     static bool supportsKeySystemAndMimeType(const String& keySystem, const String& mimeType);
 
     bool supportsMIMEType(const String& mimeType) const override;
-    std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
+    RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
     LegacyCDM& cdm() const { return m_cdm.get(); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
@@ -125,7 +125,7 @@ bool CDMPrivateMediaSourceAVFObjC::supportsMIMEType(const String& mimeType) cons
     return MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs(parameters) != MediaPlayer::SupportsType::IsNotSupported;
 }
 
-std::unique_ptr<LegacyCDMSession> CDMPrivateMediaSourceAVFObjC::createSession(LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> CDMPrivateMediaSourceAVFObjC::createSession(LegacyCDMSessionClient& client)
 {
     String keySystem = m_cdm->keySystem(); // Local copy for StringView usage
     auto parameters = parseKeySystem(m_cdm->keySystem());
@@ -133,7 +133,7 @@ std::unique_ptr<LegacyCDMSession> CDMPrivateMediaSourceAVFObjC::createSession(Le
     if (!parameters)
         return nullptr;
 
-    auto session = makeUnique<CDMSessionAVContentKeySession>(WTFMove(parameters.value().protocols), parameters.value().version, *this, client);
+    RefPtr session = CDMSessionAVContentKeySession::create(WTFMove(parameters.value().protocols), parameters.value().version, *this, client);
 
     m_sessions.append(session.get());
     return WTFMove(session);

--- a/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LegacyCDMSession.h"
+#include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
@@ -38,12 +39,20 @@ namespace WebCore {
 
 class MediaPlayerPrivateAVFoundationCF;
 
-class CDMSessionAVFoundationCF final : public LegacyCDMSession {
+class CDMSessionAVFoundationCF final : public LegacyCDMSession, public RefCounted<CDMSessionAVFoundationCF> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionAVFoundationCF);
 public:
-    CDMSessionAVFoundationCF(MediaPlayerPrivateAVFoundationCF& parent, LegacyCDMSessionClient&);
+    static Ref<CDMSessionAVFoundationCF> create(MediaPlayerPrivateAVFoundationCF& parent, LegacyCDMSessionClient&)
+    {
+        return adoptRef(*new CDMSessionAVFoundationCF(parent, client));
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
+    CDMSessionAVFoundationCF(MediaPlayerPrivateAVFoundationCF& parent, LegacyCDMSessionClient&);
+
     const String& sessionId() const final { return m_sessionId; }
     RefPtr<Uint8Array> generateKeyRequest(const String& mimeType, Uint8Array* initData, String& destinationURL, unsigned short& errorCode, uint32_t& systemCode) final;
     void releaseKeys() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LegacyCDMSession.h"
+#include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -37,23 +38,20 @@ OBJC_CLASS AVAssetResourceLoadingRequest;
 OBJC_CLASS WebCDMSessionAVFoundationObjCListener;
 
 namespace WebCore {
-class CDMSessionAVFoundationObjC;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMSessionAVFoundationObjC> : std::true_type { };
-}
-
-namespace WebCore {
 
 class MediaPlayerPrivateAVFoundationObjC;
 
-class CDMSessionAVFoundationObjC final : public LegacyCDMSession, public CanMakeWeakPtr<CDMSessionAVFoundationObjC> {
+class CDMSessionAVFoundationObjC final : public LegacyCDMSession, public CanMakeWeakPtr<CDMSessionAVFoundationObjC>, public RefCounted<CDMSessionAVFoundationObjC> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionAVFoundationObjC);
 public:
-    CDMSessionAVFoundationObjC(MediaPlayerPrivateAVFoundationObjC* parent, LegacyCDMSessionClient&);
+    static Ref<CDMSessionAVFoundationObjC> create(MediaPlayerPrivateAVFoundationObjC* parent, LegacyCDMSessionClient& client)
+    {
+        return adoptRef(*new CDMSessionAVFoundationObjC(parent, client));
+    }
     virtual ~CDMSessionAVFoundationObjC();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     LegacyCDMSessionType type() override { return CDMSessionTypeAVFoundationObjC; }
     const String& sessionId() const override { return m_sessionId; }
@@ -65,6 +63,8 @@ public:
     void playerDidReceiveError(NSError *);
 
 private:
+    CDMSessionAVFoundationObjC(MediaPlayerPrivateAVFoundationObjC* parent, LegacyCDMSessionClient&);
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
@@ -27,7 +27,7 @@
 
 #include "LegacyCDMSession.h"
 #include "SourceBufferPrivateAVFObjC.h"
-#include <wtf/RefCounted.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -36,15 +36,6 @@
 
 OBJC_CLASS AVStreamDataParser;
 OBJC_CLASS NSError;
-
-namespace WebCore {
-class CDMSessionMediaSourceAVFObjC;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMSessionMediaSourceAVFObjC> : std::true_type { };
-}
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -278,7 +278,7 @@ private:
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void keyAdded() final;
-    std::unique_ptr<LegacyCDMSession> createSession(const String& keySystem, LegacyCDMSessionClient&) final;
+    RefPtr<LegacyCDMSession> createSession(const String& keySystem, LegacyCDMSessionClient&) final;
 #endif
 
     String languageOfPrimaryAudioTrack() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2930,11 +2930,11 @@ void MediaPlayerPrivateAVFoundationObjC::keyAdded()
         m_keyURIToRequestMap.remove(keyId);
 }
 
-std::unique_ptr<LegacyCDMSession> MediaPlayerPrivateAVFoundationObjC::createSession(const String& keySystem, LegacyCDMSessionClient& client)
+RefPtr<LegacyCDMSession> MediaPlayerPrivateAVFoundationObjC::createSession(const String& keySystem, LegacyCDMSessionClient& client)
 {
     if (!keySystemIsSupported(keySystem))
         return nullptr;
-    auto session = makeUnique<CDMSessionAVFoundationObjC>(this, client);
+    RefPtr session = CDMSessionAVFoundationObjC::create(this, client);
     m_session = *session;
     return WTFMove(session);
 }

--- a/Source/WebCore/testing/LegacyMockCDM.h
+++ b/Source/WebCore/testing/LegacyMockCDM.h
@@ -49,7 +49,7 @@ public:
     virtual ~LegacyMockCDM() = default;
 
     bool supportsMIMEType(const String& mimeType) const override;
-    std::unique_ptr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
+    RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
     void ref() const final;
     void deref() const final;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -54,6 +54,7 @@ public:
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
     WebCore::LegacyCDMSession* session() const { return m_session.get(); }
+    RefPtr<WebCore::LegacyCDMSession> protectedSession() const;
 
     void setPlayer(WeakPtr<RemoteMediaPlayerProxy>);
 
@@ -98,7 +99,7 @@ private:
 #endif
 
     RemoteLegacyCDMSessionIdentifier m_identifier;
-    std::unique_ptr<WebCore::LegacyCDMSession> m_session;
+    RefPtr<WebCore::LegacyCDMSession> m_session;
     WeakPtr<RemoteMediaPlayerProxy> m_player;
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1048,7 +1048,7 @@ void RemoteMediaPlayerProxy::setLegacyCDMSession(std::optional<RemoteLegacyCDMSe
 
     if (m_legacySession) {
         if (auto cdmSession = manager->gpuConnectionToWebProcess()->protectedLegacyCdmFactoryProxy()->getSession(*m_legacySession)) {
-            player->setCDMSession(cdmSession->session());
+            player->setCDMSession(cdmSession->protectedSession().get());
             cdmSession->setPlayer(*this);
         }
     }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1409,7 +1409,7 @@ AudioSourceProvider* MediaPlayerPrivateRemote::audioSourceProvider()
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-std::unique_ptr<LegacyCDMSession> MediaPlayerPrivateRemote::createSession(const String&, LegacyCDMSessionClient&)
+RefPtr<LegacyCDMSession> MediaPlayerPrivateRemote::createSession(const String&, LegacyCDMSessionClient&)
 {
     notImplemented();
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -399,7 +399,7 @@ private:
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    std::unique_ptr<WebCore::LegacyCDMSession> createSession(const String&, WebCore::LegacyCDMSessionClient&) final;
+    RefPtr<WebCore::LegacyCDMSession> createSession(const String&, WebCore::LegacyCDMSessionClient&) final;
     void setCDM(WebCore::LegacyCDM*) final;
     void setCDMSession(WebCore::LegacyCDMSession*) final;
     void keyAdded() final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -60,7 +60,7 @@ bool RemoteLegacyCDM::supportsMIMEType(const String& mimeType) const
     return supported;
 }
 
-std::unique_ptr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::LegacyCDMSessionClient& client)
+RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::LegacyCDMSessionClient& client)
 {
     String storageDirectory = client.mediaKeysStorageDirectory();
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
@@ -51,7 +51,7 @@ public:
     virtual ~RemoteLegacyCDM();
 
     bool supportsMIMEType(const String&) const final;
-    std::unique_ptr<WebCore::LegacyCDMSession> createSession(WebCore::LegacyCDMSessionClient&) final;
+    RefPtr<WebCore::LegacyCDMSession> createSession(WebCore::LegacyCDMSessionClient&) final;
     void setPlayerId(std::optional<WebCore::MediaPlayerIdentifier>);
 
     void ref() const final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -65,9 +65,9 @@ static RefPtr<SharedBuffer> convertToSharedBuffer(T array)
     return SharedBuffer::create(array->span());
 }
 
-std::unique_ptr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(RemoteLegacyCDMFactory& factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
+RefPtr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(RemoteLegacyCDMFactory& factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
 {
-    auto session = std::unique_ptr<RemoteLegacyCDMSession>(new RemoteLegacyCDMSession(factory, WTFMove(identifier), client));
+    RefPtr session = adoptRef(new RemoteLegacyCDMSession(factory, WTFMove(identifier), client));
     if (session->m_factory)
         session->m_factory->addSession(identifier, *session);
     return session;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
@@ -30,16 +30,8 @@
 #include "MessageReceiver.h"
 #include "RemoteLegacyCDMSessionIdentifier.h"
 #include <WebCore/LegacyCDMSession.h>
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class RemoteLegacyCDMSession;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLegacyCDMSession> : std::true_type { };
-}
 
 namespace WebCore {
 class SharedBuffer;
@@ -51,10 +43,14 @@ class RemoteLegacyCDMFactory;
 
 class RemoteLegacyCDMSession final
     : public WebCore::LegacyCDMSession
-    , public IPC::MessageReceiver {
+    , public IPC::MessageReceiver
+    , public RefCounted<RemoteLegacyCDMSession> {
 public:
-    static std::unique_ptr<RemoteLegacyCDMSession> create(RemoteLegacyCDMFactory&, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
+    static RefPtr<RemoteLegacyCDMSession> create(RemoteLegacyCDMFactory&, RemoteLegacyCDMSessionIdentifier&&, WebCore::LegacyCDMSessionClient&);
     ~RemoteLegacyCDMSession();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     // MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;


### PR DESCRIPTION
#### 076349f5d081726a70e001209bb231dd767051ae
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from RemoteLegacyCDMSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=282317">https://bugs.webkit.org/show_bug.cgi?id=282317</a>
<a href="https://rdar.apple.com/138894092">rdar://138894092</a>

Reviewed by Geoffrey Garen.

Drop IsDeprecatedWeakRefSmartPointerException from RemoteLegacyCDMSession by
making it ref-counted.

* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp:
(WebCore::LegacyCDM::createSession):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivate.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp:
(WebCore::LegacyCDMPrivateClearKey::createSession):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp:
(WebCore::CDMPrivateMediaPlayer::createSession):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/platform/graphics/LegacyCDMSession.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::createSession):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::createSession):
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm:
(WebCore::CDMPrivateMediaSourceAVFObjC::createSession):
* Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
(WebCore::CDMSessionAVContentKeySession::create):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createSession):
* Source/WebCore/testing/LegacyMockCDM.cpp:
(WebCore::MockCDMSession::create):
(WebCore::LegacyMockCDM::createSession):
* Source/WebCore/testing/LegacyMockCDM.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::generateKeyRequest):
(WebKit::RemoteLegacyCDMSessionProxy::releaseKeys):
(WebKit::RemoteLegacyCDMSessionProxy::update):
(WebKit::RemoteLegacyCDMSessionProxy::getCachedKeyForKeyId):
(WebKit::RemoteLegacyCDMSessionProxy::protectedSession const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setLegacyCDMSession):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::createSession):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::create):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h:

Canonical link: <a href="https://commits.webkit.org/285921@main">https://commits.webkit.org/285921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/599b21861bc3bc2cd640047855ab1ee6317229ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66594 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65867 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7959 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11455 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4211 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->