### PR TITLE
Refactor WPT no-autospace test for no implicit initial value

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3105,7 +3105,6 @@ imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-integer-004.html 
 imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-spacing-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-spacing-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ligature-001.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-text/text-group-align/text-group-align-center-vlr.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-group-align/text-group-align-center.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected-mismatch.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<div>国国AA国国AA国国</div>
-<div>国国AA国国AA国国</div>
+<style>
+.normal { text-autospace: normal }
+</style>
+<div class="normal">国国AA国国AA国国</div>
+<div class="normal">国国AA国国AA国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<div>国国AA国国AA国国</div>
+<style>
+.no-as { text-autospace: no-autospace; }
+.manual-spacing {
+    margin: 0px 0.125em;
+}
+</style>
+<div class="no-as"><span>国国</span><span class="manual-spacing">AA</span><span>国国</span><span class="manual-spacing">AA</span><span>国国</span></div>
 <div>国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-mismatch-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-mismatch-ref.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<div>国国AA国国AA国国</div>
-<div>国国AA国国AA国国</div>
+<style>
+.normal { text-autospace: normal }
+</style>
+<div class="normal">国国AA国国AA国国</div>
+<div class="normal">国国AA国国AA国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-ref.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<div>国国AA国国AA国国</div>
+<style>
+.no-as { text-autospace: no-autospace; }
+.manual-spacing {
+    margin: 0px 0.125em;
+}
+</style>
+<div class="no-as"><span>国国</span><span class="manual-spacing">AA</span><span>国国</span><span class="manual-spacing">AA</span><span>国国</span></div>
 <div>国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001.html
@@ -4,7 +4,8 @@
 <link rel="match" href="text-autospace-no-001-ref.html">
 <link rel="mismatch" href="text-autospace-no-001-mismatch-ref.html">
 <style>
+.normal { text-autospace: normal; }
 .no-as { text-autospace: no-autospace; }
 </style>
-<div>国国AA国国AA国国</div>
+<div class="normal">国国AA国国AA国国</div>
 <div class="no-as">国国AA国国AA国国</div>


### PR DESCRIPTION
#### a7f6a0c7ef18e9c721248b6315425dc763e3c4f4
<pre>
Refactor WPT no-autospace test for no implicit initial value
<a href="https://bugs.webkit.org/show_bug.cgi?id=282358">https://bugs.webkit.org/show_bug.cgi?id=282358</a>
<a href="https://rdar.apple.com/138948483">rdar://138948483</a>

Reviewed by Tim Nguyen.

This test verifies the behavior for `no-autospace`.
For building the test, we assume that the initial value
for the property is `normal`, which is what spec currently
expects but not what WebKit is willing to implement initially.

WebKit still implements `normal` and `no-autospace` correctly,
we just don&apos;t assume the initial value to be `normal`.

Therefore, we can refactor this test to explicitly set `normal` when needed
without impacting what we are really trying to test here, which is the
`no-autospace` behavior.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected-mismatch.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-mismatch-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001.html:

Canonical link: <a href="https://commits.webkit.org/285989@main">https://commits.webkit.org/285989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d9470476cf9ff2a17a76542c45873814a2759d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58435 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23912 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66993 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21791 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-003.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/958 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66728 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-view-box-overflow.html webanimations/accelerated-animation-tiled-while-running.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16404 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8101 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->