### PR TITLE
[Cocoa] REGRESSION (283033@main) Viewer mode doesn't work for video in an iframe

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7353,7 +7353,9 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
     if (videoUsesElementFullscreen() && page->isFullscreenManagerEnabled() && isInWindowOrStandardFullscreen(mode)) {
         m_temporarilyAllowingInlinePlaybackAfterFullscreen = false;
         m_waitingToEnterFullscreen = true;
-        protectedDocument()->checkedFullscreenManager()->requestFullscreenForElement(*this, nullptr, { }, [weakThis = WeakPtr { *this }](bool success) {
+        FullscreenManager::FullscreenCheckType fullscreenCheckType = m_ignoreFullscreenPermissionsPolicy ? FullscreenManager::ExemptIFrameAllowFullscreenRequirement : FullscreenManager::EnforceIFrameAllowFullscreenRequirement;
+        m_ignoreFullscreenPermissionsPolicy = false;
+        protectedDocument()->checkedFullscreenManager()->requestFullscreenForElement(*this, nullptr, fullscreenCheckType, [weakThis = WeakPtr { *this }](bool success) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || success)
                 return;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -759,6 +759,8 @@ protected:
     bool videoFullscreenStandby() const { return m_videoFullscreenStandby; }
     void setVideoFullscreenStandbyInternal(bool videoFullscreenStandby) { m_videoFullscreenStandby = videoFullscreenStandby; }
 
+    void ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen() { m_ignoreFullscreenPermissionsPolicy = true; }
+
 protected:
     // ActiveDOMObject
     void stop() override;
@@ -1428,6 +1430,8 @@ private:
 
     std::unique_ptr<PausableIntervalTimer> m_watchtimeTimer;
     RefPtr<WTF::Stopwatch> m_bufferingStopwatch;
+
+    bool m_ignoreFullscreenPermissionsPolicy { false };
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -797,6 +797,20 @@ void HTMLVideoElement::setVideoFullscreenStandby(bool value)
     }
 }
 
+ExceptionOr<void> HTMLVideoElement::enterFullscreenIgnoringPermissionsPolicy()
+{
+    ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen();
+    return webkitEnterFullscreen();
+}
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+void HTMLVideoElement::setPresentationModeIgnoringPermissionsPolicy(VideoPresentationMode mode)
+{
+    ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen();
+    setPresentationMode(mode);
+}
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -59,6 +59,7 @@ public:
     WEBCORE_EXPORT void webkitExitFullscreen();
     WEBCORE_EXPORT bool webkitSupportsFullscreen();
     WEBCORE_EXPORT bool webkitDisplayingFullscreen();
+    WEBCORE_EXPORT ExceptionOr<void> enterFullscreenIgnoringPermissionsPolicy();
 
     void ancestorWillEnterFullscreen() final;
 
@@ -105,6 +106,7 @@ public:
     WEBCORE_EXPORT void didEnterFullscreenOrPictureInPicture(const FloatSize&);
     WEBCORE_EXPORT void didExitFullscreenOrPictureInPicture();
     WEBCORE_EXPORT bool isChangingPresentationMode() const;
+    WEBCORE_EXPORT void setPresentationModeIgnoringPermissionsPolicy(VideoPresentationMode);
 
     void setVideoFullscreenFrame(const FloatRect&) final;
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -377,7 +377,7 @@ void PlaybackSessionModelMediaElement::enterInWindowFullscreen()
     UserGestureIndicator indicator { IsProcessingUserGesture::Yes, &element->document() };
 
     if (element->fullscreenMode() != MediaPlayerEnums::VideoFullscreenModeInWindow)
-        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::InWindow);
+        element->setPresentationModeIgnoringPermissionsPolicy(HTMLVideoElement::VideoPresentationMode::InWindow);
 #endif
 }
 
@@ -404,7 +404,7 @@ void PlaybackSessionModelMediaElement::enterFullscreen()
         return;
 
     UserGestureIndicator indicator { IsProcessingUserGesture::Yes, &element->document() };
-    element->webkitEnterFullscreen();
+    element->enterFullscreenIgnoringPermissionsPolicy();
 }
 
 void PlaybackSessionModelMediaElement::exitFullscreen()


### PR DESCRIPTION
#### 89d9814e2f11b99164232dfd654cbd2df507fdc9
<pre>
[Cocoa] REGRESSION (283033@main) Viewer mode doesn&apos;t work for video in an iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=282351">https://bugs.webkit.org/show_bug.cgi?id=282351</a>
<a href="https://rdar.apple.com/138769971">rdar://138769971</a>

Reviewed by Andy Estes.

283033@main changed Viewer mode to use element fullscreen instead of video fullscreen.
Element fullscreen enforces permission policy and the old video fullscreen API does not,
so the change broke Viewer mode for video in an iframe without the &quot;allowfullscreen&quot;
property. Fix this by adding new, internal-only, methods to allow element fullscreen to
ignore fullscreen permission policy.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen): Pass ExemptIFrameAllowFullscreenRequirement to
FullscreenManager::requestFullscreenForElement when m_ignoreFullscreenPermissionsPolicy is true;
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen):

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::enterFullscreenIgnoringPermissionsPolicy): Call
ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen() before calling webkitEnterFullscreen().
(WebCore::HTMLVideoElement::setPresentationModeIgnoringPermissionsPolicy): Call
ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen() before calling setPresentationMode().
* Source/WebCore/html/HTMLVideoElement.h:

* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::enterInWindowFullscreen): Call setPresentationModeIgnoringPermissionsPolicy.
(WebCore::PlaybackSessionModelMediaElement::enterFullscreen): Call enterFullscreenIgnoringPermissionsPolicy.

Canonical link: <a href="https://commits.webkit.org/285943@main">https://commits.webkit.org/285943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692c277ecaa508e86da96100cce804c27021e235

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1487 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16715 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77340 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45494 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23844 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/906 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1735 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9897 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1554 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->