### PR TITLE
[WebXR] Use minimum near clip plane distance from the system for clamping

### DIFF
--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -378,6 +378,7 @@ public:
     FeatureList enabledFeatures(SessionMode mode) const { return m_enabledFeaturesMap.get(mode); }
 
     virtual WebCore::IntSize recommendedResolution(SessionMode) { return { 1, 1 }; }
+    virtual double minimumNearClipPlane() const { return 0.1; }
 
     bool supportsOrientationTracking() const { return m_supportsOrientationTracking; }
     bool supportsViewportScaling() const { return m_supportsViewportScaling; }

--- a/Source/WebKit/Shared/XR/XRDeviceInfo.h
+++ b/Source/WebKit/Shared/XR/XRDeviceInfo.h
@@ -39,6 +39,7 @@ struct XRDeviceInfo {
     PlatformXR::Device::FeatureList vrFeatures;
     PlatformXR::Device::FeatureList arFeatures;
     WebCore::IntSize recommendedResolution { 0, 0 };
+    double minimumNearClipPlane { 0.1 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -48,6 +48,8 @@ XRDeviceProxy::XRDeviceProxy(XRDeviceInfo&& deviceInfo, PlatformXRSystemProxy& x
     m_supportsStereoRendering = deviceInfo.supportsStereoRendering;
     m_supportsOrientationTracking = deviceInfo.supportsOrientationTracking;
     m_recommendedResolution = deviceInfo.recommendedResolution;
+    m_minimumNearClipPlane = deviceInfo.minimumNearClipPlane;
+
     if (!deviceInfo.vrFeatures.isEmpty())
         setSupportedFeatures(SessionMode::ImmersiveVr, deviceInfo.vrFeatures);
     if (!deviceInfo.arFeatures.isEmpty())

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -55,6 +55,7 @@ private:
     XRDeviceProxy(XRDeviceInfo&&, PlatformXRSystemProxy&);
 
     WebCore::IntSize recommendedResolution(PlatformXR::SessionMode) final { return m_recommendedResolution; }
+    double minimumNearClipPlane() const final { return m_minimumNearClipPlane; }
     void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) final;
     void shutDownTrackingAndRendering() final;
     void didCompleteShutdownTriggeredBySystem() final;
@@ -70,6 +71,7 @@ private:
     WeakPtr<PlatformXRSystemProxy> m_xrSystem;
     bool m_supportsStereoRendering { false };
     WebCore::IntSize m_recommendedResolution { 0, 0 };
+    double m_minimumNearClipPlane { 0.1 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::XRDeviceInfo {
     PlatformXR::Device::FeatureList vrFeatures;
     PlatformXR::Device::FeatureList arFeatures;
     WebCore::IntSize recommendedResolution;
+    double minimumNearClipPlane;
 };
 
 #endif


### PR DESCRIPTION
#### d0b1b549a5d4c98dacf06d52b880e63740d870c7
<pre>
[WebXR] Use minimum near clip plane distance from the system for clamping
<a href="https://bugs.webkit.org/show_bug.cgi?id=282321">https://bugs.webkit.org/show_bug.cgi?id=282321</a>
<a href="https://rdar.apple.com/138811538">rdar://138811538</a>

Reviewed by Mike Wyrzykowski.

Instead of hardcoding the minimum near clip plane distance, allow the system
to pass that value via XRDeviceInfo. WebXRSession will get that value
from PlatformXR::Device::minimumNearClipPlane().

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
(WebCore::WebXRSession::applyPendingRenderState):
Set the PlatformXR::RequestData based on the depth range from m_activeRenderState
after the values are clamped.
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::minimumNearClipPlane const):
* Source/WebKit/Shared/XR/XRDeviceInfo.h:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::XRDeviceProxy):
* Source/WebKit/Shared/XR/XRDeviceProxy.h:
* Source/WebKit/Shared/XR/XRSystem.serialization.in:

Canonical link: <a href="https://commits.webkit.org/285955@main">https://commits.webkit.org/285955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e5de05329463c75463670ab4e5428964577ecf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48532 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38789 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45474 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66923 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80141 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66658 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65934 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9876 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->