### PR TITLE
[JSC] ASSERTION FAILED: oldStructure == newStructure->previousID()

### DIFF
--- a/JSTests/stress/put-by-id-no-crash-interpreter.js
+++ b/JSTests/stress/put-by-id-no-crash-interpreter.js
@@ -1,0 +1,30 @@
+//@ runDefault("--useJIT=0")
+const propName = "myProp";
+var d;
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("Failure, expected: " + expected + ", got: " + actual);
+}
+
+function createDictionary()
+{
+    var object = $vm.createObjectDoingSideEffectPutWithoutCorrectSlotStatus();
+    object[propName] = 42;
+    return object;
+}
+
+function putWithSideEffects(o)
+{
+    o.dummy = {
+        toString() {
+            delete d[propName];
+            return "foo";
+        }
+    };
+}
+
+d = createDictionary();
+putWithSideEffects(d);
+shouldBe(propName in d, false);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1135,25 +1135,22 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_id)
         if (newStructure->propertyAccessesAreCacheable() && baseCell == slot.base()) {
             if (slot.type() == PutPropertySlot::NewProperty) {
                 GCSafeConcurrentJSLocker locker(codeBlock->m_lock, vm);
-                if (!newStructure->isDictionary() && newStructure->previousID()->outOfLineCapacity() == newStructure->outOfLineCapacity()) {
-                    ASSERT(oldStructure == newStructure->previousID());
-                    if (oldStructure == newStructure->previousID()) {
-                        ASSERT(oldStructure->transitionWatchpointSetHasBeenInvalidated());
+                if (!newStructure->isDictionary() && newStructure->previousID()->outOfLineCapacity() == newStructure->outOfLineCapacity() && newStructure->previousID() == oldStructure) {
+                    ASSERT(oldStructure->transitionWatchpointSetHasBeenInvalidated());
 
-                        bool sawPolyProto = false;
-                        auto result = normalizePrototypeChain(globalObject, baseCell, sawPolyProto);
-                        if (result != InvalidPrototypeChain && !sawPolyProto) {
-                            ASSERT(oldStructure->isObject());
-                            metadata.m_oldStructureID = oldStructure->id();
-                            metadata.m_offset = slot.cachedOffset();
-                            metadata.m_newStructureID = newStructure->id();
-                            if (!(bytecode.m_flags.isDirect())) {
-                                StructureChain* chain = newStructure->prototypeChain(vm, globalObject, asObject(baseCell));
-                                ASSERT(chain);
-                                metadata.m_structureChain.set(vm, codeBlock, chain);
-                            }
-                            vm.writeBarrier(codeBlock);
+                    bool sawPolyProto = false;
+                    auto result = normalizePrototypeChain(globalObject, baseCell, sawPolyProto);
+                    if (result != InvalidPrototypeChain && !sawPolyProto) {
+                        ASSERT(oldStructure->isObject());
+                        metadata.m_oldStructureID = oldStructure->id();
+                        metadata.m_offset = slot.cachedOffset();
+                        metadata.m_newStructureID = newStructure->id();
+                        if (!(bytecode.m_flags.isDirect())) {
+                            StructureChain* chain = newStructure->prototypeChain(vm, globalObject, asObject(baseCell));
+                            ASSERT(chain);
+                            metadata.m_structureChain.set(vm, codeBlock, chain);
                         }
+                        vm.writeBarrier(codeBlock);
                     }
                 }
             } else {


### PR DESCRIPTION
#### 424a5b978e6443f677a35ac612bc131d9dd5c32e
<pre>
[JSC] ASSERTION FAILED: oldStructure == newStructure-&gt;previousID()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282342">https://bugs.webkit.org/show_bug.cgi?id=282342</a>
<a href="https://rdar.apple.com/138178461">rdar://138178461</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

Folded the ASSERT and corresponding *if* into the enclosing *if*.  Added a new test that creates the conditions
that would hit the deleted ASSERT.

* JSTests/stress/put-by-id-no-crash-interpreter.js: Added.
(shouldBe):
(createDictionary):
(putWithSideEffects):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/285932@main">https://commits.webkit.org/285932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610c7bc7c964f41c74376d45efc5864f21b6c1cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58315 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23752 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67318 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80074 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73439 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63828 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65888 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7986 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95220 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1462 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20913 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->