### PR TITLE
[view-transitions] Implement `view-transition-name: match-element`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: using auto names</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<style>
+body {
+  background: rebeccapurple;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+main {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  top: 50px;
+}
+
+.item1 {
+  background: green;
+}
+
+.item2 {
+  background: yellow;
+}
+</style>
+<main>
+  <div class="item1"></div>
+  <div class="item2"></div>
+</main>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: using match-element name</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<link rel="match" href="auto-name-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  view-transition-name: match-element;
+  view-transition-class: item;
+}
+
+main.switch .item1 {
+  order: 2;
+}
+
+.item1 {
+  background: green;
+}
+
+.item2 {
+  background: yellow;
+  position: relative;
+  left: 100px;
+}
+
+html::view-transition {
+  background: rebeccapurple;
+}
+
+:root { view-transition-name: none; }
+html::view-transition-group(.item) {
+  animation-timing-function: steps(2, start);
+  animation-play-state: paused;
+}
+html::view-transition-old(*),
+html::view-transition-new(*)
+ { animation-play-state: paused; }
+html::view-transition-old(*) { animation: unset; opacity: 0 }
+html::view-transition-new(*) { animation: unset; opacity: 1 }
+
+/* This should not be used */
+html::view-transition-group(unused-id) {
+  background: red;
+}
+html::view-transition-old(unused-id),
+html::view-transition-new(unused-id) {
+  opacity: 0;
+}
+</style>
+
+<main>
+  <div class="item item1" id="unused-id"></div>
+  <div class="item item2"></div>
+</main>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+function runTest() {
+  document.startViewTransition(() => {
+    document.querySelector("main").classList.toggle("switch");
+  }).ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt
@@ -1,7 +1,8 @@
 
 PASS e.style['view-transition-name'] = "none" should set the property value
+PASS e.style['view-transition-name'] = "auto" should set the property value
+PASS e.style['view-transition-name'] = "match-element" should set the property value
 PASS e.style['view-transition-name'] = "foo" should set the property value
 PASS e.style['view-transition-name'] = "bar" should set the property value
 PASS e.style['view-transition-name'] = "baz" should set the property value
-PASS e.style['view-transition-name'] = "auto" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid.html
@@ -13,10 +13,11 @@
 <body>
 <script>
 test_valid_value("view-transition-name", "none");
+test_valid_value("view-transition-name", "auto");
+test_valid_value("view-transition-name", "match-element");
 test_valid_value("view-transition-name", "foo");
 test_valid_value("view-transition-name", "bar");
 test_valid_value("view-transition-name", "baz");
-test_valid_value("view-transition-name", "auto");
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9479,7 +9479,7 @@
         "view-transition-name": {
             "codegen-properties": {
                 "converter": "ViewTransitionName",
-                "parser-grammar": "none | auto | <custom-ident>",
+                "parser-grammar": "none | auto | match-element | <custom-ident>",
                 "settings-flag": "viewTransitionsEnabled"
             },
             "specification": {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1835,3 +1835,5 @@ most-inline-size
 flip-block
 flip-inline
 flip-start
+// view-transition-name
+match-element

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -341,19 +341,26 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
 {
     if (renderer.isSkippedContent())
         return nullAtom();
+
     auto transitionName = renderer.style().viewTransitionName();
     if (transitionName.isNone())
         return nullAtom();
+
     auto scope = Style::Scope::forOrdinal(originatingElement, transitionName.scopeOrdinal());
     if (!scope || scope != &documentScope)
         return nullAtom();
+
     if (transitionName.isCustomIdent())
         return transitionName.customIdent();
-    ASSERT(transitionName.isAuto());
+
+    ASSERT(transitionName.isAuto() || transitionName.isMatchElement());
+
     if (!renderer.element())
         return nullAtom();
-    if (scope == &Style::Scope::forNode(*renderer.element()) && renderer.element()->hasID())
+
+    if (transitionName.isAuto() && scope == &Style::Scope::forNode(*renderer.element()) && renderer.element()->hasID())
         return renderer.element()->getIdAttribute();
+
     if (isCrossDocument)
         return nullAtom();
 

--- a/Source/WebCore/rendering/style/ViewTransitionName.h
+++ b/Source/WebCore/rendering/style/ViewTransitionName.h
@@ -34,6 +34,7 @@ public:
     enum class Type : uint8_t {
         None,
         Auto,
+        MatchElement,
         CustomIdent,
     };
 
@@ -45,6 +46,11 @@ public:
     static ViewTransitionName createWithAuto(ScopeOrdinal ordinal)
     {
         return ViewTransitionName(Type::Auto, ordinal);
+    }
+
+    static ViewTransitionName createWithMatchElement(ScopeOrdinal ordinal)
+    {
+        return ViewTransitionName(Type::MatchElement, ordinal);
     }
 
     static ViewTransitionName createWithCustomIdent(ScopeOrdinal ordinal, AtomString ident)
@@ -62,6 +68,11 @@ public:
         return m_type == Type::Auto;
     }
 
+    bool isMatchElement() const
+    {
+        return m_type == Type::MatchElement;
+    }
+
     bool isCustomIdent() const
     {
         return m_type == Type::CustomIdent;
@@ -75,7 +86,7 @@ public:
 
     ScopeOrdinal scopeOrdinal() const
     {
-        ASSERT(isCustomIdent() || isAuto());
+        ASSERT(!isNone());
         return m_scopeOrdinal;
     }
 
@@ -104,6 +115,8 @@ inline TextStream& operator<<(TextStream& ts, const ViewTransitionName& name)
 {
     if (name.isAuto())
         ts << "auto"_s;
+    else if (name.isMatchElement())
+        ts << "match-element"_s;
     else if (name.isNone())
         ts << "none"_s;
     else

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -2015,6 +2015,9 @@ inline Style::ViewTransitionName BuilderConverter::convertViewTransitionName(con
     if (value.valueID() == CSSValueAuto)
         return Style::ViewTransitionName::createWithAuto(state.styleScopeOrdinal());
 
+    if (value.valueID() == CSSValueMatchElement)
+        return Style::ViewTransitionName::createWithMatchElement(state.styleScopeOrdinal());
+
     return Style::ViewTransitionName::createWithCustomIdent(state.styleScopeOrdinal(), AtomString { primitiveValue->stringValue() });
 }
 


### PR DESCRIPTION
#### b9fbc5377ba5d5e67ada02bf55c78cc6da679dae
<pre>
[view-transitions] Implement `view-transition-name: match-element`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282344">https://bugs.webkit.org/show_bug.cgi?id=282344</a>
<a href="https://rdar.apple.com/138932551">rdar://138932551</a>

Reviewed by Matt Woodrow.

See <a href="https://github.com/w3c/csswg-drafts/issues/10995#issuecomment-2551949161">https://github.com/w3c/csswg-drafts/issues/10995#issuecomment-2551949161</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/match-element-name.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
* Source/WebCore/rendering/style/ViewTransitionName.h:
(WebCore::Style::ViewTransitionName::createWithMatchElement):
(WebCore::Style::ViewTransitionName::isMatchElement const):
(WebCore::Style::ViewTransitionName::scopeOrdinal const):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertViewTransitionName):

Canonical link: <a href="https://commits.webkit.org/288102@main">https://commits.webkit.org/288102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7421358e45ce20557acfd13d63d65bc1bb824c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63788 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21511 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31220 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9011 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6398 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71363 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14373 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12689 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->