### PR TITLE
Change environment map data variable names to more descriptive ones.

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -236,7 +236,7 @@ void HTMLModelElement::dataReceived(CachedResource& resource, const SharedBuffer
         m_data.append(buffer);
 #if ENABLE(MODEL_PROCESS)
     else if (&resource == m_environmentMapResource)
-        m_pendingEnvironmentMapData.append(buffer);
+        m_environmentMapData.append(buffer);
 #endif
     else
         ASSERT_NOT_REACHED();
@@ -305,8 +305,8 @@ void HTMLModelElement::createModelPlayer()
     m_modelPlayer->load(*m_model, size);
 
 #if ENABLE(MODEL_PROCESS)
-    if (m_pendingEnvironmentMapData)
-        m_modelPlayer->setEnvironmentMap(m_pendingEnvironmentMapData.takeAsContiguous().get());
+    if (m_environmentMapData)
+        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
     else if (!m_environmentMapURL.isEmpty())
         environmentMapRequestResource();
 #endif
@@ -757,7 +757,7 @@ void HTMLModelElement::environmentMapRequestResource()
         return;
     }
 
-    m_pendingEnvironmentMapData.empty();
+    m_environmentMapData.empty();
 
     m_environmentMapResource = resource.value();
     m_environmentMapResource->addClient(*this);
@@ -765,7 +765,7 @@ void HTMLModelElement::environmentMapRequestResource()
 
 void HTMLModelElement::environmentMapResetAndReject(Exception&& exception)
 {
-    m_pendingEnvironmentMapData.reset();
+    m_environmentMapData.reset();
 
     if (m_environmentMapResource) {
         m_environmentMapResource->removeClient(*this);
@@ -788,7 +788,7 @@ void HTMLModelElement::environmentMapResourceFinished()
         return;
     }
     if (m_modelPlayer)
-        m_modelPlayer->setEnvironmentMap(m_pendingEnvironmentMapData.takeAsContiguous().get());
+        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
 
     m_environmentMapResource->removeClient(*this);
     m_environmentMapResource = nullptr;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -240,7 +240,7 @@ private:
     Ref<DOMPointReadOnly> m_boundingBoxExtents;
     double m_playbackRate { 1.0 };
     URL m_environmentMapURL;
-    SharedBufferBuilder m_pendingEnvironmentMapData;
+    SharedBufferBuilder m_environmentMapData;
     CachedResourceHandle<CachedRawResource> m_environmentMapResource;
     UniqueRef<EnvironmentMapPromise> m_environmentMapReadyPromise;
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -158,7 +158,7 @@ private:
     bool m_loop { false };
     double m_playbackRate { 1.0 };
 
-    RefPtr<WebCore::SharedBuffer> m_environmentMapData;
+    RefPtr<WebCore::SharedBuffer> m_transientEnvironmentMapData;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -575,23 +575,23 @@ void ModelProcessModelPlayerProxy::setCurrentTime(Seconds currentTime, Completio
 
 void ModelProcessModelPlayerProxy::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
 {
-    m_environmentMapData = WTFMove(data);
+    m_transientEnvironmentMapData = WTFMove(data);
     if (m_modelRKEntity)
         applyEnvironmentMapDataAndRelease();
 }
 
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()
 {
-    if (m_environmentMapData) {
-        if (m_environmentMapData->size() > 0) {
-            [m_modelRKEntity applyIBLData:m_environmentMapData->createNSData().get() withCompletion:^(BOOL succeeded) {
+    if (m_transientEnvironmentMapData) {
+        if (m_transientEnvironmentMapData->size() > 0) {
+            [m_modelRKEntity applyIBLData:m_transientEnvironmentMapData->createNSData().get() withCompletion:^(BOOL succeeded) {
                 send(Messages::ModelProcessModelPlayer::DidFinishEnvironmentMapLoading(succeeded));
             }];
         } else {
             [m_modelRKEntity removeIBL];
             send(Messages::ModelProcessModelPlayer::DidFinishEnvironmentMapLoading(true));
         }
-        m_environmentMapData = nullptr;
+        m_transientEnvironmentMapData = nullptr;
     }
 }
 


### PR DESCRIPTION
#### b235c73174d04725454884e4f80df87a0a67a0de
<pre>
Change environment map data variable names to more descriptive ones.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282355">https://bugs.webkit.org/show_bug.cgi?id=282355</a>
<a href="https://rdar.apple.com/138945410">rdar://138945410</a>

Reviewed by Ada Chan.

A follow up change to redeem unintentional renaming that happened in the
initial implementation.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::dataReceived):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::environmentMapRequestResource):
(WebCore::HTMLModelElement::environmentMapResetAndReject):
(WebCore::HTMLModelElement::environmentMapResourceFinished):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::setEnvironmentMap):
(WebKit::ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease):

Canonical link: <a href="https://commits.webkit.org/285976@main">https://commits.webkit.org/285976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98821fba7f40667e3c79d6fad0eb42f63ee25d4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16398 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8100 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->