### PR TITLE
REGRESSION (Safari 18): Audio from disabled MediaStreamTrack is published

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-clone-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-clone-expected.txt
@@ -8,6 +8,8 @@ PASS Setup for width+height test
 PASS Stopping a track should not stop its clone
 PASS Stopping a cloned track should not stop the original track
 PASS Collecting a cloned track should not stop the original track
+PASS Transferring a track should preserve enabled and readyState
+PASS Cloning a track should preserve enabled and readyState
 PASS Check cloned track settings after applying width constraints
 PASS Check cloned track settings after applying width constraint to original track
 PASS Check cloned track settings after applying height constraints

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html
@@ -143,6 +143,44 @@
         await video1.play();
         assert_equals(video1.videoWidth, 100);
     }, "Collecting a cloned track should not stop the original track");
+
+    promise_test(async (t) => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        stream.getTracks().forEach(t => t.enabled = false);
+
+        const channel = new MessageChannel();
+        const transferringTracks = { audio:stream.getAudioTracks()[0].clone() , video:stream.getVideoTracks()[0].clone() };
+
+        channel.port1.postMessage(transferringTracks, [transferringTracks.audio, transferringTracks.video]);
+        let transferredTracks = await new Promise(resolve => channel.port2.onmessage = e => resolve(e.data));
+
+        assert_false(transferredTracks.audio.enabled, "transferredTracks.audio.enabled");
+        assert_false(transferredTracks.video.enabled, "transferredTracks.video.enabled");
+
+        transferredTracks.audio.stop();
+        transferredTracks.video.stop();
+
+        channel.port1.postMessage(transferredTracks, [transferredTracks.audio, transferredTracks.video]);
+        transferredTracks = await new Promise(resolve => channel.port2.onmessage = e => resolve(e.data));
+
+        assert_equals(transferredTracks.audio.readyState, "ended", "transferredTracks.audio.enabled");
+        assert_equals(transferredTracks.video.readyState, "ended", "transferredTracks.video.enabled");
+    }, "Transferring a track should preserve enabled and readyState");
+
+    promise_test(async (t) => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        stream.getTracks().forEach(t => t.enabled = false);
+        const clone1 = stream.clone();
+
+        clone1.getTracks().forEach(t => assert_false(t.enabled));
+
+        stream.getTracks().forEach(t => t.stop());
+        const clone2 = stream.clone();
+
+        clone1.getTracks().forEach(t => assert_equals(t.readyState, "live"));
+        clone2.getTracks().forEach(t => assert_equals(t.readyState, "ended"));
+
+    }, "Cloning a track should preserve enabled and readyState");
     </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -635,7 +635,14 @@ Ref<MediaStreamTrack> MediaStreamTrack::create(ScriptExecutionContext& context, 
         });
     });
 
-    return MediaStreamTrack::create(context, WTFMove(privateTrack), RegisterCaptureTrackToOwner::No);
+    bool isEnded = privateTrack->ended();
+    Ref track = MediaStreamTrack::create(context, WTFMove(privateTrack), RegisterCaptureTrackToOwner::No);
+    if (isEnded) {
+        track->m_ended = true;
+        track->m_readyState = State::Ended;
+    }
+
+    return track;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -347,6 +347,8 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& logger, Uni
     , m_type(dataHolder->type)
     , m_deviceType(dataHolder->deviceType)
     , m_isCaptureTrack(false)
+    , m_isEnabled(dataHolder->isEnabled)
+    , m_isEnded(dataHolder->isEnded)
     , m_captureDidFail(false)
     , m_contentHint(dataHolder->contentHint)
     , m_logger(WTFMove(logger))


### PR DESCRIPTION
#### c29f5f0e0f7e949d33dd3457e4e44609a7a7219b
<pre>
REGRESSION (Safari 18): Audio from disabled MediaStreamTrack is published
<a href="https://rdar.apple.com/138321310">rdar://138321310</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281758">https://bugs.webkit.org/show_bug.cgi?id=281758</a>

Reviewed by Eric Carlson.

When cloning or transferring a track, we need to preserve track.enabled.
We make sure to copy this value in MediaStreamTrackPrivate constructor.

When transferring an ended track or a track that is getting ended, the transferring track should be in ended state.
We copy ended in MediaStreamTrackPrivate constructor and we make sure to set the track ready state to ended in MediaStreamTrack::create.

We do not do this in MediaStreamTrack constructor as this path is used for cloning a track.
When cloning a being ended track, we might also want to fire an ended event.
Setting ready state in MediaStreamTrack constructor would prevent this.

* LayoutTests/fast/mediastream/mediastreamtrack-video-clone-expected.txt:
* LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::create):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::MediaStreamTrackPrivate):

Canonical link: <a href="https://commits.webkit.org/285916@main">https://commits.webkit.org/285916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/061cc867a4af82831cf4b3ab82f64f508f92ec17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58280 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80020 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63780 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65855 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7943 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4197 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->