### PR TITLE
[css-masonry] Fix intrinsic-sizing-cols-004-mix1/2

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1766,8 +1766,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix2.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-002-mix2.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html
@@ -51,10 +51,11 @@ item {
   <item>2 2</item>
   <item style="grid-area: 1/3/3">3 3</item>
   <item>4</item>
-  <item style="width: 2ch; grid-area: 2/1">5 5</item>
+  <item style="grid-area: 2/1; width: 2ch">5 5</item>
 
   <item class="hidden" style="grid-area: 2/3; width: 2ch">0</item>
   <item class="hidden" style="grid-area: 2/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
 </grid>
 
 <grid>
@@ -131,6 +132,7 @@ item {
   <item>4</item>
   <item style="width:6ch; grid-area: 3/1/4/4">5 5</item>
 
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
   <item class="hidden">0 0</item>
   <item class="hidden">0 0</item>
   <item class="hidden" style="width:6ch; grid-area: 3/2/4/5">0 0</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html
@@ -51,10 +51,11 @@ item {
   <item>2 2</item>
   <item style="grid-area: 1/3/3">3 3</item>
   <item>4</item>
-  <item style="width: 2ch; grid-area: 2/1">5 5</item>
+  <item style="grid-area: 2/1; width: 2ch">5 5</item>
 
   <item class="hidden" style="grid-area: 2/3; width: 2ch">0</item>
   <item class="hidden" style="grid-area: 2/4">0 0</item>
+  <item class="hidden" style="grid-area: 2/1">0 0</item>
 </grid>
 
 <grid>
@@ -131,6 +132,7 @@ item {
   <item>4</item>
   <item style="width:6ch; grid-area: 3/1/4/4">5 5</item>
 
+  <item class="hidden" style="grid-column: 4; grid-row: 2;">0 0</item>
   <item class="hidden">0 0</item>
   <item class="hidden">0 0</item>
   <item class="hidden" style="width:6ch; grid-area: 3/2/4/5">0 0</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html
@@ -74,7 +74,7 @@ grid {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-column:span 2/4">5</item>
+  <item style="width:3ch; grid-column:span 2/4">5 5</item>
   <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 


### PR DESCRIPTION
#### 3155098264ca1dfb212ba388794b7a4d8aa9d81a
<pre>
[css-masonry] Fix intrinsic-sizing-cols-004-mix1/2
<a href="https://bugs.webkit.org/show_bug.cgi?id=282340">https://bugs.webkit.org/show_bug.cgi?id=282340</a>
<a href="https://rdar.apple.com/problem/138927036">rdar://problem/138927036</a>

Reviewed by Sammy Gill.

During the stretch flexible tracks we need to take into account that indefinite items are also placed in each track.
This was being ignored before, which can cause differences in flex size computations.

Update mix1 test cases:

Test 2:
The &quot;5 5&quot; is set to a width of 2ch in the original test case.

Test 6:
An extra 5 was missing.

Test 9:
The last column should be ~3ch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004-mix1.html:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::accumulateFlexFractionMasonry const):
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):

Canonical link: <a href="https://commits.webkit.org/285993@main">https://commits.webkit.org/285993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da04d9ee3f1ff789baa906ee4a939f153e1e3115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8141 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->