### PR TITLE
[GTK][WPE] Remove WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} in WebKitSettings.cpp

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -9,6 +9,7 @@ list(APPEND WTF_SOURCES
     glib/FileSystemGlib.cpp
     glib/GRefPtr.cpp
     glib/GSocketMonitor.cpp
+    glib/GSpanExtras.cpp
     glib/RunLoopGLib.cpp
     glib/Sandbox.cpp
     glib/SocketConnection.cpp

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -8,6 +8,7 @@ list(APPEND WTF_SOURCES
     glib/FileSystemGlib.cpp
     glib/GRefPtr.cpp
     glib/GSocketMonitor.cpp
+    glib/GSpanExtras.cpp
     glib/RunLoopGLib.cpp
     glib/Sandbox.cpp
     glib/SocketConnection.cpp

--- a/Source/WTF/wtf/glib/GSpanExtras.cpp
+++ b/Source/WTF/wtf/glib/GSpanExtras.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include <wtf/glib/GSpanExtras.h>
+
+namespace WTF {
+
+GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile* keyFile, const char* groupName, GUniqueOutPtr<GError>& error)
+{
+    ASSERT(keyFile);
+    ASSERT(groupName);
+
+    size_t keyCount = 0;
+    char** keys = g_key_file_get_keys(keyFile, groupName, &keyCount, &error.outPtr());
+    return adoptGMallocSpan<char*, GMallocStrv>(keys, keyCount);
+}
+
+GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass* objectClass)
+{
+    ASSERT(objectClass);
+
+    unsigned propertyCount = 0;
+    GParamSpec** properties = g_object_class_list_properties(objectClass, &propertyCount);
+    return adoptGMallocSpan(properties, propertyCount);
+}
+
+} // namespace WTF

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -43,7 +43,7 @@
 #include <cmath>
 #include <glib/gi18n-lib.h>
 #include <pal/text/TextEncodingRegistry.h>
-#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 
@@ -4299,8 +4299,6 @@ WebKitFeatureList* webkit_settings_get_development_features(void)
  */
 gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile* keyFile, const gchar* groupName, GError** error)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
     g_return_val_if_fail(keyFile, FALSE);
     g_return_val_if_fail(groupName, FALSE);
@@ -4311,17 +4309,14 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
         return FALSE;
     }
 
-    auto klass = G_OBJECT_GET_CLASS(settings);
-    unsigned totalProperties = 0;
-    GUniquePtr<GParamSpec*> properties(g_object_class_list_properties(klass, &totalProperties));
-
-    GRefPtr<GPtrArray> propertyNames = adoptGRef(g_ptr_array_sized_new(totalProperties));
-    GRefPtr<GArray> values = adoptGRef(g_array_sized_new(FALSE, FALSE, sizeof(GValue), totalProperties));
+    const auto properties = gObjectClassGetProperties(G_OBJECT_GET_CLASS(settings));
+    GRefPtr<GPtrArray> propertyNames = adoptGRef(g_ptr_array_sized_new(properties.span().size()));
+    GRefPtr<GArray> values = adoptGRef(g_array_sized_new(FALSE, FALSE, sizeof(GValue), properties.span().size()));
     g_array_set_clear_func(values.get(), reinterpret_cast<GDestroyNotify>(g_value_unset));
 
-    for (unsigned i = 0; i < totalProperties; i++) {
+    for (const GParamSpec* property : properties.span()) {
         GUniqueOutPtr<GError> lookupError;
-        const char* name = properties.get()[i]->name;
+        const char* name = property->name;
         if (!g_key_file_has_key(keyFile, groupName, name, &lookupError.outPtr())) {
             if (lookupError) {
                 g_propagate_error(error, lookupError.release());
@@ -4332,7 +4327,7 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
 
         GValue value = G_VALUE_INIT;
         bool isValueSet = false;
-        switch (G_PARAM_SPEC_VALUE_TYPE(properties.get()[i])) {
+        switch (G_PARAM_SPEC_VALUE_TYPE(property)) {
         case G_TYPE_BOOLEAN: {
             bool boolValue = g_key_file_get_boolean(keyFile, groupName, name, &lookupError.outPtr());
             if (!boolValue && lookupError) {
@@ -4380,16 +4375,14 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
         }
     }
 
-    size_t length;
     GUniqueOutPtr<GError> getKeysError;
-    GUniquePtr<char*> allKeys(g_key_file_get_keys(keyFile, groupName, &length, &getKeysError.outPtr()));
+    auto allKeys = gKeyFileGetKeys(keyFile, groupName, getKeysError);
     if (UNLIKELY(getKeysError)) {
         g_propagate_error(error, getKeysError.release());
         return FALSE;
     }
 
-    for (unsigned i = 0; i < length; i++) {
-        auto key = allKeys.get()[i];
+    for (const char* key : allKeys.span()) {
         if (!g_ptr_array_find_with_equal_func(propertyNames.get(), static_cast<gconstpointer>(key), g_str_equal, nullptr)) {
             g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE, "The %s group contains an invalid setting: %s", groupName, key);
             return FALSE;
@@ -4398,8 +4391,6 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
 
     g_object_setv(G_OBJECT(settings), propertyNames->len, const_cast<const char**>(reinterpret_cast<char**>(propertyNames->pdata)), reinterpret_cast<GValue*>(values->data));
     return TRUE;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 /**


### PR DESCRIPTION
#### 6590010e1ff81a61395344c17882942c56ceea78
<pre>
[GTK][WPE] Remove WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} in WebKitSettings.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282308">https://bugs.webkit.org/show_bug.cgi?id=282308</a>

Reviewed by Michael Catanzaro.

Introduce helpers for GLib functions which return heap-allocated
arrays, which wrap those into a GMallocSpan (same as MallocSpan,
with GMalloc as allocator by default) that takes care of freeing
memory automatically. Then use the new utility functions to remove
WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} in WebKitSettings.cpp.

* Source/WTF/wtf/PlatformGTK.cmake: List GSpanExtras.cpp for building.
* Source/WTF/wtf/PlatformWPE.cmake: Ditto.
* Source/WTF/wtf/glib/GSpanExtras.cpp: Added. Includes new functions
WTF::gKeyFileGetKeys() and WTF::gObjectClassGetProperties(), which wrap
the corresponding GLib functions and return a GMallocSpan, easing their
usage at call sites.
(WTF::gKeyFileGetKeys): Added.
(WTF::gObjectClassGetProperties): Added.
* Source/WTF/wtf/glib/GSpanExtras.h: Define GMalloc which implements
memory operations calling GLib functions while allowing per-type
overides, to be used with MallocSpan. A convenience template alias,
GMallocSpan is also defined, which takes care of picking the
corresponding GMalloc&lt;T&gt; specialization.
(WTF::GMalloc::malloc): Added.
(WTF::GMalloc::tryMalloc): Added.
(WTF::GMalloc::zeroedMalloc): Added.
(WTF::GMalloc::tryZeroedMalloc): Added.
(WTF::GMalloc::realloc): Added.
(WTF::GMalloc::tryRealloc): Added.
(WTF::GMalloc::free): Added.
(WTF::GMalloc::nextCapacity): Added.
(WTF::GMallocStrv::free): Added.
(WTF::adoptGMallocSpan): Convenience template function that forwards to
adoptMallocSpan() picking GMalloc as the allocator by default.
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_apply_from_key_file): Use the new helper functions.

Canonical link: <a href="https://commits.webkit.org/285949@main">https://commits.webkit.org/285949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01e17decaf6bdb7e3c107ff3776bcf5c2e86c68b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74291 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45529 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23862 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67428 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80187 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65973 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9911 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8065 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95330 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11467 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1572 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->