### PR TITLE
[Ruby][Continuation] InsertionPosition's parent and nextSibling (beforeChild) are in different subtrees

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7939,7 +7939,6 @@ imported/w3c/web-platform-tests/css/css-ruby/ruby-base-different-size.html [ Ima
 imported/blink/fast/ruby/ruby-first-letter.html [ ImageOnlyFailure ]
 # <rb> <rbc> inline boxes are not recognized as ruby base boxes.
 imported/w3c/web-platform-tests/css/css-ruby/ruby-line-breaking-003.html [ ImageOnlyFailure ]
-webkit.org/b/276007 [ Debug ] fast/ruby/ruby-with-continuation-crash.html [ Skip ]
 
 imported/w3c/web-platform-tests/css/css-ruby/break-within-bases/basic.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/break-within-bases/no-break-opportunity-at-end.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/ruby/ruby-text-before-child-split-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-text-before-child-split-expected.txt
@@ -9,12 +9,13 @@ layer at (0,0) size 800x36
             RenderText {#text} at (0,0) size 10x10
               text run at (0,0) width 10: "A"
             RenderInline {I} at (10,0) size 0x10
-          RenderBlock {RT} at (0,0) size 10x0
       RenderBlock (anonymous) at (0,10) size 784x0
         RenderBlock {DIV} at (0,0) size 784x0
       RenderBlock (anonymous) at (0,10) size 784x10
         RenderInline {RUBY} at (0,0) size 10x10
           RenderInline {I} at (0,0) size 0x10
+          RenderInline (generated) at (0,0) size 0x10
+          RenderBlock {RT} at (0,0) size 0x0
           RenderInline (generated) at (0,0) size 10x10
             RenderText {#text} at (0,0) size 10x10
               text run at (0,0) width 10: "B"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -72,7 +72,7 @@ static bool canMergeContiguousAnonymousBlocks(const RenderObject& rendererToBeRe
     return previous && next && previous != anonymousDestroyRoot && next != anonymousDestroyRoot;
 }
 
-static RenderBlock* continuationBefore(RenderBlock& parent, RenderObject* beforeChild)
+RenderBlock* RenderTreeBuilder::Block::continuationBefore(RenderBlock& parent, RenderObject* beforeChild)
 {
     if (beforeChild && beforeChild->parent() == &parent)
         return &parent;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
@@ -35,6 +35,8 @@ class RenderBlockFlow;
 class RenderTreeBuilder::Block {
     WTF_MAKE_TZONE_ALLOCATED(Block);
 public:
+    static RenderBlock* continuationBefore(RenderBlock& parent, RenderObject* beforeChild);
+
     Block(RenderTreeBuilder&);
 
     void attach(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -57,7 +57,7 @@ static RenderBoxModelObject* nextContinuation(RenderObject* renderer)
     return downcast<RenderBlock>(*renderer).inlineContinuation();
 }
 
-static RenderBoxModelObject* continuationBefore(RenderInline& parent, RenderObject* beforeChild)
+RenderBoxModelObject* RenderTreeBuilder::Inline::continuationBefore(RenderInline& parent, RenderObject* beforeChild)
 {
     if (beforeChild && beforeChild->parent() == &parent)
         return &parent;
@@ -84,9 +84,9 @@ static RenderBoxModelObject* continuationBefore(RenderInline& parent, RenderObje
 
 static RenderPtr<RenderInline> cloneAsContinuation(RenderInline& renderer)
 {
-    auto continuationStyle = RenderStyle::clone(renderer.style());
-    continuationStyle.setDisplay(DisplayType::Inline);
-    RenderPtr<RenderInline> cloneInline = createRenderer<RenderInline>(RenderObject::Type::Inline, *renderer.element(), WTFMove(continuationStyle));
+    RenderPtr<RenderInline> cloneInline = renderer.isAnonymous() ?
+    createRenderer<RenderInline>(RenderObject::Type::Inline, renderer.document(), RenderStyle::clone(renderer.style()))
+    : createRenderer<RenderInline>(RenderObject::Type::Inline, *renderer.element(), RenderStyle::clone(renderer.style()));
     cloneInline->initializeStyle();
     cloneInline->setFragmentedFlowState(renderer.fragmentedFlowState());
     cloneInline->setHasOutlineAutoAncestor(renderer.hasOutlineAutoAncestor());

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -33,6 +33,8 @@ namespace WebCore {
 class RenderTreeBuilder::Inline {
     WTF_MAKE_TZONE_ALLOCATED(Inline);
 public:
+    static RenderBoxModelObject* continuationBefore(RenderInline& parent, RenderObject* beforeChild);
+
     Inline(RenderTreeBuilder&);
 
     void attach(RenderInline& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);


### PR DESCRIPTION
#### 7197bea01b904080885ed9c6dfe92b2511f61ac1
<pre>
[Ruby][Continuation] InsertionPosition&apos;s parent and nextSibling (beforeChild) are in different subtrees
<a href="https://bugs.webkit.org/show_bug.cgi?id=276007">https://bugs.webkit.org/show_bug.cgi?id=276007</a>

Reviewed by Antti Koivisto.

When looking for the parent of a &lt;ruby&gt; child renderer
we should check continuation chain to make sure that it belongs
to the same render subtree as `beforeChild`.

The algorithms are already implemented as static `continuationBefore()` functions
in `RenderTreeBuilder:Block` and `RenderTreeBuilder::Inline` classes.

This patch makes them public static class methods and then uses them to
find the right parent.

* LayoutTests/TestExpectations:
* LayoutTests/fast/ruby/ruby-text-before-child-split-expected.txt:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::continuationBefore):
(WebCore::continuationBefore): Deleted.
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::continuationBefore):
(WebCore::cloneAsContinuation):
(WebCore::continuationBefore): Deleted.
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Canonical link: <a href="https://commits.webkit.org/286902@main">https://commits.webkit.org/286902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458a83dd4ba287643b58341cd4ae9646be32da4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23280 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26219 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68346 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67594 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9651 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6751 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->