### PR TITLE
com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::LocalFrameViewLayoutContext::performLayout

### DIFF
--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -102,6 +102,8 @@ public:
     void scrollbarWidthChanged(WebCore::ScrollbarWidth) final;
 private:
 
+    void updateScrollerImps();
+
     // sendContentAreaScrolledSoon() will do the same work that sendContentAreaScrolled() does except
     // it does it after a zero-delay timer fires. This will prevent us from updating overlay scrollbar
     // information during layout.

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -934,23 +934,8 @@ void ScrollbarsControllerMac::notifyContentAreaScrolled(const FloatSize& delta)
         sendContentAreaScrolledSoon(delta);
 }
 
-void ScrollbarsControllerMac::updateScrollerStyle()
+void ScrollbarsControllerMac::updateScrollerImps()
 {
-    if ([m_scrollerImpPair overlayScrollerStateIsLocked]) {
-        m_needsScrollerStyleUpdate = true;
-        return;
-    }
-
-    auto* macTheme = macScrollbarTheme();
-    if (!macTheme) {
-        m_needsScrollerStyleUpdate = false;
-        return;
-    }
-    
-    macTheme->usesOverlayScrollbarsChanged();
-
-    NSScrollerStyle newStyle = [m_scrollerImpPair scrollerStyle];
-
     Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar();
     if (verticalScrollbar && !verticalScrollbar->isCustomScrollbar()) {
         verticalScrollbar->invalidate();
@@ -970,6 +955,26 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         horizontalScrollbarMac->createScrollerImp(WTFMove(oldHorizontalPainter));
         [m_scrollerImpPair setHorizontalScrollerImp:horizontalScrollbarMac->scrollerImp()];
     }
+}
+
+void ScrollbarsControllerMac::updateScrollerStyle()
+{
+    if ([m_scrollerImpPair overlayScrollerStateIsLocked]) {
+        m_needsScrollerStyleUpdate = true;
+        return;
+    }
+
+    auto* macTheme = macScrollbarTheme();
+    if (!macTheme) {
+        m_needsScrollerStyleUpdate = false;
+        return;
+    }
+
+    macTheme->usesOverlayScrollbarsChanged();
+
+    NSScrollerStyle newStyle = [m_scrollerImpPair scrollerStyle];
+
+    updateScrollerImps();
 
     // The different scrollbar styles have different thicknesses, so we must re-set the
     // frameRect to the new thickness, and the re-layout below will ensure the position
@@ -1036,7 +1041,7 @@ void ScrollbarsControllerMac::sendContentAreaScrolled(const FloatSize& delta)
 void ScrollbarsControllerMac::scrollbarWidthChanged(WebCore::ScrollbarWidth)
 {
     updateScrollbarsThickness();
-    updateScrollerStyle();
+    updateScrollerImps();
 }
 
 static String scrollbarState(Scrollbar* scrollbar)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ADAD14E1D77A9F600212586 /* BlockPtr.mm */; };
 		1AEDE22613E5E7E700E62FE8 /* InjectedBundleControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */; };
 		1AF7B21F1D6CD14D008C126C /* EnumTraits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7B21D1D6CD12E008C126C /* EnumTraits.cpp */; };
+		1AF86FC02CD5526B00AD337C /* ScrollbarWidthCrash.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */; };
 		1C15499A2928475C001B9E5B /* WebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C24DEED263001DE00450D07 /* TextStyleFontSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */; };
 		1C2B81831C891F0900A5529F /* CancelFontSubresourcePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */; };
@@ -2208,6 +2209,7 @@
 		1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = InjectedBundleControllerMac.mm; sourceTree = "<group>"; };
 		1AEF994817A09F5300998EF0 /* GetPIDAfterAbortedProcessLaunch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GetPIDAfterAbortedProcessLaunch.cpp; sourceTree = "<group>"; };
 		1AF7B21D1D6CD12E008C126C /* EnumTraits.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumTraits.cpp; sourceTree = "<group>"; };
+		1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollbarWidthCrash.mm; sourceTree = "<group>"; };
 		1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIRuntime.mm; sourceTree = "<group>"; };
 		1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WebExtensionUtilities.mm; path = cocoa/WebExtensionUtilities.mm; sourceTree = "<group>"; };
 		1C15498F2926F944001B9E5B /* WebExtensionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionUtilities.h; path = cocoa/WebExtensionUtilities.h; sourceTree = "<group>"; };
@@ -6092,6 +6094,7 @@
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
 				7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
+				1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */,
 				5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */,
 				A17991861E1C994E00A505ED /* SharedBuffer.mm */,
 				7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */,
@@ -7111,6 +7114,7 @@
 				F418BE151F71B7DC001970E6 /* RoundedRectTests.cpp in Sources */,
 				4181C62D255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp in Sources */,
 				CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */,
+				1AF86FC02CD5526B00AD337C /* ScrollbarWidthCrash.mm in Sources */,
 				0FEFAF64271FC2CD005704D7 /* ScrollingCoordinatorTests.mm in Sources */,
 				CDC0932B21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm in Sources */,
 				7CCE7F121A411AE600447C4C /* ScrollPinningBehaviors.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ScrollbarWidthCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ScrollbarWidthCrash.mm
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "TestInputDelegate.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import "UISideCompositingScope.h"
+
+#import <WebKit/WKWebViewPrivate.h>
+
+static bool loaded = false;
+static bool webProcessCrashed = false;
+
+@interface CrashNavigationDelegate : NSObject <WKNavigationDelegate>
+@end
+
+@implementation CrashNavigationDelegate
+
+- (void)_webView:(WKWebView *)webView webContentProcessDidTerminateWithReason:(_WKProcessTerminationReason)reason
+{
+    webProcessCrashed = true;
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    loaded = true;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+static const CGFloat viewHeight = 500;
+
+static NSString *htmlPage = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px;'>";
+
+TEST(ScrollbarWidthCrash, DynamicallyChangeScrollbarWidth)
+{
+    UISideCompositingScope scope { UISideCompositingState::Disabled };
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+
+    RetainPtr delegate = adoptNS([[CrashNavigationDelegate alloc] init]);
+
+    [webView synchronouslyLoadHTMLString:htmlPage];
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView stringByEvaluatingJavaScript:@"document.documentElement.style.scrollbarWidth = 'none'"];
+    Util::waitFor([] {
+        return webProcessCrashed || loaded;
+    });
+    EXPECT_FALSE(webProcessCrashed);
+}
+
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### deb1e9b679b8b7be5fa5ee404eefdbe61077edb4
<pre>
com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::LocalFrameViewLayoutContext::performLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=282362">https://bugs.webkit.org/show_bug.cgi?id=282362</a>
<a href="https://rdar.apple.com/138879934">rdar://138879934</a>

Reviewed by Simon Fraser.

When updating ScrollbarsControllerMac for a scrollbar width change, previously we were re-using code to
update the NSScrollerImps for the width change, but this function also notifies the scrollable area of
the scrollbar width change, which will eventually call down into layout code, causing an assert. To fix this
factor out the code that updates the NSScrollerImps, as the scrollable area will properly update its width without
the call into scrollbarStyleChanged.

* Source/WebCore/platform/mac/ScrollbarsControllerMac.h:
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerImps):
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
(WebCore::ScrollbarsControllerMac::scrollbarWidthChanged):

Canonical link: <a href="https://commits.webkit.org/286023@main">https://commits.webkit.org/286023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e099dbb3fb22b2c05e8aadc9825b642478686c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38969 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24104 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80445 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1091 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10068 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1815 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1843 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->