### PR TITLE
[JSC] Wasm GC BlockSignature should hold underlying TypeDefinition

### DIFF
--- a/JSTests/wasm/stress/block-signature-create-adhoc-type-definition.js
+++ b/JSTests/wasm/stress/block-signature-create-adhoc-type-definition.js
@@ -1,0 +1,3922 @@
+//@ slow!
+//@ runDefault("--useDollarVM=1", "--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+// If a sample with this instrumentation crashes, it may need the `fuzzilli` function to reproduce the crash.
+if (typeof fuzzilli === 'undefined') fuzzilli = function() {};
+
+const explore = (function() {
+    //
+    // "Import" the common runtime-assisted mutator code. This will make various utility functions available.
+    //
+        // Note: runtime instrumentation code must generally assume that any operation performed on any object coming from the "outside", may raise an exception, for example due to triggering a Proxy trap.
+    // Further, it must also assume that the environment has been modified arbitrarily. For example, the Array.prototype[@@iterator] may have been set to an invalid value, so using `for...of` syntax could trigger an exception.
+
+    // Load all necessary routines and objects into local variables as they may be overwritten by the program.
+    // We generally want to avoid triggerring observable side-effects, such as storing or loading
+    // properties. For that reason, we prefer to use builtins like Object.defineProperty.
+
+    const ProxyConstructor = Proxy;
+    const BigIntConstructor = BigInt;
+    const SetConstructor = Set;
+
+    const ObjectPrototype = Object.prototype;
+
+    const getOwnPropertyNames = Object.getOwnPropertyNames;
+    const getPrototypeOf = Object.getPrototypeOf;
+    const setPrototypeOf = Object.setPrototypeOf;
+    const stringify = JSON.stringify;
+    const hasOwnProperty = Object.hasOwn;
+    const defineProperty = Object.defineProperty;
+    const propertyValues = Object.values;
+    const parseInteger = parseInt;
+    const NumberIsInteger = Number.isInteger;
+    const isNaN = Number.isNaN;
+    const isFinite = Number.isFinite;
+    const truncate = Math.trunc;
+    const apply = Reflect.apply;
+    const construct = Reflect.construct;
+    const ReflectGet = Reflect.get;
+    const ReflectSet = Reflect.set;
+    const ReflectHas = Reflect.has;
+
+    // Bind methods to local variables. These all expect the 'this' object as first parameter.
+    const concat = Function.prototype.call.bind(Array.prototype.concat);
+    const findIndex = Function.prototype.call.bind(Array.prototype.findIndex);
+    const includes = Function.prototype.call.bind(Array.prototype.includes);
+    const shift = Function.prototype.call.bind(Array.prototype.shift);
+    const pop = Function.prototype.call.bind(Array.prototype.pop);
+    const push = Function.prototype.call.bind(Array.prototype.push);
+    const filter = Function.prototype.call.bind(Array.prototype.filter);
+    const execRegExp = Function.prototype.call.bind(RegExp.prototype.exec);
+    const stringSlice = Function.prototype.call.bind(String.prototype.slice);
+    const toUpperCase = Function.prototype.call.bind(String.prototype.toUpperCase);
+    const numberToString = Function.prototype.call.bind(Number.prototype.toString);
+    const bigintToString = Function.prototype.call.bind(BigInt.prototype.toString);
+    const stringStartsWith = Function.prototype.call.bind(String.prototype.startsWith);
+    const setAdd = Function.prototype.call.bind(Set.prototype.add);
+    const setHas = Function.prototype.call.bind(Set.prototype.has);
+
+    const MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER;
+    const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+    // Simple, seedable PRNG based on a LCG.
+    class RNG {
+        m = 2 ** 32;
+        a = 1664525;
+        c = 1013904223;
+        x;
+
+        constructor(seed) {
+            this.x = seed;
+        }
+        randomInt() {
+            this.x = (this.x * this.a + this.c) % this.m;
+            if (!isInteger(this.x)) throw "RNG state is not an Integer!"
+            return this.x;
+        }
+        randomFloat() {
+            return this.randomInt() / this.m;
+        }
+        probability(p) {
+            return this.randomFloat() < p;
+        }
+        reseed(seed) {
+            this.x = seed;
+        }
+    }
+
+    // When creating empty arrays to which elements are later added, use a custom array type that has a null prototype. This way, the arrays are not
+    // affected by changes to the Array.prototype that could interfere with array builtins (e.g. indexed setters or a modified .constructor property).
+    function EmptyArray() {
+        let array = [];
+        setPrototypeOf(array, null);
+        return array;
+    }
+
+    //
+    // Misc. helper functions.
+    //
+    // Type check helpers. These are less error-prone than manually using typeof and comparing against a string.
+    function isObject(v) {
+        return typeof v === 'object';
+    }
+    function isFunction(v) {
+        return typeof v === 'function';
+    }
+    function isString(v) {
+        return typeof v === 'string';
+    }
+    function isNumber(v) {
+        return typeof v === 'number';
+    }
+    function isBigint(v) {
+        return typeof v === 'bigint';
+    }
+    function isSymbol(v) {
+        return typeof v === 'symbol';
+    }
+    function isBoolean(v) {
+        return typeof v === 'boolean';
+    }
+    function isUndefined(v) {
+        return typeof v === 'undefined';
+    }
+
+    // Helper function to determine if a value is an integer, and within [MIN_SAFE_INTEGER, MAX_SAFE_INTEGER].
+    function isInteger(n) {
+        return isNumber(n) && NumberIsInteger(n) && n>= MIN_SAFE_INTEGER && n <= MAX_SAFE_INTEGER;
+    }
+
+    // Helper function to determine if a string is "simple". We only include simple strings for property/method names or string literals.
+    // A simple string is basically a valid, property name with a maximum length.
+    const simpleStringRegExp = /^[0-9a-zA-Z_$]+$/;
+    function isSimpleString(s) {
+        if (!isString(s)) throw "Non-string argument to isSimpleString: " + s;
+        return s.length < 50 && execRegExp(simpleStringRegExp, s) !== null;
+    }
+
+    // Helper function to determine if a string is numeric and its numeric value representable as an integer.
+    function isNumericString(s) {
+        if (!isString(s)) return false;
+        let number = parseInteger(s);
+        return number >= MIN_SAFE_INTEGER && number <= MAX_SAFE_INTEGER && numberToString(number) === s;
+    }
+
+    // Helper function to determine whether a property can be accessed without raising an exception.
+    function tryAccessProperty(prop, obj) {
+        try {
+            obj[prop];
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    // Helper function to determine if a property exists on an object or one of its prototypes. If an exception is raised, false is returned.
+    function tryHasProperty(prop, obj) {
+        try {
+            return prop in obj;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    // Helper function to load a property from an object. If an exception is raised, undefined is returned.
+    function tryGetProperty(prop, obj) {
+        try {
+            return obj[prop];
+        } catch (e) {
+            return undefined;
+        }
+    }
+
+    // Helper function to obtain the own properties of an object. If that raises an exception (e.g. on a Proxy object), an empty array is returned.
+    function tryGetOwnPropertyNames(obj) {
+        try {
+            return getOwnPropertyNames(obj);
+        } catch (e) {
+            return new Array();
+        }
+    }
+
+    // Helper function to fetch the prototype of an object. If that raises an exception (e.g. on a Proxy object), null is returned.
+    function tryGetPrototypeOf(obj) {
+        try {
+            return getPrototypeOf(obj);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // Helper function to that creates a wrapper function for the given function which will call it in a try-catch and return false on exception.
+    function wrapInTryCatch(f) {
+        return function() {
+            try {
+                return apply(f, this, arguments);
+            } catch (e) {
+                return false;
+            }
+        };
+    }
+
+    //
+    // Basic random number generation utility functions.
+    //
+
+    // Initially the rng is seeded randomly, specific mutators can reseed() the rng if they need deterministic behavior.
+    // See the explore operation in JsOperations.swift for an example.
+    let rng = new RNG(truncate(Math.random() * 2**32));
+
+    function probability(p) {
+        if (p < 0 || p > 1) throw "Argument to probability must be a number between zero and one";
+        return rng.probability(p);
+    }
+
+    function randomIntBetween(start, end) {
+        if (!isInteger(start) || !isInteger(end)) throw "Arguments to randomIntBetween must be integers";
+        return (rng.randomInt() % (end - start)) + start;
+    }
+
+    function randomFloat() {
+        return rng.randomFloat();
+    }
+
+    function randomBigintBetween(start, end) {
+        if (!isBigint(start) || !isBigint(end)) throw "Arguments to randomBigintBetween must be bigints";
+        if (!isInteger(Number(start)) || !isInteger(Number(end))) throw "Arguments to randomBigintBetween must be representable as regular intergers";
+        return BigIntConstructor(randomIntBetween(Number(start), Number(end)));
+    }
+
+    function randomIntBelow(n) {
+        if (!isInteger(n)) throw "Argument to randomIntBelow must be an integer";
+        return rng.randomInt() % n;
+    }
+
+    function randomElement(array) {
+        return array[randomIntBelow(array.length)];
+    }
+
+
+    //
+    // "Import" the object introspection code. This is used to find properties and methods when exploring an object.
+    //
+        // Note: this code assumes that the common code from above has been included before.
+
+    //
+    // Object introspection.
+    //
+
+    //
+    // Enumerate all properties on the given object and its prototypes.
+    //
+    // These include elements and methods (callable properties). Each property is assigned a "weight" which expresses roughly how "important"/"interesting" a property is:
+    // a property that exists on a prototype is considered less interesting as it can probably be reached through other objects as well, so we prefer properties closer to the start object.
+    //
+    // The result is returned in an array like the following:
+    // [
+    //   length: <total number of properties>
+    //   totalWeight: <combined weight of all properties>
+    //   0, 1, ..., length - 1: { name: <property name/index>, weight: <weight as number> }
+    // ]
+    function enumeratePropertiesOf(o) {
+        // Collect all properties, including those from prototypes, in this array.
+        let properties = EmptyArray();
+
+        // Give properties from prototypes a lower weight. Currently, the weight is halved for every new level of the prototype chain.
+        let currentWeight = 1.0;
+        properties.totalWeight = 0.0;
+        function recordProperty(p) {
+            push(properties, {name: p, weight: currentWeight});
+            properties.totalWeight += currentWeight;
+        }
+
+        // Iterate over the prototype chain and record all properties.
+        let obj = o;
+        while (obj !== null) {
+            // Special handling for array-like things: if the array is too large, skip this level and just include a couple random indices.
+            // We need to be careful when accessing the length though: for TypedArrays, the length property is defined on the prototype but
+            // must be accessed with the TypedArray as |this| value (not the prototype).
+            let maybeLength = tryGetProperty('length', obj);
+            if (isInteger(maybeLength) && maybeLength > 100) {
+                for (let i = 0; i < 10; i++) {
+                    let randomElement = randomIntBelow(maybeLength);
+                    recordProperty(randomElement);
+                }
+            } else {
+                // TODO do we want to also enumerate symbol properties here (using Object.getOwnPropertySymbols)? If we do, we should probable also add IL-level support for Symbols (i.e. a `LoadSymbol` instruction that ensures the symbol is in the global Symbol registry).
+                let allOwnPropertyNames = tryGetOwnPropertyNames(obj);
+                let allOwnElements = EmptyArray();
+                for (let i = 0; i < allOwnPropertyNames.length; i++) {
+                    let p = allOwnPropertyNames[i];
+                    let index = parseInteger(p);
+                    // TODO should we allow negative indices here as well?
+                    if (index >= 0 && index <= MAX_SAFE_INTEGER && numberToString(index) === p) {
+                        push(allOwnElements, index);
+                    } else if (isSimpleString(p) && tryAccessProperty(p, o)) {
+                        // Only include properties with "simple" names and only if they can be accessed on the original object without raising an exception.
+                        recordProperty(p);
+                    }
+                }
+
+                // Limit array-like objects to at most 10 random elements.
+                for (let i = 0; i < 10 && allOwnElements.length > 0; i++) {
+                    let index = randomIntBelow(allOwnElements.length);
+                    recordProperty(allOwnElements[index]);
+                    allOwnElements[index] = pop(allOwnElements);
+                }
+            }
+
+            obj = tryGetPrototypeOf(obj);
+            currentWeight /= 2.0;
+
+            // Greatly reduce the property weights for the Object.prototype. These methods are always available and we can use more targeted mechanisms like CodeGenerators to call them if we want to.
+            if (obj === ObjectPrototype) {
+                // Somewhat arbitrarily reduce the weight as if there were another 3 levels.
+                currentWeight /= 8.0;
+
+                // However, if we've reached the Object prototype without any other properties (i.e. are inspecting an empty, plain object), then always return an empty list since these properties are not very intersting.
+                if (properties.length == 0) {
+                    return properties;
+                }
+            }
+        }
+
+        return properties;
+    }
+
+    //
+    // Returns a random property available on the given object or one of its prototypes.
+    //
+    // This will return more "interesting" properties with a higher probability. In general, properties closer to the start object
+    // are preferred over properties on prototypes (as these are likely shared with other objects).
+    //
+    // If no (interesting) property exists, null is returned. Otherwise, the key of the property is returned.
+    function randomPropertyOf(o) {
+        let properties = enumeratePropertiesOf(o);
+
+        // We need at least one property to chose from.
+        if (properties.length === 0) {
+            return null;
+        }
+
+        // Now choose a random property. If a property has weight 2W, it will be selected with twice the probability of a property with weight W.
+        let selectedProperty;
+        let remainingWeight = randomFloat() * properties.totalWeight;
+        for (let i = 0; i < properties.length; i++) {
+            let candidate = properties[i];
+            remainingWeight -= candidate.weight;
+            if (remainingWeight < 0) {
+                selectedProperty = candidate.name;
+                break;
+            }
+        }
+
+        // Sanity checking. This may fail for example if Proxies are involved. In that case, just fail here.
+        if (!tryHasProperty(selectedProperty, o)) return null;
+
+        return selectedProperty;
+    }
+
+
+    //
+    // "Import" the Action implementation code.
+    //
+        // Note: this code assumes that the common code from above has been included before.
+
+    //
+    // List of all supported operations. Must be kept in sync with the ActionOperation enum.
+    //
+    const OP_CALL_FUNCTION = 'CALL_FUNCTION';
+    const OP_CONSTRUCT = 'CONSTRUCT';
+    const OP_CALL_METHOD = 'CALL_METHOD';
+    const OP_CONSTRUCT_METHOD = 'CONSTRUCT_METHOD';
+    const OP_GET_PROPERTY = 'GET_PROPERTY';
+    const OP_SET_PROPERTY = 'SET_PROPERTY';
+    const OP_DELETE_PROPERTY = 'DELETE_PROPERTY';
+
+    const OP_ADD = 'ADD';
+    const OP_SUB = 'SUB';
+    const OP_MUL = 'MUL';
+    const OP_DIV = 'DIV';
+    const OP_MOD = 'MOD';
+    const OP_INC = 'INC';
+    const OP_DEC = 'DEC';
+    const OP_NEG = 'NEG';
+
+    const OP_LOGICAL_AND = 'LOGICAL_AND';
+    const OP_LOGICAL_OR = 'LOGICAL_OR';
+    const OP_LOGICAL_NOT = 'LOGICAL_NOT';
+
+    const OP_BITWISE_AND = 'BITWISE_AND';
+    const OP_BITWISE_OR = 'BITWISE_OR';
+    const OP_BITWISE_XOR = 'BITWISE_XOR';
+    const OP_LEFT_SHIFT = 'LEFT_SHIFT';
+    const OP_SIGNED_RIGHT_SHIFT = 'SIGNED_RIGHT_SHIFT';
+    const OP_UNSIGNED_RIGHT_SHIFT = 'UNSIGNED_RIGHT_SHIFT';
+    const OP_BITWISE_NOT = 'BITWISE_NOT';
+
+    const OP_COMPARE_EQUAL = 'COMPARE_EQUAL';
+    const OP_COMPARE_STRICT_EQUAL = 'COMPARE_STRICT_EQUAL';
+    const OP_COMPARE_NOT_EQUAL = 'COMPARE_NOT_EQUAL';
+    const OP_COMPARE_STRICT_NOT_EQUAL = 'COMPARE_STRICT_NOT_EQUAL';
+    const OP_COMPARE_GREATER_THAN = 'COMPARE_GREATER_THAN';
+    const OP_COMPARE_LESS_THAN = 'COMPARE_LESS_THAN';
+    const OP_COMPARE_GREATER_THAN_OR_EQUAL = 'COMPARE_GREATER_THAN_OR_EQUAL';
+    const OP_COMPARE_LESS_THAN_OR_EQUAL = 'COMPARE_LESS_THAN_OR_EQUAL';
+    const OP_TEST_IS_NAN = 'TEST_IS_NAN';
+    const OP_TEST_IS_FINITE = 'TEST_IS_FINITE';
+
+    const OP_SYMBOL_REGISTRATION = 'SYMBOL_REGISTRATION';
+
+    //
+    // Action constructors.
+    //
+    function Action(operation, inputs = EmptyArray()) {
+        this.operation = operation;
+        this.inputs = inputs;
+        this.isGuarded = false;
+    }
+
+    // A guarded action is an action that is allowed to raise an exception.
+    //
+    // These are for example used for by the ExplorationMutator for function/method call
+    // which may throw an exception if they aren't given the right arguments. In that case,
+    // we may still want to keep the function call so that it can be mutated further to
+    // hopefully eventually find the correct arguments. This is especially true if finding
+    // the right arguments reqires the ProbingMutator to install the right properties on an
+    // argument object, in which case the ExplorationMutator on its own would (likely) never
+    // be able to generate a valid call, and so the function/method may be missed entirely.
+    //
+    // If a guarded action succeeds (doesn't raise an exception), it will be converted to
+    // a regular action to limit the number of generated try-catch blocks.
+    function GuardedAction(operation, inputs = EmptyArray()) {
+        this.operation = operation;
+        this.inputs = inputs;
+        this.isGuarded = true;
+    }
+
+    // Special value to indicate that no action should be performed.
+    const NO_ACTION = null;
+
+    //
+    // Action Input constructors.
+    //
+    // The inputs for actions are encoded as objects that specify both the type and the value of the input. They are basically enum values with associated values.
+    // These must be kept compatible with the Action.Input enum in RuntimeAssistedMutator.swift as they have to be encodable to/decodable from that enum.
+    //
+    function ArgumentInput(index) {
+        if (!isInteger(index)) throw "ArgumentInput index is not an integer: " + index;
+        return { argument: { index } };
+    }
+    function SpecialInput(name) {
+        if (!isString(name) || !isSimpleString(name)) throw "SpecialInput name is not a (simple) string: " + name;
+        return { special: { name } };
+    }
+    function IntInput(value) {
+        if (!isInteger(value)) throw "IntInput value is not an integer: " + value;
+        return { int: { value } };
+    }
+    function FloatInput(value) {
+        if (!isNumber(value) || !isFinite(value)) throw "FloatInput value is not a (finite) number: " + value;
+        return { float: { value } };
+    }
+    function BigintInput(value) {
+        if (!isBigint(value)) throw "BigintInput value is not a bigint: " + value;
+        // Bigints can't be serialized by JSON.stringify, so store them as strings instead.
+        return { bigint: { value: bigintToString(value) } };
+    }
+    function StringInput(value) {
+        if (!isString(value) || !isSimpleString(value)) throw "StringInput value is not a (simple) string: " + value;
+        return { string: { value } };
+    }
+
+    // Type checkers for Input objects. We use these instead of for example 'instanceof' since we allow Input
+    // objects to be decoded from JSON, in which case they will not have the right .constructor property.
+    function isArgumentInput(input) { return hasOwnProperty(input, 'argument'); }
+    function isSpecialInput(input) { return hasOwnProperty(input, 'special'); }
+    function isIntInput(input) { return hasOwnProperty(input, 'int'); }
+    function isFloatInput(input) { return hasOwnProperty(input, 'float'); }
+    function isBigintInput(input) { return hasOwnProperty(input, 'bigint'); }
+    function isStringInput(input) { return hasOwnProperty(input, 'string'); }
+
+    // Helper routines to extract the associated values from Input objects.
+    function getArgumentInputIndex(input) { return input.argument.index; }
+    function getSpecialInputName(input) { return input.special.name; }
+    function getIntInputValue(input) { return input.int.value; }
+    function getFloatInputValue(input) { return input.float.value; }
+    function getBigintInputValue(input) { return BigIntConstructor(input.bigint.value); }
+    function getStringInputValue(input) { return input.string.value; }
+
+    // Handlers for executing actions.
+    // These will receive the array of concrete inputs (i.e. JavaScript values) as first parameter and the current value of |this| as second parameter (which can be ignored if not needed).
+    const ACTION_HANDLERS = {
+      [OP_CALL_FUNCTION]: (inputs, currentThis) => { let f = shift(inputs); return apply(f, currentThis, inputs); },
+      [OP_CONSTRUCT]: (inputs) => { let c = shift(inputs); return construct(c, inputs); },
+      [OP_CALL_METHOD]: (inputs) => { let o = shift(inputs); let m = shift(inputs); return apply(o[m], o, inputs); },
+      [OP_CONSTRUCT_METHOD]: (v, inputs) => { let o = shift(inputs); let m = shift(inputs); return construct(o[m], inputs); },
+      [OP_GET_PROPERTY]: (inputs) => { let o = inputs[0]; let p = inputs[1]; return o[p]; },
+      [OP_SET_PROPERTY]: (inputs) => { let o = inputs[0]; let p = inputs[1]; let v = inputs[2]; o[p] = v; },
+      [OP_DELETE_PROPERTY]: (inputs) => { let o = inputs[0]; let p = inputs[1]; return delete o[p]; },
+      [OP_ADD]: (inputs) => inputs[0] + inputs[1],
+      [OP_SUB]: (inputs) => inputs[0] - inputs[1],
+      [OP_MUL]: (inputs) => inputs[0] * inputs[1],
+      [OP_DIV]: (inputs) => inputs[0] / inputs[1],
+      [OP_MOD]: (inputs) => inputs[0] % inputs[1],
+      [OP_INC]: (inputs) => inputs[0]++,
+      [OP_DEC]: (inputs) => inputs[0]--,
+      [OP_NEG]: (inputs) => -inputs[0],
+      [OP_LOGICAL_AND]: (inputs) => inputs[0] && inputs[1],
+      [OP_LOGICAL_OR]: (inputs) => inputs[0] || inputs[1],
+      [OP_LOGICAL_NOT]: (inputs) => !inputs[0],
+      [OP_BITWISE_AND]: (inputs) => inputs[0] & inputs[1],
+      [OP_BITWISE_OR]: (inputs) => inputs[0] | inputs[1],
+      [OP_BITWISE_XOR]: (inputs) => inputs[0] ^ inputs[1],
+      [OP_LEFT_SHIFT]: (inputs) => inputs[0] << inputs[1],
+      [OP_SIGNED_RIGHT_SHIFT]: (inputs) => inputs[0] >> inputs[1],
+      [OP_UNSIGNED_RIGHT_SHIFT]: (inputs) => inputs[0] >>> inputs[1],
+      [OP_BITWISE_NOT]: (inputs) => ~inputs[0],
+      [OP_COMPARE_EQUAL]: (inputs) => inputs[0] == inputs[1],
+      [OP_COMPARE_STRICT_EQUAL]: (inputs) => inputs[0] === inputs[1],
+      [OP_COMPARE_NOT_EQUAL]: (inputs) => inputs[0] != inputs[1],
+      [OP_COMPARE_STRICT_NOT_EQUAL]: (inputs) => inputs[0] !== inputs[1],
+      [OP_COMPARE_GREATER_THAN]: (inputs) => inputs[0] > inputs[1],
+      [OP_COMPARE_LESS_THAN]: (inputs) => inputs[0] < inputs[1],
+      [OP_COMPARE_GREATER_THAN_OR_EQUAL]: (inputs) => inputs[0] >= inputs[1],
+      [OP_COMPARE_LESS_THAN_OR_EQUAL]: (inputs) => inputs[0] <= inputs[1],
+      [OP_TEST_IS_NAN]: (inputs) => Number.isNaN(inputs[0]),
+      [OP_TEST_IS_FINITE]: (inputs) => Number.isFinite(inputs[0]),
+      [OP_SYMBOL_REGISTRATION]: (inputs) => Symbol.for(inputs[0].description),
+    };
+
+    // Executes the given action.
+    //
+    // This will convert the inputs to concrete JavaScript values, then execute the operation with these inputs.
+    // Executing an action may change its guarding state: if a guarded action executes without raising an exception,
+    // it will be converted to an unguarded operation (as the guarding apears to not be needed). This way, we will
+    // ultimately end up emitting fewer try-catch (or equivalent) constructs in the final JavaScript code generated
+    // from these actions.
+    //
+    // Returns true if either the action succeeded without raising an exception or if the action is guarded, false otherwise.
+    // The output of the action is stored in |context.output| upon successful execution.
+    function execute(action, context) {
+        if (action === NO_ACTION) {
+            return true;
+        }
+
+        // Convert the action's inputs to the concrete JS values to use for executing the action.
+        let concreteInputs = EmptyArray();
+        for (let i = 0; i < action.inputs.length; i++) {
+            let input = action.inputs[i];
+            if (isArgumentInput(input)) {
+                let index = getArgumentInputIndex(input);
+                if (index >= context.arguments.length) throw "Invalid argument index: " + index;
+                push(concreteInputs, context.arguments[index]);
+            } else if (isSpecialInput(input)) {
+                let name = getSpecialInputName(input);
+                if (!hasOwnProperty(context.specialValues, name)) throw "Unknown special value: " + name;
+                push(concreteInputs, context.specialValues[name]);
+            } else if (isIntInput(input)) {
+                push(concreteInputs, getIntInputValue(input));
+            } else if (isFloatInput(input)) {
+                push(concreteInputs, getFloatInputValue(input));
+            } else if (isBigintInput(input)) {
+                // These need special handling because BigInts cannot be serialized into JSON, so are stored as strings.
+                push(concreteInputs, getBigintInputValue(input));
+            } else if (isStringInput(input)) {
+                push(concreteInputs, getStringInputValue(input));
+            } else {
+                throw "Unknown action input: " + stringify(input);
+            }
+        }
+
+        let handler = ACTION_HANDLERS[action.operation];
+        if (isUndefined(handler)) throw "Unhandled operation " + action.operation;
+
+        try {
+            context.output = handler(concreteInputs, context.currentThis);
+            // If the action succeeded, mark it as non-guarded so that we don't emit try-catch blocks for it later on.
+            // We could alternatively only do that if all executions succeeded, but it's probably fine to do it if at least one execution succeeded.
+            if (action.isGuarded) action.isGuarded = false;
+        } catch (e) {
+            return action.isGuarded;
+        }
+
+        return true;
+    }
+
+    // JS Action Operation groups. See e.g. exploreNumber() for examples of how they are used.
+    const SHIFT_OPS = [OP_LEFT_SHIFT, OP_SIGNED_RIGHT_SHIFT, OP_UNSIGNED_RIGHT_SHIFT];
+    // Unsigned shift is not defined for bigints.
+    const BIGINT_SHIFT_OPS = [OP_LEFT_SHIFT, OP_SIGNED_RIGHT_SHIFT];
+    const BITWISE_OPS = [OP_BITWISE_OR, OP_BITWISE_AND, OP_BITWISE_XOR];
+    const ARITHMETIC_OPS = [OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD];
+    const UNARY_OPS = [OP_INC, OP_DEC, OP_NEG, OP_BITWISE_NOT];
+    const COMPARISON_OPS = [OP_COMPARE_EQUAL, OP_COMPARE_STRICT_EQUAL, OP_COMPARE_NOT_EQUAL, OP_COMPARE_STRICT_NOT_EQUAL, OP_COMPARE_GREATER_THAN, OP_COMPARE_LESS_THAN, OP_COMPARE_GREATER_THAN_OR_EQUAL, OP_COMPARE_LESS_THAN_OR_EQUAL];
+    const BOOLEAN_BINARY_OPS = [OP_LOGICAL_AND, OP_LOGICAL_OR];
+    const BOOLEAN_UNARY_OPS = [OP_LOGICAL_NOT];
+
+
+    //
+    // Global constants.
+    //
+    // Property names to use when defining new properties. Should be kept in sync with the equivalent set in JavaScriptEnvironment.swift
+    const customPropertyNames = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+    // Maximum number of parameters for function/method calls. Everything above this is consiered an invalid .length property of the function.
+    const MAX_PARAMETERS = 10;
+
+    // Well known integer/number values to use when generating random values.
+    const WELL_KNOWN_INTEGERS = filter([-9223372036854775808, -9223372036854775807, -9007199254740992, -9007199254740991, -9007199254740990, -4294967297, -4294967296, -4294967295, -2147483649, -2147483648, -2147483647, -1073741824, -536870912, -268435456, -65537, -65536, -65535, -4096, -1024, -256, -128, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 64, 127, 128, 129, 255, 256, 257, 512, 1000, 1024, 4096, 10000, 65535, 65536, 65537, 268435439, 268435440, 268435441, 536870887, 536870888, 536870889, 268435456, 536870912, 1073741824, 1073741823, 1073741824, 1073741825, 2147483647, 2147483648, 2147483649, 4294967295, 4294967296, 4294967297, 9007199254740990, 9007199254740991, 9007199254740992, 9223372036854775807], isInteger);
+    const WELL_KNOWN_NUMBERS = concat(WELL_KNOWN_INTEGERS, [-1e6, -1e3, -5.0, -4.0, -3.0, -2.0, -1.0, -0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1e3, 1e6]);
+    const WELL_KNOWN_BIGINTS = [-9223372036854775808n, -9223372036854775807n, -9007199254740992n, -9007199254740991n, -9007199254740990n, -4294967297n, -4294967296n, -4294967295n, -2147483649n, -2147483648n, -2147483647n, -1073741824n, -536870912n, -268435456n, -65537n, -65536n, -65535n, -4096n, -1024n, -256n, -128n, -2n, -1n, 0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n, 16n, 64n, 127n, 128n, 129n, 255n, 256n, 257n, 512n, 1000n, 1024n, 4096n, 10000n, 65535n, 65536n, 65537n, 268435439n, 268435440n, 268435441n, 536870887n, 536870888n, 536870889n, 268435456n, 536870912n, 1073741824n, 1073741823n, 1073741824n, 1073741825n, 2147483647n, 2147483648n, 2147483649n, 4294967295n, 4294967296n, 4294967297n, 9007199254740990n, 9007199254740991n, 9007199254740992n, 9223372036854775807n];
+
+
+    //
+    // Global state.
+    //
+
+    // The concrete argument values that will be used when executing the Action for the current exploration operation.
+    let exploreArguments;
+
+    // The input containing the value being explored. This should always be the first input to every Action created during exploration.
+    let exploredValueInput;
+
+    // Whether exploration is currently happening. This is required to detect recursive exploration, where for example a callback
+    // triggered during property enumeration triggers further exploration calls. See explore().
+    let currentlyExploring = false;
+
+
+    //
+    // Error and result reporting.
+    //
+    // Results (indexed by their ID) will be stored in here.
+    const results = { __proto__: null };
+
+    function reportError(msg) {
+        fuzzilli('FUZZILLI_PRINT', 'EXPLORE_ERROR: ' + msg);
+    }
+
+    function recordFailure(id) {
+        // Delete the property if it already exists (from recordAction).
+        delete results[id];
+        defineProperty(results, id, {__proto__: null, value: NO_ACTION});
+
+        fuzzilli('FUZZILLI_PRINT', 'EXPLORE_FAILURE: ' + id);
+    }
+
+    function recordAction(id, action) {
+        if (hasOwnProperty(results, id)) {
+            throw "Duplicate action for " + id;
+        }
+
+        if (action === NO_ACTION) {
+            // This is equivalent to a failure.
+            return recordFailure(id);
+        }
+
+        action.id = id;
+
+        // These are configurable as they may need to be overwritten (by recordFailure) in the future.
+        defineProperty(results, id, {__proto__: null, value: action, configurable: true});
+
+        fuzzilli('FUZZILLI_PRINT', 'EXPLORE_ACTION: ' + stringify(action));
+    }
+
+    function hasActionFor(id) {
+        return hasOwnProperty(results, id);
+    }
+
+    function getActionFor(id) {
+        return results[id];
+    }
+
+    //
+    // Access to random inputs.
+    //
+    // These functions prefer to take an existing variable from the arguments to the Explore operations if it satistifes the specified criteria. Otherwise, they generate a new random value.
+    // Testing whether an argument satisfies some criteria (e.g. be a value in a certain range) may trigger type conversions. This is expected as it may lead to interesting values being used.
+    // These are grouped into a namespace object to make it more clear that they return an Input object (from one of the above constructors), rather than a value.
+    //
+    let Inputs = {
+        randomArgument() {
+            return new ArgumentInput(randomIntBelow(exploreArguments.length));
+        },
+
+        randomArguments(n) {
+            let args = EmptyArray();
+            for (let i = 0; i < n; i++) {
+                push(args, new ArgumentInput(randomIntBelow(exploreArguments.length)));
+            }
+            return args;
+        },
+
+        randomArgumentForReplacing(propertyName, obj) {
+            let curValue = tryGetProperty(propertyName, obj);
+            if (isUndefined(curValue)) {
+                return Inputs.randomArgument();
+            }
+
+            function isCompatible(arg) {
+                let sameType = typeof curValue === typeof arg;
+                if (sameType && isObject(curValue)) {
+                    sameType = arg instanceof curValue.constructor;
+                }
+                return sameType;
+            }
+
+            let idx = findIndex(exploreArguments, wrapInTryCatch(isCompatible));
+            if (idx != -1) return new ArgumentInput(idx);
+            return Inputs.randomArgument();
+        },
+
+        randomInt() {
+            let idx = findIndex(exploreArguments, isInteger);
+            if (idx != -1) return new ArgumentInput(idx);
+            return new IntInput(randomElement(WELL_KNOWN_INTEGERS));
+        },
+
+        randomNumber() {
+            let idx = findIndex(exploreArguments, isNumber);
+            if (idx != -1) return new ArgumentInput(idx);
+            return new FloatInput(randomElement(WELL_KNOWN_NUMBERS));
+        },
+
+        randomBigint() {
+            let idx = findIndex(exploreArguments, isBigint);
+            if (idx != -1) return new ArgumentInput(idx);
+            return new BigintInput(randomElement(WELL_KNOWN_BIGINTS));
+        },
+
+        randomIntBetween(start, end) {
+            if (!isInteger(start) || !isInteger(end)) throw "Arguments to randomIntBetween must be integers";
+            let idx = findIndex(exploreArguments, wrapInTryCatch((e) => NumberIsInteger(e) && (e >= start) && (e < end)));
+            if (idx != -1) return new ArgumentInput(idx);
+            return new IntInput(randomIntBetween(start, end));
+        },
+
+        randomBigintBetween(start, end) {
+            if (!isBigint(start) || !isBigint(end)) throw "Arguments to randomBigintBetween must be bigints";
+            if (!isInteger(Number(start)) || !isInteger(Number(end))) throw "Arguments to randomBigintBetween must be representable as regular integers";
+            let idx = findIndex(exploreArguments, wrapInTryCatch((e) => (e >= start) && (e < end)));
+            if (idx != -1) return new ArgumentInput(idx);
+            return new BigintInput(randomBigintBetween(start, end));
+        },
+
+        randomNumberCloseTo(v) {
+            if (!isFinite(v)) throw "Argument to randomNumberCloseTo is not a finite number: " + v;
+            let idx = findIndex(exploreArguments, wrapInTryCatch((e) => (e >= v - 10) && (e <= v + 10)));
+            if (idx != -1) return new ArgumentInput(idx);
+            let step = randomIntBetween(-10, 10);
+            let value = v + step;
+            if (isInteger(value)) {
+              return new IntInput(value);
+            } else {
+              return new FloatInput(v + step);
+            }
+        },
+
+        randomBigintCloseTo(v) {
+            if (!isBigint(v)) throw "Argument to randomBigintCloseTo is not a bigint: " + v;
+            let idx = findIndex(exploreArguments, wrapInTryCatch((e) => (e >= v - 10n) && (e <= v + 10n)));
+            if (idx != -1) return new ArgumentInput(idx);
+            let step = randomBigintBetween(-10n, 10n);
+            let value = v + step;
+            return new BigintInput(value);
+        }
+    }
+
+    // Heuristic to determine when a function should be invoked as a constructor. Used by the object and function exploration code.
+    function shouldTreatAsConstructor(f) {
+        let name = tryGetProperty('name', f);
+
+        // If the function has no name (or a non-string name), it's probably a regular function (or something like an arrow function).
+        if (!isString(name) || name.length < 1) {
+            return probability(0.1);
+        }
+
+        // If the name is something like `f42`, it's probably a function defined by Fuzzilli. These can typicall be used as function or constructor, but prefer to call them as regular functions.
+        if (name[0] === 'f' && !isNaN(parseInteger(stringSlice(name, 1)))) {
+          return probability(0.2);
+        }
+
+        // Otherwise, the basic heuristic is that functions that start with an uppercase letter (e.g. Object, Uint8Array, etc.) are probably constructors (but not always, e.g. BigInt).
+        // This is also compatible with Fuzzilli's lifting of classes, as they will look something like this: `class V3 { ...`.
+        if (name[0] === toUpperCase(name[0])) {
+          return probability(0.9);
+        } else {
+          return probability(0.1);
+        }
+    }
+
+    //
+    // Explore implementation for different basic types.
+    //
+    // These all return an Action object or the special NO_ACTION value (null).
+    //
+    function exploreObject(o) {
+        if (o === null) {
+            // Can't do anything with null.
+            return NO_ACTION;
+        }
+
+        // TODO: Add special handling for ArrayBuffers: most of the time, wrap these into a Uint8Array to be able to modify them.
+        // TODO: Sometimes iterate over iterable objects (e.g. Arrays)?
+
+        // Determine a random property, which can generally either be a method, an element, or a "regular" property.
+        let propertyName = randomPropertyOf(o);
+
+        // Determine the appropriate action to perform given the selected property.
+        // If the property lookup failed (for whatever reason), we always define a new property.
+        if (propertyName === null) {
+            let propertyNameInput = new StringInput(randomElement(customPropertyNames));
+            return new Action(OP_SET_PROPERTY, [exploredValueInput, propertyNameInput, Inputs.randomArgument()]);
+        } else if (isInteger(propertyName)) {
+            let propertyNameInput = new IntInput(propertyName);
+            if (probability(0.5)) {
+                return new Action(OP_GET_PROPERTY, [exploredValueInput, propertyNameInput]);
+            } else {
+                let newValue = Inputs.randomArgumentForReplacing(propertyName, o);
+                return new Action(OP_SET_PROPERTY, [exploredValueInput, propertyNameInput, newValue]);
+            }
+        } else if (isString(propertyName)) {
+            let propertyNameInput = new StringInput(propertyName);
+            let propertyValue = tryGetProperty(propertyName, o);
+            if (isFunction(propertyValue)) {
+                // Perform a method call/construct.
+                let numParameters = tryGetProperty('length', propertyValue);
+                if (!isInteger(numParameters) || numParameters > MAX_PARAMETERS || numParameters < 0) return NO_ACTION;
+                let inputs = EmptyArray();
+                push(inputs, exploredValueInput);
+                push(inputs, propertyNameInput);
+                for (let i = 0; i < numParameters; i++) {
+                    push(inputs, Inputs.randomArgument());
+                }
+                if (shouldTreatAsConstructor(propertyValue)) {
+                  return new GuardedAction(OP_CONSTRUCT_METHOD, inputs);
+                } else {
+                  return new GuardedAction(OP_CALL_METHOD, inputs);
+                }
+            } else {
+                // Perform a property access.
+                // Besides getting and setting the property, we also sometimes define a new property instead.
+                if (probability(1/3)) {
+                    propertyNameInput = new StringInput(randomElement(customPropertyNames));
+                    return new Action(OP_SET_PROPERTY, [exploredValueInput, propertyNameInput, Inputs.randomArgument()]);
+                } else if (probability(0.5)) {
+                    return new Action(OP_GET_PROPERTY, [exploredValueInput, propertyNameInput]);
+                } else {
+                    let newValue = Inputs.randomArgumentForReplacing(propertyName, o);
+                    return new Action(OP_SET_PROPERTY, [exploredValueInput, propertyNameInput, newValue]);
+                }
+            }
+        } else {
+          throw "Got unexpected property name from Inputs.randomPropertyOf(): " + propertyName;
+        }
+    }
+
+    function exploreFunction(f) {
+        // Sometimes treat functions as objects.
+        // This will cause interesting properties like 'arguments' or 'prototype' to be accessed, methods like 'apply' or 'bind' to be called, and methods on builtin constructors like 'Array', and 'Object' to be used.
+        if (probability(0.5)) {
+            return exploreObject(f);
+        }
+
+        // Otherwise, call or construct the function/constructor.
+        let numParameters = tryGetProperty('length', f);
+        if (!isInteger(numParameters) || numParameters > MAX_PARAMETERS || numParameters < 0) {
+            numParameters = 0;
+        }
+        let inputs = EmptyArray();
+        push(inputs, exploredValueInput);
+        for (let i = 0; i < numParameters; i++) {
+            push(inputs, Inputs.randomArgument());
+        }
+        let operation = shouldTreatAsConstructor(f) ? OP_CONSTRUCT : OP_CALL_FUNCTION;
+        return new GuardedAction(operation, inputs);
+    }
+
+    function exploreString(s) {
+        // Sometimes (rarely) compare the string against it's original value. Otherwise, treat the string as an object.
+        // TODO: sometimes access a character of the string or iterate over it?
+        if (probability(0.1) && isSimpleString(s)) {
+            return new Action(OP_COMPARE_EQUAL, [exploredValueInput, new StringInput(s)]);
+        } else {
+            return exploreObject(new String(s));
+        }
+    }
+
+    const ALL_NUMBER_OPERATIONS = concat(SHIFT_OPS, BITWISE_OPS, ARITHMETIC_OPS, UNARY_OPS);
+    const ALL_NUMBER_OPERATIONS_AND_COMPARISONS = concat(ALL_NUMBER_OPERATIONS, COMPARISON_OPS);
+    function exploreNumber(n) {
+        // Somewhat arbitrarily give comparisons a lower probability when choosing the operation to perform.
+        let operation = randomElement(probability(0.5) ? ALL_NUMBER_OPERATIONS : ALL_NUMBER_OPERATIONS_AND_COMPARISONS);
+
+        let action = new Action(operation);
+        push(action.inputs, exploredValueInput);
+        if (includes(COMPARISON_OPS, operation)) {
+            if (isNaN(n)) {
+                // In that case, regular comparisons don't make sense, so just test for isNaN instead.
+                action.operation = OP_TEST_IS_NAN;
+            } else if (!isFinite(n)) {
+                // Similar to the NaN case, just test for isFinite here.
+                action.operation = OP_TEST_IS_FINITE;
+            } else {
+                push(action.inputs, Inputs.randomNumberCloseTo(n));
+            }
+        } else if (includes(SHIFT_OPS, operation)) {
+            push(action.inputs, Inputs.randomIntBetween(1, 32));
+        } else if (includes(BITWISE_OPS, operation)) {
+            push(action.inputs, Inputs.randomInt());
+        } else if (includes(ARITHMETIC_OPS, operation)) {
+            if (isInteger(n)) {
+                push(action.inputs, Inputs.randomInt());
+            } else {
+                push(action.inputs, Inputs.randomNumber());
+            }
+        }
+        return action;
+    }
+
+    const ALL_BIGINT_OPERATIONS = concat(BIGINT_SHIFT_OPS, BITWISE_OPS, ARITHMETIC_OPS, UNARY_OPS);
+    const ALL_BIGINT_OPERATIONS_AND_COMPARISONS = concat(ALL_BIGINT_OPERATIONS, COMPARISON_OPS);
+    function exploreBigint(b) {
+        // Somewhat arbitrarily give comparisons a lower probability when choosing the operation to perform.
+        let operation = randomElement(probability(0.5) ? ALL_BIGINT_OPERATIONS : ALL_BIGINT_OPERATIONS_AND_COMPARISONS);
+
+        let action = new Action(operation);
+        push(action.inputs, exploredValueInput);
+        if (includes(COMPARISON_OPS, operation)) {
+            push(action.inputs, Inputs.randomBigintCloseTo(b));
+        } else if (includes(BIGINT_SHIFT_OPS, operation)) {
+            push(action.inputs, Inputs.randomBigintBetween(1n, 128n));
+        } else if (includes(BITWISE_OPS, operation) || includes(ARITHMETIC_OPS, operation)) {
+            push(action.inputs, Inputs.randomBigint());
+        }
+        return action;
+    }
+
+    function exploreSymbol(s) {
+        // Lookup or insert the symbol into the global symbol registry. This will also allow static typing of the output.
+        return new Action(OP_SYMBOL_REGISTRATION, [exploredValueInput]);
+    }
+
+    const ALL_BOOLEAN_OPERATIONS = concat(BOOLEAN_BINARY_OPS, BOOLEAN_UNARY_OPS);
+    function exploreBoolean(b) {
+        let operation = randomElement(ALL_BOOLEAN_OPERATIONS);
+
+        let action = new Action(operation);
+        push(action.inputs, exploredValueInput);
+        if (includes(BOOLEAN_BINARY_OPS, operation)) {
+            // It probably doesn't make sense to hardcode boolean constants, so always use an existing argument.
+            push(action.inputs, Inputs.randomArgument());
+        }
+        return action;
+    }
+
+    // Explores the given value and returns an action to perform on it.
+    function exploreValue(id, v) {
+        if (isObject(v)) {
+            return exploreObject(v);
+        } else if (isFunction(v)) {
+            return exploreFunction(v);
+        } else if (isString(v)) {
+            return exploreString(v);
+        } else if (isNumber(v)) {
+            return exploreNumber(v);
+        } else if (isBigint(v)) {
+            return exploreBigint(v);
+        } else if (isSymbol(v)) {
+            return exploreSymbol(v);
+        } else if (isBoolean(v)) {
+            return exploreBoolean(v);
+        } else if (isUndefined(v)) {
+            // Can't do anything with undefined.
+            return NO_ACTION;
+        } else {
+            throw "Unexpected value type: " + typeof v;
+        }
+    }
+
+    //
+    // Exploration entrypoint.
+    //
+    function explore(id, v, currentThis, args, rngSeed) {
+        rng.reseed(rngSeed);
+
+        // The given arguments may be used as inputs for the action.
+        if (isUndefined(args) || args.length < 1) throw "Exploration requires at least one additional argument";
+
+        // We may get here recursively for example if a Proxy is being explored which triggers further explore calls during e.g. property enumeration.
+        // Probably the best way to deal with these cases is to just bail out from recursive explorations.
+        if (currentlyExploring) return;
+        currentlyExploring = true;
+
+        // Set the global state for this explore operation.
+        exploreArguments = args;
+        exploredValueInput = new SpecialInput("exploredValue");
+
+        // Check if we already have a result for this id, and if so repeat the same action again. Otherwise, explore.
+        let action;
+        if (hasActionFor(id)) {
+            action = getActionFor(id);
+        } else {
+            action = exploreValue(id, v);
+            recordAction(id, action);
+        }
+
+        // Now perform the selected action.
+        let context = { arguments: args, specialValues: { "exploredValue": v }, currentThis: currentThis };
+        let success = execute(action, context);
+
+        // If the action failed, mark this explore operation as failing (which will set the action to NO_ACTION) so it won't be retried again.
+        if (!success) {
+            recordFailure(id);
+        }
+
+        currentlyExploring = false;
+    }
+
+    function exploreWithErrorHandling(id, v, thisValue, args, rngSeed) {
+        try {
+            explore(id, v, thisValue, args, rngSeed);
+        } catch (e) {
+            let line = tryHasProperty('line', e) ? tryGetProperty('line', e) : tryGetProperty('lineNumber', e);
+            if (isNumber(line)) {
+                reportError("In line " + line + ": " + e);
+            } else {
+                reportError(e);
+            }
+        }
+    }
+    return exploreWithErrorHandling;
+})();
+
+
+
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const log = function (v) { };
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+/**
+@returns {[F32, I32, F64]}
+ */
+let fn0 = function () {
+
+return [5.5476368290907105e-22, 79, 0.42040003435666096e-40];
+};
+/**
+@returns {void}
+ */
+let fn1 = function () {
+};
+/**
+@returns {void}
+ */
+let fn2 = function () {
+};
+/**
+@returns {void}
+ */
+let fn3 = function () {
+};
+/**
+@returns {void}
+ */
+let fn4 = function () {
+};
+let tag0 = new WebAssembly.Tag({parameters: []});
+let tag8 = new WebAssembly.Tag({parameters: []});
+let global0 = new WebAssembly.Global({value: 'i64', mutable: true}, 3708037917n);
+let global1 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let global3 = new WebAssembly.Global({value: 'f32', mutable: true}, 28266.665117909095);
+let global4 = new WebAssembly.Global({value: 'f32', mutable: true}, 221475.53108143734);
+let table0 = new WebAssembly.Table({initial: 27, element: 'anyfunc'});
+let table3 = new WebAssembly.Table({initial: 37, element: 'externref'});
+let table4 = new WebAssembly.Table({initial: 50, element: 'externref'});
+let table5 = new WebAssembly.Table({initial: 80, element: 'externref', maximum: 645});
+let table6 = new WebAssembly.Table({initial: 83, element: 'anyfunc', maximum: 420});
+let table7 = new WebAssembly.Table({initial: 82, element: 'externref'});
+let table8 = new WebAssembly.Table({initial: 55, element: 'anyfunc', maximum: 55});
+let m0 = {fn0, fn1, fn3, fn4, global4, table0, table3, table7, table8, tag1: tag0};
+let m1 = {fn2, table2: table0, table4, table6, tag0, tag2: tag0, tag3: tag0, tag4: tag0, tag5: tag0, tag7: tag0, tag8};
+let m2 = {global0, global1, global2: null, global3, global5: -84979.81895452089, table1: table0, table5, tag6: tag0};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+let i0 = await instantiate('AGFzbQEAAAABHQdgAAF/YAADe3x+YAAAYAAAYAADfX98YAAAYAAAAvYCHgJtMANmbjAABAJtMANmbjEAAwJtMQNmbjIAAgJtMANmbjMABgJtMANmbjQAAgVleHRyYQVpc0pJVAAAAm0xBHRhZzAEAAMCbTAEdGFnMQQAAwJtMQR0YWcyBAAGAm0xBHRhZzMEAAMCbTEEdGFnNAQABQJtMQR0YWc1BAADAm0yBHRhZzYEAAICbTEEdGFnNwQAAwJtMQR0YWc4BAADAm0yB2dsb2JhbDADfgECbTIHZ2xvYmFsMQNvAQJtMgdnbG9iYWwyA3AAAm0yB2dsb2JhbDMDfQECbTAHZ2xvYmFsNAN9AQJtMgdnbG9iYWw1A3wAAm0wBnRhYmxlMAFwABsCbTIGdGFibGUxAXAAFQJtMQZ0YWJsZTIBcAAGAm0wBnRhYmxlMwFvACUCbTEGdGFibGU0AW8AMgJtMgZ0YWJsZTUBbwFQhQUCbTEGdGFibGU2AXABU6QDAm0wBnRhYmxlNwFvAFICbTAGdGFibGU4AXABNzcDAgEFBBQEbwFEmwNwASdtcAFH2gRvAVTqBAUGAQOQCJEODQMBAAUGFgNwAdIAC38BQdnC87IEC38BQdKSDgsHdAwHdGFibGUxNAELB2dsb2JhbDYDBgZ0YWJsZTkBAQdnbG9iYWw4AwgHdGFibGUxMAEGB3RhYmxlMTUBDAd0YWJsZTExAQcHZ2xvYmFsNwMHB3RhYmxlMTIBCQdtZW1vcnkwAgADZm41AAYHdGFibGUxMwEKCboECgdwBNIFC9IEC9IGC9IECwBBEAsLAQAFBgMGAAMCBAYDAD4DAAMAAAQCAAMBBgIABgMCBAIEBAQCBQEEAQEDAwUBAwQCBAEBBgIBBQQAAwEABAUFAAQEAgQAAQQCAQQEAwYIQQwLcCvSBAvSAgvSAgvSBQvSAAvSAgvSAgvSAgvSBgvSAwvSBQvSBAvSAQvSBAvSAAvSAQvSAAvSAwvSAwvSBAvSAgvSAQvSBQvSAQvSBQvSBgvSBQvSBAvSAgvSBgvSAgvSAQvSAgvSBQvSAAvSBQvSAQvSAwvSBAvSAwvSAgvSAgvSAQsGCkEcC3AL0gML0gEL0gYL0gUL0gEL0gQL0gML0gYL0gIL0gQL0gQLB3BR0gAL0gYL0gIL0gYL0gUL0gML0gIL0gIL0gML0gML0gYL0gYL0gQL0gEL0gIL0gIL0gIL0gIL0gUL0gIL0gML0gQL0gML0gAL0gYL0gQL0gML0gQL0gQL0gIL0gUL0gEL0gML0gQL0gYL0gEL0gIL0gQL0gIL0gEL0gAL0gEL0gYL0gYL0gIL0gAL0gAL0gQL0gIL0gEL0gYL0gIL0gAL0gAL0gAL0gAL0gQL0gYL0gYL0gML0gIL0gML0gAL0gEL0gIL0gYL0gML0gML0gML0gEL0gEL0gUL0gYL0gQL0gAL0gYL0gML0gYL0gAL0gUL0gELAQAGAwUABAABBgtBDQtwAdIACwYIQQQLcAXSAQvSAgvSAwvSBAvSBgsGCkEPC3AB0gULDAEJCmsBaQoAcAB8AH8CfwFwAXADfwF+AX0BfBAA0gEDfEOVoUWsJAMCAgIAQQgRAwj8EAVBAnAOAQMBAQABC0ECcA4CAgACCwwBAAsDfUGmAQ0BDwALiyAADQCO0gQGfQ8ACyQEIAFBAXAOAQAACws9CQIAQduZAQsHe/you7RRGgIAQdyMAgsB/QECiAUBAWIAQeEhCwPgK+cBAZgBCdoNNH5+Obdx7gECtN8BAA==', importObject0);
+let {fn5, global6, global7, global8, memory0, table9, table10, table11, table12, table13, table14, table15} = /**
+  @type {{
+fn5: () => void,
+global6: WebAssembly.Global,
+global7: WebAssembly.Global,
+global8: WebAssembly.Global,
+memory0: WebAssembly.Memory,
+table9: WebAssembly.Table,
+table10: WebAssembly.Table,
+table11: WebAssembly.Table,
+table12: WebAssembly.Table,
+table13: WebAssembly.Table,
+table14: WebAssembly.Table,
+table15: WebAssembly.Table
+  }} */ (i0.instance.exports);
+table12.set(61, table3);
+table11.set(57, table7);
+global1.value = 'a';
+global6.value = null;
+log('calling fn5');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn5();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@param {ExternRef} a2
+@returns {[I32, FuncRef, ExternRef]}
+ */
+let fn6 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [7, a1, a2];
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {void}
+ */
+let fn7 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+/**
+@param {I64} a0
+@param {I32} a1
+@returns {[I64, I32]}
+ */
+let fn8 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [1064n, 23];
+};
+/**
+@returns {void}
+ */
+let fn9 = function () {
+
+return fn5();
+};
+/**
+@returns {void}
+ */
+let fn10 = function () {
+
+return fn5();
+};
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@param {ExternRef} a2
+@returns {[I32, FuncRef, ExternRef]}
+ */
+let fn11 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [74, a1, a2];
+};
+/**
+@param {I64} a0
+@param {I32} a1
+@returns {[I64, I32]}
+ */
+let fn12 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [877n, 18];
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {void}
+ */
+let fn13 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+/**
+@param {I64} a0
+@param {I32} a1
+@returns {I32}
+ */
+let fn15 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return 64;
+};
+let tag10 = new WebAssembly.Tag({parameters: ['i64', 'i32']});
+let m3 = {fn6, fn7, fn8, fn9, fn10, fn14: fn5, fn15, memory1: memory0};
+let m5 = {fn11, fn13, tag9: tag8};
+let m4 = {fn12, table16: table4, tag10};
+let importObject1 = /** @type {Imports2} */ ({extra, m3, m4, m5});
+let i1 = await instantiate('AGFzbQEAAAABUw9gAAF/YAAAYAAAYAAAYAN/cG8Df35wYAN/cG8Df3BvYAN/cG8AYANwf34AYANwf34DcH9+YANwf34AYAJ+fwF/YAJ+fwJ+f2ACfn8AYAAAYAAAAqYBDwJtMwdtZW1vcnkxAgOQCJEOAm0zA2ZuNgAFAm0zA2ZuNwAJAm0zA2ZuOAALAm0zA2ZuOQANAm0zBGZuMTAAAQJtNQRmbjExAAUCbTQEZm4xMgALAm01BGZuMTMABwJtMwRmbjE0AAICbTMEZm4xNQAKBWV4dHJhBWlzSklUAAACbTUEdGFnOQQAAgJtNAV0YWcxMAQADAJtNAd0YWJsZTE2AW8AHQMDAgMOBAUBcAEiIgZNCH8BQdO7+QwLfQFDN5dXkgt7Af0M3SiRJ3IhQpmF6H/Me8+nlQt+AUKawswRC34BQvnKt9Z9C28B0G8LbwHQbwt8AUQNisOS/SN2oAsHgQENB21lbW9yeTICAAhnbG9iYWwxMwMECGdsb2JhbDExAwIHdGFibGUxNwEBBGZuMTYAAQRmbjE3AAgHZ2xvYmFsOQMACGdsb2JhbDE0AwUIZ2xvYmFsMTYDBwhnbG9iYWwxNQMGCGdsb2JhbDEwAwEIZ2xvYmFsMTIDAwRmbjE4AAsJSAYCAUEaCwACAAUGAUETC3AC0gEL0gcLAgFBEQsAAgIGBgFBAgtwBdIDC9IEC9IIC9ILC9IMCwYBQQwLcAHSCQsCAUEGCwABCgwBBQqnDgKCDg0CfwBvAm8AfgB/AXACbwJ7AHwDfwF+AX0BfBAMEAoEQAYCAgFBBEEAQQD8DAQBAg5EnsuUMQWC4Z8jAY8Gf0Rkjnbju1phtUEXQQBBAPwMAwEkBwMADAMACwwACwZvEApBBXAOBQIDAQQFAgv8EAH8EAEkAEECcAQCEApBBnAOBgQDBQECAAILAn0MAgALQae6+Q4NBCQBAm8GffwQAEEFcA4FAwQFBgICAAskAQZAGAMCDkEEEQEB0gxBnQEOBgQGAwIFAAAAAQtBoqnlAA0BBgIDAwZ8DAULAm8gDEIBfCIMQh1UDQEGDQcB/BABcCUBIAVBnICMAyQARDece6D/UnzHIAAhACMAQQdwDgcDBwYIAAkFCAtBAhEBAQJ/EAr9EP0WBgwAAAtBBnAOBgIHBgQIBQIACyQFQe8mQQZwDgwGBAEFAwUDBwUGBQcDCwIOQ6eW1n/8EAFBB3AOBgQBAAUGAwcLAwBD0t9G1SMDw9IIQ0lbRnUDf/0MZY1vWUR0GxL1gDrTV7rqMP1eIQcgBAJ8QQMNByAKQQFqIgpBBUkEQAwCC0EDEQMBIAtBAWoiC0EGSQRADAILAn0gDkQAAAAAAADwP6AiDkQAAAAAAIBCQGMNAyADIgYgAUEBcA4BBQULRFWYLpc5PclBRJ2u8YBvLx7vDAAAC9IAQ8xuOwQkAfwQAEECcAQNBQwAAAv9DJap1edQmNgmC2kzrwZBYJAkAiMFDAMACwALPwAjAUPlEJijIwBBAnAEAAIB0gFB44oIDAEACwAFIAP8EAH8EABwJQAMAgALBH9BuNaehgEFIwAMAAALQQZwDgYFAgYEAAMAC/0Mm+GRht9YdQZmGzpVu608giQCAwP9DLW6pnBhAWmKkAuVIhuQlmYjBgJ8DAMACwALA30jBP0SJAIMBQAL/AXD0gMjBAZ8DAMLIwUjBiECIwT9DNu+uvVDdL7sYNBL2KEhKNMkAtILIwcGQBAKQQZwDgYCBAYAAwUDAAtDiG/gkJEgByQC/BAADQQGcAYADAQLDQUCAAwEAAtBAnAEcAYAAg0MCQALQ3SU4+QkAQ8LQ/d5OFYCcAYNBgECAERGAr12fVgjDkTqpst7ZGH6/2UMAAALQQdwDgcBCgAGBwkICAvSBgZ/DAEL/REkAj8AQQZwDgUJCAUHAAYLDAcACwAFA30MBAALAAsMAAALQ9YnGy4kASIEQpurqJGls81mQ2xVuP3SBdIGIwL9wAEjBSQF/YgBIghDz8AdBf0gAAZ/DAMLQQJwBG8QCkEFcA4FBQIEAwYFAAUPAAv9DNlCZB7K25yBc9D1nvBicK4kAtILA34MBgALQiXSC0HJtaqBBUEFcA4FAwIFAQQBCz8ADQQgByAGIQUjAULPAAJvDAEACyIFQYUBDgUCBAABAwIAAQv9DP2NGwme0WbsXB6l6IhIBG4kAhAKQQRwDgQAAQMCAQsjBP0MWtgMFldJ8ZY807j1eYvrRf1/0gkGcAIB/Qx6iablxDE1AOOg0NQEx8oiPwANAwJ+IwANAyMDwiQDAwLSA/wQAUEEcA4EBAIGBQQLDwALJAQkAgwCCwwCAAALRBQFV11/ragLJAcCfhAKQQNwDgMBAwICC/0MrRgBbhw2mmdcZiaMKmRcVQJvAw0gACQAAnwDA9IK0gr8EAECQPwQAEAABG8CDgwAAAtD0pGXZES2S0hotAoxzAwDAAUMCAALA3wGbyMC/BABREKjldKxFLn0IAAkAPwQAUEBcA4BBAQLIwBBBHAOBAEIBwYIC9IK0gTSANIGBn5BF0EAQQD8DAAB/BAAGkEDDgQHBgEICAEL/BAAQQRwDgQABgUHBQsNBgJ7AgLSAiMADQAjBdFBBHAOBAYIBwAIC0TDJ3QUUS8uCwwCAAsACwwECyQH/QxRUJdJeRjYgzSkGC/VjqSPPwANA0NuEPwl/SADQ3pdcIcDeyMF0gBED5KsCiDqcRvSAtIDPwAkAENM/kymQ9zy+Cv9DAL9M7/dHOSIkqLO2pV6Zq/9DF9zZr8jCsECHy6RzcVsMEL9ewN7IAtBAWoiC0EHSQ0BBgMMABkQCkUNAhAKRQRADAILDAYLAgIgCkEBaiIKQQ1JDQEMBgALAAsACwALAAsGcAYDDAMLEApDnfU8EQZ9AwAGAyALQQFqIgtBIkkNAUEFEQ4BIAtBAWoiC0EjSQRADAILEApBBHAOCwQEBQYFBAUABAQEBQtBEkEAQQD8DAABBgEDAAYDDAAACxAKQQRwDgQBBgUHBwshAQYDAg0MAgALDAcBC0EgQQRwDgQABQQGBgsgDUMAAIA/kiINQwAA4EBdDQBDWDJwTwwBAAtBA3AOAwQCAwMLXw4DAgEDAQshBNFBA3AOAwIBAAELDAEACw8BCyEKAnsCbwJ/AnACfgB+A38BfgF9AXwGDRgABg0MAQsPAQsLIwUBB8XuxdpeWsQBAAEGmyPHk1xeAgBBszELAXgAQYzqAAsA', importObject1);
+let {fn16, fn17, fn18, global9, global10, global11, global12, global13, global14, global15, global16, memory2, table17} = /**
+  @type {{
+fn16: (a0: FuncRef, a1: I32, a2: I64) => void,
+fn17: () => void,
+fn18: () => void,
+global9: WebAssembly.Global,
+global10: WebAssembly.Global,
+global11: WebAssembly.Global,
+global12: WebAssembly.Global,
+global13: WebAssembly.Global,
+global14: WebAssembly.Global,
+global15: WebAssembly.Global,
+global16: WebAssembly.Global,
+memory2: WebAssembly.Memory,
+table17: WebAssembly.Table
+  }} */ (i1.instance.exports);
+table15.set(4, table7);
+table12.set(6, table15);
+table4.set(29, table7);
+table5.set(42, table3);
+table7.set(45, table4);
+table12.set(57, table15);
+table4.set(6, table12);
+table7.set(66, table12);
+table12.set(57, table5);
+table5.set(28, table15);
+table12.set(18, table11);
+table4.set(6, table15);
+table3.set(17, table7);
+table5.set(29, table5);
+table11.set(25, table3);
+table5.set(57, table5);
+global8.value = 0;
+global0.value = 0n;
+global16.value = 0;
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn16(fn5, k, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn16(fn16, k, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {void}
+ */
+let fn19 = function () {
+
+return fn17();
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {[FuncRef, I32, I64]}
+ */
+let fn22 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, -7, 1309n];
+};
+/**
+@returns {void}
+ */
+let fn23 = function () {
+
+return fn18();
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@returns {void}
+ */
+let fn25 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+let tag12 = new WebAssembly.Tag({parameters: ['anyfunc', 'anyfunc']});
+let tag13 = new WebAssembly.Tag({parameters: ['anyfunc', 'i32', 'i64']});
+let tag16 = new WebAssembly.Tag({parameters: []});
+let global19 = new WebAssembly.Global({value: 'i32', mutable: true}, 2675307246);
+let global20 = new WebAssembly.Global({value: 'f32', mutable: true}, 541747.855364518);
+let global21 = new WebAssembly.Global({value: 'i64', mutable: true}, 4202672823n);
+let m6 = {fn20: fn17, fn25, fn26: fn5, global20, memory3: memory0, tag15: tag0};
+let m7 = {fn19, fn22, fn24: fn5, global17: global12, global18: global11, global21, tag12, tag16};
+let m8 = {fn21: fn5, fn23, fn27: fn18, global19, global22: global16, table18: table7, table19: table12, tag13, tag14: tag0};
+let importObject2 = /** @type {Imports2} */ ({m6, m7, m8});
+let i2 = await instantiate('AGFzbQEAAAABcRNgAnBwAntwYAJwcAJwcGACcHAAYAN/cHsCcH1gA39wewN/cHtgA39wewBgAABgAABgAABgAXsDcH57YAF7AXtgAXsAYAN/fnsDb3xwYAN/fnsDf357YAN/fnsAYAAAYAAAYANwf34AYANwf34DcH9+AqICFwJtNgdtZW1vcnkzAgOQCJEOAm03BGZuMTkAEAJtNgRmbjIwAAYCbTgEZm4yMQAQAm03BGZuMjIAEgJtOARmbjIzABACbTcEZm4yNAAQAm02BGZuMjUAAgJtNgRmbjI2AAcCbTgEZm4yNwAHAm03BXRhZzEyBAACAm04BXRhZzEzBAARAm04BXRhZzE0BAAHAm02BXRhZzE1BAAQAm03BXRhZzE2BAAQAm03CGdsb2JhbDE3A34BAm03CGdsb2JhbDE4A3sBAm04CGdsb2JhbDE5A38BAm02CGdsb2JhbDIwA30BAm03CGdsb2JhbDIxA34BAm04CGdsb2JhbDIyA3wBAm04B3RhYmxlMTgBbwA0Am04B3RhYmxlMTkBbwEWqQQDAgECDQkEAAsABQAFAAIHEwIHbWVtb3J5NAIABXRhZzExBAAMAQYKwAgBvQgFAH8DfwF+AX0BfAMPBhD9DKbnlMx3FppkeRbSbRBUUd/9DKzj+3LEfvLiHAfnnyDZe1MCQAYQEAVB0KAF/BAB/BABcCUBPwBBBHAOBAEEAAICCxAEIAdEAAAAAAAA8D+gIgdEAAAAAAAAFEBjBEAMAwsjAP0MIpYcdbHl4VkF8FtoM/10piABIAECfwYIDAAACyAFQgF8IgVCG1QNAwIIDAIACwALQQNwDgMDAAEBCwYLQsYB/R4A/fsBAnwMAQALAkACDxAAIARBAWoiBEEHSQ0E/BABQ3NluElEAAAAAAAAAIACfwZ9DAcLAnACDxAFDAMACwALAAsACxAHQ3nch8YkAyAHRAAAAAAAAPA/oCIHRAAAAAAAADZAYw0DIwACQBAFDAIACwAL/QyRvuMAUEBO4jNiAGOs72O4BgtBhJmX/AJBBHAOBAABAgQECyQFAwsgAkEBaiICQSdJBAoMAQsgBUIBfCIFQgtUBAoMAQsgB0QAAAAAAADwP6AiB0QAAAAAAAA8QGMNACQB/QyKcZRwBuRJ3fjBGJ26pUAVJAEMBAALAhAGB0HCDSQCBgYYBQwACyMAUA0CQYj6/Jh/DQEMAAALBgYGDwYIDAELGARBsgFBBHAOCQABAgICAgICAgQLDAEACwYJBgkCQAwDAAsGCSQBIwNB7sS/iX8EfSAFQgF8IgVCCFQNBSAEQQFqIgRBGEkEQAwGCwwEAAUCBv0M39b7OCDt+6S6lpS0d4Xz2AMKIAVCAXwiBUIDVA0AIwJBA3AOBwYBAQEBCAEGCwYLAgv9av1kQQVwDgUCAQcACQELDAELBgYPC0LR6pHxkEUGfQwGCwwBAAsCfSMC/BABcCUB/BAADQcjAP0MFa5NC+fpvIiobQSlcMqWFULDttn5sOWrfyQAQbPrqI9/DQf97AEGCgwACz8AQQJwDgIHBQULDAALJAMCewIGBg8GEAwJCxgEDAAACyADQQFqIgNBA0kNBUHnAUECcAR/DAcABQYQGAIGBwYGQZMBAnwMCAAL/Qx3xt5uGaB91WlnYcPTdGqR/cMBIwDDJARBBHAOBAkHAAEBCwIPRENuuMTVR/b/RIiy/i72RKSgJAVBMcFBBHAOBAcAAQkJCxgCIAFB2ABBAnAEQAwGAAUMAAALAnAPAAsAC0ECcA4CBAYGCwILAgskASMEJAALIAJBAWoiAkEqSQ0FAg8LBg9BmtDpAQ4EBwUBAAcLBn4GBgMGDwALDAALDAEBC0EHQQNwDgMEBgAEAAskAyAEQQFqIgRBJUkEQAwFCyAAPwBBAnAOCwMFBQMDBQMFAwUFAwsGCgtB1AFBAnAOAgIEAgsLRH+P08D+8AfmPwBBAnAOAgACAAsLBn1EnSobKBHFaK0CQAwAAAv9DGg3eimJJBRIwl+vFFn8sgEkAUHziNIFQQFwDgABCyMDJAMkAw8BCws0BgBB+f4ACwc1sq4QwbZuAQgfS0ZbopBw/wEC7gYBCT1U2pps5HSYgQBBq64CCwJEvAEBMQ==', importObject2);
+let {memory4, tag11} = /**
+  @type {{
+memory4: WebAssembly.Memory,
+tag11: WebAssembly.Tag
+  }} */ (i2.instance.exports);
+table11.set(41, table5);
+table3.set(25, table7);
+table4.set(12, table5);
+table3.set(22, table11);
+table5.set(40, table7);
+table5.set(53, table12);
+table7.set(1, table4);
+table4.set(5, table5);
+table15.set(7, table12);
+table4.set(18, table11);
+table3.set(6, table3);
+table11.set(49, table7);
+table11.set(49, table12);
+table7.set(38, table15);
+table11.set(57, table12);
+table15.set(33, table12);
+table3.set(1, table5);
+table5.set(62, table7);
+table3.set(28, table4);
+table11.set(68, table12);
+table12.set(18, table12);
+table12.set(6, table5);
+table15.set(57, table3);
+global9.value = 0;
+global12.value = 0n;
+global10.value = 0;
+global16.value = 0;
+global6.value = null;
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn16(fn16, k, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {void}
+ */
+let fn31 = function () {
+
+return fn5();
+};
+/**
+@returns {[I32, F32]}
+ */
+let fn33 = function () {
+
+return [16, 7.181448310427595e-46];
+};
+let global26 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, fn18);
+let global27 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global6.value);
+let table20 = new WebAssembly.Table({initial: 88, element: 'externref'});
+let table21 = new WebAssembly.Table({initial: 83, element: 'externref', maximum: 96});
+let m9 = {fn29: fn17, fn30: fn18, fn32: fn5, fn34: fn17, global23: global9, global24: global3, global25: global16, global26, global29: global14, global30: global12, memory5: memory4, table21, tag17: tag16};
+let m10 = {fn28: fn18, fn31, fn33, global31: global11};
+let m11 = {global27, global28: global12, table20};
+let importObject3 = /** @type {Imports2} */ ({m9, m10, m11});
+let i3 = await instantiate('AGFzbQEAAAABWhBgAAJ/fWAAAGAAAGACcHsAYAJwewJwe2ACcHsAYAAAYAAAYAAAYAV+e3B8ewJ/e2AFfntwfHsFfntwfHtgBX57cHx7AGAAAGAAAGADcH9+AGADcH9+A3B/fgKRAhQCbTkHbWVtb3J5NQIDkAiRDgNtMTAEZm4yOAAHAm05BGZuMjkACAJtOQRmbjMwAAwDbTEwBGZuMzEADAJtOQRmbjMyAAcDbTEwBGZuMzMAAAJtOQRmbjM0AAcCbTkFdGFnMTcEAAECbTkIZ2xvYmFsMjMDfwECbTkIZ2xvYmFsMjQDfQECbTkIZ2xvYmFsMjUDfAECbTkIZ2xvYmFsMjYDcAEDbTExCGdsb2JhbDI3A3ABA20xMQhnbG9iYWwyOAN+AQJtOQhnbG9iYWwyOQNvAQJtOQhnbG9iYWwzMAN+AQNtMTAIZ2xvYmFsMzEDewEDbTExB3RhYmxlMjABbwBYAm05B3RhYmxlMjEBbwFTYAMDAg8KBA0EbwBKbwAycAAjbwBNB0EHB3RhYmxlMjUBBQRmbjM1AAcHdGFibGUyNAEEB3RhYmxlMjMBAwdtZW1vcnk2AgAEZm4zNgAIB3RhYmxlMjIBAgk2BAYEQQsLcAbSAAvSAQvSAgvSAwvSBAvSBgsGBEESC3AB0gULAgRBEAsAAQcGBEEfC3AB0ggLDAEDCtRrAuE/BwBwAX4CfQN/AX4BfQF8Aw0GAAIABnwgCEEBaiIIQS5JDQMgBkEBaiIGQQpJDQMgC0QAAAAAAADwP6AiC0QAAAAAAAA+QGMNAxAFiyQBJABCBwZABgACAQZ+Qf6d5gBBAnAECAwEAAUCf0LYkMWq7ppu/Qz1FXkPl0x/vtKzevEZADGTQRQlBEQmhbqMzyh7dSMIEAj8EAIMAAALQQNwDgMCAAQACwIGDAQACwwDCwZ+DAELUCQAwiEDIAZBAWoiBkEgSQ0GAwEgC0QAAAAAAADwP6AiC0QAAAAAAAAiQGMEQAwBCwwBAAsgAiIC0gIGfRAEAgIGAQIGBgwCB9ICIAENAkH6nvYT/BAFcCUF0gMjB7QMBQALDAELIwdESiFZvKs09v8gACMCDAcBCxgEDAAACz8AQQJwDgEBAwsCfRAG/BAAQQJwDgIBAwMAC5QCfdIG0gFBE0ECcAQBIwK2DAEABSMAQQNwDgMCAAQECz8AQQJwDgIDAQMBCyQBA28GDUO174lcAnzSASAEuwwAAAs/AEEBcA4IBQUFBQUFBQUFAAALIwcjB4UGQCAAQ+6dOTMDf0Hr/+ABIQHSBSMG/BAEDQVDkUFzWYuNBnACbyABQQNwDgMFBwMHC0TSMR2gkuvkRgwHCz8ADQEgAyEDIgBDmKsPRSMHJAVC3QBQJAD8EAIkALwjAEEDcA4DAQMFAwsNBCMCRO5ZzsK5XvR/BkAgCUIBfCIJQilUDQIGCES+J2AeOyVDQfwQBAQA/BAFQf2FttAHDQdBAnAEDQJAEAYQASAGQQFqIgZBDkkEQAwHCwICQuMAwgJwIAMgAUEUQQBBAPwMAgQjAvwQBEEIcA4HAgcLAQkDBQYLJAQiAyAEIwXSAkRg7WiH+Xa05AwLC9IFIAAkA/wQBdIBRDrjjRv/Aw5XA2/SA9ICQZKv1vB+DQYgBCIFJAEgBfwQBCACQucAIgO6DAsACyMFJAUkBgwKCwwECwYCDAML0gVC9wACfgJ/IAZBAWoiBkEeSQ0NAgICBwwBAAsACwICDAQACwALAAsABQwDAAskAfwQBXAlBQJ9AgDSAkTIkYgJ0743WSABQQVwDgUCCAYEAwgLQqON/uqxnX8/AEECcAQG0gRDsCQNZ/wEIAUMAQAF0gQgANIC0gcjB/wQAw0EQSBBAEEA/AwCBKcgAiECQfz/A3EgAv4rAgAhA0HZAUEGcA4GAggABAYDBAELIwBBBXAOBQcDAgUBBwtEjKITgVvwziidDAcL/BABQQRwDgQABQEDBQEL0gjSCEGwmP34eUEBQQJwBHACBj8AQQJwBG8MBwAFDAcAC/wQBEEEcA4EBgQAAgAL/BABBAwgCEEBaiIIQSdJBEAMCwsgB0EBaiIHQRBJBEAMBAvSBNIGQbKh/8UAIQEgA0EIQQBBAPwMAAQgBfwFU0ECcAQBDAAABSAFi9IG0gIgAfwQAwZ/BgcQBAIBDAMACwIHDAQACwYCDAYLDAUAC0SFV7GyWoL//yABDAAZCQALBH8MBgAFDAQAC0ECcAQNBgEZ0gEjBAwECwVBEUEAQQD8DAIEBgwMAAELDAgACwR/EAUMCwAFQcsBDQgCfAJ/DAoACwALAAtBAnAECAUMBAALt/wQAyQAtiMFJAX8CQAgAkL7AD8ADQD8EAAGfQwECwwKCwZvIAEaQQwOBAcDBQEDCyMDQxEi1n/8BCQH0gXQbyQGQRJBAEEA/AwDBNICIARDi8p3/yQBvCQAIwUCbwIBDAAAC0Qv1OHK2YV8DT8AIwVB7PyExwAaQQwOBAUDBwEHC0EeQQBBAPwMAwRCFPwQAUECcAQNBQwBAAsjAwwBCyAKQwAAgD+SIgpDAAAUQl0NAgJAQt4BA30GAtICAkAjASEFIAZBAWoiBkEbSQ0CEAREi8QVHUaKzJIMCgAL/BADQQJwBAIMCQAF0gQ/AA0H0gcgAkQ4MrJw5RcapkHagQlBAXAOAQoKCyMEQ55bTPsGfAwBCwwJAAsgB0EBaiIHQR1JDQA/AA0FIApDAACAP5IiCkMAABBCXQ0AAgjSBCAEu9IIIAIkBdICIAIkBSMIJAg/AAZ9QyXEQY8YCfwFIAFBBXAOBQQACAYCBgELEABBDhEIBCACJAUgAiMIIAWQRLEh+3j4FY0Pm/wQAUEEcA4EAQcDBQUL/BACQQRwDgMCAAYECwZvAggGBxgGDAMACwZwDAcHAEEADQMMAwAACyEAEAQCAQwDAAsGDQcABn4QBCAGQQFqIgZBBkkEQAwGCwIBAn1C7Ne19dGYzQZ7DAIACwALIwIMCQskBwwACyAHQQFqIgdBJkkNCtIGA28MBQALA3xBnpad+AFBA3AOAwUHAwULQghC7gHSAz8ADQQgBfwQAA0CIgQjAvwQAkECcAR/AgcMBgALAAUMBQALQQNwDgMCBgQCC0KrBkQaHXVa61Gw80IMQdwBA34QAwIBIwYGQAYCGAcHAAIHDAUACwwAC9IGQt0A/BAB0gD8EARBBHAOBAMABwUHCxAAIAZBAWoiBkEkSQ0KDAIACwZAIAtEAAAAAAAA8D+gIgtEAAAAAAAAKkBjBEAMCwsMAgsgBAJAIwMMAQALIwYkBiAA/BAABH8gBSQBIAhBAWoiCEEUSQRADAsL0gHSBSAEIAMiAwJwAn3SAj8ADQT8EAQMAgALAAsABQYM0gQgBEHLhquKAwQBBn4MAgtCiQEkB/wQAQwCAAX8EABBBXAODgYGBgYIBgYGCAQBBgAGBAskASMCPwAMAQsDANIDIwMgAyQHDAIACwwFC0EDcA4CAwUBBSACugwGAAvSBfwQA0EDcA4DAAIEAAABCyEDIAdBAWoiB0EWSQRADAgLIwcGfgJ8IAMMAQALDAULfvwQBUECcA4CAQMDAQv8EAVBAnAOAgACAAsgAUEBcA4BAQELDAILIAIgBSQBJAVDzNjYAQJvIwVDBWYj5gJvQjojAEECcARwAgEMAAALIAlCAXwiCUIXVARADAcLQzddKHkhBSMCDAMABSABQQJwBH8GfhAAIwMDQAJ+/BADDAMACwALQSBBAEEA/AwABAwCCyQFQvuht/vvh9UBJAUCBwtBDREHBCALRAAAAAAAAPA/oCILRAAAAAAAADpAYw0HQQsRBwQGDRgGQ840sbgjBbkMBAAFQQ8RCAQgCEEBaiIIQQNJDQc/AAwAAAsgAUH3ByEBQQJwBH5B3d0ABn9BiZkDQQBBAPwIAABE2yW0W7fXPbYkAgJ/QRARDAQCDCAHQQFqIgdBIUkNCgYABgEYCD8AQQFwDgEBAQtEOjJblGvVeYoMBwsgCEEBaiIIQQ5JDQkgAyIDDAIAC0AAJADSAiAFAkDSBiMDA29D4sf26iMF0gYCfwMMIwIMCQALAAsACwALjtIEIAUkASMEIgAgAgJ8BgEYAQMAIwEiBSIFA0BBjgG+PwAgA8QMBAALAAsAC9IDQzGVFhckAULkhZ6G924MAQtzRSAAQ9t4XiEiBEKxoo3Xwn4MAAVCfwwAAAshAmhBAnAEBgwAAAUCAQwBAAsACyAHQQFqIgdBEEkEQAwHCyAHQQFqIgdBJ0kNBiAHQQFqIgdBAkkEQAwHCxAA0gFBzgHSA9ICQtsAQd+0xs15RIRvuGVAkkUUQfm4vBRBAXAOAQMDCwZ+EAW8JAAGQBgDQSJBAEEA/AwBBAJADAAAC0ECcARvQRBBAEEA/AwDBCAIQQFqIghBEUkNB0LHAUKrASADIgLSAiAERJwYQh7A8Pj/DAQABQZwEAIjACEBIAhBAWoiCEEaSQ0IEAJB/AUiAQZ/Bm8jAkHjAUEBcA4BBwcACyQGEAAgAj8ADAALSfwQAHAlACABDQP8EAUGfQIGDAAACyAJQgF8IglCFlQEQAwKCyALRAAAAAAAAPA/oCILRAAAAAAAAD1AYwRADAoLEAMgCUIBfCIJQglUBEAMCgsgB0EBaiIHQRFJBEAMCgsGfQYGIAZBAWoiBkEVSQ0LDAALIAZBAWoiBkEYSQ0KBggCAAZ/A0AgACEAIAhBAWoiCEEYSQRADAELQcMBQf//A3EpAGtEE9Cvc4c8OSUjA/wQAfwQAw4AAwsMAgtBAXAOAQEBAAsMAgsGAEELEQIE0ghDQXu2EwwCAAv8BHokB/wQBUECcAQBBn0jBCAADAQLJAEGCAYNBm8gCUIBfCIJQiJUDQ4/AA4DAgMBAQsgBQZ8/BAABn8CACMADgIEAwULIwYMCAtBA3AOAwMCAQELREAARE7GRCAqDAoLIAdBAWoiB0EISQ0MBm9BDxEMBAIIDAIACwwCAQsgBEQqbn07ZSQcQQwJCwYMDAALIAdBAWoiB0EBSQ0LIAhBAWoiCEEISQ0LBQYGA34GBiMC/AJBAnAEDD8AQQRwDgQDAAEEBAELQQ4RAgQGCNIA/BABBAdBlwFBAnAEbwJADAIACwAFIApDAACAP5IiCkMAABRCXQ0REANDiO4VuiQBQQ0RDAQMAwALIwMkBAZvAg0gCUIBfCIJQgdUDRIMBwALIAdBAWoiB0EHSQRADAULBgwYAwJ8AgwDDQwGAAsACwALIAFBAXAOAQ4OCwwJAAELIAUMBhkjCCQIIAdBAWoiB0EWSQRADAMLIAlCAXwiCUIXVARADAMLDAMLDAMLIAdBAWoiB0EISQRADA4LQQhBAEEA/AwABAIGIAZBAWoiBkEvSQ0BIAUkASAIQQFqIghBJEkEQAwCCwIGEAUhBUEWQQBBAPwMAwT8EAINAdIIAm8gAgwKAAsACwYCEAAZ/BACDQQL0gcCfCABIAMhA0H8/wNxIAP+MgIAQg5aIgHSBCMBkZAMBgALDAsLAw0gB0EBaiIHQSRJBEAMAQtBtKQSQvoBDAgACwAL0gf8EAVBAnAEfAYGIApDAACAP5IiCkMAAIA/XQ0OAgEgBkEBaiIGQQ9JDQ9B7QAkAAYHAgEMAgALAgwMAgALBwAMAAs/AA0EQRARAQQDACAHQQFqIgdBIkkNEEQUIy4Uz0O1+5kkAgINDAAACwwCAAvSByAFDAULEAIGDQwACwYHAn0MAQALIwgkCAwGCwwCC0MoMTMSIAIMBwAFQTVBAnAEAgwAAAUgB0EBaiIHQS1JDQ4MAAAL0gcDfxAEQjoMCAALAAskAvwQAA0AIwEMAwsgB0EBaiIHQStJBEAMDAsgCEEBaiIIQSNJDQsCfwwBAAtBAXAOAQAAC8DSBAZ/IwAkACAIQQFqIghBBkkNCwYA0gDSAEQDbzxTFnJhKAJ9EAAgAUECcAQGIAdBAWoiB0ETSQRADA8LBQwAAAsGCAIGIAlCAXwiCUImVA0PIAQGfyMI/WRBAnAOAgIBAQALBnAGDAwAC0GSCg0BQYgDAn4MAgALeiAFIAMkBT8AQQJwDgICAQELPwAMBAsGDQIHDAIACwZAPwBBA3AOAwIBAAABC9ICA38jBwwKAAtBAnAOCwEBAQABAQEBAQEBAAALEAIMAAsgC0QAAAAAAADwP6AiC0QAAAAAAAA9QGMEQAwOCwNwA34CBhAAEAMMAAALRLoK1Wqc1lhRDAwACwALAAskAQwJCyMCJAIMAgELIAFBqAEkAEH//wNx/hQAACMD/BABDQIhAETvqXtobSD7fwwHCwwACwwGCyIAIQD8EAE/AEhBAnAECNIBQYABQQFwDgEAAAsQAPwQBSACDAELDAILQuUB0gdBlAEkACAB0gcGfvwQBQZ/IAtEAAAAAAAA8D+gIgtEAAAAAAAAMUBjBEAMCAsgB0EBaiIHQQ9JDQcGbyAIQQFqIghBCkkNCCAIQQFqIghBEUkEQAwJCxAGQwHkdNNB+qnBwnhC2wAMAgskBiAIQQFqIghBBEkEQAwICyAJQgF8IglCFVQEQAwICyAA0gcgAyQFIAUkAUJMDAELIAEcAX8kAENmK4Hb/BAAQQJwBAg/AEP5ptqBJAEgBYsMBQAFBgYCDQYC0gMgBEGOuRlBBHAOBAMBAgAACyMBQRhBAEEA/AwDBEEAQQNwDgMBAAIAC0ELEQEEGAQMAAuO/BABJAADcEEVJQQhAAIH/BABQQFwDgEAAAv8EAH8EAFwJQECQCAKQwAAgD+SIgpDAADgQV0EQAwJCyAGQQFqIgZBLEkNAQYHAgAGBgwCCwYMQsUBDAULIApDAACAP5IiCkMAAPBBXQRADAQLDAIACwwHAQs/AELOAAwCCyQGAghDMKmIwSQBIAZBAWoiBkENSQ0BAgAgCUIBfCIJQjFUBEAMAwtDhKDT/0Mv8WmLRN6dy5Ah4f1EDAYACwALAAvSByADDAALBn5BDhEHBCMHAn8gAQsOAQAAAQsDQAt7AkAMAAALBkAGfCAJQgF8IglCClQEQAwICwwBC0Q3GulZxaaSCgwDCyICIAECfj8AIwIkAiQA/BACaSEBIAFDlwz/bCQBQuIBDAAACyMHtCEFIAIGfCACeiQHRHZAmfd1HvP/JAICBwwAAAsgB0EBaiIHQQhJDQYDDQMHIABEcRleYZW8xSYMBQALAAsjAgubDAILIwNEkxbjS0STQGsMAQskBkOQQvqg0gNCAyABaSAFDAILIAIhA/wQAiIB/BACcCUCJAb8EAJBAnAEbyALRAAAAAAAAPA/oCILRAAAAAAAAD5AYwRADAQLIwYMAAAFQQ8RAgQgBNIAIARCmta3yZOw3Mt5eSQHIwPSBUHhk4vQeSEBQe6mBUECcAQBBgAQAQwBCwwCC/wQAiQAIwAhAdIFIAUhBNIAQ54Xapz8BAZ9Q/GFKmtB2gBBAXAOAQAAAQtCpQEkBULhACQHjiQBIQMgASQAQRNBAnAEBgwAAAUGQAtEKknh2/6kMLHSBkHNkucBA3wGAgsgCEEBaiIIQTBJBEAMBgsMAQALAAsaIAAgAiQHJAQ/ACQAQQckAAJABgAMAQsMAwALIAUkASABJADSBRr8EAT8EARyJAAaAn0gACQEIwFEAIorAGFPnhGaJAKNDAAACyEERHNTFzsHUdOXIAIkByQC/BAFIgFB//8DcTQC8AG6IARC7wEjAGhBAnAEBgYMCwskByMGQe4B/BAB/BAAcCUADAAAC0GRAUECcAQNRF7KhtdFH1jyBn3SCEPoa2WpDAALJAH8EARBAXAOAAALJAYa0gXSAiACp0SGztj9Ga1RWvwGBkALUAQMCz8AIQEkAD8AJABBkeOEPkECcAQMIAhBAWoiCEEeSQ0DAgwCAtIAQ3222Jj8AUEDcA4DAQIAAgELDAEAAQsGBgsFBn0QBgwBCyQBQckBJAALQ8UYd5ACcCAHQQFqIgdBFUkEQAwECyAA/BAEDQAL/BACQf//A3ErAusBIwMkAyABQQJwBAZBDRENBCAGQQFqIgZBFkkNAwskAiEAJAEaIwckByMHJAUaBgjSA0Od705kQuYAJAWLQTRBAXAOAQAACyAGQQFqIgZBC0kEQAwDCyMAJAAgASEBIAFEE5pCwUvcmvckAkND53u+IwEkAQwBC4shBEH//wNxIAQ4AtUHIAUhBCAIQQFqIghBLEkNAQYIQyo4vJUkAUEMEQwECyABBH3SAkGl6TJnQtvAjSgaIQEGf0Nw6R4F/AEYA0GhxwJBAEEA/AgCACQARPzaaJPzNiSIn/wCJAAGbwICAwELC0OiyPrXDAELJAYaIAhBAWoiCEEOSQ0C/BAF/BABcCUBJAYDfAMIC0PUuSflDAEACyQC0gBEMMMgdBkemcJEEWi2SF4p+auevcMGfCMH0gUgACQDIAEkAELDAMIjACQA0gQaIwIMAAsjAPwQAnAlAiMEQ8gCP3AjAZckAQZ/RN9HuNIb5rqFJAIgBkEBaiIGQRFJBEAMBAsgBkEBaiIGQR9JDQMjAAtBh/YAQeLZAUGR1AH8CgAAIQEkA0QFNJtQ2gjz/yQCQYEIJAAkBiAAPwAjANIFPwCzDAAFAgEgCkMAAIA/kiIKQwAAgD9dBEAMBAsCACAHQQFqIgdBJEkNBAwBAAsACyAKQwAAgD+SIgpDAABAQl0EQAwDCwIMQ7eb9JsMAQALAAskAQYBBgACfBAEDAIAC/wHJAUMAQsMAQtB1LTNAkTzej42N9JIiSQCPwAGQAZAGQJ9IAtEAAAAAAAA8D+gIgtEAAAAAAAAPUBjBEAMBQsGfAwDCwZ9EAQgCkMAAIA/kiIKQwAAoEFdBEAMBgsGBgwACwwDAAELDAAACyEECwvSBkG/zgoaQecAIAECcEEIQQBBAPwMAQRBCSUEA3AgCUIBfCIJQitUBEAMAQsQAwYGC0EcJQQiAAsMAAAL/BABQQJwBAIFEAALIQD8EARwIAAmBL4hBCABIQH8EAUkANIDIAEkAERMhFA/KQD0NgZwPwAhAUEJJQQMAAELJAMkAiAFAn0GAQsDb0EMEQYEQSslAwsgBdIF/BAERAAAAAAAAACAIAAGfyMFQz+g1f8MAQtBAnAEfET1ibGgEAPXnQwAAAVETzXDd4h7+K8LQ9FxnDcMAAskASQBQ5bupP8kAQN8EAbSA0E6QQJwBAwFCwJ/Bm8jAiQCAgACASAHQQFqIgdBI0kNBEOLQyBjBn0CbwYCIwAMBgsgB0EBaiIHQRBJDQYGABACQcEADAYLDAMACwwDCyAAIQCNlCEF/BACQQFwDgEAAAsgAUG7CwwCCwwDCyQGIApDAACAP5IiCkMAAERCXQRADAILIAhBAWoiCEEqSQRADAQLQY0BCyEBPwAkAPwQACQAA29BCyQAPwAkAAYBQQAOAQAACyAKQwAAgD+SIgpDAABgQV0NACMGCxoa0gQaIAlCAXwiCUIZVA0CAnwgBCQBBnAjAwwACyQEAgwLAgYDByAAJARE6/B9aKnz/X8MAgALAAsACwN9IAlCAXwiCUIXVARADAEL0ggjAEECcAQBCxpD+fxWkSEEBnAjAAZA0ghEfuH3+CDoRywkAhoLQf//A3EwAIsHJAdBGSUEDAABCyQDQ1vC+yACbwYNBgHSAEGn3McRQQJwDgIAAQALBgILDAALRAAAAAAAAAAAGiMDJARBj8QAuCQC0gcaEAQGDCAIQQFqIghBGEkEQAwECyAHQQFqIgdBLkkEQAwECwsCCAsjApokAkETJQILJAYjAhokAUMtUsE3C44kASMGJAabAn4CByAHQQFqIgdBIkkNBBAGIAdBAWoiB0ECSQRADAULIAlCAXwiCUIAVA0ECyAHQQFqIgdBBEkNA0NsiDzhJAECDQwAAAvSAiMIJAhD4fTZiyQB0gJCjOrMsuCYXQwAAAtBrwFBAnAEcEELJQQkBBAGAggLBm9BLyUCCyQGIAAFIwQMAAALIQAkByMB0gAaJAEkAhAARGrhHifDwYyQCyQCGhoCQEMfi8XOkUNaCMQKlSAAAn1Bg7vOAkEBcA4BAQELjowiBJCQJAEaJAECfgMNIAZBAWoiBkEkSQRADAULBgYjBbUgBVtBAnAOAgMAAwsLDAEAC0LkAMRaQQFwDgEAAAtFJABB//8DcS4B7gUjAQwAC/wQABokASQAAg3SCBoL0gUgBSQBQe+T1gBBAnAEfUPir/2QDAAABUOnSP9/JAEgCEEBaiIIQS1JDQEgBkEBaiIGQQxJBEAMAgsgBQshBSADBn8gBCQBIApDAACAP5IiCkMAAMBBXQRADAILBgYL0gQjCESBKZ4F0OjpZhoGQCAHQQFqIgdBCUkEQAwDCwtDIOIKJSIE/SAB/XQkCNIFIAN7JAUaIAEMAAEHAEGcsoEBDAALJAAkBdIIGiADp60/AAR9Am8DBgsjBgsgBQwAAAUgBAskAfwQBdIAIAQkAQZ8RFxHayqijmoqC/wQBCIBJAAGfAMAPwBBAnAEfSAFDAAABSAFCyEEQf/O3tYAAm8jBgwAAAskBkMXBW+v0gYgBPwFIgIkBxoLjIsGcEERJQQMAAskAyEFIQHSAxoGDAMGDAEACwtE4qTiMEjxFqsLniQCIAEgAyQFIAIkBQQIRG6K5hGFXhM3JAILIwdBn/fJBEGS4gNu/BADJAAgAD8A/BAFcCUFAm8QAyADJAXSBgJ/Am8gCUIBfCIJQhxUDQMgBkEBaiIGQSBJDQNBFyUA0gPSBPwQAwQCBQsgAEOpRxFnJAHSBBohACMBAkACDSAGQQFqIgZBK0kEQAwGCwsLJAFEmilShOGsTmskAtIDIwhCq9KHoBFE0Aha2gKvda0kAiQFIANCr9j1i6TMnpIeJAcGfQYGBn0gBkEBaiIGQSZJBEAMBwsgC0QAAAAAAADwP6AiC0QAAAAAAABCQGMEQAwHCwZ+DAIAAQu0An8gBkEBaiIGQQFJDQcjB0LDAAJ8IAdBAWoiB0ErSQ0IAgcMAAALIAhBAWoiCEEFSQ0IDAMACwALDQAMAgsMAQsgBkEBaiIGQQdJDQRDyD047QshBEENDAEACwALQf//A3EyAOsCJAcDfiADCyQHGkEaJQUkBgYCQ1LFilQaGQsgC0QAAAAAAADwP6AiC0QAAAAAAAAyQGMNAf4DAAIAIAhBAWoiCEErSQRADAMLPwAjAQJAC0MPUxPYJAELQuj42uSCus+IC7TSCBr8BSQFJAEkAAZ+An8gAQskAEL/AQskBSMGCyQGA35C9tLwxNjn1EQLGiAEJAEjASQBRI3sjVVUgtHTJAI/ACQAJAYkA/wQBHAjAyYEIQMkAhokANIAQ/QJRP5Ex6RHMrGorUgkAiMAQf//A3E1Ab0GJAX8AL5BlAEkABoCfiAIQQFqIghBGkkEQAwCC0L9AAsa0gAa/BACJAAaIQIaCwIAQfKL7gJDI+Hu7QuOQakB0ggaJAAhBEH//wNxIAQ4ALIDQQklBCMAQQJwBAxErl6YaZUIliT8ByQFBSMAIAIhAyEBCyMAQe2vGkUkAGdBAnAEBhAF/BADQQFwDgEAAAv8EAVCyNrSNQwAC+4rCwF7AHsBfgF7AnsCfgJwA38BfgF9AXwDCAZ9Q0wXo3ckASAM/BACIwXSBT8AAn/9DOT6sfc0JWjnVhUDvSs8lZoiBf0ZBgwAAAtChvyosbqCfz8A/BAAcCUARITfvNnMt4HSmgZ8AgD9DK2a887zRIyBoNtixhuP/XgkCCASQwAAgD+SIhJDAAAUQl0EQAwEC0KA8LlhBnvSBiMEBn4CDEOoKW4FIwNEqHnSqh7v8n8kAiMCvcIMAQAL/BACQRJBAEEA/AwCBPwQAT8AQQJwBH/9DEqMokmrbARpy4MMBlZvqdIjAyQE/BADDQIMAgAFIA9BAWoiD0ErSQRADAcLRPlytOEt9esjDAQAC0EFQQBBAPwMAwQkAPwQBUH//wNx/V0CjQP9xAFBAnAEABAABg0MAAtCnNGZsv0BBnwGQNIAQ7e3By4MBwv9DMxm04pKVj6adoRyKG0WLD8MAwsDfAMAAgIgAwwHAAsACwALAAUgEUIBfCIRQhVUBEAMBwtBoMoMJAADCCMCDAUACwALDAIBAAsiACEL0gjSAURDs1ohR/op4gwCCyQIJAXSBSMGIwQkBCAHQgoiCv0eACQIQQpBAEEA/AwDBEEaQQBBAPwMAgQgDSAHAwUGBAJAQ4Med0QgAENbLB/9QcYBQQJwBAIGDAZvDAIL0gNDY12xqvwE/RL8EAAGbxADIA9BAWoiD0EdSQ0JQebFqA0OAgECAwELJAb8EAVwJQX9DNkrviRvnhm7phKj+UR9wndDpjoN1yQBQa2gjglB//8Dcf0AAoECQ78DAMEGQCARQgF8IhFCE1QNCSMBDAgLDAcAC9IFQQFBAnAOAgABAAALDAULBn4gDkEBaiIOQQxJDQYCACAPQQFqIg9BHUkEQAwICxAAAwYGBkKW+G0/ACQAvyIDDAcLIA5BAWoiDkEZSQ0IIBJDAACAP5IiEkMAAAxCXQ0AAgzSA9IHPwBBAXAOAAABCyATRAAAAAAAAPA/oCITRAAAAAAAgEFAYwRADAkLRAm4AoM3xTk7DAYACwALDAML/RICbxAC/BAB0gBDkgEUY4sjA/wQBEECcARAQZYcQQBBAPwIAgALJAMkAULMqsq+1p2r4n5CigFCH/0M+P2Oz2X/C/CHi9mb+hhXrv3sAUPBDuX0JAEhAX8GbwYCAnwCCCARQgF8IhFCGlQNCgIBDAMACwALAAuaDAYLIBFCAXwiEUIiVA0HBn4GB/wQAgN/IBNEAAAAAAAA8D+gIhNEAAAAAAAALEBjBEAMAQsgD0EBaiIPQSZJDQD8EAUkAAYMAgwgDkEBaiIOQQJJDQwMAwALDAALIA39DL9rub3lj/ls4c/bf/SMHZMMBQALQQFwDgEAAAsgEEEBaiIQQS1JDQj9DOI4rWbnTmUikGeaAq071B3SBCMD0UECcAQHBQMNAg3SBkTmgziwaWEWTgJ/RP+28HXhXcd4DAoACwALAAsACyMGQQdBAnAOAgECAQtEYZ81pMqp/3+ZDAUHAAYM0gHSBvwQAkEBcA4BAAALQgAgDUECJADSB9IE0gPSACAMIwgMAgAHACAPQQFqIg9BKEkEQAwICyARQgF8IhFCA1QNB0TOLb/EOCckbgwFCwwAC9FB//8Dcf4SAAAb/XxEAAAAAAAAAAAhAwwAAAALAn0DByAQQQFqIhBBGkkEQAwBCyAOQQFqIg5BKEkNAAIA0ghEfr77tSHFOTEMBQALAAsACwALJAbSBiALQQ1BAEEA/AwABCQFQruEfiEL/BABIAwCQAwAAAskAyABBnsjAyQDRC9mWXOaPBolDAIAC9II0gMjBT8AA3BC5QE/AESv7YL8DBo9rQwCAAvSB0Navns+DAILDAELIgNh/BABQbnoBEECcARABQwAAAtB//8Dcf0IALsDQbWV7aN5/WwiCSMEBnsCAQYARBnpuyw5IP9/0gIGfRACBg0DfxABDAQACyMDJANBAnAOAgADAwsgEEEBaiIQQRpJDQUMAgELIAUMAgsMAgvSBwJ9Qpbp7AUkByAPQQFqIg9BGUkEQAwECwYMGAEGewJ9EAYjAQwEAAsMAwsMAQALQQNBAEEA/AwDBAwBCwJvEAYDAiAPQQFqIg9BKkkNACAOQQFqIg5BDEkEQAwECyAOQQFqIg5BB0kNA0LXyL+NSsMkBwIAIA5BAWoiDkERSQ0EAgIgEUIBfCIRQhNUBEAMBgtCyI+NzANEhHMyFSZql5kjCCMI/fgBJAhC4gD9HgACb0KSxOT86gD8EAMDQAJ/QRARBwT9DPI3n2AdjyAXPAniSUQmd2n9+AH8EAMMAAALDQL9DAg3qpXJFtJeXjR9/WS1MScGfULHfiAM0gFCOgJwDAQACyEMQwfJitgMAAEBC/0gAP19/acBJAgCAQIHIwhCoAEiC/0eACQIQYyGgrZ5PwBBA3AOAwABBAELAgEMBAALIwgiBSQIIBFCAXwiEUIGVARADAILEAIMAwsMAgALAAsjAULqutuaqMYAJAcMBAtC4gBBBUEAQQD8DAMEeT8AQQJwBH0GDQIN0gj9DOSGEX8tq+BgRl6QuoVYSkUkCEQWkCryhRN/MCMADgIAAQABAAsL0gBDAACAf9IGIwEMBAAFBgEDBwYMEAQMAAsGfiARQgF8IhFCH1QEQAwGC9IBBn0QBCATRAAAAAAAAPA/oCITRAAAAAAAgEZAYwRADAMLIA5BAWoiDkEMSQRADAMLIBFCAXwiEUIXVA0CDAML/AUjBQwAC7UjBCINIgwjAyQE/BAFQQFwDgEBAQsjByQHAnsgE0QAAAAAAADwP6AiE0QAAAAAAABCQGMNBwwBAAsGQCATRAAAAAAAAPA/oCITRAAAAAAAAEhAYwRADAULDAELAnAgBgZwBn1CfgZwPwBBB0EAQQD8DAAEJABCvafM33QDfwYIAgwQBCMGDAsACyAOQQFqIg5BE0kNAQYNDAELQ6oRxD78EAUCfj8AQpF5DAAAC/0Mb832F+oKM1WIwNyoNSrtcz8AQQJwDgIABgYLIBFCAXwiEUIdVARADAkLIBBBAWoiEEElSQRADAkL0gUgCSQI/BAFJAAGf/0MNTnuCdZg2VQDQxqJcaosL/3gAUKUAQJ/Qb39CwwBAAs/AAwAC0EBcA4ABQsNBHs/AEOeGoAy/BAFDQEgBPwQAvwQAkEBcA4CBAQEC/wQAUECcA4CAgECAQtDK+oDjgwHCwwAC0T4U2omR3O1KEMDzQC30gAjAQwBCz8AQzHrKfXSB/wQAPwQAwZwIwYkBgYBDAALAnwGDAcAIAunQQFwDgEAAAEBCwMB/BADJAAGfxACIA5BAWoiDkEtSQRADAcLIA5BAWoiDkENSQRADAoLBgAjAbxnIwYGQCAPQQFqIg9BKUkNCNIGRN/RvkTTKOF2DAQLJAb8EAVwIwYmBfwQBGgMAQtBqpec6AEMAAskAES/IYjf+YhG8f0U/YMBBAf9DPZBcG/Lcw0SDuvS1mKVElX8EAQNACIJAkAgEUIBfCIRQiFUBEAMCAvSAiMFQtsAhUMAAID/DAUACyMEDAML0gEjAQwDAAsjAwwBAQufIgO90gXSAAJ7AgAgE0QAAAAAAADwP6AiE0QAAAAAAAAxQGMEQAwJCxAEBgIYAv0MqG+naluf+9Vfm4Ftb6gD3P10DAEACwALROfIwQMwVS2u/AL9qwH8EAP8EARwJQQMAAskA/wQBHAjAyYEBm9Bux8jA9IC/QxmjcHcTq0+/VOImbcr1KpZAkAL/aoBIwACQCARQgF8IhFCCVQNBCAPQQFqIg9BBkkEQAwFC0OfdLb/DAYAC0ECcAQBC0T5zuMUEe91Zf0UJAj94wEjBSEKJAj9DIkrtpZdlkCfN+QgrnjTm4D97AFC1gE/APwQASANQvSugHMCcCAQQQFqIhBBC0kNBAIC/QxFSJ+tj4P+Xu18bZcX5xlYA3wGfQYBDAMLAggCDSAFBm8GCAIAAgZCswH8EAUjCCQIQQVwDgUCAAUIBAULDAEAC9IIQePJ4gjSBCAMQ9LOihDSCCMA/BAEQQRwDgQGAAIDAgELBgZBDBEBBAZwDAEL/BADJAAMBwsgEUIBfCIRQhJUDQ0GDQwDCyMBDAMLDAoLDAMAAAsMAgv8EAA/AA0BQQFwDgEBAQskAiMIJAj8EAIOAQAACyAKQYEBJAAiBiQHBnwCByAOQQFqIg5BE0kEQAwHCwsGAAYN0gga/BAAQo69qH0CfgYHQ4kBD2MkAQsMAQALQ5n6ix0jAARvIBJDAACAP5IiEkMAAIBBXQ0I/BACQQFwDgEBAQUgEEEBaiIQQQdJDQv8EAIgByQIQQFwDgEBAQskBkEOQQJwBH3SB0NW8pZ/DAoABUQ/2lDlq/QZKAwDAAsMCQv9DKGl36r/J/FLDAAFvqifLCj8EAMjACQAQQJwBAYGDf0MofPUUh0osobv2yU1jnWkhSQIAgIgEkMAAIA/kiISQwAAQEBdDQwDDAYCIBNEAAAAAAAA8D+gIhNEAAAAAAAAREBjDQsZBgYQBQwOCyAQQQFqIhBBDEkNAQsQAAYBCwsgEEEBaiIQQStJBEAMCgv9DNnTVytGiuLFyMfexl9YMxEkCAwBAAsLIA9BAWoiD0ERSQRADAgLCyQIIBBBAWoiEEEwSQRADAcL0gIaIBNEAAAAAAAA8D+gIhNEAAAAAAAAOkBjDQn9DOcIz3MK40CMpvYR3Zga0kRCJkLO+vOJfwJvQ19D1m4MBQALDAcLQQJBAXAOAQQEC9IIIwQMAAsiDSINQQRBAEEA/AwBBAZ7AnsgE0QAAAAAAADwP6AiE0QAAAAAAABIQGMNBQIAIBNEAAAAAAAA8D+gIhNEAAAAAAAAGEBjBEAMCgsQBQZ+QfsBJAAGAQcAIwQkBP0Mvqae/nSspJZA+AZkszEPrAwDCwYAEAL9DN6ebJCClLEMniV3sYiBs3L8EABBAnAOAgQDAwsMBgvSAtIIGkEKQQBBAPwMAwQGfiAQQQFqIhBBC0kNBwJ+IwI/AEECcAQNCyQCQs6lgSIkBQYCDAAACyAEDAMAC0PpSP+0JAELIwMiDP0MmQ07gHHwUuC4vM7P3KP1lgIEDAIACwALDAQLJAggEEEBaiIQQS5JDQcDBgYMAn4/AP0MuHaROelqLIpmxZvE6SR8vAwDAAs/AAZ9IwMkBNIBBn4QASATRAAAAAAAAPA/oCITRAAAAAAAgEhAYwRADAwLAm8jANIB/Qwt/PCBl+lsco6Hz1JGNekvIwP9DKisQ3Ld7Egv8RmwvIbufJYMBQALDAULBn0gEEEBaiIQQRFJDQj8EAVBAXAOAQICC0MlWoVqQ+Qz50wjAEECcAQAIA9BAWoiD0EVSQ0LDAIABdIFQxaDU8nSAdIDAm8CAQYMCwsGDAcAAgAgDkEBaiIOQQ5JBEAMDAsgEEEBaiIQQR9JDQ4gDkEBaiIOQQZJDQ4gE0QAAAAAAADwP6AiE0QAAAAAAAA/QGMNCyASQwAAgD+SIhJDAABwQV0EQAwPCwIAIA5BAWoiDkEtSQRADAgLDAYACwALJAFBAnAOAgAEBAsgEEEBaiIQQRBJBEAMCgtECTGua/y/0rT8EAJBAXAOAAMLQQhBAEEA/AwABAJ9DAMACwALDAULDAQLCyMIC/2JAQIF/ckB/BAB/WwkCEMNbyiwDAYACz8ABn9BywALRFbKJkl5yL8aJAJB//8DcTIB9gEhAEH8/wNxIAD+KwIAJAcjAiQCJAVE/VDRDJyh9H8kAiQD/BAEcCMDJgQjAPwQAXAlAQJvIBFCAXwiEUIvVARADAgLIwEMBgALRGtn0458jwqMIwZD7T6L/yMIJAj8EAMjA0Qhhw7jZoD3fwZwQQJBAEEA/AwABAZACwZvBgIDBwtC1OLScgZ9IA9BAWoiD0EgSQRADAgLIA5BAWoiDkEeSQRADAsLAgwgDkEBaiIOQQ5JDQsLDAEAAQcAIBFCAXwiEUIQVA0KIA5BAWoiDkEYSQ0KIBNEAAAAAAAA8D+gIhNEAAAAAAAAMUBjDQogEUIBfCIRQgpUDQoGeyAKQR9BAEEA/AwDBMIGQAYBQ6iZGVUMAwsgEEEBaiIQQSVJDQwLIQYjCPwQAkEBcA4AAgskCCMADQEgEkMAAIA/kiISQwAAQEBdBEAMCAvSCAJ8IA5BAWoiDkEiSQ0LBgAMAwuPDAYACyQCGgJ9AgYLBg0LAn0CewINCwwEAAsACwALCwwICyATRAAAAAAAAPA/oCITRAAAAAAAACxAYwRADAkLIwb9DKWeUioqUzRTNmeOrO0ILwH9gwFBA3AOAwYCAAALDAELJAQCb0E4JQUkBgYIEAEZCwIAQdUBA3v9DHOilH2HOMkeTOl1jx+ilHYiCf0MYgdjyjlGi0qbkJgDp7nVzCQIIQEQBNICRHZrsNHMes8wJAIaEAX9EyQIJAAgD0EBaiIPQRBJDQkCBv0MjUj38a0AV4C6ViDnV6rWfCIHGiMIIQkLAn0gDkEBaiIOQRlJDQEjCCQI/BABJAA/ACQA0gdE52XTxQaUlkAaGiAQQQFqIhBBBkkNByAQQQFqIhBBHUkNCkNm9zIVCwwEAAsACwALPwBBAnAOAgQABAsMAwuM0gT9DA3Bt0pTD9j1RmJqfcvUIhf9DOl77cXMdOeKREYonIxQXVP9LCQI/Qz0Y+b3jXsDY5srvbmxsaIOJAga0gRDuWJ3+QwDC/wQA0EBcA4BAgILIBBBAWoiEEEvSQRADAMLIAkhBEEQJQMLJAYiAQYFBm8gEEEBaiIQQRNJDQNEGWp/MQni8f8aDAELJAYDAyQIJAREY/082JUm6/EkAtIIIwEMAgALEAEMAAskCCQA/BACBAcLGiQFGkRUC5M1DwuVlyQCQf//A3H9CADWA/wQABr94wEkCEMAAAAAQarpAUEAQQD8CAIADAALRGkZnJPO38JjIQNCxPmFeCQFGgNvIA5BAWoiDkEXSQ0ABnAGAEHyACMBCyQBQQJwBABDAAAAACQBRN6l3qyLiJhEQcyMnAIkAEHDw82ZfiQAJAIQAwYBGSAOQQFqIg5BBkkNBAsQBQwAAAVB3Ij4NQZ/IwBBAnAEBwsDBgsgEEEBaiIQQQNJDQQjBiQGIBFCAXwiEUIKVA0EQZX2tgckACAQQQFqIhBBIUkEQAwFCyMAC0xDdNRO0gwAAAskAUECcAQNCyAPQQFqIg9BA0kEQAwDCyAPQQFqIg9BJUkEQAwDC0EEJQQLJAMgE0QAAAAAAADwP6AiE0QAAAAAAABEQGMEQAwCC0ESJQNB5gcGfiAQQQFqIhBBL0kNAkLsAHkLIQtB/v8DcSAL/j8BACQFJAZByQAlACQGAgELIA9BAWoiD0EUSQ0BQS0lAQskBhAECyMH/QylXn6Ch8QicS6VKcVl/DZBAnwjAyQD/BAB0gdCBlAkAD8AJAAaJABEtxv0JeLzx90LJAIkCCABIgQjBCMC/QxA3FW49BcOTo/NZ78Gm3D6/YgBCwsPAwEAAEGF0QALAzcM7QEA', importObject3);
+let {fn35, fn36, memory6, table22, table23, table24, table25} = /**
+  @type {{
+fn35: (a0: FuncRef, a1: I32, a2: I64) => [FuncRef, I32, I64],
+fn36: (a0: I64, a1: V128, a2: FuncRef, a3: F64, a4: V128) => [I64, V128, FuncRef, F64, V128],
+memory6: WebAssembly.Memory,
+table22: WebAssembly.Table,
+table23: WebAssembly.Table,
+table24: WebAssembly.Table,
+table25: WebAssembly.Table
+  }} */ (i3.instance.exports);
+table3.set(0, table5);
+table12.set(12, table25);
+table20.set(55, table15);
+table11.set(23, table23);
+table4.set(44, table12);
+table11.set(51, table5);
+table12.set(46, table15);
+table21.set(18, table25);
+table4.set(42, table15);
+table3.set(2, table21);
+table25.set(63, table21);
+table25.set(18, table25);
+table20.set(7, table23);
+table5.set(10, table4);
+table5.set(20, table5);
+table20.set(11, table4);
+table22.set(53, table22);
+global13.value = 0n;
+global3.value = 0;
+global16.value = 0;
+global15.value = 'a';
+global27.value = null;
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn35(fn17, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn35(fn35, global8.value, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn35(fn17, k, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn16(fn5, k, global0.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {void}
+ */
+let fn38 = function () {
+
+return fn5();
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {[FuncRef, I32, I64]}
+ */
+let fn42 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn35(a0, a1, a2);
+};
+let global35 = new WebAssembly.Global({value: 'i32', mutable: true}, 3451506441);
+let table26 = new WebAssembly.Table({initial: 88, element: 'externref', maximum: 935});
+let table30 = new WebAssembly.Table({initial: 85, element: 'anyfunc', maximum: 619});
+let m13 = {fn37: fn16, fn40: fn18, global33: -17698.05107815217, global35, table26};
+let m14 = {fn38, fn39: fn36, global32: global16, table28: table22, table30, tag21: tag16, tag22: tag16, tag23: tag8, tag24: tag16, tag25: tag8};
+let m12 = {fn41: fn5, fn42, global34: global10, table27: table26, table29: table8, table31: table13, tag26: tag16};
+let importObject4 = /** @type {Imports2} */ ({m12, m13, m14});
+let i4 = await instantiate('AGFzbQEAAAABRgxgAAFwYAAAYAAAYAADe39wYAAAYAAAYAAAYAAAYANwf34AYANwf34DcH9+YAV+e3B8ewV+e3B8e2AFfntwfHsFfntwfHsCuQIWA20xMwRmbjM3AAgDbTE0BGZuMzgABQNtMTQEZm4zOQAKA20xMwRmbjQwAAYDbTEyBGZuNDEAAgNtMTIEZm40MgAJA20xNAV0YWcyMQQABQNtMTQFdGFnMjIEAAQDbTE0BXRhZzIzBAABA20xNAV0YWcyNAQABANtMTQFdGFnMjUEAAYDbTEyBXRhZzI2BAABA20xNAhnbG9iYWwzMgN8AQNtMTMIZ2xvYmFsMzMDfAADbTEyCGdsb2JhbDM0A30BA20xMwhnbG9iYWwzNQN/AQNtMTMHdGFibGUyNgFvAVinBwNtMTIHdGFibGUyNwFvACYDbTE0B3RhYmxlMjgBbwADA20xMgd0YWJsZTI5AXABJ9MCA20xNAd0YWJsZTMwAXABVesEA20xMgd0YWJsZTMxAXABBK8CAwMCBAkEBgFwARzFAQUGAQP3DaYgDQkEAAcABQAIAAUGDwJ/AUHU1KOTAQtvANBvCwdSCQdtZW1vcnk3AgAEZm40NAAHBXRhZzE4BAAIZ2xvYmFsMzgDBQhnbG9iYWwzNwMECGdsb2JhbDM2AwAFdGFnMjAEAwRmbjQzAAYFdGFnMTkEAgnaAggCBUEACwAEBgACBAVwJtIAC9IDC9IGC9IFC9IBC9IFC9IHC9IEC9IFC9IDC9IFC9IBC9IAC9ICC9IBC9IFC9IBC9IDC9IGC9IEC9IBC9IDC9IFC9IGC9IAC9ICC9IHC9IGC9IBC9IFC9IAC9IEC9ICC9IAC9IEC9IEC9IEC9IHCwMASgQEBAcHAAUGAgQEBQAABgICAgQABAQEAAQAAQQCAAcFBAEBAAEHBAAGAwMFBwEGBgIDBAQABgACBQYHBAICAgcEBAMAAwIGAwcHAwBbBAICAQEDBAUGAwcAAAcHBAABAwYHAgUDBwQFAAYDBQEHAAMABgEEAQYHAQUFAwEFBAUBBwEABAMDAQMBAwEDBQcAAwAFBQMDAwIHAgcABgUFBgMBAQcABQUDBQIFQQELAAEABgZBFwtwBNIBC9IDC9IEC9IGCwYFQQELcAHSAgsCA0EhCwACBQcMAQEKyz4C+gsNAH8BcAF/AX8BcAF+AnsAbwB7A38BfgF9AXwgBCAGQSMlBCMAA3AGAQICAgQCAiAE/QwDGNeIJCqDTS5/Ja6+Z/jJQQElBESf0BcEw+aVg/0Mkg4Z16q1oGP4vDhnW8eQChACIgX9HwJBmuy5byIBQQJwBAFDBlQ+J0Lz0QFBFUEFQQL8DAEG/BADQQJwBAYCAQJ9An4gAiICQQJwBH0GAQcBAgL8EAT8EAEkBCMBBn0CBiMFIwRnIwNBAnAEANIA0gVB557FgAIhAkHvASACQQJwBAZBJQ0LBn0jAD8AQQxwDgwFAw4LAQYKDxINDBAFAAs/APwQBnATBgYLaf0MDyQ5K6fOSfMZcHfDyfdVECEG/RHSB/wQAUELcA4LDQsMCgkOCAQBAxAIBQIDDAwACwAL0gdB1qbVD0ELcA4LDQsIAgAPCQcMCgMJCwwHC0SsZvtHstml0SMFRJnd4YkFrNwZJABEf48g0SkfJUL8EAUNAUGqAUEKcA4SCAoLAA0FAAsLAQsFBggBBwoJCQAAAAsMBhk/AA4JBQwACgcGCQgEDAtCpp+JGiEEAgAMBAALAAUjAw0HDAQAC9IFIAb94QEDfQ8ACwALAAv8EAAEcAwEAAVDsMqfwQZwAgUMBwALDAcBCwwAAAsGbwwECyACQQhwDgwEBAAABgIGCAMIBQYBAQsMAAtDsuidwwJ/IAdBAWoiB0ENSQ0GBgQDAQwBAAsYBQwCAAtBBnAOBgMEAQYCAAILJAIjAw0FAn9BtfjftQNBBXAOCgMDBgYDAwIDBAIBC9IBIwNBBXAOBQADBQECAwsMAAsgA/0Mra2oJ3FMmeuSSxjH/hHB0QZAIAAjASMBIwEjBUEqDQL8EAVBAnAEBQwBAAXSBEOV0MBmIwRBBXAOBQMFAQIAAwALIwLSBNIDQ9I6waH9E/36AT8AQQRwDgQBAgAEAQvSANIC0gPSAPwQAUEDcA4DAQADAwsCAgwDAAsCBwwDAAsGBAwDC0EZEQIGDwsMAQALIgACbwJ+BgIMAAsGBAIDBgRBvAFBA3AOAwUCAAIL/BAFQQJwBH9B69DyDCMBBn0DByAJQQFqIglBMEkEQAwBC9IDIwUGb0EZEQcGIAdBAWoiB0EwSQRADAIL0gDSBvwQBg0IQb+dq98BDAMBAQtDZudTYowgA/wQAPwQA3AlAwJAIwRBA3AOCAUACAgAAAgICAv8EAMMAgAL0gRDjYCfKwwACwZ8DAYBCyQAIAQiBAwDBQ8AC0ECcA4CAQQECyMAIwAkAEN4i0iVBn8MAQtBAnAOAgMAAwv9DGoRQgP9rqPUw6975/kvMhxBCEETQQf8DAEE/WP8EAVqJAREYQqjBrZG+/+bJAAMAgAL/RL9YAZ/BgUGBESalcsulT81Jv0U/BAADAILAwP9DF/lTHLKRm3JIAs8UlqkEVdD73GX/0SrwdJKsTdZiyQAQQBBEEEA/AwBBdIGBn4CASMF/QwGcqia2QSXPZYjjMrlWYsGQeDsDEEDcA4DBgADBgELDAILRC75jBnLM2dhAm8MBQALAAtEqsLEtsyQgjM/AAwBAQALDAILDQEhBQwBAAsjAQN/BgMgCUEBaiIJQStJDQECAgJAIApCAXwiCkIsVARADAQLAnsCAAIC0gYjA0ECcAQFAgcMAgALAAUgB0EBaiIHQQRJDQcMBQALPwANB0NdIHzAJAJB+QFBBHAOBAQHAwAECwJ9BgUMBRkMCAtEbinOIhDOSkgkANIDPwBBA3AOAgMEBwskAgwGAAsAC/wQAkEDcA4DBAEAAQsgB0EBaiIHQRVJBEAMAwsjACQAQ7HC6ytBKkH//wNxLQC1Bg4CAwAACwYD0gNBPUEBcA4BAwML/BACQQFwDgEAAAsCfEG6tMoBJAQPAAsAC/0MZnpeFTBvLB/HuAOHKlJ3qQJvBgcCBQwBAAsgBCMDQQJwDgICAAILAgIMAAALBgJCO0IRIAEOAgIAAAsMAQALRE21A0qAzpSpQZfPghMkAyQAIAAjACQAPwAkBD8AQQFwDgEAAAvMMggAcAFwAX8AcAN/AX4BfQF8A28GAQYAQYziKg0BIAhCAXwiCEIQVA0CAgZECqwOpIDgrw1Eu4kUmqQlL8ogAtIDIAAMAQALIAL8EAMCfRAEQ3W+Tuf8AQ0CAgIgBkEBaiIGQSpJDQQMAAALIAhCAXwiCEIuVARADAQLBgMMAwvRaWcgAAwBAAtDfGd2eru2QwNM3H+RQY0FQQFwDgEBAQv8EAVCm5jvj8JODwsgBUEBaiIFQRVJBEAMAQsGAQwACwIGEAQgBkEBaiIGQQdJDQEGfkKbAQwACwJwBgcGBAIBEAYCBAIFAgM/AAJ+IAlDAACAP5IiCUMAAAhCXQRADAoLDAIACwALAAsMBQALAAsMAwsGByABPwANAAZwDAELIQD8EAVwIAAmBQJ/BgMQAQMDBnAjAw0EBgVENlYQJm+n9X8CfAYAIABEMxYBCRFfC0cMAQsgAwwICyQAJAAjAkT9UqgvGfO3/ZkkACAEDAQLQg8gAiMAJAA/AA0HIAMgBEEDcA4CBQcECyAA/AkAIQAMBQALIAQMAQsMAwsjAiQCQQNwDgwBAAABAAMAAAAAAwAACyMC/ADSAENUQsrdIAAMAQELDAELIwIkAkNirVOdQRhBDUEB/AwBA/wAQQFwDgIAAAALRAdQwrj523xq/AcgAoYhAtIH0gbSA9IGIAMgASIEQQJwBG8jAUEBQQZBAPwMAQVByAQCfgIDQ+IQPXqM0gM/AEECcARADAAABUGBpAcNAAYEIAdBAWoiB0EESQRADAYLIAhCAXwiCEICVA0FAm8MAQALRO4DED7GVzmHA3AMAgALIwFE4t0PG5+hPjVBxZvajQEEBwIFBgIZAgcCQAwFAAsACwMBAn8DBBAEAgMQAQwEAAsACwALAAv8EARBBXAOBQEEAAIDAQsDBAIEBgYMBAsCBQMEDAUACwALAAsAC/wQBUECcAR/Bm9DAAAAgCQC/BAEQQRwDgUFBAMCAgILDAcABSAAIARBBHAOBAEDAgQCAQsNAwJ/AgcMBAALAAtBBHAOBAIAAwEDC0I0DAQLQakBQQJwDgIAAQAAAAsDQEEeQQFBHfwMAQQgCUMAAIA/kiIJQwAAREJdBEAMAQsMAQALRJEwC4qJutIvnSQADAALAn4gBkEBaiIGQQBJDQQCBtIFQgAMAwALAAsACyMCBn7SAkHTh6zjBgZAGAT8EAZKPwAGbyAFQQFqIgVBLEkNBCMEJAMCfCAFQQFqIgVBKkkNBQICAn1B2wFBAnAEAwwCAAXSB0OhFMEiIwBCLEN4eb0WDAEACyIAIQBBAXAOAQEBAQsgBEEBcA4BAAABC0QJEXLCcTssUQwAAAv8EAYhAdICIAIMAQsMAgALIAAiAAN8BgUgBkEBaiIGQSNJBEAMBQsGbyAIQgF8IghCClQNBdIFBnACBQMBIAlDAACAP5IiCUMAAIBBXQ0FAgQGfiAIQgF8IghCJ1QNByAHQQFqIgdBHkkNAiAFQQFqIgVBBUkNAiAHQQFqIgdBL0kNAkHBAD8AJARBA3AOAwMBBgYBC0Lc76T7mQm6IwEkAAZAIAMMBAskACMBmdICIwVB/OiuJyQDDAgLAgAGABAEDAYLDAMACwALDAALIAhCAXwiCEIcVA0DIApEAAAAAAAA8D+gIgpEAAAAAAAAFEBjDQYgB0EBaiIHQRJJBEAMBwsjA0EBcA4BAgILQsgBDAMLDAMLQugBDAEACyQAQugADAALIAH8EAVwJQX8EANBLmj8EANBAnAEfdICQ/B5aMAMAAAFEAbSBEG94QNENh/uCclupIf8EAZC3OxhIQIiAUECcARvROxoLAQ7El6h0gH8EAIEfSAFQQFqIgVBK0kEQAwFCyAHQQFqIgdBFkkNBBADQRoRBQbSBQZwAgQjBdIAPwBBAXAOAQAAC0GiuAEGQAIEEAYGByADDAMLDAAACyAJQwAAgD+SIglDAAC4QV0NBgwAC0OgukJiPwANASQCIwD8EAYkA/wDQv6/52QgAwwACwZ9EAQgBkEBaiIGQQBJDQUgAfwQAnAlAiAEDgICBAQLJAICftIFPwBBAnAEbyAIQgF8IghCCFQNBgIDBn0CAQJAIAVBAWoiBUEFSQ0KDAEACwALQ5enXgtDvo77NQJvIAhCAXwiCEIvVA0JQRoRBQYCAAJ9AkACBgwBAAsACwIDBgRBztoBJATSAT8AQQFwDgEAAAsgAD8AQQFwDgECAgsMAQALDAgLRCV3P8Xy2jKiBn8QBBAGPwBBAnAEAQZ9Bn1BGBEEBkOak3n0DAELJAJBpAFBAXAOAAELDAMACz8ABwBBFxEGBkGmAQwACwQCBgMGBAwACwwBC/wQBCEERCyBN/QCLFw0JAAhA/wQBHAgAyYEQgtB4QEkA9IGBm8gAtIBIwH8AkEBcA4HAQEBAQEBAQELQtEBIwL8EAJBA3AOAwIGCAYLQdLmlQgCcCME/BAFrCECIgEEQAZvIAZBAWoiBkEMSQRADA0LIAhCAXwiCEIbVA0MIApEAAAAAAAA8D+gIgpEAAAAAAAAMUBjDQwGfENMBRXi0gT8EAQNAvwQAgJ8BgQGAwIBDAYACyMCQ8WiE7SMjkNFOzBADAwLIQD8EAZwIAAmBiADDAULDAMACwZwDAMBCwwDAAv8BnsMBwALDAgLEAQgCkQAAAAAAADwP6AiCkQAAAAAAAA/QGMNCiAGQQFqIgZBGEkNCgIFAkAgCEIBfCIIQhtUBEAMDQsgBUEBaiIFQRZJDQwCA/wQA/wQAHAlANFBAnAOAgECAQvSBiMEIQRDhpiOkgwECwwACwNAIAVBAWoiBUELSQRADAELAwQGACAB/BAFJAOtQdzBAQ0IIwUjBA0KDAcL0gIjACQAIAK0u9IDIAAjA0J9AggPAAsACwALIwVBwNCfFQ0EIAECfiAIQgF8IghCIFQNCwYAEATSBiMFDAYBAAsMAQAL0gD8EAEEBwwAAAUMAAALQQBBAnAEbwIEQxQwvTPSBSMF0gUjAkMEjXFkJAJBxakBDQgMCgALAAUgASMAJABC3wHDQyEe/sAjBSMC0gIjBUSD7JSlo3z8/yMCDAcACwwEC0GGhAJB9AFBt+UC/AsAIQBBAnAEfELiACICDAUABQIGAkAGAdIB/BAEIQT8EAQNAvwQBkEDcA4DAQIAAAv8EAIhBEEZEQEGEAEGByAAQprg9JX+k774AwwICwwBCwwACwYAIAhCAXwiCEIfVARADAwLIAdBAWoiB0EiSQ0LIAZBAWoiBkEqSQ0LIAhCAXwiCEIYVARADAwLIAlDAACAP5IiCUMAAOBAXQ0LIwRBG0EiQQD8DAEGBEAFAgAGQCAKRAAAAAAAAPA/oCIKRAAAAAAAADJAYwRADA8LIwVExBfSJyv1k+skACADQ2OeviFEs4+G2/ub3cIgAEScP0OnLvH6/wwECyAGQQFqIgZBA0kNDUPkiK+4Bn5CJBgFIAD8EANBAXAOAQEBC/wQBkI6EAAjAyQEQ4EQk2MMBAv8EABBAnAEfNIAAnD8EAXSBdIBIwXSBkSZ1QeB7AHAEgwDAAsABSAJQwAAgD+SIglDAADIQV0EQAwNCwIFIAZBAWoiBkEHSQRADA4LBgEMAAsGBAZ9DAILDAYLAnBD/cY7GAZAAgQQBAwAAAsgBkEBaiIGQRFJBEAMEAsMAgAACwwMAAsCfSAGQQFqIgZBHkkEQAwPCyAFQQFqIgVBDUkNDkEZEQEG0gcjA0EBcA4BAQEBC0HjAEEBcA4AAAsgAb5EzJUWSsos8X8/AA0AmtIGBnwgCEIBfCIIQghUBEAMDgtCoAEhAhABIwC9DAgLIwUMCwsMAQv8EAJBywMhBLf8EAMGfSAFQQFqIgVBHUkNC/wQAtICA33SBELnm6ntzwa0DAoACwwDCwwGC5qfYkHaK0EAQQD8CAAAQQJwBAcgCUMAAIA/kiIJQwAAAEFdBEAMCwtD6XHtaQwIAAVEJV7jKv0QFlsGbyAJQwAAgD+SIglDAAAQQl0EQAwMCwJ+BgcMAAsGbwwDCyABQQVwDgUBCQMLBgYL0gQjAJ4jAEMhS+D/DAcLDAELIAH8EANwJQNEV7faFEypbjH8AkECcAQHCAkLIAPQcCIAQjMCfgMC0gcjBPwQAUX8EAFwJQFE4HDHmbnPmDkGbwIFIAZBAWoiBkEmSQ0CDAAAC0GfAUL4pJmJi8+GeAwCCwwFAAtD1lJ0vQwCCyABQQFwDgEEBAsgAAJ8BgAjAQwBCyAEIAIhAgZ8Bn8jBAJAQfYLDgIAAAALIgEiBAwABwAGf0Hw8wNC8gBB6gEMAAsCbwJ/QZoDDAIACwALIwMMAAELAnACAyAEQQJwBEAMAAAFAgcGfAwCAQtBGkEQQQD8DAEGBkDSBNIFQeDugMIEQQNwDgMAAgEAGSAEQQNwDgMCAAEACwwECyACDAgL/QzBOvcMKZrGht8ZpHF4zacARFIczCwOAM7JIwLSBSAE0gdCA/wQBPwQBHAlBCAC/BAGQQFwDgAHCwJAIAZBAWoiBkEFSQ0MC/wQA0EBcA4BBAQL0gYgASQEQdqyjRr8EAJKJATSAQZADAAL0gQgBEECcAR8/BAE0gEgANICIAP8EANBAnAEfQZwEATSByAAIwXSA0EaQRNBA/wMAQNC8QHCewwIC9IDIwQkAwJw/BAAQf//A3EuACP8EANBAnAEfEQ+Z+O4VyDVRAwEAAUjACQAIAlDAACAP5IiCUMAAEBBXQRADA8LIwEgAUEEcA4DAwQABQv8BwwIAAsABQN+QRoRBwYgCkQAAAAAAADwP6AiCkQAAAAAAAA/QGMNAEH/09PwB0ECcARA/BAGQQFwDgEAAAsgB0EBaiIHQRhJDQ1BzgAlAwN/0gIaIwQCfQJ9IwIL0gMaJAJEN4Qg/oQfkgQMBAALAAsACwALDAMAAAUCBxAGRF0xSvmVNlAnDAMACwALDAELDAAAC50kACMFDAcLDAUBCyEDBAAgB0EBaiIHQQFJBEAMCAsCcCAHQQFqIgdBEkkNCAYGIAZBAWoiBkEjSQ0JC0PDk5eEQeOi9v0HQQJwDgIGBAQLDAAABSAFQQFqIgVBK0kEQAwIC0GoPERgyMBZ4aossb3EDAIACyIA/BABJAMjA0H8/wNx/hACAAR/CAkFBgZDzQK4IAwECyMDIQFBpQEMAAALJATSBwJwIApEAAAAAAAA8D+gIgpEAAAAAAAAQEBjBEAMCAsCBwZvAn8gCEIBfCIIQiNUDQoCQCABDQDSAkIlDAYBCwwCAAtBAXAOAQEBCwwHC0EDJQUhACAA0gVB6QD8EAZwJQYGfSAHQQFqIgdBH0kEQAwJCwYD/QzI4rmlvWzdKQdrKw/9rFgLIwJEn4mpesJxwUokAELeASABQQJwBAT8EAUaQQAOAQAACyECDAELDAELRAb94L+l+RYsRG0ag5jC9QvVZSEBDAMLPwBBAnAEfUPt6k9vJAL8EAbSASMAJABEPJL2zMlgK+YkACABIAIgAooMAgAFAgMQAwYHIAVBAWoiBUEHSQ0JIAZBAWoiBkEcSQ0JAgHSABoGbyAFQQFqIgVBF0kNC9IDIwMNAtIAGhogAyMCDAkLAn4jBQwFAAsACwtEjqBHyO3QwtwkAAJ9QfeAAiQEBnwgBUEBaiIFQSpJDQpElnac+QW7MBsgAUEBcA4AAAsDb0Rbbo80kQ3oPSQAAn5CAQJ/IAIMAQALAAsMBQALAAsACwAL/AVENxCvzkTNrvcjBQwFBfwQBCQEIApEAAAAAAAA8D+gIgpEAAAAAACAQEBjDQYDAUKcAQwCAAsACyAERKn9pqfDGCVT/AJqQQJwDgICBAIL0gdCn77gu3ohAj8AQQJwBEAMAAAFC9IDGtIHQhAhAkRHxoEmysoksUPBQTduDAAFAgEgCUMAAIA/kiIJQwAA4EFdBEAMBgtBufCg7gBBAXAOAQAAC0TThTlIPqWFEAZAC0PFrtdUQonhRBoMAgALDAEF/AkAQcgAJQBEssWEVXfene8a0gfSAiMBJAAgAkEPQRJBBfwMAQYhAhoaRASaWGEu6lfPPwD8EAVBAnAEAENlspT9DAIABQIHDAAAC0EYJQYL0gIaQ3yVECIMAQALDAELJAJB//8DcS0A3wMkBEHcpNUoQQJwBAAgBkEBaiIGQQFJBEAMAwsGcEEgJQQLBm8jBdIDQZ+gh79/JAQaIwXSByMEQpey2eH7eD8AJAPSAhohAvwQAXAlAQwACwwBAAUgAwwAAAsGfSMD/BABJAREOJX542aJJVG2DAAACyAAIAQkBEQnKNAtah7xKSQAQdwAQQJwBH9DPmFNiEEBDAAABUHfAAZ9BgMGAgwAC/wQBAwCCyAA/BADJARB6AEkAyEAIQAgAyAEswwACz8A/AkADAALIgQgBCQE0gIgA0HoAEKrs/XZbAwCBUEDQQlBE/wMAQMjBQv8EARC14C8nX4gBCQEQc4AREjp39lta75EQ/CNoqNDI0kQKQJAIAZBAWoiBkECSQRADAILCxokAhogBCQEQf//A3EvAWIkAxojA0EPQRxBAfwMAQMkA0ECcAR+IAlDAACAP5IiCUMAADBBXQRADAILIAhCAXwiCEIhVA0BQhbSB0HfBUECcAQCBnwgCUMAAIA/kiIJQwAADEJdBEAMBAsjAAcCDAEAC5+a0gREWFNElCgmIERD+DB5d9IFQ1Zk0X9DKw39f5GTJAIauyMBJACbIAFBAXAOAwAAAAALIwAkAEQD+a+VMwRaIpokANIAGiABJAMjABoaDAAABSAFQQFqIgVBAkkEQAwCCwICCwYFCyACCyECGiEDGhoaQZ4GQf//A3EtAPwEBn8gB0EBaiIHQRJJDQHSABogBkEBaiIGQSZJBEAMAgsgCEIBfCIIQgFUBEAMAgtBIAtBAnAEByAIQgF8IghCDFQEQAwCCwYBCwUGAyAIQgF8IghCJlQEQAwDCyAGQQFqIgZBMEkNAiAGQQFqIgZBJkkNAhAEIApEAAAAAAAA8D+gIgpEAAAAAAAAIkBjBEAMAwsQBAwBC0LgACECIQP8EAZwIAMmBv37ARoLIwE/ACQEJAAjBRpBAnAEb0OwO/yT/AH8EAQiBMADfSAAIQAjAgsGfgIAAgHSBkHkAEEBcA4BAAALQSElAwvSAtIG0gQaA34Cb9IG0gdB9QEGfESZT5aMsmDyf/wQA/wQAHAlAPwQBUECcA4CBAEBCxokAxpBwAAkBESO2NMIbTrLYD8AuCQAAn5C+ML/zot7/BAGQQJwDgIDAAALIwRBAXAOAQICC0HFAEEMQQX8DAEEDAIACwwAC8RBp+TJsHpBAnAEfCAIQgF8IghCIFQNAiAHQQFqIgdBK0kNAgMBCyAKRAAAAAAAAPA/oCIKRAAAAAAAgERAYwRADAMLIAZBAWoiBkEvSQ0CIAhCAXwiCEIpVA0CIAZBAWoiBkEiSQ0CRNuilL/n0gPXDAAABSMACyQAQRFBC0EM/AwBAxqMIwLSBRoDcBABAgAgAyIAC0H7FARvIwUMAgAFQrOozsoseSMEQQJwBH0DACAErHpDTvZmqgwBAAsABUMAAAAAC7v8Bxp7IAPSACMDJAQa0gBDG5a0KvwAJAMgASEBGiEDIQL8CQAjASQAIAZBAWoiBkEaSQ0BQQ0lAQwCAAsMAQALIAAgAyEAIQAhACABHAF9JAIkA7IjBCQEQdoBIQEa0gcaQRoRAgZBAiUCBSAJQwAAgD+SIglDAAAAQF0EQAwCCyAHQQFqIgdBL0kEQAwCC0NPI/ODJAIGftIEGj8AJAMGQAsgB0EBaiIHQQ5JDQIgCkQAAAAAAADwP6AiCkQAAAAAAAA9QGMEQAwDCyACAn4gAyIAGkLBAAwBAAsMABlC1ABEAAAAAAAAAIA/AEECcARwRNMQCIcmfQOCBn9BkMQMQQJwBABDn9pIQyACDAMABSAFQQFqIgVBCkkEQAwGCwZ/BgMgCkQAAAAAAADwP6AiCkQAAAAAAIBHQGMEQAwICyAGQQFqIgZBEUkNB/0M1I+O56WcrSiXVUqPTTPX6/1oIwH8AgwDCwwBCwwBCwN9QdHm5gNB+P8Dcf4RAwAMAwALA3wgBUEBaiIFQQpJBEAMBgv8EAUMAQALtpIjAwwACyEBJAAQA0EKJQYMAAAFIAIMAQALIQAkAAshAgYAQw3s1JkkAj8AJAMgB0EBaiIHQQJJDQIQBiMBIAAMAAEAAAELIwEkACEAIwVBAkElQQD8DAEFCyAEGiMCJAIaIAIhAhogBkEBaiIGQTFJDQAgCUMAAIA/kiIJQwAAMEFdBEAMAQsgCkQAAAAAAADwP6AiCkQAAAAAAIBGQGMEQAwBC0EXJQELGkEBJQVByNvPOCQERP5EGHZRVq+AJAD8EAD8EARwJQTSBRrSAxrSBBoDb0EiJQAL0gAjBBoa/BACJAMjBKwjBUHVDiEEIwUaGhpCf0L2t8OliaH1AVUkBCAEJAMa/BAAPwAkBCMCQwBdFy1CyYD0mfLEAlAkBEHnAb5bQfoAJAMkAyQCHAFwIgPRGkEPJQMjBEECcAR/Q+IOZHbSARokAiMEDAAABSMEQQJwBEALIwP8EAIMAAALIAFBAnAEAQsEAQJ/DAEACwAFCyMEQQJwBAcFC0HYscMEQi4LCwwBAEGeJAsFOoLOhPc=', importObject4);
+let {fn43, fn44, global36, global37, global38, memory7, tag18, tag19, tag20} = /**
+  @type {{
+fn43: () => void,
+fn44: (a0: FuncRef, a1: I32, a2: I64) => [FuncRef, I32, I64],
+global36: WebAssembly.Global,
+global37: WebAssembly.Global,
+global38: WebAssembly.Global,
+memory7: WebAssembly.Memory,
+tag18: WebAssembly.Tag,
+tag19: WebAssembly.Tag,
+tag20: WebAssembly.Tag
+  }} */ (i4.instance.exports);
+table20.set(1, table21);
+table12.set(48, table7);
+table25.set(25, table15);
+table20.set(33, table4);
+table26.set(44, table20);
+table4.set(6, table20);
+table3.set(23, table11);
+table20.set(58, table22);
+table3.set(6, table23);
+table4.set(15, table26);
+global13.value = 0n;
+global16.value = 0;
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn35(fn36, global9.value, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn35(fn43, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn44(fn43, global9.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn44(fn35, global7.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {F64} a0
+@param {FuncRef} a1
+@param {FuncRef} a2
+@returns {[F64, FuncRef, FuncRef]}
+ */
+let fn45 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [1.3012687000442607e-24, a2, a1];
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {void}
+ */
+let fn46 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn16(a0, a1, a2);
+};
+/**
+@returns {I32}
+ */
+let fn47 = function () {
+
+return 8;
+};
+/**
+@returns {I32}
+ */
+let fn49 = function () {
+
+return -7;
+};
+/**
+@returns {I32}
+ */
+let fn50 = function () {
+
+return 1;
+};
+let global39 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let global40 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global6.value);
+let table33 = new WebAssembly.Table({initial: 92, element: 'anyfunc'});
+let m16 = {fn47, global41: global3, global45: global11, global46: global11, memory8: memory4, table32: table21, tag30: tag13};
+let m15 = {fn45, fn46, fn48: fn43, fn49, fn50, global39, global43: global11, global44: global35, table33, table35: table6};
+let m17 = {global40, global42: 417356.4654070051, global47: global11, table34: table0, table36: table8};
+let importObject5 = /** @type {Imports2} */ ({extra, m15, m16, m17});
+let i5 = await instantiate('AGFzbQEAAAABsQEbYAABf2AAAX5gAABgAABgA29wbwJ7cGADb3BvA29wb2ADb3BvAGACf34Dfn5/YAJ/fgJ/fmACf34AYAAAYAAAYAAAYAN8cHACcH5gA3xwcAN8cHBgA3xwcABgA39+ewF9YAN/fnsDf357YAN/fnsAYAAAYAAAYANwf34AYANwf34DcH9+YANwf34DcH9+YANwf34DcH9+YAV+e3B8ewV+e3B8e2AFfntwfHsFfntwfHsC0gIXA20xNgdtZW1vcnk4AgOQCJEOA20xNQRmbjQ1AA4DbTE1BGZuNDYAFQNtMTYEZm40NwAAA20xNQRmbjQ4AAMDbTE1BGZuNDkAAANtMTUEZm41MAAABWV4dHJhBWlzSklUAAADbTE2BXRhZzMwBAAVA20xNQhnbG9iYWwzOQNvAQNtMTcIZ2xvYmFsNDADcAEDbTE2CGdsb2JhbDQxA30BA20xNwhnbG9iYWw0MgN9AANtMTUIZ2xvYmFsNDMDewEDbTE1CGdsb2JhbDQ0A38BA20xNghnbG9iYWw0NQN7AQNtMTYIZ2xvYmFsNDYDewEDbTE3CGdsb2JhbDQ3A3sBA20xNgd0YWJsZTMyAW8BUOIEA20xNQd0YWJsZTMzAXAAXANtMTcHdGFibGUzNAFwAAcDbTE1B3RhYmxlMzUBcAAeA20xNwd0YWJsZTM2AXAAJgMDAhEQBA8EbwEY7wFvACZwAAlwAEgNCQQADwAVAAIAFAY5CX8BQaORrZUFC28B0G8LfQFDDZ6lAwtvAdBvC28B0G8LbwHQbwt/AUGRLgtvAdBvC30BQ/npWB0LB8kBFAhnbG9iYWw1NgMOCGdsb2JhbDU3Aw8FdGFnMjkEAghnbG9iYWw0OAMECGdsb2JhbDUxAwkIZ2xvYmFsNTADCAhnbG9iYWw1OAMQBGZuNTIACAhnbG9iYWw1NAMMB3RhYmxlMzkBCAhnbG9iYWw1MwMLBGZuNTEABwhnbG9iYWw1OQMRCGdsb2JhbDU1Aw0IZ2xvYmFsNDkDBgd0YWJsZTM3AQUFdGFnMjgEAQd0YWJsZTM4AQcIZ2xvYmFsNTIDCgV0YWcyNwQACdcECgVwU9IFC9IAC9IGC9ICC9IDC9IHC9IGC9IFC9IEC9IDC9IAC9IDC9IHC9IIC9ICC9IGC9IFC9IBC9IAC9IHC9IDC9ICC9IHC9IIC9IBC9IBC9ICC9IGC9ICC9ICC9IDC9IBC9IBC9ICC9IEC9IDC9IIC9IDC9IIC9IIC9ICC9IIC9IGC9IBC9IBC9IFC9IIC9IAC9IGC9ICC9IGC9IHC9IHC9IEC9IAC9IIC9IAC9IIC9IEC9ICC9ICC9IDC9IDC9IAC9ICC9IIC9IGC9IGC9ICC9IHC9IIC9IIC9IBC9IAC9IDC9IBC9IGC9IDC9IFC9IHC9ICC9ICC9IGCwVwLtICC9IIC9ICC9IBC9IEC9IIC9ICC9IIC9IAC9IGC9IGC9IFC9IBC9IFC9IDC9IEC9IFC9IAC9IDC9IDC9IHC9IBC9IBC9IEC9IBC9IDC9IAC9IBC9IEC9IGC9IGC9IEC9IGC9IHC9IEC9IEC9IAC9IEC9IEC9IEC9IBC9IFC9IIC9IEC9IFC9IECwMANAAIBQEGAQUFAQUBCAUFAAQGAAEFAQgBBQgHBwQCAAEGBwYEBwYBAAQDAQIDBQIBBAAIAAMGAUEFC3Ae0gYL0gUL0gQL0gcL0gEL0ggL0gAL0gcL0gML0gQL0gEL0gIL0gML0gEL0gYL0gIL0gEL0gAL0gUL0gYL0gIL0gYL0gAL0gAL0gcL0gYL0gYL0gUL0gYL0ggLAgdBAgsAAQACA0EWCwABAQIIQSwLAAQCBAUGAgNBBwsAAQMGB0EBC3AB0gcLAgdBAQsAAQgMAQQK9CkCxyIJAnAAfwJ/AXAAfwN/AX4BfQF80gL8EAREdkzKB+lXkSy9BgcCez8AJAkGABAE0gEGfQICQQRBLUEQ/AwAAwJwBgECAEErAnvSAETdbCuE7yX/f7YgAkKTASEBIQKQA38DAwILBm8MAQv9DOQC1Hw6ZuVJMHmzqXjYEpYjDQJ9AnwgBAwIAAsAC/0TDAoLDAYACwALAAsACwwECyIB0gH9DMdVnqi2Q3VVqWSjFZQbwNUMBAtD//AgWyMGPwBBAnAEEwUMAAALDAMLIwMjBiECJBEjD0ECcAR9EAUkBUK0hoABPwAEfEQxJ3zlour1/wwAAAUCQENghfDSBkAMAQskAgZvQorf0banmn7SAyACDAYLBnzSAEPgFsynDAQLRK8aYeaiIW7IAn8MAQALDAQLAnAjBAJ9QbiI9ZYCQQJwBH0jAgwEAAXSANIEIwsjET8ADAYACyQLA3sgAwwCAAsACwALJAEjASIDA0AgCkEBaiIKQQ5JBEAMAQtCNfwQAgwEAAsAC9IBRGJNqZP5a620QfkBIQYjAyQL0gZCLAN+0gdDC1bLGAwBAAv8EAUMBAUCf9IB0gX8EAVBAnAECkEuEQAIDAEABQwAAAvSAkLEdf0MlNmHWZHfwPLRro/7bSkY0f3BASQH/RIjBQwAC0ECcAR/Q4bSglMMAgAFBgwMAAvSA/wQBAwAAAskCQZ+IwgjDETIcnwQYTwx7SAD0gICfwIAAgACCwJABgoGAAwCCw0ARMMoawuyB1PWQeupygZBA3AOAwIAAQALIwcMCQv9DAdAUQaZy75H+rV6cv4PX/kjBtIFQ3xMsX8kAiAEQgL9DJjRMBPuPGeJFbZhyRzH9F8MCAtCxADSA/0MlL35fbhBloXDZtsazhS9Vz8AQQJwBG8CDAIDQ+nj8079EwwKAAsACwAFEAUMAgALQQJp/BADDQb8EARwJQQ/AAwGAAsMAAvBDAQAC2gMAwtEm/F7VXO7ac39FAwDAAsgBQ4BAAALJBH8EAL8EAZwJQYjCkNPejFyIAHSByML/BAEDAAHAKcMAAtDAAAAAAJAQwz/j1qQIwH9DDkwUy7SxrFJLz0UF6pZrGwMAQALQRwkBUOfgZAT/QxhEkWR8lnqsU6MWIHOckyrJAb8EAZBAnAEf9IA/QwuG7FbHnZ/LK6H6myCIbmAIARBHEEvQQf8DAAERDDbQiuZ+ix+IwEjAURF8Sj1FwUDA/0U/cQBAnBDJUZLQLwMAQALAAVEEgaHcGxw9/+2jSQR0gVBHkEWQR/8DAAI0gFEC3rfXLE8VgFCy0gjBgwBAAskDyMFHAF9QbmozyEiBUGRz9sB/Q9B/6C/Df1sDAAACwwBGQJ+IwhEzQ6kWciPa+fSBUEKIwRCvgEhAf1fIAYjA0EJIgYhBkOmGm5B/BAHQQJwBBQMAAAFDAAAC16tAgcMAQALAAu6Qu05IgE/AEECcAR8RBij67IV3Y0lQ5C4YOL9EyECDAAABRACIgD8EABwJQAJAQtD8DNF3CQCRIGiA3cEIpyKmkLtAdIA/QyvS/8x7Ru/glqfmZleT/LzQ/+I6/lDv2DtUAJ8BgwCAwILDAIACwALAnACb0EAQRRBAvwMAAcMAgALAAskAUEBQSNBAvwMAQQCAAYC/BAGBHBB/gAEFAwEAAVCqdfR2tqp4v97/BAADQBE+LP0VhkKGcwMBQsMAwAFDAMACyQBDAALDAEACw4BAAALAhMMAAALRDjp1ZVBeRPPRKVU7xlmFJHJQQVBAEEA/AwBAiMPQQFwDgEAAAEAAAtChQECfCMERMecYgdcZvP/DAAAC7bSAUPoZp/1Bn/8CQEQBgwAC0ECcARv/BAEQf7/A3H+EwEARPEAdJT5ALEjQR4kD51ExwXllVWFY2U/AAkBBQN90gD9DEzbeBKWUMUAyr3GFsHCr2YjEUGuwhokD/0TAm8jDiQNQS4RAAhBAnAEAwUMAAALIAlBAWoiCUEpSQRADAILIAlBAWoiCUEISQRADAIL0gPSAkQSI0QnU+ry//0MmBixS66UySqXj9a2j4JJaULmAfwQBNID0ghCAiMNQoL2n87HsJ4cIQEMAAALIAQkAQwBAAsACwZwIwwkCv0MNRpHd1n0ikrwBmtvvbU5Uj8A/QxZoQuBl8ifX5+qTrTr+sQ+QRdBGEEQ/AwBCCMBJAH9DPhU0/O0CWgJOeQFhXEd5y8jA/0gAv2oAf2+AULK1hH9HgAGcAJADAAACwJ8QS8RAAg/AEECcAR9AhMMAAALBgEDb9ID0gP9DPo0ndsUD3Xg+uAcPT1jy+xEaH753oh34R8jCUEBcA4BAwML/BABBH4GFBAEIwskAv0M+y9SluNKffTWf5w6ODF6GCQEDQAgBwJ9DAEAC9IBIAMMBQvSASMCBn8GAwwACwZ7BkAGbwwBCwN+IAlBAWoiCUEHSQ0AAgoMAgALAAsMBAcCDAQLQn8MAwsjAv0gAEIvIQEgBPwQBEECcA4CBQYGCw0C/RNEFNHvItbY18n8BiADDAQABT8A/QwEZs5bDIZRJ/Nsh+lBx0pC/Qx1kwp0SRYb448QaLliJZhCIgJClKO8uvST5AQMAQALBn5BLxEACCMCDAILDAALRMqcg2asUJst0gUGbwIKDAAACwYK/QyreLZKOFAs77bP44oklkLu/BAC0gggBwwFC9IG0gYgBT8AAm8GA0TjxDRi4IHX8EGL7uYwDQD8EAgNBAwECyMMC0HPtgFB5KcDQfuHAfwKAAD8EAQhAAN/IwH8EAVBAnAOAgUEBAtBAXAOAgAAAAEACyMLDAAFIwJCg/qc7Y7lwqPeACADIAZBAnAEcNIGAm9EJuN6pxb25deb0gb8EAb8EAYJBgALJBBCPAZ/A38gC0IBfCILQitUBEAMAQsgACACIAEgBf0R/ckB/BAAQdz7AkECcAQCCwZvBgIGfSAMQwAAgD+SIgxDAABAQl0EQAwECwwBC/wQBAwDC0EIJQUMAAsjAgwDAAsMAAvAQZXSogpOQQJwBHACfAIBQR9BD0EB/AwBBPwQAQN+IAhBAWoiCEEnSQ0AAgBB0gAMAAALuEMaJ8ujDAUACwALAAsABUEAQQJwBAsFC9IFIAZBAnAEDAsaBgsLPwAkCQILAhMDA0SP8uVv8oIBMAwGAAsACwALAAsgASEBIQMhAfwQCCMBDAQABQYMCyAD0gLSA0SWZuQn1asQQwwCAAsMAwsCfQIUCwYB0gQaIAbSARoaBhP9DIAAdcAaJEfIn5S/elogWC4jACQAAntCJgwCAAshAv2oASQGCz8APwAkBQJADAAAC9IGIwkEfyABDAEABQYCGAcCChAEJAkMAAALAgwMAAALQdTqDQsEfAYUC0SAWtIk77v+awwAAAUQBPwQAiEFQQJwBApEcQLMe7sMlbsMBAAFCz8AIQZERgGfqnWcQPoLDAIBC/0M+kb5ZXK62RM9d+NCfcR1Ev2oASQHIw4jCCQEIwIMAAALjZeQJBEGewIUIAckAQsCeyMEDAEACwsiAiQHIQBEgyo2tsKPBhsMAAsjBCQIIwUCfkEiQQJwBH5Cqemig7nztQJEgoTsZXkSpZwaCQQFQSwRAAgiBkH//wNxKQO0BwwAAAv8EAYNAAs/APwQB3AlByMI0gQaJAYMAQskAQJ+QYzKzPwAJAUgAQshASMA/Qz2GWDU9F+k5O8ilzQWKTfZJAcaIQI/AEECcAQAEAUMAAAFIwkLTUH//wNxLQDJByEFAnxES69c3Cj68v8jCyMMJBAkAgJvBgILQQAlBQtDwPDNHyQRJA0LGiQG/BAHJAUjAQvSAT8AQQJwBH8CDAwAAAsjDwwAAAUjAEQmEz+Xshr2OP0MgXIMeBzYy5RLx/UzFp3vTv0MYObnbzOKxm2HXMiHJ28c+v14IQIaA3wgCkEBaiIKQQJJDQBEfXYHjwRBUL4LnUOAzIAaQpYBIQG7/QxH4Vws9Zkei7NUZ6JVXpFeJAQgA0EdQQ1BD/wMAQghAxr8EAJEIxFykzeP/P+e/RQjDSQN/aEB/BADDAAACyQP/BAAJAkgBvwQA3AlAyEDGtIEIAQCfAIA0gEaIAckAdIF/BADJAVDhRKG4SQRGgJ9AhQMAAALIwIL/BABaQwAAAshBUSRqx2iSl7+fwwAAAsJAAsGfQIMCyMR0gTSAyAG0gEaQQJwBAIMAAAFCwZ+QoABDAAACyEBGhoMAAALjz8AJA8CfgYKC0KwkrGUrz38CQMiAQvCQsOOHiMA/BACQf//A3EzAckB0ggaRCBtwxeqNliBGiMNJA7SARrSCBoDfUOusaODCxohASQNPwD8EAVwJQX8EAH9DJnC1JfA3nQvkJsH4ER/XtIhAj8AJA9BAnAEFAUGAkHuopGqf0ECcA4CAAEACwv9DLB+fvNFWx+fJWkDNWrhhg1EfaPmj7k1RyT9IgD9DFwaYVF9GsMArVlna5OdhtM/AP2tAUEPQcEAQQP8DAAD/SEB/AYhAf0MMofQP0xRXaPx6cVWNrJmZSQHJAbSBRokDiEBRKI5VqQ52PdDIwj8EAgkBf18AkAMAAALIQIgAD8AQQJwBBQLJA/9DCzHnVwzFn/KBynyjK7Yb7/9gAH9qgH94QHSCBr9xwEkCBohASQLQf//A3H9AwMO/ccB/SEBIws/AEECcARv0gMaQQ8lBiMKDAAABQICA3wMAQALAAtDmfmc/yQRQQUhAEEaJQDSBBoLJAwkERohAT8AQQJwBAMFQauUOA0ACwJ/IAckARAE/QzFywFqlFH8qu9pEpT9/3VvIQICfkKRx9KHs4qkoMwACyEBCyQJIQEGe/0MyBn32KDWMcBjAo1uFphBFwsjDdIAAn9CzAEhASMJDAAACyEGQfoLQfO8AUHcqQL8CgAAGiQOQ7a7T94GcAILC0MAAAAA0gEaJAIjAyQRPwBB//8Dcf0ABOEDJAcGbwYTC9IBGgILC0EBJQULBnBC2AD9EiQGIAMLQ65b44dEgKajHEaNUlUaGgwACyQB/BABQQJwBH1Dk3MXdwwAAAUCAdIH0gYaAkACQAtEejtLN15kwTEaCyMMQvzvttUiDAAACyEBQ6TKt5ELBkALIxD8EANB//8DcTUCNPwQACQPIAX9Ef10JAchASQQl5D8ASQFIQL9DHE/4563xg06DR8XIval7e4gAP3LAf0WByQPGiMJBAEDAgsjCP1kJAnSA/wQBCQFGiAHIQdCgAEMAAAFIAELIQFBECQPIwkgAQIHAgcgACQJeyEBJAX9DPENVbAAccavVdHZF22vs3gkBwYBAgBB+QELZyQPBnxEdT4r/SS2SIoYA0P9x5CdJBEaQtHx7J3m2Nvsebk/AEN7TBOoJAIkBRoCAEHu2QILJA8gAQv8EAQ/ACQJA3BBAyUCQfzmA0GM9ANBh6ID/AoAAAskAbfSBSMAJAwa/BAGIQYaeT8AQQJwBBQL/Qxdn7rSgVk8ofFdiCPh0ScDGiMDGj8ARAAAAAAAAACAQQVBJ0EU/AwAAxokBXlB7JEBQYuyjLABQfeAA/wLAP0SAnD8EAIhAAYD/BAIJAUMAAsjAQsgAiQEJAEkBiMJIQZCCULWlP23YUHs5gsLCxshAQMTEAZFDQALIwlCzgACBwIJIQFBAXAOAQAAC0Kl0qyJ/IF7PwAkD6ckDyABQs3twAb9EiICJAfSARrSBRpBAUEnQQT8DAECIgEgAUS7mMMjFUqsPBoGQAtBBAwAAAsbAnACCwsDAQJ+AnAjAQsMAgALAAsACz8AJAU/ACQJJAH9EiQIIAWtvxojCSMAIwuPJBECbyAEAm8Cf0NVqsWfjvwAC60hAUE4JQALDAAACyQAJA4Cb0PRMqsTJAtBEyUFCyQO/BAAcCMOJgAjD7NBASQJJAv8EABCwAEgAiMNJBALqAcGAX4CcAN/AX4BfQF8BnADewIKBhQgB0EBaiIHQS5JDQIgCEEBaiIIQQNJDQL9DGgey0ErAkLvJNOjkPLyGJpEQ6DDDRo2DHL9IgEiAiQIQuDmkat1Bn1BLREACAJv0gNB9KQPDgECAwsgAiQG/BAIsgZ8IAdBAWoiB0EiSQRADAULQ5oqNc8PCz8AIgBBAnAOAgIBAQv9DJmTAHRlSAqcp5xVt2oD+75CiQJETiIMzccUWgrSAtIGIwlBAnAEAdIIBn8GAkEIQRtBEPwMAQQGEwwFCwwDCwwDCw0CAnsCAAwDAAsACwAFAgIjDkNQrfk9QqKMjoWKuU4MAQALAAv9EiQEQc2G6hJBAnAEEwUgCEEBaiIIQQVJDQMCcAIUQQFBBHAOBAMEAgAEAAsCCgMAIwUNAyAEDAIACwALAAsjCyQCIgUMBAsjAQwDCwwAC/0MKRXtHZ8BXBdraXFn0B9CVfwQB/wQAHAlACMEQQr8EAMEFAUMAAALQQJwBBMgB0EBaiIHQSdJBEAMAgsGCxAD/BABJAkMAQsgB0EBaiIHQRxJBEAMAgsCAgIMAgPSBSMJJAn9DFpT9wSKXneYRBWqUZr6FOQ/AEEEcA4EAwIAAQALBhMgB0EBaiIHQTBJBEAMBQsQBUECcAQMBgIGCgwBCwYLIwE/AEHtAEECcAQUBgz8EAdBCXAOCQYAAQIHBAUIAwgLDAALDQH8EAJBB3AOBwUEAQIABgMBC/0McD/kkWBKKiOc7WbqYvIsNgJ8BgEgBkEBaiIGQStJDQgMBgshAwwFAAv9IgACewwDAAtEnCePlXn1fywjCiQOA3AMBgAL/BAIJAUkAf0iAEQUtkl+2kbAK/0iACEC/YkBIQIMBAv8EANBBXAOBQMAAQIEBAELEAQNAPwQBEH+/wNx/hMBAEMj3qdcJAJBBHAOCwAAAAACAQMCAwMBAQELIwMPC/wQAUECcA4CAAEBAQsgC0QAAAAAAADwP6AiC0QAAAAAAAAxQGMNAQJ/AnwjArxBAXAOAAILIwxEeMWxE43HYdkaJAwDeyAGQQFqIgZBCEkNAyAHQQFqIgdBMEkNAEMoUEIIDAUACwAL/BAHQQFwDgEAAAskCCQNJAYgBkEBaiIGQSZJBEAMAQsjBv3gAdICBnsQBfwQBHAlBCMKJAAMAgEL/acBIQJDxThQgwwCAAskB0H0APwQAXAlAQskAQYLIARCggE/AEEBcA4BAAAACyADIQFDQeMQTwsLIgQBCHZZps9W+tboAQeeMiA+yaraAQPCqIQAQeq7AQsC47Q=', importObject5);
+let {fn51, fn52, global48, global49, global50, global51, global52, global53, global54, global55, global56, global57, global58, global59, table37, table38, table39, tag27, tag28, tag29} = /**
+  @type {{
+fn51: (a0: I32, a1: I64, a2: V128) => [I32, I64, V128],
+fn52: (a0: I32, a1: I64, a2: V128) => F32,
+global48: WebAssembly.Global,
+global49: WebAssembly.Global,
+global50: WebAssembly.Global,
+global51: WebAssembly.Global,
+global52: WebAssembly.Global,
+global53: WebAssembly.Global,
+global54: WebAssembly.Global,
+global55: WebAssembly.Global,
+global56: WebAssembly.Global,
+global57: WebAssembly.Global,
+global58: WebAssembly.Global,
+global59: WebAssembly.Global,
+table37: WebAssembly.Table,
+table38: WebAssembly.Table,
+table39: WebAssembly.Table,
+tag27: WebAssembly.Tag,
+tag28: WebAssembly.Tag,
+tag29: WebAssembly.Tag
+  }} */ (i5.instance.exports);
+table3.set(17, table37);
+table11.set(53, table12);
+table5.set(0, table26);
+table3.set(32, table12);
+table3.set(5, table26);
+table7.set(43, table12);
+table5.set(2, table21);
+table12.set(40, table25);
+table15.set(15, table7);
+table21.set(66, table25);
+table7.set(71, table11);
+table21.set(73, table37);
+table26.set(41, table7);
+table26.set(14, table26);
+table7.set(19, table37);
+table12.set(14, table11);
+table4.set(34, table22);
+table20.set(19, table15);
+table4.set(43, table12);
+table5.set(48, table26);
+table26.set(14, table12);
+table22.set(42, table21);
+table5.set(26, table22);
+global21.value = 0n;
+global36.value = 0;
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn44(fn16, global57.value, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn35(fn52, global35.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn16(fn52, k, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn35(fn51, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn44(fn36, global35.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn44(fn44, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {I32}
+ */
+let fn56 = function () {
+
+return 75;
+};
+/**
+@returns {void}
+ */
+let fn59 = function () {
+
+return fn17();
+};
+/**
+@param {I64} a0
+@param {I64} a1
+@returns {void}
+ */
+let fn60 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {[FuncRef, I32, I64]}
+ */
+let fn61 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn44(a0, a1, a2);
+};
+/**
+@returns {I32}
+ */
+let fn62 = function () {
+
+return 61;
+};
+/**
+@param {FuncRef} a0
+@param {I32} a1
+@param {I64} a2
+@returns {void}
+ */
+let fn64 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn16(a0, a1, a2);
+};
+/**
+@returns {I32}
+ */
+let fn65 = function () {
+
+return 6;
+};
+let tag45 = new WebAssembly.Tag({parameters: ['i64', 'i64']});
+let global60 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, fn52);
+let global61 = new WebAssembly.Global({value: 'f64', mutable: true}, 35929.499684711205);
+let global62 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, fn18);
+let global65 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global40.value);
+let m18 = {fn56, fn59, fn60, fn62, fn65, global60, global61, global65, memory9: memory0, tag38: tag19, tag40: tag19, tag41: tag8, tag43: tag16, tag45};
+let m19 = {fn53: fn35, fn55: fn44, fn57: fn44, global62, global64: global0, tag37: tag18, tag44: tag16};
+let m20 = {fn54: fn16, fn58: fn18, fn61, fn63: fn35, fn64, global63: global12, tag39: tag29, tag42: tag16};
+let importObject6 = /** @type {Imports2} */ ({extra, m18, m19, m20});
+let i6 = await instantiate('AGFzbQEAAAABeBFgAAF/YAN/e3ABcGADf3twA397cGADf3twAGACfn4DfH57YAJ+fgJ+fmACfn4AYAAAYAAAYANwf34AYANwf34DcH9+YANwf34DcH9+YANwf34DcH9+YAN/fnsBfWADf357A39+e2ADf357A39+e2ADf357A39+ewKFAx4DbTE4B21lbW9yeTkCA5AIkQ4DbTE5BGZuNTMACwNtMjAEZm41NAAJA20xOQRmbjU1AAoDbTE4BGZuNTYAAANtMTkEZm41NwAKA20yMARmbjU4AAgDbTE4BGZuNTkABwNtMTgEZm42MAAGA20yMARmbjYxAAoDbTE4BGZuNjIAAANtMjAEZm42MwAMA20yMARmbjY0AAkDbTE4BGZuNjUAAAVleHRyYQVpc0pJVAAAA20xOQV0YWczNwQABwNtMTgFdGFnMzgEAAgDbTIwBXRhZzM5BAAJA20xOAV0YWc0MAQABwNtMTgFdGFnNDEEAAgDbTIwBXRhZzQyBAAHA20xOAV0YWc0MwQACANtMTkFdGFnNDQEAAcDbTE4BXRhZzQ1BAAGA20xOAhnbG9iYWw2MANwAQNtMTgIZ2xvYmFsNjEDfAEDbTE5CGdsb2JhbDYyA3ABA20yMAhnbG9iYWw2MwN+AQNtMTkIZ2xvYmFsNjQDfgEDbTE4CGdsb2JhbDY1A3ABAwMCCwsEBAFvAFANEQgABwAGAAgABgAJAAMACAAJBn8KfQFDs+mFfQt/AUHuAwt8AUQqaEPguufWUwt8AUQ+f2lBlsmnkAtwAdIAC3sB/QxPAyK9NiY3VhJ2OANI1f/fC3wBREvXMyc1CikLC3sA/QysQRs5TtPv5lOlYqy3ES0cC30BQ0DuvUULewH9DMcFMssHWc+zTwuXBMcYV5ELB7cBEwV0YWczNAQEBXRhZzM2BAcIbWVtb3J5MTACAAhnbG9iYWw2NgMGBXRhZzMzBAMFdGFnMzUEBgV0YWczMgQCCGdsb2JhbDY3AwcIZ2xvYmFsNzIDDQhnbG9iYWw2OQMJCGdsb2JhbDY4AwgHdGFibGU0MAEACGdsb2JhbDcwAwoIZ2xvYmFsNzQDDwhnbG9iYWw3MQMLBGZuNjYADghnbG9iYWw3MwMOBGZuNjcADwV0YWczMQQADAEJCrZXAsk0CwFwAHABcABwAXsAcAB7A38BfgF9AXwCABAMDAAACwJvRBu1WVERMhgyQQAhASQBAgcMAAALIwgDewYH0gBBAEECcAR//Qxd4X6pipiqVxZcbyUwn/I1JAsMAQAFAggDCAYIAgAgCUIBfCIJQh5UDQYQDUUEQAwHC0SrG0TtrPbEu9IAIwwkASMCBnACBwII/BAAQQVwDgUIBgEEAAQLDAULQs7wvr/FUiMDA3xDhZxO8PwQAEECcAR9IAhBAWoiCEEXSQ0J/BAAQQNwDgMGBAgIBQIABggCAAYAQ2a57IxCc3okAwwEC0EEcA4EBwEJCwEBAQsMCQsGBwcEDAoLIAhBAWoiCEEwSQ0K0g4jDEQhMwA0byWPKyAADAMACwwDCwJ7BghCpKachgH8EAAMBAsMCAALAAskAQYGAgVWJAcCfv0MNAB8KR/DzK9eoLhcN5ewgiMGQrP5sZOIy92uOgwAAAv8EAANCCQEEA1FBEAMCgsMAQALA3wGCAIIEA1FBEAMCAv8EAANAQYAAgjSD0K045ea7vvI5t8A0gAjD/2nASQPIAQMBgALQgBBFrgkAT8AQQZwDgYHAgQBCQsBCwwFCyADDAMLEA1FDQUMBAAL/BAA/BAAcCUADAkLIAhBAWoiCEEuSQ0HQuYB/QyixbyYwZSxe/4K1SNd1fCZAkAMBQAL/ZQBIQX9DKBHs0GG2bxXjSzSPeVemXhETpsPj53fkucGfQIIBggGCEH6+PwAIQEYANIP0g9CjtTwtb+hrHwhAiABDAQLIAlCAXwiCUIUVA0JDAQAC0P10k60GAAGbwwFCyMA/Qy0wdd4/1FaX2szpEifHN4bJAvSAEG2AUEDcA4DBgQCBgtDDULxadIPQ7Kccmv9EyQLQ7dYVRWRRLWjTc1ym34cRKU7H/D6j/XZRLHScyeudmHc/Qx9W6WD2VGNFCyTxo5SSVpKIwUhAyQLQ3Q0LjxB8AQMAAsNAELCACQDDAQLAgggCUIBfCIJQhNUDQUMBAALAAsQDUECcA4CAAICCxADDAALQQFwDgEAAAtD3fPqfyQG/QwxBTqupAzUhGRIEN+Xqzw0IwrSD0Nrk51hJA5D3ER9SQZ9QtUAIQIgAfwQAEECcAQABgdE2cnWgaJk+X/8EAAMAQsCCAYIIw9Ei5anUm/2Ilv8AkECcA4CAQABCxANRQ0DAgcMAQALIAlCAXwiCUINVARADAQLBgf8EAAMAgsjCb0jCyAEPwAGcCAJQgF8IglCL1QEQAwFCz8A/BAAQQFwDgECAgAL/QxkVuUcFrGF1Gs3r+48zwny/BAADAELQr0BJAQgCUIBfCIJQidUDQIgBkEBaiIGQQ5JDQIQDPwQAHAlAAwDBSMBIwLSANIPIAX9DNpINki57YsdjA9LCjN3D3skCyQLPwAMAAALrSEC/BAA/BAABkAGcEQOAko4rWhDnCQBIAZBAWoiBkEZSQRADAQLIAdBAWoiB0EeSQ0D/QxmJqXZn3ANBsPamlKoGKd7PwANAfwQAEECcAQARHS9R1GVXbjYPwBBAXAOAAIABSALRAAAAAAAAPA/oCILRAAAAAAAACxAYw0E/QzzjijgAolfHG9GqASaJqV5/BAADAAAC0EBcA4BAQELIgREU4k/Tn6/ftokCERx6xYmbxPgtyQMQpmKloKw2I70ZSECQYsBQQFwDgEAABkCcAIAIAZBAWoiBkEdSQRADAUL0g7SDkEyJAf9DA50PUo3//KusGL1LzvmBoAGfUKIl5QCQ7XmxysMBAtEAAAAAAAAAICeQ/e7pOG7YUEBcA4BAgILQQJwBEAjA9IOCQILIAlCAXwiCUIEVA0DIAhBAWoiCEElSQRADAQLQbABDQFB+wFBAXAOAQEBAQELPwAOAQAACwZADAALHAF/BkBB6+XswHoEcAwBAAUQDUUEQAwECyAIQQFqIghBL0kNAwJ/EA1FDQRDCfvD2/wQAAwAAAtBAXAOAQEBCwNw/BAADQEQBiME/BAAQQFwDgEBAQskAP0MvpdRD/INj2WAKnSI6toAISEFJAUGBz8AviQGIAtEAAAAAAAA8D+gIgtEAAAAAACAREBjDQMjCgZ+BntB7QH8EAANAg4CAwICC9IOA3xCu73wuMABJAMMAgALQezYAT8ADQJBAnAOAgIBAgsGe/wQAEECcA4CAgECC0KF7JGj55bXe/0eAf2kAQ4CAQABC0NfddjaJA4MAAEZDAALJAcgB0EBaiIHQRhJBEAMAgsjCSQMIAtEAAAAAAAA8D+gIgtEAAAAAAAAKEBjBEAMAgsjAUSmG0mqB7MDy0OAeUbEJAY/AAZ/AgDSDyMCPwD8EABBAnAOAQEAAAELGABBAnAEfvwQAAJ+AgcgBkEBaiIGQRpJBEAMBQsMAAALEA3SACMLPwD9rQEGfQYAIAhBAWoiCEEASQ0FA30CAAIHEA1FBEAMAwvSAAZwIAP9DBEf+Ur2ObcL0jYTth5iR9xE1GVpMDL5bEskCULzAAwGAAvSACAEA3BCtAEMBwALAAsACwALJAZBHUECcAR9/BAA/QxvtkbSQAVwm91jD9YWo68AQi8MBAAFBgcCANIPQnwMBQALQQFwDgEAAAsQDUUEQAwHCwYIDAALAwBEAgPsA66qEKefvdIPQ4ssJn/SDyABQQJwBH8DBwYHAgf8EAAMAwALBwnSDkTo5he3DRrtAUG8k83/AEEBcA4BAAAAC9IO/Qzcvtmgy6Z5fuhQS4MrBEJcBnAQDQwFCyQF/fsB/agB/eAB/QxshJ5m1UTRTU5Ku62oQb/y/bcBQ4QoPe0GfQIIBnsgCEEBaiIIQRFJBEAMBgv8EAAMBwsiBf3KASQPBgcHDgYC/Qw4q/5fgU7+YMD3HeHPUhtgAn0GBxAFAgcgAQJ9IAZBAWoiBkEkSQ0REAZDBcR10gJvIApDAACAP5IiCkMAACRCXQRADAoLDAcACwALAAsMAAEAC0Rl64FbB5GdJkTRmfFM0L2prCACv5sgAUECcA4CAwIDAAsMAwvSDj8AQQJwDgIAAQELIAZBAWoiBkEgSQRADAMLDAAL0g9BgOEBDAULRJBJHC2EsnrwQsYAQ9w2o/8MAwALIwwjDJ/8B0HnlIIJQQJwDgIFBgYFIw4MBAALDAIACyIBQQJwBHxEwWLdXMZRVh/9DEDMpzMU+2ZOXY3btPzXN+FCouWcyOXK3fKkf0RsbAcznOg5YQwAAAUgBSIF0g9BrfLm7wUMAgAL/QzhcbjhpHTHz6FChOazJ2U5/f0BIgX9+wH9pAH8EABwJQAMBwvSD0MhdgSZDAELQQJwBH1Cg7K51QBBwQFByQD8EABDE3GtqQZ8IwkYBESwwTc+t/dZYKRDqSXr/yQGA0AgB0EBaiIHQQpJBEAMBwtCwQAMAwALAAUQAyEBEANDbix8MSQG/QzcBrhr68BnswPryLs5KIAgJAsjCtIAIwshBSMPIQVEUERSjGwg9//9DMQ/0Y10C3j/yJR5bhxV5dBD9zoYeQwAAAsMAwsMAgsMAAEFEAYjCdIO0g/8EAAhAUK9/9GExsVnAn5C/s6z+sJv0g78EAD8EABwJQAGbyMEDAILDAQACwYFggwBCwwAC0EAQQJwBHDSAP0M8Vy4uRA+A86ggcZCrNPFRUQXf0jGd2P3//wQANIAQ/Hinnn8EAANAQJ+RAQZIoAqztOwAnwGfkPOO4+S0gAgAr8MAQsMAQukJAFDB2VlHAwCC0KJAUQPS4CsusGYeAZvQvG4m6zUudLpXXn9Ev2EAUX9ESQLRBMm7TcaonKQ/AP8EAAgBf0MCKae2C3EfLUxM+A0yg0aXP0xRODqpBsuOcA1/SIBIQUkB/wQAHAlAAwECyMF0g8GfQNvAggMAAAL0gAGfSAHQQFqIgdBEEkEQAwGCyMEA38GByAHQQFqIgdBDEkEQAwICyAJQgF8IglCHlQEQAwICwIIAggQBQIAIAdBAWoiB0EnSQRADAcL0g7SAEL44uKF1tvkj35EO2pBPg1YchEkDEMmmFT6DAcACwALAAsYAyALRAAAAAAAAPA/oCILRAAAAAAAABRAYw0GIwgkDCAHQQFqIgdBJEkNAkGmsbMZ/Qxsp1gl/gehAkJ3mHAnOYZPIQVB//8DcSAF/VsBvAcAQ4viln/8BCAF/BAAQQJwBH0gBkEBaiIGQS1JDQEQDUUEQAwICwIH/BAAQQFwDgEAAAsgCUIBfCIJQhdUDQEGB9IOIwQkBCMAIgAGfQYAIAtEAAAAAAAA8D+gIgtEAAAAAAAAQEBjDQpEc0aprL6ZdhQjBQwIC0EBcA4BAQELRP5k0HEv55RCBn0/AAJ7BgcQDUUNBSAIQQFqIghBHEkNBwwAC/wQAAZAIAdBAWoiB0EJSQRADAYL0gBE2w1054Q2kbrSDkRf1M4N9HTCZyMIQQ4cAXwkCEGbueD2AUECcA4GAwMDAAMDAwtBAnAEcCALRAAAAAAAAPA/oCILRAAAAAAAACZAYw0FAgD8EAAMAAALQ1YXTuUMAgAF/BAAQQJwBHwQBiAKQwAAgD+SIgpDAAAUQl0EQAwJCwII/BAAQQJwDgIFAAULBnAjBkRqEf5GmqiaYwZ/0g5BDw0G/BAAQZKAAQ0GDAALDQH9DB5rHKRwdvp1Cqa9J9Azw+oMAwsjDP0U0g8gAz8AQQFwDgEEBAUQBRAJBnvSDgZ7IApDAACAP5IiCkMAALBBXQRADA8LIwEMAgsGe0QUFZrdSnR43gwCC0O8Zx2PQpfa/uy7/seNGPwQAA0F/BAAQQFwDgEFBQsMAgsjANIAIwcOAQMDC9IO0g/SDiMIJAgjBSQFRISnRadkBvWQQYTP2f180g5BnrUBQQFwDgECAgsGQCAHQQFqIgdBJ0kEQAwFCxADDQIMAgALJAtBAXAOAAEL0gA/AEH//wNx/QgAzgMhBULvAUTJXlmKvRWMaAJ8EAwGfwIIAgcgBSIF/VMMAgALAAsQDUUNBkH1AEEBcA4BAgIAC0AAIwj9FPwQAPwQAHAlAAwKAAv8EAANANIORGadpulJQG3m0g8jBNIAIAQMBgsjAAwFAAX9DB9RaqmM3l0dymKHPgfajLj97wEGcBAGAgBCyajErH9Q/BAADAAAC0LPACQEBH39DLO0d1AULYnrwoLdx63pDfr9HQH9EkGyPCMOIwhD5hx2lgwEAAUgC0QAAAAAAADwP6AiC0QAAAAAAAA4QGMEQAwEC0MexwG7JAb8EABDgR+r4/0T/SEAnQZ7IwQGewYIIAdBAWoiB0EXSQ0GDAALIAhBAWoiCEEaSQRADAYL/BAA/BAA0g5BrY7QAPwQAHAlAAwMCyEFUEECcAR+Bm/SDiMHQt4BeSECQf7/A3EgAv4jAQAMAQv9DE/0ox9ZY5En79k0RtjJfXDSACMJQ4nGCkkkBv0UDAEBBUOFcUNXBn/8EAA/AAwACw4FCAYECgIKC9IA/BAAJAc/APwQAPwQAPwQAHAlANIO0g4aAnwCb/0MJ5Wn3iukJs1v8/WUwIlHLAwCAAsACyQMQdIA/RAMAAsCfPwQACQHIwggAQQIIwQkA9IOPwANACMODAoBCwwAAAs/AEECcAQHIAhBAWoiCEEkSQ0EIwr9DLz/pBiNJuRO5pCuqG+7q65EQINGiBZUrL38EAD8EABwJQAMCwAFCwZwQbwBRD+F5q3vbQJ+Q+ad4L78BCICRL5jP9tbYAoR/RQhBSIC/Qwfx+3Q3A2ZXH/Rz1gABI0CIQVB7AACfAYHAgggB0EBaiIHQRZJBEAMCAsMAQALBgcYDkHVvP+ZBUECcAR9/QyNACQzn13CGwf3dXjyH4+dJA8GAEIWBkAYAP0SJA/SDiMMIAUCfgYADAQLAkAQBQwAAAtBAXAOAAMACwJwIAZBAWoiBkEFSQ0LDAMACwwGCw0BIAhBAWoiCEEHSQ0JAgggB0EBaiIHQRdJDQjSAEQWK2dsbLh7ET8AJAcMAwALAAX8EAAOBwEBAQEBAQEBCyMBDAEBARlEveFor0BRd4oMAQsjAQsjBgwHCwwHCwwDCyQF/WFDblAUewwAC9IOGiQGQqGRn4neuf4T/R4AGgZ+Qcaf5QxBAnAEbxANAnwgBkEBaiIGQQ9JBEAMBgsGACMKDAgLQQJwBH0QDUUEQAwHCwYHCwYIIAhBAWoiCEEoSQ0FIAtEAAAAAAAA8D+gIgtEAAAAAAAAEEBjBEAMBgsGCNIP0gBCoAEMBQALBwAgCUIBfCIJQilUDQXSAEKrtpmj0P0pDAQLQwAAAIAMBwAFIAFB//8DcSgA3gRBAnAEcNBwDAkABSAJQgF8IglCFVQNByMN/foB/aoBIw39hgEkCyMKCwwIAAsGfRANRQRADAsLIAdBAWoiB0EXSQRADAsLIAIjDPwQACAFIQVB//8DcSAF/VoAiwUDDAEACwwGC7YMBQAF0g4GfwYAIApDAACAP5IiCkMAAIBBXQ0GRGDXmRfTMtgC0g9DifVhYwwJAQsMAAskBxogBkEBaiIGQShJDQIGCAtCxOR5DAEACwwIAAtX0gD8EAAkB0KaASQE0gAjBQwEAAtBAnAEQBAFBQt5JANDb6QknAwCCyQGGiAGQQFqIgZBB0kNAEHDACUA0g8jDyEFIwUMAgALIw0gAAwBC0RSzXMGsJPgjyQM/BAADQEMAQUGCP0MV7LOun3iJyfycG9hpYkiOyIFIQUMAAvSDhoCB9IO/Qxq2q5Nr6HNePs/F0A1bdQT/QxVn0v59zlfty9056n2TcitIwwkCCQLA3wCACMADAMACwALAAsACyIEJAIkAwNAEA1FDQIjCyQLBgdEK9pUnkggJwtC3YKVpc0A/Qx9nvyR9kMe/WnLSvJcUiPw/WgGbwYHPwAjDCQIDgYAAAAAAAACCyMC/BAAQQFwDgABC/wQAAJ//BAADAAAC0EBcA4BAAALEAnSACABJAcjBEQjHpO+xJ9h2EMqktKmu6IgACQC/AbDWPwQAHAlAAwDAAtBrIjxACIBAn8Dfv0MvdevYR4FH3mNTX1fIwjPsSQLIAlCAXwiCUIOVARADAQL/Qy7jdWWfYwgPcI0F7MkdkcxBkAgAgJADAAAC3ohAiAJQgF8IglCBlQNBAJ7DAEACwN8BgAgCEEBaiIIQRpJDQMgCkMAAIA/kiIKQwAADEJdDQNDCgBWvf0MGMWJPyk06pChA2l6QkSTBERequy9fvbl7/0iACQLIwcMAAtBAXAOAQEBCyQMIgUGbyAHQQFqIgdBKEkNBQwBCwwFCwNAAn8GCAsjBwJwIAdBAWoiB0ENSQ0GAm9BOiUADAgACwALAAsACwALAAscAX8kBxr8EAAkB/wCQQJwBG8gAWckByAIQQFqIghBCkkNAiAHQQFqIgdBBkkEQAwDCwIIDAAACyMGQ/RgdfEgACIDQrwBJAQkAv0MNjoTqJXhHTH6o2mxHkXL1yQP/RMkCwwBAAUDfUNcQ6aGJAYjBCQEAwgCAEHGki4LQQJwBAcgCUIBfCIJQixUDQUgBkEBaiIGQQtJDQH9DCIisEyqVYsiGnGL1GC/Y9AkCwYIIAtEAAAAAAAA8D+gIgtEAAAAAAAAQkBjDQYMAAtCLnoiAiQDBgAGbyAGQQFqIgZBBEkEQAwICwYICwZAEA1FBEAMBQsLBggCQAsgBf1/RJOLNm8ipGfNJAwkCyMGDAcAAAELIAZBAWoiBkEQSQ0DIAlCAXwiCUIjVA0DIAhBAWoiCEEYSQ0HDAIACwwHAQsNAAULCwMAIwQ/ACQHuiQMQqABJAMQCUECcAQHCxANRQ0E0g4aQdn5xRELIQEgCUIBfCIJQgxUDQMgB0EBaiIHQR9JDQAgBkEBaiIGQTFJDQPSAAZ+Qt2A3bK6v5tgDAALIgL9Ev1hQvMAIwYMAgALAAvSDvwQAESO1OBDVWj2ciML/ckB/WNBAnAEbyAJQgF8IglCIlQNAkNYY+8XQg8GfCMMJAgDAES4z4ynfCRJeiQMIAELJAf9DMyQJwB/xDylJqIREKjXo2AkCxANRQ0D0g78EABBI7IMAgskDCQDDAEABSAHQQFqIgdBHkkNAhANRQ0CQQ4lAAv8EABBAXAOAQICCyQGJA79DI3fav2AnO08MRb+QQJT52EkCwN7IwtDZkqvf0LensvT28muBCQE/RP93QH8EABBAnAEfETOGeoje2YISNIPGp8MAAAFIAdBAWoiB0EbSQ0CRADyRHKI19z8DAAAC/wGJAMkDyMGQ4iW5OokDtIOQYz0ys8B0g4aIgFBAnAECAsajUGh6QAkB/0TCz8AQQJwBEAgBkEBaiIGQRBJDQEFRAAAAAAAAPD/IwgGQBAJ/RAkCwcMBgT8EABBAnAOAgECAgskD/0SQfoAQQJwDgIAAAEL/BAADQCkIwAkACQBCyMHQfz/A3H+EAIAtyQJIQUaIQPSDhr8EAD9HAFD4nxPsP0gASMIQ/MsjPON/AEkByQJIgUgAvwQAPwQAHAlAAwBAAtCyQAhAv35Af3tAdIPQyIowYkkDho/AEECcAR/BgAgAQshAQYICwJwIwL8EAD8EABwJQD8EAAkB/0M4OBWWQsNKAOxoq/djLfOACQPDAIACwAFEAwL/BAAcCUADAALGr4jB/wQAHAlABojDP0UIQX9DJLdaya8nAdZ25Tcd/7DxzUkCxojBUHYlBTSDkQw2TDK3AgnfkGLmgwECAwAAAULJAgaQqmvWwYL/RIGb0EmJQD8EABBAnAECAsjCfwQACQHJAlEv03h/bJXO78kCSMAJAILIAMkAtIOGho/AETdLPr06THTaP0U/QzJwNpUCCaSm92m11x7HEPtJA8iBSQL/YwB/XohBUH//wNxIAX9VwDyBwAkD/0M0wLrQjteDlWJdNFtUsJXmP1+PwAkB0H9AEECcARABQshBdIPGiID0g8a/BAAQQJwBADSDhoQBSMHDAAABUGGjwMLIgEkBwJAC/wQAPwQAEMAAACAJAZvIwMMAAsL6CIHAG8BfgB/A38BfgF9AXz8EABBwoQD/BAAQQJwBAfSAP0MFYd+2kfJ4gu/XroWzweNXSQLIwH9DOoa0bgnGcYOGKbsaXvkgm4DbyABQQFwDgEBAQtC6fKU07GN+IMMpwZwBgACBwwDAAtExvamOeXMdxj8EAANAgZv/BAADQMCAAwEAAsNA0Md4JloJAbSD/wQAAwBC0GK0bwBDAAL0g/8EABBAnAEfPwQACQH/BAADQIGAAIA/Qyt6X1Xv5XLQ1j9IIhUm800Am8MBQALAAsNAwwDC9IPQdEADQJDRnWE/9IAQ+KP7RQkBiABIQFDPGDEoPwEQpyl+3kGBSECQrTwxIoHC1dDV9q7siQG/BAAQQFwDgECAgABBQwCAAsjDwJ/DAIAC0EBcA4BAQELIwMDQNIP0g/SDtIOAn4MAgALAAunDQAiAPwQAEEBcA4BAAALIQEEQAIIBggMAgtB3QAOAgABAQELIwrRQQFwDgEAAAsCCAwAAAsQBgIHBgAGCAwCAQsGAAwCCw0BDAELIwQkBA0A0gD9DJa/QJr0yOTO7gbnITjxFzD9DDUpxcBQL/VB/iKYbByX7ZrSDz8ABn8CfEQn90/Yr9EIW720A2/8EAAMAgALAAv9DOPhzXHmrR7OSPGxRqncTpQkCyMG0gBBlbOe7AAMAAsNAP0MfsB005jzLz/Xi7EEUWU8rSQLQQFwDggAAAAAAAAAAAALBntC38wZe7SO/QydZV9PKRDwIVXF+WyD30rn/YoBA3sGByABQQFwDgEAAAsgCEMAAIA/kiIIQwAAGEJdBEAMAQsgACMBIwJDN/0lDfwEQQMEfgYHIAVBAWoiBUEwSQ0CIAENAPwQANIPIAMMAQsgB0IBfCIHQgRUDQEGACMK0g8jCfwQAEECcARA/QyHSqGdyJwWhpHgHyMo47gqDAQABQZv0g/8EABBAnAEfhADDAMABULXAAwEAAsiAwwDC0LizgEMAgALn0PP74q+JAZENt3uf7wZmEX8EAAMAAvSDj8A/Q8MAgX8EAD9DLh6mah20bxrxWlIM4EvKrEGbyAGQQFqIgZBC0kEQAwDCwIABgcMAAsjBv0T/BAAQQJwBAAgBEEBaiIEQS9JBEAMBQsGACAEQQFqIgRBAkkNBQMHQpDToPncIQwFAAtDaEXYiP0TJA8CCETMYEldVt6HLtIPIwQMBQAL/BAADAELDAAFBgDSDvwQAAwBCwwBCwwAAAshAfwQACMBIwQGfUNVm4YLDAALJA4MAQELAm8QAyAB/QxRsixTuiCTbR2l9u12zeYTDAMACyADJAQDfQYHDAAL/BAAQQJwBHAQCdIPRIJYSlpABUCDnUS6q+0r3x7x/0Hhj+PNfUECcARABSAHQgF8IgdCMFQEQAwFCwwAAAudZANAPwBBAnAEfgIAEA1FDQI/ACADDAEACwAF/BAAQQJwBG8GewZAQ3zT4v8GfiAHQgF8IgdCBFQEQAwICwIIDAAAC/0MCl/2vraHAJFOymo1z5oSDAwCCwwDAAsjBSIAIgAgAUSo70xTYIjyc/wHJARBAXAOAQQEAQcIxNIP/BAAJAf8EAAjASQM/BAAQQJwBAAQBRAJuPwCQn8iAwwDAAVC3QAMAwALQQJwBHAQDELsppbjmqTfAiMB/Qym43Pbca4jQL1M2Bbq+j+p0g78EAD9EQwBAAUGB9IPIwZESaIz0rkQBiAJAgsQDUUEQAwFCxANRQRADAULAgAgBkEBaiIGQRtJDQcCBwwAAAsGCCAFQQFqIgVBL0kNCgJ9EA1FBEAMCgsQDUUEQAwMCyAGQQFqIgZBIUkEQAwICyAGQQFqIgZBIkkNBwwBAAtDOE/8kSMJnvwDDAEAC0LsASMHQekCdAwACwJ/Iwj9DI4PB7TMGag490R0dhAkrB0MAgALAAsMBAtBAUECcARwRGZQLGmdycQ8/AYCbyAGQQFqIgZBAUkNBkSndku1mGsBz/wGDAMACwAFIwgjAiMKBnAjBER8bOWKc0UQEdIP0g4jAAwBCwwECyMF/BAAQQFwDgEDAwXSDkHbtQFBr+QCQaiRAfwKAABDZk7aHiMMJAiNAkAMAAALQaLaAyQHRAo6Y8y4LChfRAewSEOe/qZEpZ6eIw4gAgwBAAsjB/wQACMP/agBDAYLQuQADAMAC/wQAHAlAP0ME8Q6XwPtUs2Sz+y/UAX32iQL0g79DKuH0qwIOfs8deGuSVss/+oMBAX8EABBAnAEbyAFQQFqIgVBMEkNBAIAIwsMBgALAAUGCAwACxANRQ0EIAhDAACAP5IiCEMAAKBAXQ0C0g8/AEECcAR/AgAgBkEBaiIGQSJJBEAMBwtBzAHABnsCCAYIDAALDAAACwYIAgfSD0GlAQwDAAsgB0IBfCIHQg5UBEAMBwvQbwwECxAFIARBAWoiBEEiSQ0FRCsf/cNTWX3uJAggBkEBaiIGQSBJDQUjAgJ+IAVBAWoiBUEkSQ0IQYjSqQEMAwAL0g4jBCID/BAADQYMBgsMBwtBAnAEfSAHQgF8IgdCKlQNBAYHBkAYCEH/pD1BAXAOAQAACyACJAMgBUEBaiIFQS5JBEAMBQsCfdIOQbKvAz8AQQFwDgECAgALJA7SDtIORBatDOqa1lSkJAE/AAwBAAUCbwZAIAVBAWoiBUECSQRADAcLDAALAn8GB9IOIAMMCAsjC9IO0g/8EABBN0ECcAR8QboBDAQABSAHQgF8IgdCIVQNCQJwEAYgB0IBfCIHQhhUDQgQDUECcAR/A30GcCAHQgF8IgdCIVQNDdIO0g4GfSAEQQFqIgRBLkkEQAwDCyMHDAYLDAcBC0LbAEMAAAAADAYACwAFBgAGCBgAIw0MDQsMAwALDAUACwALIAH8EABBAnAOAgMAAwELDAIAC0Pp6jOXDAALIAP8EABBAXAOAQQEBUHZ5QFB2eQBQQFwDgAAC2dBAnAEfwIIAgcLDAAACwNABggMAAsCACMI/AcjDCQIPwAMAAALDAEACwAFIAVBAWoiBUEoSQ0FIAVBAWoiBUEQSQ0D/BAADAAAC/wQAHAlAAwAC/0MZzr1IExyx7MAbK0cUePq6yMDIQMMBAALBkAGAAMHEAxBAXAOAAILBghBjQEMAQsgBEEBaiIEQS5JDQQCACAGQQFqIgZBBUkEQAwGCwIIDAMACwALIwgCQAsGfiAEQQFqIgRBJEkEQAwECwIIIwEaAgcQBgwAAAv8EABBAnAOAgMAAwsCexAFEA1FDQRE7zXrZqUk9v8gAQwCAAsMBgtDJON4l0LbALSTQvwADAMLQQFwDgAACyQF/BAAQQJwBH4gAUECcAQI0gAjACIAJAUgACQFQT9BAnAEACAIQwAAgD+SIghDAAAcQl0NA0PWVstKGhANRQ0FIAZBAWoiBkERSQRADAQLIAZBAWoiBkEnSQ0FDAEABSAHQgF8IgdCDlQEQAwGC0H2+gMNAQYAEAUMAgtBAXAOAQEBCwQIBgcLBSACDAQACxoMAAsQDUUNARAGRBm3WJ+yWYmjQtEADAAABUKcAf0SIwkDQCMDDAMACwALDAEAC0K6qIblwxA/AA0ADAALA0AjBT8A/BAAcCUAIwcaIAO/0gDSAPwQAAR8IAVBAWoiBUEGSQRADAILAgcLQSxCugECQAwAAAvSDhpBv/e9OyQHQQ8kByMOQwAAgH8DfEQSJ6E5KEX77EHbAUEBcA4AAQsMAAUjCQv8ByQEQc0BRSQHGiMFIQAaJAnSDtIAIw/SAEGIifSgeAZ9Q1dDbD8LJAZBAnAEfgIHEA1FDQMMAAALIw5B2QCyJA4kBiAIQwAAgD+SIghDAAA4Ql0NAQIHRM2Jx/qh+Pj//BAAQQFwDgEAAAsQA7gkAUEHQQJwBAcFDAAACyAIQwAAgD+SIghDAADwQV0EQAwDCyMEBQZ+IAVBAWoiBUEkSQRADAQLQsSxDgwBCwtBAdIA/BAAJAcaJAckBBokDwJ/QZSIwAD9DG1x1dIDsQu6ie0p1EvSEIkkCwv9DEeqtlBec2B73du28M7/ZCcMAgALAAsMAAELBntC3wAkAz8AJAcCCAv9DJIom5CvgjgAnkeNxaV9M1hDArXtJSQOCyMN/foB/ecBJAvSDxpC/NyRhO6UxtsD/QyIeXqUYnKXgj1AIZVs90/DJA/9Ev1qIw8aJA8aQqEBQyIxZI0kDiQEEA38EAD8EAAkB2xDd4l2jSQG0g8GbwIAQcIB/QzjjTXggDo6LJNz2nncLRLvPwBBAnAEfETn007v4hL8/yMEQuUAIwIkAgZvQckAJQALDAIABdIPGkQkM0NFB63szvwQAAQAIwcMAgAFBgA/ACEBRD1cWjUkS0EoDAIACwwAAAtBAXAOAQAAC/wQAAwACyEBQtKDjOiIj4l1IwFCOAZ9Q0FBTs8MAAs/ACEBA28gBEEBaiIEQRNJDQBCzwAjCSQBJAMGACAFQQFqIgVBJEkNAf0MCIejt2KBAXUuq0xqR6SCBf19AnxE1yDwTNI6r4sLJAxDld8fPSQORGQU0BeqR1Yp0g5EfXN4K9ICyJQkCETPapDiammfPSML/RkADAALJAcQDCEBQbsB0g4GewYHDAAAAQtBlQEkB/0MSeUbeWscb2Ox5joCQHQkZyMHQQFwDgEAAAv97QEaIwG9IQMGfUPuxv6s0g4aCz8AJAeRREtfWQWwrHfN/RT9oAE/ACQH/YABIAMaGiMGGhoaJAdBOCUAIwvSAEQlk+ENPby6tiQMIw4kDhokD9IAGtIPGv0MMgZlxTugvGw3RLaEUMywikGXAUECcAQIBgcMAQELBQskCws/AEEBcA4BAAAACyACJAQaIw4kBiADJAQgAdIOQ0IByOz9EyQPAm/SDtIPGgJw0g4a0HAkABAJJAcgAD8ABH8DeyMN0g9EQg4EE2NY8f8kCCMJJAga/X8LJAsgAAwBAAXSDxoQCQtBAXAOAQAACyQF/BAAJAcgANE/AAZ8AwgLQp8B/RIgASQHQ4XuXA0kDiQPQ75qvvWO/RP9HwMkBiMBCyQBIQFDvO6h0yQOJAcaEAUDe/0Mt7WiCvaAXcSjKB/kD340fQs/ACQHJAsjAEP6+qzyjvwEvyQB/BAAJAckBT8AQQJwBHACACMHC9IPQsm8DyQD0g4aGkECcAQHBQwAAAv9DAJxsbLrFwhsmjFzpSgZC+/9DBj8IkHoo4EMPAMfmODZfv8kDyQLBgf9DGgCyqDFqMbzBaOGaCqSjf39fyQLBgAMAQsOCgAAAAAAAAAAAAAAAAsjBiQO/Qw7UlaILDEcTsJuwJmlnM0f/R0BBnDQcP0MHhWhJbVtGqbI7FmAcESetwJ//BAAQQJwBAACCAwAAAsjBwwBAAUgAQsLJAc/AAJvQRwlACMADAEACwwCAAsMAAAFIwALJAVBFCUAQjBDtFmpaBrCA39C53UhAiMHCyQHv/0UJA9Cit4AJAMLIAEhASMNJAsjDEGU8QBBu5eQmwFByrUD/AsARHDOdhTSX7uWYUH//wNxLwDpBiQHQtkAJAMjC/0YBAJ/AgAjBwJwAgcgAAwBAAsACyQKCwwAAAtJJAc/ACQHIw0kC/0MvqS9BejLOBWviULTfuF22iQLIAAGQAIICwsjDCQB/QyN27AL0kefH2XI94WAcJRGIwUjDwZwEAbQcAsgAv0SIw0kCxpBJ/wQAHAlABokCiQPIQDSDxr9aiQLQbGA9tUAJAckChoaIQH8EAD8EABwJQAa/BAAJAcaJAdCCvwQAEECcARwRJaWX2hI4xLyJAwjBUR7e9LmJ88xeRokCiMADAAABdBwCyQAJAQGez8AJAcCe/0MZ6i/GyByBmz2p3OLqRAkVQwAAAsGfBAGRMJeEdSvk/h/CwJAC/0iAdIOQzVJLfIkBkS9UljgD7xfARpD5UxnPI4/ABoaGgskD9BwJAUjCiMHviQOQQcjBAYMJARCGAsLC20JAEGxrgILA4d1XABBuqkDCwiLgJAT8RZtIgEFOgtuE6sCAEHQlwMLCXKSCXHJbb66rQEJUF1sAhbdLo5OAgBB2/0CCwAAQf4HCwRwy3laAgBBjJIDCwcVujw6hU8CAEGVzQELCG7YrcQvrQkY', importObject6);
+let {fn66, fn67, global66, global67, global68, global69, global70, global71, global72, global73, global74, memory10, table40, tag31, tag32, tag33, tag34, tag35, tag36} = /**
+  @type {{
+fn66: (a0: FuncRef, a1: I32, a2: I64) => [FuncRef, I32, I64],
+fn67: (a0: FuncRef, a1: I32, a2: I64) => [FuncRef, I32, I64],
+global66: WebAssembly.Global,
+global67: WebAssembly.Global,
+global68: WebAssembly.Global,
+global69: WebAssembly.Global,
+global70: WebAssembly.Global,
+global71: WebAssembly.Global,
+global72: WebAssembly.Global,
+global73: WebAssembly.Global,
+global74: WebAssembly.Global,
+memory10: WebAssembly.Memory,
+table40: WebAssembly.Table,
+tag31: WebAssembly.Tag,
+tag32: WebAssembly.Tag,
+tag33: WebAssembly.Tag,
+tag34: WebAssembly.Tag,
+tag35: WebAssembly.Tag,
+tag36: WebAssembly.Tag
+  }} */ (i6.instance.exports);
+table7.set(2, table37);
+table26.set(63, table5);
+table40.set(32, table11);
+table37.set(2, table25);
+table4.set(0, table23);
+table5.set(13, table23);
+table11.set(5, table4);
+global8.value = 0;
+global13.value = 0n;
+global53.value = 0;
+global6.value = null;
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn67(fn5, k, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn66(fn36, global19.value, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn66(fn66, global9.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn44(fn35, global37.value, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn66(fn36, k, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn66(fn66, k, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn67(fn66, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn66(fn66, k, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn5');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn5();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn16(fn66, global57.value, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn66(fn52, k, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {void}
+ */
+let fn68 = function () {
+
+return fn5();
+};
+/**
+@returns {void}
+ */
+let fn70 = function () {
+
+return fn18();
+};
+/**
+@returns {void}
+ */
+let fn71 = function () {
+
+return fn43();
+};
+/**
+@returns {I32}
+ */
+let fn72 = function () {
+
+return -8;
+};
+/**
+@param {FuncRef} a0
+@param {F64} a1
+@param {I32} a2
+@returns {void}
+ */
+let fn74 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+let global75 = new WebAssembly.Global({value: 'f64', mutable: true}, 239818.5037566815);
+let global76 = new WebAssembly.Global({value: 'i32', mutable: true}, 1371818810);
+let global78 = new WebAssembly.Global({value: 'f32', mutable: true}, 306411.1459596106);
+let global83 = new WebAssembly.Global({value: 'f64', mutable: true}, 40622.72660511809);
+let table43 = new WebAssembly.Table({initial: 86, element: 'anyfunc', maximum: 278});
+let m22 = {fn68, fn70, fn74, global75, global80: global0, memory11: memory2, table41: table21, table43};
+let m21 = {fn69: fn5, global76, global78, global79: global11, global81: global68, global82: global71, table42: table8, table44: table5};
+let m23 = {fn71, fn72, fn73: fn16, global77: global56, global83, table45: table21};
+let importObject7 = /** @type {Imports2} */ ({extra, m21, m22, m23});
+let i7 = await instantiate('AGFzbQEAAAABswEdYAABf2ADcHx/A31wfmADcHx/A3B8f2ADcHx/AGAACW9we3B+e3x+fmAAAGAAAGACe34Df3B7YAJ7fgJ7fmACe34AYAF/Ant+YAF/AX9gAX8AYAADf3t+YAAAYAAAYAADe3t7YAAAYAAAYAAAYAAAYANwf34AYANwf34DcH9+YANwf34DcH9+YANwf34DcH9+YAN/fnsBfWADf357A39+e2ADf357A39+e2ADf357A39+ewLXAhcDbTIyCG1lbW9yeTExAgOQCJEOA20yMgRmbjY4AAUDbTIxBGZuNjkADwNtMjIEZm43MAASA20yMwRmbjcxABIDbTIzBGZuNzIAAANtMjMEZm43MwAVA20yMgRmbjc0AAMFZXh0cmEFaXNKSVQAAANtMjIIZ2xvYmFsNzUDfAEDbTIxCGdsb2JhbDc2A38BA20yMwhnbG9iYWw3NwNvAQNtMjEIZ2xvYmFsNzgDfQEDbTIxCGdsb2JhbDc5A3sBA20yMghnbG9iYWw4MAN+AQNtMjEIZ2xvYmFsODEDfAEDbTIxCGdsb2JhbDgyA3sBA20yMwhnbG9iYWw4MwN8AQNtMjIHdGFibGU0MQFvAVCUBANtMjEHdGFibGU0MgFwATCKAgNtMjIHdGFibGU0MwFwAVaWAgNtMjEHdGFibGU0NAFvAE4DbTIzB3RhYmxlNDUBbwEo5wEDAwIZFQQRBG8BFvcBcAArbwA6cAFO9QYGbg5vAdBvC38BQSYLfwBBzAELewH9DB8u/9wSc/WGOLscCePFcj0LfQFDZQtuiQt9AUOxYeN/C3AB0gcLfgFClwELfwFBrQELfQFDxwJkpAt+AULIaQtwAdICC30BQ6ARM7gLfAFE75HALjV9njcLB7sBEghnbG9iYWw4OQMOBGZuNzYACQd0YWJsZTQ3AQYIbWVtb3J5MTICAAhnbG9iYWw5MgMRCGdsb2JhbDg1AwkHdGFibGU0OQEICGdsb2JhbDg0AwcHdGFibGU0OAEHCGdsb2JhbDg2AwoIZ2xvYmFsOTQDFghnbG9iYWw4OAMNCGdsb2JhbDg3AwwIZ2xvYmFsOTADDwhnbG9iYWw5MQMQBGZuNzUACAhnbG9iYWw5MwMVB3RhYmxlNDYBBQnEAwoCAkE3CwALAAUIAAcDAgYJBggCBkEjCwAGAAAIAQIDAgZBDwsAHAUGBQMGAgIJAAYEBgAHCQkICAMEAwEACQgDBQADAF8HAQADAQYAAwkAAAQCBAMJCAQGAQAJCAYDAAkGBwYIAQUBCQIIAgkDBQQCBgIACQMDAQkFAQgCBgEJBwgEAAcGAAUGCQQIBAUCBgYCBwQCBQkICQMEAQYHBAICAAcAAwVwTNICC9IGC9IHC9IFC9IDC9IBC9IJC9IEC9IEC9IIC9IFC9IHC9IGC9IBC9IJC9IBC9IBC9IHC9ICC9IGC9IDC9IDC9IEC9ICC9IAC9IDC9IIC9IIC9ICC9IHC9IHC9IGC9IAC9IEC9IBC9IDC9IJC9IHC9IGC9ICC9ICC9IEC9IBC9IBC9IEC9IBC9IHC9IHC9IEC9ICC9IIC9IBC9IEC9ICC9IEC9IDC9IDC9IFC9IAC9IEC9IGC9IDC9IGC9ICC9IAC9IIC9IDC9IIC9IBC9IGC9IEC9IEC9IFC9IJC9IDC9IGCwYCQTcLcATSAAvSAQvSAgvSAwsCAUEcCwACBAcCCEHEAAsAAgUJAgZBCAsAAQYGAUEeC3AB0ggLDAEECnUCQAQDfwF+AX0BfAITIw5BzAFBAnAEAAMADAIACwAF/BAADAAACw4BAQELIAL9TULcYULYAdID0glDDlYKIQwAAAsyDAJ/AW8AcAJ8AXwBcAF+AX8DfwF+AX0BfAYSBg4MAQtBx6nzAEECcA4CAAEACw8BAQsLLAQCAEH+hQILA6FO5wIAQaHyAAsCwAgBBlO0pAYqzgIAQfzPAgsGYA52JVwz', importObject7);
+let {fn75, fn76, global84, global85, global86, global87, global88, global89, global90, global91, global92, global93, global94, memory12, table46, table47, table48, table49} = /**
+  @type {{
+fn75: (a0: I32, a1: I64, a2: V128) => F32,
+fn76: (a0: FuncRef, a1: I32, a2: I64) => void,
+global84: WebAssembly.Global,
+global85: WebAssembly.Global,
+global86: WebAssembly.Global,
+global87: WebAssembly.Global,
+global88: WebAssembly.Global,
+global89: WebAssembly.Global,
+global90: WebAssembly.Global,
+global91: WebAssembly.Global,
+global92: WebAssembly.Global,
+global93: WebAssembly.Global,
+global94: WebAssembly.Global,
+memory12: WebAssembly.Memory,
+table46: WebAssembly.Table,
+table47: WebAssembly.Table,
+table48: WebAssembly.Table,
+table49: WebAssembly.Table
+  }} */ (i7.instance.exports);
+table40.set(47, table40);
+table23.set(33, table11);
+table3.set(22, table5);
+table4.set(35, table46);
+table26.set(80, table25);
+table15.set(59, table48);
+table5.set(42, table7);
+table25.set(56, table21);
+table37.set(21, table3);
+table7.set(42, table22);
+table23.set(49, table48);
+table26.set(49, table3);
+table26.set(47, table12);
+table23.set(1, table48);
+table37.set(16, table7);
+table4.set(35, table23);
+table11.set(14, table7);
+table3.set(27, table22);
+table20.set(66, table15);
+table46.set(8, table26);
+table26.set(0, table25);
+table48.set(34, table46);
+global91.value = 0n;
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn67(fn51, k, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn16(fn35, k, global91.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn76(fn44, k, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn67(fn36, k, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn76(fn17, global9.value, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn44(fn67, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn76(fn35, global19.value, global0.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn44(fn43, global7.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn16(fn51, global76.value, global0.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn44(fn17, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn67(fn5, k, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn44(fn44, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn76(fn51, k, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn76(fn66, k, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn35(fn43, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn44(fn17, global7.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn66(fn16, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn76(fn52, k, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn67(fn44, global37.value, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {[I64, I32]}
+ */
+let fn81 = function () {
+
+return [34n, 67];
+};
+/**
+@returns {void}
+ */
+let fn82 = function () {
+
+return fn17();
+};
+/**
+@returns {I32}
+ */
+let fn84 = function () {
+
+return -3;
+};
+let table50 = new WebAssembly.Table({initial: 86, element: 'externref', maximum: 747});
+let table52 = new WebAssembly.Table({initial: 90, element: 'externref', maximum: 90});
+let m25 = {fn77: fn51, fn85: fn17, global99: global20, tag48: tag16, tag51: tag29, tag53: tag31};
+let m26 = {fn78: fn52, fn79: fn51, fn80: fn16, fn82, fn83: fn51, fn88: fn18, table51: table10, tag49: tag36, tag52: tag16};
+let m24 = {fn81, fn84, fn86: fn43, fn87: fn35, global95: global11, global96: global12, global97: global83, global98: global91, table50, table52, table53: table7, tag47: tag35, tag50: tag8, tag54: tag18};
+let importObject8 = /** @type {Imports2} */ ({extra, m24, m25, m26});
+let i8 = await instantiate('AGFzbQEAAAABkgEXYAABf2AAAn5/YAAAYAAAYAAAYAAAYAAAYAADb297YAAAYAAHe397cHt7b2AAAGAAAGAAAGADcH9+AGADcH9+A3B/fmADcH9+A3B/fmADcH9+A3B/fmAFfntwfHsFfntwfHtgBX57cHx7BX57cHx7YAN/fnsBfWADf357A39+e2ADf357A39+e2ADf357A39+ewKQAx4DbTI1BGZuNzcAFANtMjYEZm43OAATA20yNgRmbjc5ABQDbTI2BGZuODAADQNtMjQEZm44MQABA20yNgRmbjgyAAMDbTI2BGZuODMAFANtMjQEZm44NAAAA20yNQRmbjg1AAUDbTI0BGZuODYABANtMjQEZm44NwAPA20yNgRmbjg4AAsFZXh0cmEFaXNKSVQAAANtMjQFdGFnNDcEAAoDbTI1BXRhZzQ4BAAGA20yNgV0YWc0OQQABgNtMjQFdGFnNTAEAAIDbTI1BXRhZzUxBAANA20yNgV0YWc1MgQABgNtMjUFdGFnNTMEAAsDbTI0BXRhZzU0BAALA20yNAhnbG9iYWw5NQN7AQNtMjQIZ2xvYmFsOTYDfgEDbTI0CGdsb2JhbDk3A3wBA20yNAhnbG9iYWw5OAN+AQNtMjUIZ2xvYmFsOTkDfQEDbTI0B3RhYmxlNTABbwFW6wUDbTI2B3RhYmxlNTEBcAE+ywMDbTI0B3RhYmxlNTIBbwFaWgNtMjQHdGFibGU1MwFvABUDBAMSEQYEIQhwABlwATuIAm8ACHAAL3ABIZ4DbwAScAFU/QVvAQ+HBwUGAQPgFuAoDREIAAQACgAMAAYAAgAKAAIAAwZGCn0BQwvhSncLcAHSAwtvAdBvC38BQZDrw+UDC3AA0gILfwFB+pH+8nsLcAHSBgt+AUKCAQtwAdIDC3wBRP//A6SLXL31Cwf1ARgEZm45MgAOB3RhYmxlNTgBCAlnbG9iYWwxMDMDCAlnbG9iYWwxMDcDDARmbjkxAA0HdGFibGU1OQEKCWdsb2JhbDEwNgMLCWdsb2JhbDEwNAMJCWdsb2JhbDEwNQMKB3RhYmxlNjABCwRmbjg5AAYHdGFibGU1NAECCWdsb2JhbDEwMAMFCWdsb2JhbDEwOQMOB3RhYmxlNTYBBQlnbG9iYWwxMDIDBwV0YWc0NgQFBGZuOTMADwlnbG9iYWwxMDgDDQRmbjkwAAgJZ2xvYmFsMTAxAwYIbWVtb3J5MTMCAAd0YWJsZTU1AQQHdGFibGU1NwEGCZsCDgYFQTgLcAPSCwvSCgvSCgsCBUEXCwAkBgsOCw0NCwgICAkJAgQPDQ8LCAMBDgUKBwgEDAYLAQoCDwYKAghBCAsAGQgPDgQNDQYBBQAGCgoCBwUCDgIIAQYIBgsDACgICwwPDwsMAA4MDAsJDgsDCAgLCw4FDwAODwkIAwoICQkBCwkPDggEAghBGgsABwoDAA0FBAwCBUEcCwAfBgkGBQUBCAILBAYIAA4BCAoFCAALCwYLCAACBAwHAgYIQQULcAPSAAvSAgvSBgsGAUEHC3AB0gELBghBGAtwAdIDCwIFQRgLAAEEBgRBEgtwBdIFC9IIC9IJC9ILC9IPCwIFQTYLAAIHDAIFQRsLAAEKBgFBDQtwAtINC9IOCwrVZQO0QQUBcAN/AX4BfQF8QSlBAnAEDCMJQrsBQdzy5QVBAXAOAQAACxAJ0gIjC/wQCUTB52qUEGrSdUGGlQEkCPwQBUECcARwQQRBAEEA/AwHCgYIEAsMAAALAwACBAwAAAsCAiMLJA0jDiEDIANEh/JKDWpk2LEkAvwQCQJ8/QwU95Gyh42WPcNluYo62p+I/QyimoS67ljFY9D/0Wqi5/w7BnwCftIN/QzVJSiDpQ3UeRZiWusvgog3/WIkAEScS879M4pnzkN+b0+2A34GeyMKQQJwBAUCAxAMRQRADAQLBgMMAAELDAEACwAFEAxFDQcICAvSASMLDAcBC/0MVHCxjwcw/9Pn0M+AZ45EhdIB/QyEalb0vtNoD7ucmXSPslYYIgHSCCAADAEACwAL0g4jB/wQCkECcAQJQeqjIA0DQRMRBgQMAwAFBgJEFOCMbrZ7x7kMAgsgAfwQBkH//wNx/hIAAEEBcA4BAwML0gQ/AEEBcA4BAgILDAAACwJ9IAZBAWoiBkEeSQRADAMLIAZBAWoiBkEOSQ0CAgdBAEEBcA4BAgIBC0Kz882Y1nICfCAGQQFqIgZBH0kNAyAJQgF8IglCG1QNAxAHQQFwDgECAgv8EAEgAkGg7gFBAXAOAQMDCyQEJAINACQOQ8haVaEjAgJ8Bm8MAgskByALRAAAAAAAAPA/oCILRAAAAAAAADtAYw0CBgMZIAM/AA4BAQELIwYMAwv8ByEAIwUGcELNASQD0glCrM6FsH79DO7tRiIEatGsLCsLRC3VijUiBCMGQrMBAkD9DOIgeCSOTRSPxlQhacEjn/T9oAEkAEMb7yhikfwQAEECcARvQRMRBgRDDjzctkPJ9wunIAQCbwwEAAsABQwDAAsCQEH/AkEDcA4DAAEDAQskB0TgSN5RBtvJjgZAAn8MAgALDQMGQAIDQQNDMV/K0UOKNtNZIwEGeyMCQeQEQQVwDgUEAwYBAgIACyMD/Qy2hlDV1yne3S4Ob5BD0sapIgH9hAFBBXAOBQMABQIBAQsMAAsZEAxFDQT8EAQkCgwACyQOA0AGASAHQQFqIgdBJ0kEQAwGC9IL/BACQQJwBH4gBkEBaiIGQQZJBEAMBwtBxukCQQJwDgIFAwMFAn5D3Sj4fyMAQbWIBkECcA4CBgQECwwAAAv9DMtLOIsYIVti9RgaWXf+PmUkAAN8AgQgBQwIAAsACz8AQQJwDgICBAILQQJwDgIDAQMLQihDq3+ZeAZ7Qgm/nSAFIwcjBgwFAQv8EApBAnAOAgIAAgAAC7UkBQwAAQshAiQEvf0MgvPz7dE59Qh8p4pTfryzXSIEIQG6/RQkAAN8IAlCAXwiCUIGVARADAELIAtEAAAAAAAA8D+gIgtEAAAAAAAAOkBjBEAMAQsQBRAEDQF5PwBBAXAOAQEBCwZv0g9Ez4iXwUL5ofsGexAMRQRADAQLIAZBAWoiBkEYSQRADAQL/BAGBAYgB0EBaiIHQQJJDQQMAAAFDAMACxAMRQ0DBn0jDEMr/gzzIwoOAQMDC0L6ACMBJAFB167l+XlBAXAOAQICGUKMAQZACyQBA38gCkMAAIA/kiIKQwAAEEJdBEAMBQtBFREGBBAEDgEDAwsEQAJ9BgkQDEECcA4CBQICCwwDAAv8BEPNrYh/An8MBAALDQMkBSQBIAdBAWoiB0EwSQRADAULBQwDAAv9DOn2TJdHWztBVZKJCNnSOQr9DJa2MRkxBIJvJucXj9qvc61CyaGPbAZwDAMLQqgBRAAAAAAAAACAIwgNAj8ADQIhA/wQCQ4BAgIL0ggGb9IFQfDLiecGJAgjAyQMQTAaQQUOAQICAQsMAAskByIDAnwDf/0MEYczit84aDafifJA9ef1ef3JAf0Mp+wbuHScSFenreYKGPTMiiEE/SEADAEACwALRD1RaLQJWCBMIQMhA5kCfUGIi6/re0EBcA4BAQEL0gzSCf0MrIq3ra/teAaLyzCL8KTSMEE2QQBBAPwMCwUjDNIE/BAHQQFwDgAACwYEBgFDniYQatIPQ+4jFez9DN+07QVbRIZmyPvdsfjBsMskAD8AIwx7Q9Ui+P/8EAlE2KfAJzvAQmI/AEEBcA4HAQEBAQEBAQEBAQsjAbn8Ag4BAAALIAdBAWoiB0EBSQRADAELQhH8EAVBDEEAQQD8DAMEJAgkASAHQQFqIgdBJkkNAELrAb/8EAj8EAhwJQgiBSACDAEACyMF/AQkDEPwM/R4QTxDc177MJDSCQN8Qu/WnJl8IgD8EAfSDSMKJAj8EAhB//8DcTIA1AYkDCMCJAIjAiQOIwIDbyAHQQFqIgdBKkkNAULT7QAjBSMMIw5EeSPJ6IL6iFcjAiEDJA4kAiADAnAGA0NYZ6V80gVDvaiw4kEbQQBBAPwMCwcjCkEBcA4BAAALEAsjASIARAAAAAAAAAAAQ+bxXGUGfAICIAhBAWoiCEEjSQ0E0gtDoQjB4iQFIAAjBSQF/BAHJAgkA0Moafbwi/0M12p/duHiWMLlURx/eZ+XtyQA/BAADQACfCAHQQFqIgdBFkkNBAwBAAsMAQsjBQNAEAcCfyAC/QzWSd93GA7Hv1h9pti2L5OsBntBvssIRIPYrbG9I+dI/RQMAAAL/UwkAENGVSxS/BALBAEgBkEBaiIGQSdJDQUgAf3HASQAIAdBAWoiB0EGSQRADAMLIwgjDQwHAAUGCwwAC0SpYzLLF29cYwwDAAskCtIGQowGPwBBAnAEfCAKQwAAgD+SIgpDAAAcQl0EQAwGCyAJQgF8IglCA1QNBgYDIAMkDiALRAAAAAAAAPA/oCILRAAAAAAAgENAYw0GQRIRBgQGAiAIQQFqIghBDUkNBAwAC0Gdg6bqewwCCwIJIwIiAyIDBn4GA0TKAg4nbmriwiQCIAdBAWoiB0ErSQ0FIAdBAWoiB0ETSQ0FDAABCyAGQQFqIgZBFUkNCCALRAAAAAAAAPA/oCILRAAAAAAAgEdAYwRADAgLPwAMAwsGfyMMJAwCcAZvEA/SAv0MrkcQaL5SemtKHqjtsIxApNIKIwEjDQJ9BgIgCUIBfCIJQhNUBEAMCQsCCQIKDAAAC/wQCAwFAAtElcRWKTYfO0kkDgwFCwIK0goGfyAIQQFqIghBLkkNDQYDBgYjAyMD/RL9GQFBA3AOAwMBAAMLDAALIAtEAAAAAAAA8D+gIgtEAAAAAAAASEBjDQ0CAURscoHW3+b5//wQA0VBAnAOAggLCwtCqQHEIgDSC0Ljgt75mH4gAyQCAkAQCyAKQwAAgD+SIgpDAAAkQl0NDURDFZSG4OGS7wwLAAskA9IHAn1BkwpBAnAECQIB0gD8EAVBAXAOAQQEC0EBcA4BAwMFIwoMCgALDAQACwwCC/wQBHAlBAwNCxAMRQRADAsLIAH9dPwQAQwGC0Ov/VmqWw0BDAsLIwG5/QxJCiNMLNtnQdr+HQnDh6Tp/YQBDAELJA0gCEEBaiIIQRxJBEAMCAvSAAZ7Q8+sy38jACEEAn7SCdIDQSRBAEEA/AwJB9IL/QxdNmwaaKpGtHuNeBwBHvfzDAEACyEAJAUgCUIBfCIJQitUBEAMCQsgCEEBaiIIQQRJDQgGBENEdYh/IAIgAyQODAsLIAdBAWoiB0EOSQRADAkLIwT8EAlE8BYeD+LVmycMBgv9YUEfQQBBAPwMAgVCh5jwtK+zAtIN/QymA6607cRvstAZz46ru/g7An0CfQIIDAAACyAIQQFqIghBG0kEQAwKCxAFAgECDCALRAAAAAAAAPA/oCILRAAAAAAAADRAYw0LIAlCAXwiCUIKVA0MIwskBgIG/BAGtwwKAAsACwALAAsACyQF/e8BAnzSByABBntBB0EAQQD8DAABIAIMCAELBnzSA0RVegZuLmWbwiEDIwIGQCALRAAAAAAAAPA/oCILRAAAAAAAgEBAYwRADAwL/BAL/RAhAQwAC5n8BwJ/BgxDQg9cBP0T/BAFQQFwDgEAAAsgCkMAAIA/kiIKQwAABEJdBEAMCwsjCPwQAHAlAP0MSaKYS6wAHoq3lbdDQ7j+/P37ASEBRJuh2tuLjUBdIwQ/AAwGAAtBAnAEACMIIAUkCwwDAAVD03/rf0SA9USJ3M2oeiMLDAkAC0ECcAQABgwCBhAIQc+LnewA/BAJDAIACwILBggQDEUNDhAEQQJwBAQCBwwBAAsABUG5mAr8EAYNByQK0gkjCD8ADAcACyQBQu0BIQAYAUEUEQQEDAEACxgNQcHdl8R5DAYFBn4GfQJwIAdBAWoiB0EkSQ0OBgIgBSABQ9GR/REjB9IPIwAiASMKQQFwDgEAAAsGf0QW3fleDxaCBQwMCwwDAAsGfUQGy51l/FYdPvwQAg0EJALSCvwQAQwGCyQEJAYQDEUNCRAMRQ0JQcEADAIBC0Pkw2iHQs/HlJR+IAMCcEEPQQBBAPwMCgQjAtIBIwYhAkP/04br0gdBkLcBDAUACwZ//QyR+gt19jlhr9RBpmKfWIezIgEkABAMAn0gCEEBaiIIQQRJDQoCDBAF0gH9DDteISjnC08kDrHgJPsD7ysjDiQOIAAjACIEBn0jBBgCIwEMAwALAAv8AEkYBEECcARAQQoMCAAFBgUQDxAEQQJwDgIAAQALIAUMDgsGe9IF/BALQQJwBAIgBEEPQQBBAPwMCQUMAQAFBnsgBQwNC9ICQa/CzNp6DAYAC/0Mbx7mzFN5F/TPHWjCMpIm0AwAC9ILQy3cQZEkBP0MZZWU6VUAOZ3Ul8VKl0k80iIE/YEB/fwB/WgGcEIbDAELDAoACyIAIQACAwZwAgQMAgALEAkgCUIBfCIJQipUDQ0QDAwFCyQGIAtEAAAAAAAA8D+gIgtEAAAAAAAAPUBjBEAMDAsQDEUEQAwMCz8ADAQLIAdBAWoiB0ERSQ0KIwYhAhAERf0PIQRB+/IBDAYL/Q8kACEAIATSCQZ+IAtEAAAAAAAA8D+gIgtEAAAAAAAASEBjDQoQDEUEQAwICyMJIQL8EABCzAEMAAu5DAcACwwGAAsiAwwCCwwCCyMLIwIjBP0Mui25yT7n+7yZfhEATf7WWP0MRuYhWg6J9qf0ICHIPjFvCyMEIw0MBAVERk+j4arr3m79FCIBJAAjCf0MGgJNHV4kDbzl1KazTf4SkP2jAQwBAAsMAgtBAnAEA/0MEs5c94guPkYMmPpUFB/cHvwQAiQIBnAgBkEBaiIGQRlJDQZBpuzVCUEBcA4BAQELDAMLIwTSBwZ+0gVCv67RtCEMAAtBjgEkCkIuugwBAAvSBCAB/ewBQq2F74n+iNWof0HTgO0a/BAFSyQKBn8DDAJ8An0gBkEBaiIGQSBJDQJBmwEECv0MTw4rVpj+wmvJaLaqV7JYsUTU6Ni0Qqjw/wwCAAUGASAHQQFqIgdBBUkNCEM4P7HsQsqCq8IAJAHSDyMAQQNBAEEA/AwBBSQA/QxTA+Atp2MYbIh/sQ1zvZxN/eAB/e8BIgH9hAFBAXAOAQEBAQsNAAJvBgFDGJpFJwwDC0ECcAQJEAgGANIC/QzR+L2GTN89uE7OvMW8fIjC/akB/YMBBAA/AAwAAAVDyeSEn/wQCg4BBQULDAALDQIMAgAFQiAkDPwQAwwGAAtEz5JuIvB9AQvSAkQDSMMxnyq1iQZ80gpDvcd08UHhAgwGCyML/BAGIwwGEAwACyEAQf//A3EgAP4iAADSDNIJIwskBkL0AQJ8DAIACwALIwoMBAsQDEUNBv0MN/liA/YtG0Zwa4nRfJUrVkPOrB050gkjCyIF0gNEPooRMe8BY9eaDAQLIAT8EAkMAgvSBCAERAJF7GevQJgZDAIACxAJIAdBAWoiB0EvSQ0EAkAQDAwBAAsGBAv9DCIrCjiXhb2cmJPFzKK2Fz4jBZD9DAotdhQtWOEVA0VUk++n13EkAEK4AcIkDEH36gEGfv0MaDWiaXT1ySkNmm1/A+dbPyEEIAdBAWoiB0ETSQ0FAgkGAv0MM7jCKLyX5qha/zmxA3EsGiQADAAAAAEAC0KptI2GfXkjAgwDAAvSBQZ8Q1bckJQkBRAMDAILIwcgBEOBxG6CQ7DlmGcjCSABJAAMBgtC+AAiAD8AGyQBBnAGDCMNQQRBAEEA/AwBASQLIAtEAAAAAAAA8D+gIgtEAAAAAAAAJkBjDQYjBf0TJAAQCAIIDAEACxgBBgcgC0QAAAAAAADwP6AiC0QAAAAAAIBAQGMEQAwHCwYJ/QzHV1uG+f4TGux843KP5RrR/XQkAAJ9IAhBAWoiCEERSQ0IIAZBAWoiBkEiSQ0HIAdBAWoiB0EISQ0IBgRBKkEAQQD8DAQBBwwGBQwAAAv9DBgVf0kim2nShu3MO18wGwwhBPwQCA0AIAZBAWoiBkEnSQRADAoLBwYQDEUEQAwJC0HksBQMBQv9DO8j30KxdM8P1xzNmw/2Q18kAAYJIAlCAXwiCUIYVARADAoLBgsCBvwQCgwHAAtCKyQBDAAL0gJEBQW11x9FWvY/AEEBcA4BBgYACwwBAAskBCAGQQFqIgZBJkkNBiAIQQFqIghBLUkEQAwICyMDQTtBAEEA/AwAASIAIwUCcEQHVLcC3tbuEZ0MBQALJA0kBCQBAgkGb9ILAnwgBkEBaiIGQTFJBEAMCwv8EAWsIQBDLf7intIOIw79DKqZiQIrGGZTPpKHr9nFzmMiBP0dAHv8EAUMBgAL/QxxmrTmNZWwDVdzjPL3VQ8/JAAMBgAL/BAJIwsMCQAL/BABDAMLJAchASIBPwBBAnAECxAH/BAKDAMABdIG/BALDAMAC/1ePwAjDQwEC0Pdxe7U0HDSBNIGIwsMBgvSDyMAPwAMAAELQzAaLyP9DEIr3+v9BDLKOXci/t8d2VPSD9IM/QzADkXJiQiDp53lI0pA56Nt/coB/BAH/QyMDinpi/XKNYX+4k9Niw87IQFBAnAEBRAFIAMgA0IlQ8zFuntC55vQ+JPbrtwAQ7jL+if8AQ0AJAH9E0KSAcQhAP3sAfwQCkEBcA4AAAEL/BAI0gL9DFiHEcyW9aRWgWX8gWUZX90iAdINPwAjBwZwIAZBAWoiBkEeSQ0DBgQYAAYDQrqH3eL97uVhegZwAgsCABAJAgYQBwJw/Qzkv6sFber5+CwnPDEKuEGz/YABJAAMAQALAAtBBQ0BAgRDxPm6SCQEIAQhAQwCAAsACw0CCyAGQQFqIgZBHUkNBdIEQrQBAn0MAgALJAUDcCAHQQFqIgdBAEkEQAwBC/wQAg0CAgsgAKdBAnAECAUQCEHm6w5BA3AOAwEABAABCyAIQQFqIghBBUkEQAwJCyAIQQFqIghBD0kNCAwDC0MrZd5tIAT9U0ECcAQEAnz8EAPSBiMMuUHoi8c3QtIB/RIiBEThv9YWFWw3KyQCBkAgBkEBaiIGQRdJBEAMCgtChRtEnAr/DUJNXBIMAQskAAZ7IAZBAWoiBkEgSQ0DIABC37qY2JbyF4QjCfwQBEECcARADAMABQYJAgvSB0PjhhZgIwQjDtIBBkAGQAsL0gTSCdIIIwx5wvwQAkECcAR8DAkABUEUQQBBAPwMCQcMAwAL0gEjAgwKAAsMAQsjC0E0QQVBAEEA/AwFBw0FQukAJAMgAHkkDCQGIwzSDUHQjM8BQQNwDgMGAAMACwwEC/0MnLPlMPynoBVbUlHXsBj45iEE/QxXNdNj1DEBqoNaf3rRvK+C/S39DEjLTi/yFCGO0PTh095ececjCEECcAQJIAlCAXwiCUIxVA0JIwXSBxpEp9ipruWhpIsMBwAFIAL9DLTuFQWT8ctBPLaoUXb0cNIGQAskAP0MuojQj1XB+67LfFr9xqmD9j8AIw4MAQALIwBBliFBv/wZQZzFA/wLACQAQtIAxCIA0gojDCQM/QxIh8o43R8dsiUucr8u5WITBkAGQCMNDAcLGAb9gAEkACMEJAUaIgAkAT8AQQJwDggEBAQEBAQEBAEL/RRCPUT8wr+BprtkRQwFC0EWQQBBAPwMCQHSDyMKQQJwBAwLQe6e9P8BDgkCAgICAgICAgICC/0McmIPgPedBHwtbeYpgKTTZ0GZ3LCeAkEBcA4BAQEZ/BALDQEgBkEBaiIGQR5JDQYjCwwACwwBCyMNAm8gC0QAAAAAAADwP6AiC0QAAAAAAAAAAGMEQAwFCwZAC/wQBD8AJAhBAnAEQAZ7DAEBCz8AQQFwDgEAAAELAgcgCkMAAIA/kiIKQwAAEEJdBEAMBwsQD0RoETQa9lBslSQOQSAlAAZ+RLzK/EHHKJjCDAQLJAMMAQALAAsgBCQAIwgCbyAJQgF8IglCKFQNBSAHQQFqIgdBIkkEQAwFCwIEBgAgCUIBfCIJQgRUBEAMBwsQDEUNBgwBC0EBcA4BAAALBn9CrwEhACALRAAAAAAAAPA/oCILRAAAAAAAAENAYwRADAYL/BAIQQJwBAFBAwwBAAUgBkEBaiIGQRtJDQcjBgwDAAtBAnAEAEGS4rOlB9IB0gkaGgwAAAUCfENZkJl/JAUGAEIGtAZwIAtEAAAAAAAA8D+gIgtEAAAAAACASEBjBEAMCgsGAQYMQwIls38kBBAFAgAgBkEBaiIGQRhJDQwgB0EBaiIHQSRJDQ0QDEUEQAwOCwYGBgcGAwsQDEUNDxAJDAMLIQQjDiQODAkL0gDSDRpDKLTetCQFGkESEQQEAn4gB0EBaiIHQQ5JDQ4QDEUEQAwOCyAJQgF8IglCD1QEQAwOC9INRBm9AyOMNvGYQ1qIfEUkBQwGAAsACwZ9DAELIwYMDQv8EARDx+t6VCQEDAQLDAMLIwQkBAwHCwZA0go/AAwDCwwBCwwECwwACxpBKCUA/BADQQFwDgEAAAskB/wQA3AjByYDJAchBUEeJQoLDAELJAICcAYCQSEOAQAAC9INQtkBtERUirJagd+6iQZv/BAL/Q8kAAIMC0E6JQIYBUGNAr5CvKuYdgZvIAhBAWoiCEEnSQRADAQLIAhBAWoiCEEdSQRADAULQQ0lCSQHIwTSDBokBRAMRQ0EAgMgBkEBaiIGQSBJDQQQDEUEQAwGCwsgC0QAAAAAAADwP6AiC0QAAAAAAAAzQGMEQAwFCyMEJAUCCCAHQQFqIgdBDUkNBCAJQgF8IglCKVQEQAwFCwYICwsGACAAQ9tWORT8BCQMJAMgBkEBaiIGQRNJBEAMBQsgBkEBaiIGQQpJDQQGBhlBBEEAQQD8DAAIIw4kAvwQBgwBCwZ+Bgf9DIt02JkAZNpoHBEJg3PdzJkkACAHQQFqIgdBI0kEQAwICwIBIAlCAXwiCUIDVA0I/BAKDAMACwwCCyQADAILJAFBCwwACyQKIAhBAWoiCEEmSQ0EBgFE6YCqEa1/cE1BI0EAQQD8DAcHJA4gCUIBfCIJQhBUBEAMBgtE0FhKYQH2TV4kAkL2ASEA0g3SAhoaAgwgC0QAAAAAAADwP6AiC0QAAAAAAABFQGMEQAwHCwsjDEM2xTVuIwgkCCQFQdC1AQwACyQI0g0aJAEGAgwACwIJ/QyfWpzZxTvZwa0baZXecTILBn0jDSEF/BAFBAsLQ1UPF9YLIwX8AEECcAQFC/0gASMKQQJwBAlENALyWsg8vyBEmKheYkEdhhem/AZDnl39TEN+HNBgJAQ/ANIGQyKbCtUkBRpn/BAI0gZBA0EA/BADJAhB//8DcTIB/wckAyQKGj8AGyAEPwAkCCIE/YkB/eMB/QyH+b0Ijp/ZHyWo4TMjjZGmIgQGfgZADAAACwN/IAZBAWoiBkEcSQ0AIwEMAQALJAggCEEBaiIIQQdJDQZC8AHSBNBwDAUL/R4A/fgB/S/9FgK3IAIMBAAFAn8gBkEBaiIGQR1JDQdEnX+QDmuJtP/SCQZ/AgYL0gf8EAgMAQsMAAsCfCMOC9INIwIGcCAGQQFqIgZBDUkNByAKQwAAgD+SIgpDAACgQF0EQAwIC0EfJQVC48v0oIrNi8Y+JAMYAgZ+IAC6JA5C8AAMAAALJAxDXuW2VSQE0fwQBGoEACMKDAAABQYLA30QDEUNCQwBAAskBEK44bN20g0aeyQMC0HZAAwAAAskCNIBIAQkAPwQBSQKPwAkCBokDtIM/BAGAkALQQAaJArSCtIMGj8A/BABJApEvm80WscBPHckDkECcAQBIwhntyQCBm8CBiMFIw4kAgJ/AwsLBgbSDdIKQzM4QKf9DMVAzfkm9E4hYA/FXppQk1f9HQEiALQjDSEFJAQkBUIoef0SJABCkAEjAyACDAgLIwkCfwwCAAsACwALIAhBAWoiCEEbSQRADAkLQQklCwsMAwAF0g/8EAatJAEaA3v9DMT4EowuMYbxdtb8RXFjVeILQThBAEEA/AwLBSEEQqwBRKX+TBzdX0uY0gdEnCnx+qbx9P8kAhqaQsoBJAxERgiZU/oElXMgAAZ/PwALIwG5vdIG0g0aQiYiAEEiDAAACyQIJANCTQJ8Q6NXzwQkBBALIAhBAWoiCEEYSQRADAcLRJUzaHfyFWMQC5ojCwwDAAsMAQALDAALJAc/APwQAXAlAQwACwwDC9IN0g4aGv0MIj1W+5g6OcsuLa3RCadaOCQADAIACwALAnw/ACQKAgwLQfPFBSQKRH5MJjvoyp/ICyQOmiEDPwAkCNIH0gFCfyQDPwAkCCACDAAFQQ0lBAskDSQCQesAQcEASvwQBXARAgWsIgAhACEFIwb9DMFfBdJjWwHQTGlrb/NwAfwkAP0MZBSQjpFlkJ3PmLTmeM0eBv1kJAokBhr9DGUpKEx5umQYjZKYGHgRBFokAANwQSslB9ICIw5BEkEAQQD8DAEFJAIaQeW/MiMEIAFDE1MRrPwFPwD8EAtwJQskByEABnsQDyMADAALIwUkBSQAQejpM0H//wNx/QcA/wQkACIBJAAkBCQIQe/pxqMBJArSBxpEOQmpX1nCUe/9DHFnSNIU3o1STKJjR7lZnN39DNOXwbH/JArKurST9n9Ca4f9PCQAIQMLIgIhBQZACyMB/QzP+H3NdtUB01xeXhYD9fGGIwlBr4u9EEECcAR+QnYMAAAFQqzW/ZPwmPb3APwQBA4DAAAAAAtDEU6IpyQEIAQiAfwQCCQK0goaJAAkAyEFIwvR/c0BQQ0lByQGRM4lAYlrXG+OJA4CfyMKIw0kCwwAAAskCP3gASACRB3CnCt1FmrfIAQLix4NAX4AfQF+AHACcAJwAXsAcAJ/A38BfgF9AXwCBAYLAnxB2NEMDgICAQEL0gX8EAH8EAsGcAwBC/wQAUECcAQEAwfSBPwQBw0B0ghDubtDs48GfgIKBgEQDEUEQAwECwYDAgQGBgwACwwGAAsMAAsGB0H3pQNBBHAOBAYCBQcCCyMFBnAgDkEBaiIOQSpJBEAMBQsCAwYHEAsMCAsiBCMBeQwEAAtEXcVFZhosSVojAyIAIQAkAkKHAb8iAyQCAgEMCAALIgwCfwYA/QytuDANaAjQngvByEAZs08iJAD9DBENOJdqbnDyqVFc9e/2q0EiAUHt3AAMAQsCbxAFQu6JsYjp/LQEwgwFAAsDewwIAAv9UwwAAQsOAQEBCyECIwAGe/0Mw+/57dKTZK0+cY/n2FC9kQwACwZ9IA9BAWoiD0EESQ0EBkAjA7TSCCMA/Qz+LVfstCTTkLXC/gW8jrEq/BAIQf//A3E0AJcBPwAMAgEBGdID0gdEy1ThDbqo8f8GfvwQCw0JBgsGCBkGCwIJ0gIGbwYABgoCBfwQAAwCAAsCBAwQAAsQBQsQBAwAAAELQQJwBEAFDAcACwwOCyQHRDn9Vx4Pd0OG/Qxg4dYihB3azBVJQ9o3TrkBQzh95uU/AAkFCyQHQqfQH/0eAUPsAJr/DAULIBNEAAAAAAAA8D+gIhNEAAAAAAAAMEBjDQggAiQGBggCcCMDJAEMCwALIgL8EARBCHAOEAABAgIHCwoKBwoMCgQKAgoKCwtChLh/RIc5A6mka/V/IgMjC0KIAdINIwACQELS77KsBAwHAAvSCkESQQBBAPwMBghC0cKlAwwGCwwJC9IG0gkjDSQNPwBBBXAOBAcAAwgGCwwGC/0MA+h9Xwz/dArw+veuQwQmXCQA/SADIQv9XyEEBm8MBwsCff0Mse6i7SzYxq2s/gU6CfP2ikNutkrCPwBBBHAOBAcFBgIGC9IA/BAAQQRwDgQFAQYEBgtBAXAOAQEBCwwECyMHQee0sOt9QQNwDgMCAQMDCyMLIgojCEEDcA4DAAIBAQELIAD9EiQAIQL8EAFBAnAOAgABAAv9DC+3OlKe8J8thES8bwsxAacjCSMNJA1D004kvgZ+0grSDkGRz6gDIQ1EHCmSB5PciaRCzwsMAAALIwskBiIGIQW7/BADrEMAAIB/JAT9EgJ7QwWD6pUjByQHQTBBAEEA/AwMAQZ8DAILIwD8EAdBAXAOAQAACwZ7DAEL/VIgB/wQAA0AQQlBAEEA/AwFBSAGtSMDBm8gCyIEIwz9HgADfiAOQQFqIg5BIkkEQAwBCwYLDAAAAQALQRRBAXAOAQICC/0SJAACfQZvEAkCBgwEAAtDe6Pd/0EuQQBBAPwMAgcGf0GslwgMAAsNASMHDAAL/QxARDxzHEOtNVYXmoT7156WIQtEVpWXxwTgGj4hA0ENQQBBAPwMBgQMAQsGewwCCz8AQQFwDgEBAQtBJ0EAQQD8DAwF0gkgByEK0gz9DMfiCbx0RIkKnetLZ0x4h7/SBvwQCSQIIwMGewYJAgECfCMC0gAjACQA/BADDQT9DPbpuy+L62NqRF+rFlfO7Rn9qQEMAwALAAtB//8Dcf0KA0MhCyAL/aoBJAD8EARBAXAOAQICCwJAIA0kCgsjBAZ8DAIL/AMGfQIA0gU/AEEBcA4BAwMLQQFwDgECAgsjCkEBcA4BAQELJAAjBCMKIg1BAXAOCAAAAAAAAAAAAAtDJJ4K56lEDsZ41wnpLCL8B/wQBQR/QzyxRvj8BEEaQQBBAPwMBAEgAz8APwAMAAAFAgtD6RL+9kHoiM6vAg4BAAALAgkGfUEYQQBBAPwMBwoCCwYCAn0DBSARQgF8IhFCAFQEQAwBCwYMIw3SA9ICIwQgAkNsg4V/DAILAggMBAALAAtB9QVBAnAOCAECAgECAgEBAQv9DEJ84ZnnZmIwdHvvNSlKVP0CeyMKDQJBwQH9DJ+N5v1niXLVnDS+q0Qcr4IMAAALPwBBNQwECxAMDAML0gH8EAsMAgvSDkECJAgCewYGDAALAgkgDAwDAAsACwAL0g79DFiY3eXUyaBtq+ykDjROlH8hAfwQASMJJA0CQAwAAAtEf6I14ltxRUNCKkH65Y/FBgwAAAsDcAIEPwAjBiAAJAz9DL2w5P3zRjCjo88ABOSTfc78EAPAQQJwBH3SC0Lkw/8BQeMBDQEiAEO4LPl/DAAABQwBAAsjBPwFA3wDCiATRAAAAAAAAPA/oCITRAAAAAAAgERAYwRADAIL0gNDJaQXokQdSWyh8e7/f9IKQa0HQQFwDgECAgsCCRAPIA5BAWoiDkEmSQ0BIBFCAXwiEUIxVA0BAn4gEUIBfCIRQgpUDQQQC/wQBkEBcA4BAwMLIQAGAAwDC6whBhAMRQ0DBgsMAAsgA/0UQgIkAz8AQQFwDgECAgALJAf9DRkCARsHBAUcBxQIDBERExZCASIA0g5B/gDSCkTHEx2rFjxh2D8ADgEBAQsjA1AiDRpBAA4BAAAAAAsDCwYMAnwCfCAOQQFqIg5BLkkNBBAEQQFwDgECAgsMAAALQv0APwBBAXAOAQAAAAvSDvwQCQJ7RAPkjaWYJxyg/RQMAAALIQtBAnAEBQYBDAELQTtBAXAOAQAAAAvSByMHJAcjAkN1OS5KJAQkAv0Mf0aM/Pct3QarT65JD2T7twJ90gogBERzUgITGfaYbbYkBAZ7/BAA/QxXfIaBs52F1UXf0FFmopm6IQtB//8DcSAL/VoCpwUC/BACAn7SC9IMIwkGe9IOQRlBAEEA/AwICELiAf0Mt9urXInOewQKFTb1YgHA8CEEDAEL/fwBDAELAnACfAZwQ90yLl0jBV8kCNII/BAL/BAFcCUFDAILJAYCBgwAAAsDBgYJRP/NgYrZ5HZdDAILJAcMAwALQez1DEEjQQBBAPwMCgdBAnAEAwUQByQIQyx1/8NBAEEBcA4BBAQL0g8Db0EBJQD8EAlC2QEGfiABRFoky58jqdFC/RQhAQwEC4ohAEH+/wNxIAD+RgEAIQYkB0SZ+b++zA4hzAwBAAsCfSAEDAMAC9INPwAjC0K3n7motKG6n34hAANAIwb8EANBAXAOAQICCyEKJAj8EARBAnAEAUK5KiMIJAogDAR8EAQMAQAFBgwCCgN+RE3l0cCo0x21DAMACwALC0T3+5z0b0XiMPwQBvwQBSQKQQJwDgIAAgALIwLSDyMNJAtC1pzH44EP/RIhC9INQ8W46VT9EwwDBRAMRQRADAYLIBFCAXwiEUItVARADAcLIBFCAXwiEUIhVA0FAgBCAv0SA31DlcXx7v0TDAUACwALAAskCMIkAfwQACQKQY604wEkCNINGgZwROMoOZZ/CPI00g1BzSkkCiAIDAALJA0aDAMLJA5Bu+cCQf//A3EqAoYB/BALQn0gAQwBAAEBCyQLwiQDJArSBdIARFZjyNwXEuoVJAJCqODD2/CP3AA/AEECcAR9IwUMAAAFIA9BAWoiD0EGSQ0EBn0GBSARQgF8IhFCJ1QEQAwHCyAQQQFqIhBBIEkEQAwHCwsgD0EBaiIPQSJJDQVCxAEiBiAHIgnRBn0QBSMFJARDhyhPXQwBCwwABwAQDEUEQAwGCwYHEAesIQVBBSUGJAcjCiENAwNCjKipISQB0gBDo5XBLQwFAAsjB0G7reQnA3AjBiIKJAsGCQZvQQQlBgsGf0MKcEjMDAcL/A8CCQMLJAf9kgEMBAALQfLOA0ECcAQKCyQG/BABcCMGJgFBHv0MHEOVfKn/7Uh+ly/RkO2vPQwDCwZwIA9BAWoiD0EuSQRADAcLAwgL0g4aIAcLJA0MAhkDByATRAAAAAAAAPA/oCITRAAAAAAAACZAYw0AEAxFBEAMAQsjByAIJAtBByUG/BAI/Qz4ujyomIRfVwadcbfDrWtaDAMACyQA/BALJAgCQAtBKUEAQQD8DA0HGvwQBP0QJAD9DB2WjCo9nHkxkUhz1NERcQwgBSQDDAILCwwBC/wQCyQK/UAhBBpDhFx/kgskBdIEGiAGJAEkAEO68+YJJAUaIwhBAnAEBgIIAgULCwwAAAUL/BALJAj9DGcKlc87oBs/u15voxju23wCcCAOQQFqIg5BGkkNAQYBIwxBLxgDJAp5JAwgEEEBaiIQQSxJBEAMAwvSDNIDGkILQeLDA0H5B0GZmQH8CwD8EAn9ESQA/BAJIQwjCyQGJAP9DNu4q1aeck4GfvE/GCy2BKD9qAH9GwIkCAJwIBFCAXwiEUItVARADAMLIAgLIggkDRogCgshByQAGgsjCfwQByQKIwAkACEK/QyuCDohgOTytkyD/UGUsXfU/ckBIgQaIwtC7QF7IAkGQAskCyQMIwcgAf2DAUECcAQHIBBBAWoiEEEISQRADAIL/Qzt0WkVrX/l1NyifPDU7xVcJABBBiUGQTUlAiQHIwMkASMH/QxqjEwCzcTbMmX913hPH6a6DAAABRAH/Qx9AxvA7+HzIhBFiL79+xlLAnsjDPwQCiQKBm9DaH31ZQJwIBBBAWoiEEElSQRADAULPwAkCv0MlE5sGcVyxDH1p5agw+9UKyEEIBJDAACAP5IiEkMAAIA/XQRADAULQQElASQGQQclCgskDSQF/Qz1wGU3P9FHRNeKcUKFzPsCDAELJAchBQMKQvn60MbLvXwkDAYFIwAMAgsL/QxzmZ3FfP1e0YxU9kX6qQyeC/0nIwghDSEE/RH9IQEhA0EHJQJBASUAJAcgAMIkAUETJQMkB0EIJQtEDIy+bix/xRwGQEGQ+QIOAAAHAhAMJAggEkMAAIA/kiISQwAAAABdBEAMAwsLnyED/QwmMbRGYwiHfYWB28QaKp7LCyEEJAckB0Qf9/hcDKoD10P7Y8Jc0ggaJAUkAj8APwAkCiQIJAcLIAy+Iw0kC/0TJAD8EAQkCCQG/BAIcCMGJggkDCQIIwH9Ev2UASQAQQEiDCEMQvNsIQAQDwYMC/wQCyQIQ2/a8P/9EyQAQ3f5+kePIw4kDotEgjwBg99yip8Gf0EDCyEMIgMaJAQjCCQKIwD9FQdB//8DcTMAZyMBVCQIAggMAAALIAb9DHOc1SgrPLvkl4vDDWewdEEiC0EDJQQjAiMADAABC48GDAF/AnACfgB7AHwCfAJ9AHADfwF+AX0BfAYAIwgYACMGIQJCGf0MBCAUmcL2C/FHuR17DmsQFxABJAUQB0IAQfsAQtHF2a4H/RI/AD8AQQJwBHwCf0MQJjD5IAfSDgZ+/BAHAnAjDHskAxAHQtUAJAz8EAZwJQYkBwZ9AgACQCMGRAk5X7cmp0jABn4jBwZ7AgIjAiAEUPwQCEECcAQJDAEABSADIwgOAgQLAQtBGUEAQQD8DAIFQzt8m7iNDAULAkAMAwALAgLSDUPBDIQSDAUACwJARJjuZnplsp0j/AcjCPwQBUEDcA4DAwAKAAsMAgvSDfwQBwwCCyQBn/wGDAQLBgsPAAtEAAAAAAAAAIAMBQtBAXAOAQUFC0Lv2eJ5IwAkAEOvBnZOQ1zVxe0kBIwGfAIADAYACwQBAgACBwYM/QzI6m8O/Ev6vbkZYnisEZgGA0D8EAEMAwALBnwPC0Qbc04e0csfJKIMBAsPAAv9TdIBIAYMAgELDAQABQYEBwbSCiMCIQYjAwZvQoLgDyQBEAdBAnAECz8AJAoCCAwKAAsABdINQt7FoPOqfiAF/BALDgIECAQLBgcCDAwKAAsMAgvSCgZw0gwDeyAORAAAAAAAAPA/oCIORAAAAAAAAEFAYw0ADAMACz8ADAcL/BAJQQJwDgIIAQgBCyMA/eABJAAgAgwDCwYJDAcL0SEAJABB3AEMBAALDQUkDAYDGQwACwYJQR5BAEEA/AwLBfwQBAQDBgn8EAAkCgwBAAv8EAoMBQsgAiMGBnAMBwcNBgEQDEEBcA4BCAgLIwoMBQvSDtIBQ5bUnv8/AAwECyMMJAwCew8ACwZvDAYLA0D9DATrV7dG9WoXRJ/WLG9p/pwkAEHnAUEBcA4BBgYLJAf8EANBAXAOAQUFCwwDAAskDfwQBHAjDSYEAwj8EAsMAgALDwEZBgH8EAJC/gAMAQtBAXAOAQMDC78kAkLVAPwQBEEBcA4BAgIACw0BDwEFA3AQDEUNAAwCAAsAC52e0gMjCtIEIwpBAXAOAgAAAAEL', importObject8);
+let {fn89, fn90, fn91, fn92, fn93, global100, global101, global102, global103, global104, global105, global106, global107, global108, global109, memory13, table54, table55, table56, table57, table58, table59, table60, tag46} = /**
+  @type {{
+fn89: (a0: I32, a1: I64, a2: V128) => [I32, I64, V128],
+fn90: () => void,
+fn91: (a0: I64, a1: V128, a2: FuncRef, a3: F64, a4: V128) => [I64, V128, FuncRef, F64, V128],
+fn92: (a0: I64, a1: V128, a2: FuncRef, a3: F64, a4: V128) => [I64, V128, FuncRef, F64, V128],
+fn93: () => void,
+global100: WebAssembly.Global,
+global101: WebAssembly.Global,
+global102: WebAssembly.Global,
+global103: WebAssembly.Global,
+global104: WebAssembly.Global,
+global105: WebAssembly.Global,
+global106: WebAssembly.Global,
+global107: WebAssembly.Global,
+global108: WebAssembly.Global,
+global109: WebAssembly.Global,
+memory13: WebAssembly.Memory,
+table54: WebAssembly.Table,
+table55: WebAssembly.Table,
+table56: WebAssembly.Table,
+table57: WebAssembly.Table,
+table58: WebAssembly.Table,
+table59: WebAssembly.Table,
+table60: WebAssembly.Table,
+tag46: WebAssembly.Tag
+  }} */ (i8.instance.exports);
+table22.set(15, table21);
+table60.set(0, table50);
+table25.set(71, table5);
+table21.set(51, table20);
+table12.set(53, table40);
+table52.set(70, table12);
+table22.set(72, table22);
+table11.set(38, table23);
+table7.set(50, table37);
+table22.set(47, table52);
+table21.set(27, table26);
+table37.set(10, table26);
+table48.set(1, table11);
+table54.set(3, table22);
+table60.set(9, table50);
+table4.set(14, table37);
+table25.set(70, table12);
+table23.set(43, table7);
+table50.set(56, table37);
+table54.set(84, table48);
+table50.set(18, table20);
+global107.value = 0n;
+global88.value = 0;
+global61.value = 0;
+global85.value = 'a';
+global6.value = null;
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn5');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn5();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn67(fn93, global92.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn66(fn92, global51.value, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn44(fn16, global35.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn76(fn92, global103.value, global91.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn44(fn75, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn76(fn51, global57.value, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn44(fn67, global57.value, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn67(fn51, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn35(fn52, global35.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn67(fn67, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn66(fn75, global7.value, global12.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn67(fn91, k, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn35(fn44, global7.value, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn66(fn89, global8.value, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn44(fn93, global19.value, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn44(fn91, k, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn66(fn76, global92.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn66(fn44, global67.value, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn76(fn92, global19.value, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn17');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn17();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn67(fn89, global19.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn67(fn18, global8.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn35(fn93, k, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn66(fn76, global7.value, global0.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn66(fn43, global8.value, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn18');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn18();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn76(fn52, k, global91.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn76(fn35, global37.value, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn5');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn5();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn66(fn89, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn76(fn93, global51.value, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn16(fn51, global57.value, global12.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn16');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn16(fn76, k, global21.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn76(fn92, global67.value, global13.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn67(fn76, global105.value, global13.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn67(fn67, global103.value, global21.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn43');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn43();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn44');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn44(fn93, k, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn90');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn90();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn76');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn76(fn16, global103.value, global107.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn93');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn93();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn35');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn35(fn90, k, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+let tables = [table7, table5, table52, table50, table46, table26, table11, table40, table15, table4, table12, table22, table3, table21, table37, table23, table48, table20, table25, table60, table54, table57, table33, table13, table10, table47, table38, table39, table6, table49, table24, table43, table8, table0, table9, table30, table14, table17, table58, table59, table56, table55];
+for (let table of tables) {
+for (let k=0; k < table.length; k++) { table.get(k)?.toString(); }
+}
+})().then(() => {
+  log('after')
+  report('after');
+}).catch(e => {
+  log(e)
+  log('error')
+  report('error');
+})

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3254,12 +3254,12 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addFusedIfCompare(OpType op, Expression
 
     consume(operand);
 
-    result = ControlData(*this, BlockType::If, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature->argumentCount(), liveScratchGPRs, liveScratchFPRs);
+    result = ControlData(*this, BlockType::If, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount(), liveScratchGPRs, liveScratchFPRs);
 
     // Despite being conditional, if doesn't need to worry about diverging expression stacks at block boundaries, so it doesn't need multiple exits.
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
 
-    LOG_INSTRUCTION("IfCompare", makeString(op).characters(), *signature, operand, operandLocation);
+    LOG_INSTRUCTION("IfCompare", makeString(op).characters(), *signature.m_signature, operand, operandLocation);
     LOG_INDENT();
     splitStack(signature, enclosingStack, newStack);
 
@@ -3520,12 +3520,12 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addFusedIfCompare(OpType op, Expression
     consume(right);
 
 
-    result = ControlData(*this, BlockType::If, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature->argumentCount(), liveScratchGPRs, liveScratchFPRs);
+    result = ControlData(*this, BlockType::If, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount(), liveScratchGPRs, liveScratchFPRs);
 
     // Despite being conditional, if doesn't need to worry about diverging expression stacks at block boundaries, so it doesn't need multiple exits.
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
 
-    LOG_INSTRUCTION("IfCompare", makeString(op).characters(), *signature, left, leftLocation, right, rightLocation);
+    LOG_INSTRUCTION("IfCompare", makeString(op).characters(), *signature.m_signature, left, leftLocation, right, rightLocation);
     LOG_INDENT();
     splitStack(signature, enclosingStack, newStack);
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -59,7 +59,10 @@ struct CompilationContext;
 struct ModuleInformation;
 struct UnlinkedHandlerInfo;
 
-using BlockSignature = const FunctionSignature*;
+struct BlockSignature {
+    const FunctionSignature* m_signature;
+    RefPtr<TypeDefinition> m_generatedUnderlyingType;
+};
 
 enum class TableElementType : uint8_t {
     Externref,

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -148,15 +148,15 @@ struct IPIntControlType {
     {
         ASSERT(i < branchTargetArity());
         if (blockType() == BlockType::Loop)
-            return m_signature->argumentType(i);
-        return m_signature->returnType(i);
+            return m_signature.m_signature->argumentType(i);
+        return m_signature.m_signature->returnType(i);
     }
 
     unsigned branchTargetArity() const
     {
         return isLoop(*this)
-            ? m_signature->argumentCount()
-            : m_signature->returnCount();
+            ? m_signature.m_signature->argumentCount()
+            : m_signature.m_signature->returnCount();
     }
 
 private:
@@ -1969,7 +1969,8 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElse(ControlType& block, Sta
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElseToUnreachable(ControlType& block)
 {
-    const FunctionSignature& signature = *block.signature();
+    auto blockSignature = block.signature();
+    const FunctionSignature& signature = *blockSignature.m_signature;
     m_stackSize = block.stackSize();
     changeStackSize(signature.argumentCount());
     auto ifIndex = block.m_index;
@@ -2264,7 +2265,8 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::endBlock(ControlEntry& entry, S
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
 {
-    const FunctionSignature& signature = *entry.controlData.signature();
+    auto blockSignature = entry.controlData.signature();
+    const auto& signature = *blockSignature.m_signature;
     for (unsigned i = 0; i < signature.returnCount(); i ++)
         entry.enclosedExpressionStack.constructAndAppend(signature.returnType(i), Value { });
     auto block = entry.controlData;
@@ -2317,7 +2319,7 @@ auto IPIntGenerator::endTopLevel(BlockSignature signature, const Stack& expressi
 {
     if (m_usesSIMD)
         m_info.markUsesSIMD(m_metadata->functionIndex());
-    RELEASE_ASSERT(expressionStack.size() == signature->returnCount());
+    RELEASE_ASSERT(expressionStack.size() == signature.m_signature->returnCount());
     m_info.doneSeeingFunction(m_metadata->m_functionIndex);
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -35,7 +35,7 @@
 
 namespace JSC { namespace Wasm {
 
-struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
+struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> {
 
     using BranchHints = UncheckedKeyHashMap<uint32_t, BranchHintMap, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -137,14 +137,14 @@ public:
         {
             ASSERT(type != BlockType::Try && type != BlockType::Catch);
             if (type != BlockType::TopLevel)
-                m_stackSize -= signature->argumentCount();
+                m_stackSize -= signature.m_signature->argumentCount();
 
             if (type == BlockType::Loop) {
-                for (unsigned i = 0; i < signature->argumentCount(); ++i)
-                    phis.append(proc.add<Value>(Phi, toB3Type(signature->argumentType(i)), origin));
+                for (unsigned i = 0; i < signature.m_signature->argumentCount(); ++i)
+                    phis.append(proc.add<Value>(Phi, toB3Type(signature.m_signature->argumentType(i)), origin));
             } else {
-                for (unsigned i = 0; i < signature->returnCount(); ++i)
-                    phis.append(proc.add<Value>(Phi, toB3Type(signature->returnType(i)), origin));
+                for (unsigned i = 0; i < signature.m_signature->returnCount(); ++i)
+                    phis.append(proc.add<Value>(Phi, toB3Type(signature.m_signature->returnType(i)), origin));
             }
         }
 
@@ -158,9 +158,9 @@ public:
             , m_tryCatchDepth(tryDepth)
         {
             ASSERT(type == BlockType::Try || type == BlockType::TryTable);
-            m_stackSize -= signature->argumentCount();
-            for (unsigned i = 0; i < signature->returnCount(); ++i)
-                phis.append(proc.add<Value>(Phi, toB3Type(signature->returnType(i)), origin));
+            m_stackSize -= signature.m_signature->argumentCount();
+            for (unsigned i = 0; i < signature.m_signature->returnCount(); ++i)
+                phis.append(proc.add<Value>(Phi, toB3Type(signature.m_signature->returnType(i)), origin));
         }
 
         ControlData()
@@ -217,7 +217,7 @@ public:
 
         BlockSignature signature() const { return m_signature; }
 
-        bool hasNonVoidresult() const { return m_signature->returnsVoid(); }
+        bool hasNonVoidresult() const { return m_signature.m_signature->returnsVoid(); }
 
         BasicBlock* targetBlockForBranch()
         {
@@ -273,16 +273,16 @@ public:
         FunctionArgCount branchTargetArity() const
         {
             if (blockType() == BlockType::Loop)
-                return m_signature->argumentCount();
-            return m_signature->returnCount();
+                return m_signature.m_signature->argumentCount();
+            return m_signature.m_signature->returnCount();
         }
 
         Type branchTargetType(unsigned i) const
         {
             ASSERT(i < branchTargetArity());
             if (blockType() == BlockType::Loop)
-                return m_signature->argumentType(i);
-            return m_signature->returnType(i);
+                return m_signature.m_signature->argumentType(i);
+            return m_signature.m_signature->returnType(i);
         }
 
         unsigned tryStart() const
@@ -4376,14 +4376,14 @@ void OMGIRGenerator::connectControlAtEntrypoint(unsigned& indexInBuffer, Value* 
 
 auto OMGIRGenerator::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex) -> PartialResult
 {
-    TRACE_CF("LOOP: entering loop index: ", loopIndex, " signature: ", *signature);
+    TRACE_CF("LOOP: entering loop index: ", loopIndex, " signature: ", *signature.m_signature);
     BasicBlock* body = m_proc.addBlock();
     BasicBlock* continuation = m_proc.addBlock();
 
     block = ControlData(m_proc, origin(), signature, BlockType::Loop, m_stackSize, continuation, body);
 
-    unsigned offset = enclosingStack.size() - signature->argumentCount();
-    for (unsigned i = 0; i < signature->argumentCount(); ++i) {
+    unsigned offset = enclosingStack.size() - signature.m_signature->argumentCount();
+    for (unsigned i = 0; i < signature.m_signature->argumentCount(); ++i) {
         TypedExpression value = enclosingStack.at(offset + i);
         Value* phi = block.phis[i];
         append<UpsilonValue>(m_proc, origin(), get(value), phi);
@@ -4426,13 +4426,13 @@ auto OMGIRGenerator::addLoop(BlockSignature signature, Stack& enclosingStack, Co
 
 OMGIRGenerator::ControlData OMGIRGenerator::addTopLevel(BlockSignature signature)
 {
-    TRACE_CF("TopLevel: ", *signature);
+    TRACE_CF("TopLevel: ", *signature.m_signature);
     return ControlData(m_proc, Origin(), signature, BlockType::TopLevel, m_stackSize, m_proc.addBlock());
 }
 
 auto OMGIRGenerator::addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack) -> PartialResult
 {
-    TRACE_CF("Block: ", *signature);
+    TRACE_CF("Block: ", *signature.m_signature);
     BasicBlock* continuation = m_proc.addBlock();
 
     splitStack(signature, enclosingStack, newStack);
@@ -4484,7 +4484,7 @@ auto OMGIRGenerator::addElse(ControlData& data, const Stack& currentStack) -> Pa
 auto OMGIRGenerator::addElseToUnreachable(ControlData& data) -> PartialResult
 {
     ASSERT(data.blockType() == BlockType::If);
-    m_stackSize = data.stackSize() + data.m_signature->argumentCount();
+    m_stackSize = data.stackSize() + data.signature().m_signature->argumentCount();
     m_currentBlock = data.special;
     data.convertIfToBlock();
     TRACE_CF("ELSE");
@@ -4990,7 +4990,7 @@ auto OMGIRGenerator::endBlock(ControlEntry& entry, Stack& expressionStack) -> Pa
 {
     ControlData& data = entry.controlData;
 
-    ASSERT(expressionStack.size() == data.signature()->returnCount());
+    ASSERT(expressionStack.size() == data.signature().m_signature->returnCount());
     if (data.blockType() != BlockType::Loop)
         unifyValuesWithBlock(expressionStack, data);
 
@@ -5020,19 +5020,20 @@ auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expre
         --m_tryCatchDepth;
     }
 
+    auto blockSignature = data.signature();
     if (data.blockType() != BlockType::Loop) {
-        for (unsigned i = 0; i < data.signature()->returnCount(); ++i) {
+        for (unsigned i = 0; i < blockSignature.m_signature->returnCount(); ++i) {
             Value* result = data.phis[i];
             m_currentBlock->append(result);
-            entry.enclosedExpressionStack.constructAndAppend(data.signature()->returnType(i), push(result));
+            entry.enclosedExpressionStack.constructAndAppend(blockSignature.m_signature->returnType(i), push(result));
         }
     } else {
-        for (unsigned i = 0; i < data.signature()->returnCount(); ++i) {
+        for (unsigned i = 0; i < blockSignature.m_signature->returnCount(); ++i) {
             if (i < expressionStack.size()) {
                 ++m_stackSize;
                 entry.enclosedExpressionStack.append(expressionStack[i]);
             } else {
-                Type returnType = data.signature()->returnType(i);
+                Type returnType = blockSignature.m_signature->returnType(i);
                 entry.enclosedExpressionStack.constructAndAppend(returnType, push(constant(toB3Type(returnType), 0xbbadbeef)));
             }
         }
@@ -5040,7 +5041,7 @@ auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expre
 
     if constexpr (WasmOMGIRGeneratorInternal::traceStackValues) {
         m_parser->expressionStack().swap(entry.enclosedExpressionStack);
-        TRACE_CF("END: ", *data.signature(), " block type ", (int) data.blockType());
+        TRACE_CF("END: ", *blockSignature.m_signature, " block type ", (int) data.blockType());
         m_parser->expressionStack().swap(entry.enclosedExpressionStack);
     }
 

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -312,7 +312,7 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
 
         Type type = { typeKind, TypeDefinition::invalidIndex };
         WASM_PARSER_FAIL_IF(!(isValueType(type) || type.isVoid()), "result type of block: "_s, makeString(type.kind), " is not a value type or Void"_s);
-        result = m_typeInformation.thunkFor(type);
+        result = { m_typeInformation.thunkFor(type), nullptr };
         m_offset++;
         return { };
     }
@@ -325,7 +325,7 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
     const auto& signature = info.typeSignatures[index].get().expand();
     WASM_PARSER_FAIL_IF(!signature.is<FunctionSignature>(), "Block-like instruction signature index does not refer to a function type definition"_s);
 
-    result = signature.as<FunctionSignature>();
+    result = { signature.as<FunctionSignature>(), nullptr };
     return { };
 }
 
@@ -334,8 +334,8 @@ inline typename ParserBase::PartialResult ParserBase::parseReftypeSignature(cons
     Type resultType;
     WASM_PARSER_FAIL_IF(!parseValueType(info, resultType), "result type of block is not a valid ref type"_s);
     Vector<Type, 16> returnTypes { resultType };
-    const auto& typeDefinition = TypeInformation::typeDefinitionForFunction(returnTypes, { }).get();
-    result = &TypeInformation::getFunctionSignature(typeDefinition->index());
+    auto typeDefinition = TypeInformation::typeDefinitionForFunction(returnTypes, { });
+    result = { &TypeInformation::getFunctionSignature(typeDefinition->index()), typeDefinition };
 
     return { };
 }


### PR DESCRIPTION
#### 57538110b768d4e03c1779de5b7fc9e1cc1a4425
<pre>
[JSC] Wasm GC BlockSignature should hold underlying TypeDefinition
<a href="https://bugs.webkit.org/show_bug.cgi?id=282363">https://bugs.webkit.org/show_bug.cgi?id=282363</a>
<a href="https://rdar.apple.com/138177632">rdar://138177632</a>

Reviewed by Justin Michaud.

Wasm GC BlockSignature is not holding adhocly created TypeDefinition as
RefPtr. That&apos;s completely wrong: not holding TypeDefinition is allowed
because it is generated in wasm types in the section, and held by
ModuleInformation. If it is adhocly generated, it must be retained.

This patch fixes it by changing BlockSignature to keep underlying TypeDefinition
via RefPtr.

* JSTests/wasm/stress/block-signature-create-adhoc-type-definition.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::ControlData::branchTargetArity const):
(JSC::Wasm::BBQJITImpl::ControlData::branchTargetType const):
(JSC::Wasm::BBQJITImpl::ControlData::argumentType const):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBlock):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoop):
(JSC::Wasm::BBQJITImpl::BBQJIT::addIf):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElse):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElseToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTry):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTryTable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReturn):
(JSC::Wasm::BBQJITImpl::BBQJIT::addEndToUnreachable):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addFusedIfCompare):
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::splitStack):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBlockSignatureAndNotifySIMDUseIfNeeded):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::binaryCompareCase):
(JSC::Wasm::FunctionParser&lt;Context&gt;::unaryCompareCase):
(JSC::Wasm::FunctionParser&lt;Context&gt;::checkBranchTarget):
(JSC::Wasm::FunctionParser&lt;Context&gt;::unify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseNestedBlocksEagerly):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntControlType::branchTargetType const):
(JSC::Wasm::IPIntControlType::branchTargetArity const):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::endTopLevel):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::ControlType::loop):
(JSC::Wasm::LLIntGenerator::ControlType::block):
(JSC::Wasm::LLIntGenerator::ControlType::if_):
(JSC::Wasm::LLIntGenerator::ControlType::createTry):
(JSC::Wasm::LLIntGenerator::ControlType::createTryTable):
(JSC::Wasm::LLIntGenerator::ControlType::branchTargetArity const):
(JSC::Wasm::LLIntGenerator::ControlType::branchTargetType const):
(JSC::Wasm::LLIntGenerator::addElseToUnreachable):
(JSC::Wasm::LLIntGenerator::addReturn):
(JSC::Wasm::LLIntGenerator::addEndToUnreachable):
(JSC::Wasm::LLIntGenerator::endTopLevel):
* Source/JavaScriptCore/wasm/WasmModuleInformation.cpp:
(JSC::Wasm::ModuleInformation::operator delete):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::create): Deleted.
(JSC::Wasm::ModuleInformation::functionIndexSpaceSize const): Deleted.
(JSC::Wasm::ModuleInformation::isImportedFunctionFromFunctionIndexSpace const): Deleted.
(JSC::Wasm::ModuleInformation::typeIndexFromFunctionIndexSpace const): Deleted.
(JSC::Wasm::ModuleInformation::exceptionIndexSpaceSize const): Deleted.
(JSC::Wasm::ModuleInformation::isImportedExceptionFromExceptionIndexSpace const): Deleted.
(JSC::Wasm::ModuleInformation::typeIndexFromExceptionIndexSpace const): Deleted.
(JSC::Wasm::ModuleInformation::importFunctionCount const): Deleted.
(JSC::Wasm::ModuleInformation::internalFunctionCount const): Deleted.
(JSC::Wasm::ModuleInformation::importExceptionCount const): Deleted.
(JSC::Wasm::ModuleInformation::internalExceptionCount const): Deleted.
(JSC::Wasm::ModuleInformation::toCodeIndex const): Deleted.
(JSC::Wasm::ModuleInformation::toSpaceIndex const): Deleted.
(JSC::Wasm::ModuleInformation::memoryCount const): Deleted.
(JSC::Wasm::ModuleInformation::tableCount const): Deleted.
(JSC::Wasm::ModuleInformation::elementCount const): Deleted.
(JSC::Wasm::ModuleInformation::globalCount const): Deleted.
(JSC::Wasm::ModuleInformation::dataSegmentsCount const): Deleted.
(JSC::Wasm::ModuleInformation::table const): Deleted.
(JSC::Wasm::ModuleInformation::global const): Deleted.
(JSC::Wasm::ModuleInformation::initializeFunctionTrackers const): Deleted.
(JSC::Wasm::ModuleInformation::referencedFunctions const): Deleted.
(JSC::Wasm::ModuleInformation::hasReferencedFunction const): Deleted.
(JSC::Wasm::ModuleInformation::addReferencedFunction const): Deleted.
(JSC::Wasm::ModuleInformation::isDeclaredFunction const): Deleted.
(JSC::Wasm::ModuleInformation::addDeclaredFunction): Deleted.
(JSC::Wasm::ModuleInformation::isDeclaredException const): Deleted.
(JSC::Wasm::ModuleInformation::addDeclaredException): Deleted.
(JSC::Wasm::ModuleInformation::functionWasmSizeImportSpace const): Deleted.
(JSC::Wasm::ModuleInformation::functionWasmSize const): Deleted.
(JSC::Wasm::ModuleInformation::usesSIMDImportSpace const): Deleted.
(JSC::Wasm::ModuleInformation::usesSIMD const): Deleted.
(JSC::Wasm::ModuleInformation::markUsesSIMD): Deleted.
(JSC::Wasm::ModuleInformation::usesExceptions const): Deleted.
(JSC::Wasm::ModuleInformation::markUsesExceptions): Deleted.
(JSC::Wasm::ModuleInformation::usesAtomics const): Deleted.
(JSC::Wasm::ModuleInformation::markUsesAtomics): Deleted.
(JSC::Wasm::ModuleInformation::doneSeeingFunction): Deleted.
(JSC::Wasm::ModuleInformation::typeCount const): Deleted.
(JSC::Wasm::ModuleInformation::hasMemoryImport const): Deleted.
(JSC::Wasm::ModuleInformation::getBranchHint const): Deleted.
(JSC::Wasm::ModuleInformation::clobberingTailCalls const): Deleted.
(JSC::Wasm::ModuleInformation::callCanClobberInstance const): Deleted.
(JSC::Wasm::ModuleInformation::addClobberingTailCall): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::ControlData::ControlData):
(JSC::Wasm::OMGIRGenerator::ControlData::hasNonVoidresult const):
(JSC::Wasm::OMGIRGenerator::ControlData::branchTargetArity const):
(JSC::Wasm::OMGIRGenerator::ControlData::branchTargetType const):
(JSC::Wasm::OMGIRGenerator::addLoop):
(JSC::Wasm::OMGIRGenerator::addTopLevel):
(JSC::Wasm::OMGIRGenerator::addBlock):
(JSC::Wasm::OMGIRGenerator::addElseToUnreachable):
(JSC::Wasm::OMGIRGenerator::addEndToUnreachable):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::parseBlockSignature):
(JSC::Wasm::ParserBase::parseReftypeSignature):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::destroy):

Canonical link: <a href="https://commits.webkit.org/285969@main">https://commits.webkit.org/285969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88d5d6392768742cb7e682385da2f25099d32774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23908 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67474 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80234 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73595 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66002 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8096 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95376 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1618 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20946 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1647 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->