### PR TITLE
[Navigation] NavigationResult.finished resolves earlier than expected

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7519,11 +7519,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/r
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload.html [ Skip ]
 
-# These are likely fixed with https://bugs.webkit.org/show_bug.cgi?id=282137
-imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept.html [ Pass Failure ]
-# Single flakey test case ("Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)")
-imported/w3c/web-platform-tests/navigation-api/focus-reset/basic.html [ Pass Failure ]
-
 # -- View Transitions -- #
 # Reftest failures:
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
@@ -1,6 +1,7 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: UnknownError: Uncaught Error:
 
-Harness Error (FAIL), message = Unhandled rejection: Uncaught Error:
+Harness Error (FAIL), message = Unhandled rejection
 
 PASS NavigationTransition finished promise is fulfilled on success
 PASS NavigationTransition finished promise is rejected on error

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
@@ -1,18 +1,12 @@
 
-FAIL An element with autofocus, present before navigation, gets focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
-FAIL Two elements with autofocus, present before navigation; the first gets focused assert_equals: Focus stays on the initially-focused button during the transition expected Element node <button autofocus=""></button> but got Element node <button autofocus=""></button>
-FAIL An element with autofocus, present before navigation but disabled before finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
-FAIL An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <button autofocus=""></button>
+PASS An element with autofocus, present before navigation, gets focused
+PASS Two elements with autofocus, present before navigation; the first gets focused
+PASS An element with autofocus, present before navigation but disabled before finished, does not get focused
+PASS An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused
 FAIL Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused assert_equals: Disabling the initially-focused button temporarily resets focus to the body expected Element node <body>
 
 <script type="module">
 promise_setup(async () => ... but got Element node <button autofocus="" disabled=""></button>
-FAIL An element with autofocus, introduced between committed and finished, gets focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <body>
-
-<script type="module">
-promise_setup(async () => ...
-FAIL An element with autofocus, introduced after finished, does not get focused assert_equals: Focus stays on the non-autofocused button during the transition expected Element node <button></button> but got Element node <body>
-
-<script type="module">
-promise_setup(async () => ...
+PASS An element with autofocus, introduced between committed and finished, gets focused
+PASS An element with autofocus, introduced after finished, does not get focused
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
@@ -1,10 +1,13 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
+
+Harness Error (FAIL), message = Unhandled rejection
 
 PASS Invalid values for focusReset throw
 PASS Does not reset the focus when no navigate handler is present
-FAIL Resets the focus when no focusReset option is provided assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
-FAIL Resets the focus when focusReset is explicitly set to undefined assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS Resets the focus when no focusReset option is provided
+PASS Resets the focus when focusReset is explicitly set to undefined
 PASS Resets the focus when no focusReset option is provided (nontrivial fulfilled promise)
-FAIL Resets the focus when no focusReset option is provided (rejected promise) assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
-FAIL Resets the focus when focusReset is explicitly set to 'after-transition' assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS Resets the focus when no focusReset option is provided (rejected promise)
+PASS Resets the focus when focusReset is explicitly set to 'after-transition'
 PASS Does not reset the focus when focusReset is set to 'manual'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
+
+Harness Error (FAIL), message = Unhandled rejection
 
 PASS Focus should be reset before navigatesuccess
 PASS Focus should be reset before navigateerror

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL (not provided) + after-transition assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS (not provided) + after-transition
 PASS (not provided) + manual
 PASS after-transition + manual
-FAIL after-transition + (not provided) assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
-FAIL manual + after-transition assert_equals: Focus stays on the button during the transition expected Element node <button></button> but got Element node <body><button></button><button tabindex="0"></button></body>
+PASS after-transition + (not provided)
+PASS manual + after-transition
 PASS manual + (not provided)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/resources/helpers.mjs
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/resources/helpers.mjs
@@ -10,6 +10,7 @@ export function testFocusWasReset(setupFunc, description) {
 
     const button = document.body.appendChild(document.createElement("button"));
     const button2 = document.body.appendChild(document.createElement("button"));
+    button.tabIndex = 0;
     button2.tabIndex = 0;
     t.add_cleanup(() => {
       button.remove();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -999,6 +999,9 @@ webkit.org/b/164888 fast/shadow-dom/focus-navigation-passes-svg-use-element.html
 webkit.org/b/202497 imported/w3c/web-platform-tests/shadow-dom/focus/ [ Skip ]
 imported/w3c/web-platform-tests/shadow-dom/focus/focus-pseudo-matches-on-shadow-host.html [ Pass ]
 
+imported/w3c/web-platform-tests/navigation-api/focus-reset/basic.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept.html [ Skip ]
+
 # This test needs to be rewritten to use runUIScript to work on iOS
 webkit.org/b/152993 http/tests/contentdispositionattachmentsandbox/form-submission-disabled.html [ Skip ]
 


### PR DESCRIPTION
#### 144f09fb32d5645dd4c7368857f6a98810f9c438
<pre>
[Navigation] NavigationResult.finished resolves earlier than expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=282137">https://bugs.webkit.org/show_bug.cgi?id=282137</a>

Reviewed by Alex Christensen.

Add a workaround for waitForAll ending earlier than expected. This fixes most focus-reset
tests but also should help ordering-and-transition tests (currently blocked by <a href="https://bugs.webkit.org/show_bug.cgi?id=277948).">https://bugs.webkit.org/show_bug.cgi?id=277948).</a>

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/multiple-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/resources/helpers.mjs:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/285951@main">https://commits.webkit.org/285951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c793adb6398721696247238198d5e7384c7853

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66692 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8064 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4359 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->