### PR TITLE
[iOS] Camera view remains visible and active after opening a new tab in 3rd-party browsers

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -899,6 +899,8 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
     [_cameraPicker setSourceType:UIImagePickerControllerSourceTypeCamera];
     [_cameraPicker setMediaTypes:[self _mediaTypesForPickerSourceType:UIImagePickerControllerSourceTypeCamera]];
     [_cameraPicker setDelegate:self];
+    // Modal presentation style must be set before accessing the presentation controller.
+    [_cameraPicker setModalPresentationStyle:UIModalPresentationOverFullScreen];
     [_cameraPicker presentationController].delegate = self;
     [_cameraPicker setAllowsEditing:NO];
     [_cameraPicker _setAllowsMultipleSelection:_allowMultipleFiles];


### PR DESCRIPTION
#### 3c71c873941e76477894bb7e1ee013d0d404609c
<pre>
[iOS] Camera view remains visible and active after opening a new tab in 3rd-party browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=276132">https://bugs.webkit.org/show_bug.cgi?id=276132</a>
<a href="https://rdar.apple.com/130986409">rdar://130986409</a>

Reviewed by Tim Horton.

The camera capture view does not dismiss itself after a new tab is opened, and
can end up displayed after switching to a site that&apos;s unrelated to the one
requesting the upload.

278816@main fixed the same issue for file pickers and other picker views by
dismissing view controllers for pickers when the associated `WKWebView` was
removed from the view hierarchy.

This solution worked well for everything except the camera capture view, which
has a `FullScreen` modal presentation style. The effect of this presentation
style is that the views beneath the presented content are removed from the view
hierarchy. Consequently, 278816@main introduced a regression where camera
capture views would always be instantly dismissed after presentation.

278827@main addressed that regression by preventing dismissal if the `WKWebView`
was removed from the hierarchy as a result of a fullscreen presentation. This
fix left camera capture views vulnerable to the same issue that previously
affected the file picker.

To fix, use the `OverFullScreen` modal presentation style to ensure that
presenting the camera capture view does not remove the `WKWebView` from the
view hierarchy. This allows existing logic to dismiss pickers when the web
view is removed from the hierarchy to kick in. The logic to prevent `FullScreen`
presentations from dismissing pickers is preserved to avoid unexpected
regressions.

* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:

Originally-landed-as: 280938.260@safari-7619-branch (756e84d044e2). <a href="https://rdar.apple.com/138931678">rdar://138931678</a>
Canonical link: <a href="https://commits.webkit.org/285934@main">https://commits.webkit.org/285934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eccb47f18e830a72bd8100c7d3fa00b7731cbd63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58336 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16678 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45441 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8006 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1502 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->