### PR TITLE
Take a foreground activity assertion for Web Extension background content.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -450,8 +450,7 @@ bool WebExtensionContext::unload(NSError **outError)
     m_mainMenuItems.clear();
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    m_inspectorBackgroundPageMap.clear();
-    m_inspectorExtensionMap.clear();
+    m_inspectorContextMap.clear();
 #endif
 
     m_pendingPermissionRequests = 0;
@@ -2071,20 +2070,21 @@ RefPtr<WebExtensionTab> WebExtensionContext::getCurrentTab(WebPageProxyIdentifie
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // Search open inspector background pages.
-    for (auto entry : m_inspectorBackgroundPageMap) {
-        auto *webView = std::get<RetainPtr<WKWebView>>(entry.value).get();
+    for (auto entry : m_inspectorContextMap) {
+        auto *webView = entry.value.backgroundWebView.get();
         if (webView._page->identifier() == webPageProxyIdentifier) {
             if (includeExtensionViews == IncludeExtensionViews::No)
                 return nullptr;
 
-            result = m_tabMap.get(std::get<WebExtensionTabIdentifier>(entry.value));
+            result = m_tabMap.get(entry.value.tabIdentifier.value());
             goto finish;
         }
     }
 
     // Search open inspectors.
     for (auto [inspector, tab] : openInspectors()) {
-        if (Ref { inspector }->protectedInspectorPage()->identifier() == webPageProxyIdentifier) {
+        Ref protectedInspector = inspector;
+        if (protectedInspector->protectedInspectorPage()->identifier() == webPageProxyIdentifier) {
             if (includeExtensionViews == IncludeExtensionViews::No)
                 return nullptr;
 
@@ -3195,16 +3195,15 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorB
 {
     Vector<PageIdentifierTuple> result;
 
-    for (auto entry : m_inspectorBackgroundPageMap) {
-        RefPtr tab = getTab(std::get<WebExtensionTabIdentifier>(entry.value));
+    for (auto entry : m_inspectorContextMap) {
+        RefPtr tab = getTab(entry.value.tabIdentifier.value());
         RefPtr window = tab ? tab->window() : nullptr;
 
         auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        RetainPtr webView = std::get<RetainPtr<WKWebView>>(entry.value);
-
-        result.append({ webView.get()._page->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        auto *webView = entry.value.backgroundWebView.get();
+        result.append({ webView._page->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
     }
 
     return result;
@@ -3220,7 +3219,8 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorP
         auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        result.append({ Ref { inspector }->protectedInspectorPage()->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        Ref protectedInspector = inspector;
+        result.append({ protectedInspector->protectedInspectorPage()->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
     }
 
     return result;
@@ -3502,8 +3502,13 @@ void WebExtensionContext::loadBackgroundWebView()
     clearError(Error::BackgroundContentFailedToLoad);
     m_backgroundContentLoadError = nil;
 
+    Ref backgroundPage = *m_backgroundWebView.get()._page;
+    Ref backgroundProcess = backgroundPage->protectedLegacyMainFrameProcess();
+
+    // Use foreground activity to keep background content responsive to events.
+    m_backgroundWebViewActivity = backgroundProcess->throttler().foregroundActivity("Web Extension background content"_s);
+
     if (!protectedExtension()->backgroundContentIsServiceWorker()) {
-        Ref backgroundPage = *m_backgroundWebView.get()._page;
         backgroundPage->protectedLegacyMainFrameProcess()->send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageIDInMainFrameProcess()), identifier());
 
         [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL()]];
@@ -3528,6 +3533,7 @@ void WebExtensionContext::unloadBackgroundWebView()
 
     m_backgroundContentIsLoaded = false;
     m_unloadBackgroundWebViewTimer = nullptr;
+    m_backgroundWebViewActivity = nullptr;
 
     [m_backgroundWebView _close];
     m_backgroundWebView = nil;
@@ -3604,9 +3610,9 @@ void WebExtensionContext::unloadBackgroundContentIfPossible()
     }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    if (!m_inspectorBackgroundPageMap.isEmptyIgnoringNullReferences()) {
+    if (!m_inspectorContextMap.isEmptyIgnoringNullReferences()) {
         scheduleBackgroundContentToUnload();
-        RELEASE_LOG_DEBUG(Extensions, "Not unloading background content because an inspector background page open");
+        RELEASE_LOG_DEBUG(Extensions, "Not unloading background content because an inspector background page is open");
         return;
     }
 #endif
@@ -3914,8 +3920,8 @@ WebExtensionContext::InspectorTabVector WebExtensionContext::loadedInspectors() 
 
     InspectorTabVector result;
 
-    for (auto entry : m_inspectorBackgroundPageMap)
-        result.append({ entry.key, getTab(std::get<WebExtensionTabIdentifier>(entry.value)) });
+    for (auto entry : m_inspectorContextMap)
+        result.append({ entry.key, getTab(entry.value.tabIdentifier.value()) });
 
     return result;
 }
@@ -3927,23 +3933,21 @@ RefPtr<API::InspectorExtension> WebExtensionContext::inspectorExtension(WebPageP
 
     RefPtr<WebInspectorUIProxy> foundInspector;
 
-    for (auto entry : m_inspectorBackgroundPageMap) {
-        auto *webView = std::get<RetainPtr<WKWebView>>(entry.value).get();
+    for (auto entry : m_inspectorContextMap) {
+        auto *webView = entry.value.backgroundWebView.get();
         if (webView._page->identifier() == webPageProxyIdentifier)
-            foundInspector = &entry.key;
+            return entry.value.extension;
     }
 
-    if (!foundInspector) {
-        for (auto [inspector, tab] : openInspectors()) {
-            if (Ref { inspector }->protectedInspectorPage()->identifier() == webPageProxyIdentifier)
-                foundInspector = inspector.ptr();
+    for (auto [inspector, tab] : openInspectors()) {
+        Ref protectedInspector = inspector;
+        if (protectedInspector->protectedInspectorPage()->identifier() == webPageProxyIdentifier) {
+            const auto& inspectorContext = m_inspectorContextMap.get(inspector);
+            return inspectorContext.extension;
         }
     }
 
-    if (!foundInspector)
-        return nullptr;
-
-    return m_inspectorExtensionMap.get(*foundInspector);
+    return nullptr;
 }
 
 RefPtr<WebInspectorUIProxy> WebExtensionContext::inspector(const API::InspectorExtension& inspectorExtension) const
@@ -3951,8 +3955,8 @@ RefPtr<WebInspectorUIProxy> WebExtensionContext::inspector(const API::InspectorE
     ASSERT(isLoaded());
     ASSERT(protectedExtension()->hasInspectorBackgroundPage());
 
-    for (auto entry : m_inspectorExtensionMap) {
-        if (entry.value.ptr() == &inspectorExtension)
+    for (auto entry : m_inspectorContextMap) {
+        if (entry.value.extension == &inspectorExtension)
             return &entry.key;
     }
 
@@ -3970,12 +3974,11 @@ HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::Inspecto
     if (!inspectorProxy)
         return result;
 
-    ASSERT(m_inspectorBackgroundPageMap.contains(*inspectorProxy));
+    ASSERT(m_inspectorContextMap.contains(*inspectorProxy));
 
-    auto [tabIdentifier, webView] = m_inspectorBackgroundPageMap.get(*inspectorProxy);
-    ASSERT(webView);
-
-    result.add(webView->_page->legacyMainFrameProcess());
+    const auto& inspectorContext = m_inspectorContextMap.get(*inspectorProxy);
+    if (auto *backgroundWebView = inspectorContext.backgroundWebView.get())
+        result.add(backgroundWebView._page->legacyMainFrameProcess());
 
     return result;
 }
@@ -3987,8 +3990,8 @@ bool WebExtensionContext::isInspectorBackgroundPage(WKWebView *webView) const
     if (!protectedExtension()->hasInspectorBackgroundPage())
         return false;
 
-    for (auto entry : m_inspectorBackgroundPageMap) {
-        if (webView == std::get<RetainPtr<WKWebView>>(entry.value))
+    for (auto entry : m_inspectorContextMap) {
+        if (webView == entry.value.backgroundWebView)
             return true;
     }
 
@@ -4053,8 +4056,8 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
     ASSERT(isLoaded());
     ASSERT(protectedExtension()->hasInspectorBackgroundPage());
 
-    ASSERT(!m_inspectorBackgroundPageMap.contains(inspector));
-    if (m_inspectorBackgroundPageMap.contains(inspector))
+    ASSERT(!m_inspectorContextMap.contains(inspector));
+    if (m_inspectorContextMap.contains(inspector))
         return;
 
     class InspectorExtensionClient : public API::InspectorExtensionClient {
@@ -4117,44 +4120,52 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         configuration.processPool = inspectorWebViewConfiguration.processPool;
         configuration.websiteDataStore = inspectorWebViewConfiguration.websiteDataStore;
 
-        auto *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration];
-        webView.UIDelegate = m_delegate.get();
-        webView.navigationDelegate = m_delegate.get();
-        webView.inspectable = m_inspectable;
+        auto *inspectorBackgroundWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration];
+        inspectorBackgroundWebView.UIDelegate = m_delegate.get();
+        inspectorBackgroundWebView.navigationDelegate = m_delegate.get();
+        inspectorBackgroundWebView.inspectable = m_inspectable;
 
         // In order for new web view to use the same process as _relatedWebView we need to force it here. Otherwise a process swap
         // will happen because the Inspector URL scheme and Web Extension scheme don't match.
-        webView._page->setAlwaysUseRelatedPageProcess();
+        inspectorBackgroundWebView._page->setAlwaysUseRelatedPageProcess();
 
         Ref inspectorExtension = result.value().releaseNonNull();
         inspectorExtension->setClient(makeUniqueRef<InspectorExtensionClient>(inspectorExtension, *this));
 
-        m_inspectorBackgroundPageMap.set(inspector.get(), TabIdentifierWebViewPair { tab->identifier(), webView });
-        m_inspectorExtensionMap.set(inspector.get(), inspectorExtension);
+        Ref process = inspectorBackgroundWebView._page->legacyMainFrameProcess();
+
+        // Use foreground activity to keep background content responsive to events.
+        Ref inspectorBackgroundWebViewActivity = process->throttler().foregroundActivity("Web Extension Inspector background content"_s);
+
+        InspectorContext inspectorContext {
+            tab->identifier(),
+            inspectorExtension.ptr(),
+            inspectorBackgroundWebView,
+            inspectorBackgroundWebViewActivity.ptr()
+        };
+
+        m_inspectorContextMap.set(inspector.get(), WTFMove(inspectorContext));
 
         RefPtr window = tab->window();
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
         auto appearance = inspector->protectedInspectorPage()->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
 
-        Ref process = webView._page->legacyMainFrameProcess();
         ASSERT(inspectorWebView._page->legacyMainFrameProcess() == process);
         process->send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(inspectorWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
-        process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(webView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
+        process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(inspectorBackgroundWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());
 
-        [webView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL()]];
+        [inspectorBackgroundWebView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL()]];
     });
 }
 
 void WebExtensionContext::unloadInspectorBackgroundPage(WebInspectorUIProxy& inspector)
 {
-    ASSERT(m_inspectorBackgroundPageMap.contains(inspector));
+    ASSERT(m_inspectorContextMap.contains(inspector));
 
-    auto [tabIdentifier, inspectorWebView] = m_inspectorBackgroundPageMap.take(inspector);
-    m_inspectorExtensionMap.remove(inspector);
-
-    [inspectorWebView _close];
+    auto inspectorContext = m_inspectorContextMap.take(inspector);
+    [inspectorContext.backgroundWebView _close];
 
     inspector.protectedExtensionController()->unregisterExtension(uniqueIdentifier(), [](Expected<void, Inspector::ExtensionError> result) {
         if (!result)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -122,6 +122,7 @@ class SessionID;
 namespace WebKit {
 
 class ContextMenuContextData;
+class ProcessThrottlerActivity;
 class WebExtension;
 class WebUserContentControllerProxy;
 struct WebExtensionContextParameters;
@@ -221,7 +222,6 @@ public:
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     using InspectorTabVector = Vector<std::pair<Ref<WebInspectorUIProxy>, RefPtr<WebExtensionTab>>>;
-    using TabIdentifierWebViewPair = std::pair<WebExtensionTabIdentifier, RetainPtr<WKWebView>>;
 #endif
 
     using ReloadFromOrigin = WebExtensionTab::ReloadFromOrigin;
@@ -270,6 +270,15 @@ public:
         Sidebar,
         Tab,
     };
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    struct InspectorContext {
+        std::optional<WebExtensionTabIdentifier> tabIdentifier;
+        RefPtr<API::InspectorExtension> extension;
+        RetainPtr<WKWebView> backgroundWebView;
+        RefPtr<ProcessThrottlerActivity> activity;
+    };
+#endif
 
     WebExtensionContextParameters parameters() const;
 
@@ -971,6 +980,7 @@ private:
     String m_previousVersion;
 
     RetainPtr<WKWebView> m_backgroundWebView;
+    RefPtr<ProcessThrottlerActivity> m_backgroundWebViewActivity;
     RetainPtr<NSError> m_backgroundContentLoadError;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 
@@ -982,8 +992,7 @@ private:
     bool m_safeToLoadBackgroundContent { false };
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    WeakHashMap<WebInspectorUIProxy, TabIdentifierWebViewPair> m_inspectorBackgroundPageMap;
-    WeakHashMap<WebInspectorUIProxy, Ref<API::InspectorExtension>> m_inspectorExtensionMap;
+    WeakHashMap<WebInspectorUIProxy, InspectorContext> m_inspectorContextMap;
 #endif
 
     HashMap<Ref<WebExtensionMatchPattern>, UserScriptVector> m_injectedScriptsPerPatternMap;


### PR DESCRIPTION
#### ec4101c7ba77986e1c0d4919df38a3e896ff2e3c
<pre>
Take a foreground activity assertion for Web Extension background content.
<a href="https://webkit.org/b/282346">https://webkit.org/b/282346</a>
<a href="https://rdar.apple.com/problem/138936474">rdar://problem/138936474</a>

Reviewed by Brian Weinstein.

We need to take a foreground activity assertion to prevent the background web view process
from being suspended and not responding to events.

Refactor the inspector extension maps into one, since we need to track an activity there too,
and having a single map is more maintainable.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::inspectorBackgroundPageIdentifiers const):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::unloadBackgroundWebView):
(WebKit::WebExtensionContext::unloadBackgroundContentIfPossible):
(WebKit::WebExtensionContext::loadedInspectors const):
(WebKit::WebExtensionContext::inspectorExtension const):
(WebKit::WebExtensionContext::inspector const):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::isInspectorBackgroundPage const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/285928@main">https://commits.webkit.org/285928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81d564cb01b7eff85cd5f3a9cb3b75325b35f70f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25425 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58317 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16664 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77254 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48481 "Too many flaky failures: compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html, fast/events/ios/key-events-comprehensive/key-events-control-option.html, fast/events/ios/key-events-comprehensive/key-events-meta-control.html, fast/events/ios/key-events-comprehensive/key-events-meta-option.html, fast/events/ios/key-events-comprehensive/key-events-meta-shift.html, fast/events/ios/key-events-comprehensive/key-events-meta.html, fast/events/ios/key-events-comprehensive/key-events-option-shift.html, fast/events/ios/key-events-comprehensive/key-events-option.html, fast/events/ios/key-events-comprehensive/key-events-shift.html, fast/events/ios/tab-into-text-field-inside-iframe.html, fast/forms/ios/focus-radio.html, fast/forms/ios/focus-reset-button.html, fast/forms/ios/focus-ring-size.html, fast/forms/ios/focus-search-field.html, fast/forms/ios/focus-submit-button.html, fast/forms/ios/focus-text-field.html, fast/scrolling/ios/key-command-scroll-to-top.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45404 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7990 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11460 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1468 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->