### PR TITLE
Update fast/mediastream/microphone-interruption-and-audio-session.html to get more meaningful error messages

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -8,6 +8,22 @@
  </head>
 <body>
     <script>
+    function wait1sForMute(track, testName)
+    {
+        return new Promise((resolve, reject) => {
+            track.onmute = resolve;
+            setTimeout(() => reject("rejected mute for " + testName), 1000);
+        });
+    }
+
+    function wait1sForUnmute(track, testName)
+    {
+        return new Promise((resolve, reject) => {
+            track.onunmute = resolve;
+            setTimeout(() => reject("rejected unmute for " + testName), 1000);
+        });
+    }
+
     var context = new AudioContext();
     promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({audio: true});
@@ -16,7 +32,7 @@
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test1");
 
         // Muting capture should trigger change of category.
-        const onMutePromise1 = new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve);
+        const onMutePromise1 = wait1sForMute(stream.getAudioTracks()[0], "onMutePromise1");
         if (window.internals)
             internals.setPageMuted("capturedevices");
         await onMutePromise1;
@@ -24,7 +40,7 @@
         let clone = stream.clone();
         assert_equals(internals.audioSessionCategory(), "AmbientSound", "test2");
 
-        const onUnmutePromise1 = new Promise(resolve => stream.getAudioTracks()[0].onunmute = resolve);
+        const onUnmutePromise1 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise1");
         if (window.internals)
             internals.setPageMuted("");
         await onUnmutePromise1;
@@ -32,14 +48,14 @@
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test3");
 
         // PlayAndRecord should stick even with capture interruption.
-        const onMutePromise2 = new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve);
+        const onMutePromise2 = wait1sForMute(stream.getAudioTracks()[0], "onMutePromise2");
         if (window.internals)
             internals.beginAudioSessionInterruption();
         await onMutePromise2;
         clone = stream.clone();
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test4");
 
-        const onUnmutePromise2 = new Promise(resolve => stream.getAudioTracks()[0].onunmute = resolve);
+        const onUnmutePromise2 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise2");
         if (window.internals)
             internals.endAudioSessionInterruption();
         await onUnmutePromise2;


### PR DESCRIPTION
#### c1aeb1763d76f2f2dc6ea4211c5ad75e6c25bd63
<pre>
Update fast/mediastream/microphone-interruption-and-audio-session.html to get more meaningful error messages
<a href="https://rdar.apple.com/138912337">rdar://138912337</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282328">https://bugs.webkit.org/show_bug.cgi?id=282328</a>

Reviewed by Jean-Yves Avenard.

Listen to mute/unmute events and reject the promise after a timeout of 1 second to have the test fail early with an error message.

* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html:

Canonical link: <a href="https://commits.webkit.org/285948@main">https://commits.webkit.org/285948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c3e30e4756c5233258c3baba0b8b32a93bdcfbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58294 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/818 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66595 "Found 12 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-positioned-spans.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-clip-path.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-overflow.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7961 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1426 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->