### PR TITLE
Improve matching webarchive file extension when loading in ephemeral datastore

### DIFF
--- a/LayoutTests/compositing/tiling/crash-when-unapplying-mask-border-expected.txt
+++ b/LayoutTests/compositing/tiling/crash-when-unapplying-mask-border-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/compositing/tiling/crash-when-unapplying-mask-border.html
+++ b/LayoutTests/compositing/tiling/crash-when-unapplying-mask-border.html
@@ -1,0 +1,43 @@
+<html>
+
+<script src="../../resources/ui-helper.js"></script>
+
+<style>
+  :root {
+    mask-border-source: repeating-radial-gradient(closest-side at 9px, blue 0% 68%);
+  }
+
+  *:read-write {
+    column-width: 0;
+    margin-bottom: 1000em;
+    backdrop-filter: opacity(0%);
+  }
+</style>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+  }
+
+  function main() {
+    document.designMode = "on";
+
+    setTimeout(async () => {
+      document.styleSheets[0].deleteRule(0);
+
+      await UIHelper.renderingUpdate();
+
+      if (window.testRunner)
+        testRunner.notifyDone()
+    });
+  }
+</script>
+
+<body onload="main()">
+  <video hidden controls>
+  </video>
+  <pre contenteditable>This test passes if it does not crash</pre>
+</body>
+
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed-expected.txt
@@ -1,0 +1,1 @@
+Test Page. Some Text.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="connect-src https://127.0.0.1:8443 https://localhost:8443">
+<script>
+if (window.testRunner) {
+    window.testRunner.waitUntilDone();
+    window.testRunner.dumpAsText();
+}
+function runTest() {
+    document.getElementById('an').click();
+}
+</script>
+</head>
+<body onload="runTest()">
+<a id="an" href="https://localhost:8443/security/contentSecurityPolicy/resources/sample.html" ping="https://localhost:8443">Click It</a>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Refused to connect to https://localhost:8443/ because it does not appear in the connect-src directive of the Content Security Policy.
+Test Page. Some Text.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="connect-src https://127.0.0.1:8443">
+<script>
+if (window.testRunner) {
+    window.testRunner.waitUntilDone();
+    window.testRunner.dumpAsText();
+}
+function runTest() {
+    document.getElementById('an').click();
+}
+</script>
+</head>
+<body onload="runTest()">
+<a id="an" href="https://localhost:8443/security/contentSecurityPolicy/resources/sample.html" ping="https://localhost:8443">Click It</a>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sample.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sample.html
@@ -1,0 +1,12 @@
+<html>
+    Test Page.
+<script>
+    function finishTest(){
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+<body onload="finishTest()">
+<a>Some Text.</a>
+</body>
+</html>

--- a/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer-expected.txt
+++ b/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer-expected.txt
@@ -1,0 +1,2 @@
+ALERT: PASS
+

--- a/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
+++ b/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<body>
+    <script>
+
+    const WORKER_CODE = `
+        self.onmessage = e => {
+            const arrayBuffer = e.data;
+            const uint8Array = new Uint8Array(arrayBuffer);
+
+            uint8Array[0] = 1;
+
+            while (uint8Array[0] === 1) {
+
+            }
+
+            arrayBuffer.grow(5);
+        };
+    `;
+
+    async function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async function main() {
+        const w = new Worker(URL.createObjectURL(new Blob([WORKER_CODE])));
+
+        const arrayBuffer = new SharedArrayBuffer(1, {
+            maxByteLength: 5
+        });
+
+        const uint8Array = new Uint8Array(arrayBuffer);
+        w.postMessage(arrayBuffer);
+
+        while (uint8Array[0] === 0) {
+            await sleep(0);
+        }
+
+        const array = [new ArrayBuffer(0x1000_0000), new ArrayBuffer(0x400_0000 - 19)];
+        array.__defineGetter__(2, () => {
+            uint8Array[0] = 2;
+
+            return arrayBuffer;
+        });
+
+        array[37] = new Uint8Array([
+            0x00, 0x00,
+
+            0x37, 0x13, 0x00, 0x00,  // 0x1337,
+            0x10,  // StringTag
+            0x05, 0x00, 0x00, 0x80,  // length
+            0x68, 0x65, 0x6c, 0x6c, 0x6f,  // hello
+
+            0xff, 0xff, 0xff, 0xff,  // TerminatorTag
+        ]);
+
+        const result = structuredClone(array)[0x1337];
+        alert(result === undefined ? 'PASS' : 'FAIL');
+    }
+
+    globalThis.testRunner?.waitUntilDone();
+    globalThis.testRunner?.dumpAsText();
+
+    main().catch(e => {
+        console.log(e);
+    }).finally(async () => {
+        globalThis.testRunner?.notifyDone();
+    });
+
+    </script>
+</body>

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_ratectrl.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_ratectrl.c
@@ -2182,11 +2182,9 @@ int vp9_calc_iframe_target_size_one_pass_cbr(const VP9_COMP *cpi) {
   const RATE_CONTROL *rc = &cpi->rc;
   const VP9EncoderConfig *oxcf = &cpi->oxcf;
   const SVC *const svc = &cpi->svc;
-  int target;
+  int64_t target;
   if (cpi->common.current_video_frame == 0) {
-    target = ((rc->starting_buffer_level / 2) > INT_MAX)
-                 ? INT_MAX
-                 : (int)(rc->starting_buffer_level / 2);
+    target = rc->starting_buffer_level / 2;
   } else {
     int kf_boost = 32;
     double framerate = cpi->framerate;
@@ -2204,7 +2202,8 @@ int vp9_calc_iframe_target_size_one_pass_cbr(const VP9_COMP *cpi) {
     }
     target = (int)(((int64_t)(16 + kf_boost) * rc->avg_frame_bandwidth) >> 4);
   }
-  return vp9_rc_clamp_iframe_target_size(cpi, target);
+  target = VPXMIN(INT_MAX, target);
+  return vp9_rc_clamp_iframe_target_size(cpi, (int)target);
 }
 
 static void set_intra_only_frame(VP9_COMP *cpi) {

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1948,11 +1948,7 @@ private:
                 if (arrayBuffer->isResizableOrGrowableShared()) {
                     appendObjectPoolTag(ResizableArrayBufferTag);
                     write(ResizableArrayBufferTag);
-                    uint64_t byteLength = arrayBuffer->byteLength();
-                    write(byteLength);
-                    uint64_t maxByteLength = arrayBuffer->maxByteLength().value_or(0);
-                    write(maxByteLength);
-                    write(arrayBuffer->span());
+                    writeResizableArrayBuffer(arrayBuffer->span(), arrayBuffer->maxByteLength().value_or(0));
                     return true;
                 }
 
@@ -2629,6 +2625,13 @@ private:
     void write(std::span<const uint8_t> data)
     {
         m_buffer.append(data);
+    }
+
+    void writeResizableArrayBuffer(std::span<const uint8_t> data, size_t maxByteLength)
+    {
+        write(static_cast<uint64_t>(data.size()));
+        write(static_cast<uint64_t>(maxByteLength));
+        write(data);
     }
 
     Vector<uint8_t>& m_buffer;

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -134,6 +134,8 @@ void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& dest
 #endif
 
     Ref document = *frame.document();
+    if (!document->checkedContentSecurityPolicy()->allowConnectToSource(pingURL))
+        return;
     document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
 
     request.setHTTPMethod("POST"_s);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4636,6 +4636,8 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
 
     if (wasTiledLayer || isTiledLayer)
         client().tiledBackingUsageChanged(this, isTiledLayer);
+
+    oldLayer->setOwner(nullptr);
 }
 
 void GraphicsLayerCA::setupContentsLayer(PlatformCALayer* contentsLayer, CompositingCoordinatesOrientation orientation)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4674,7 +4674,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     if (preferences().loadWebArchiveWithEphemeralStorageEnabled() && navigation && policyAction == PolicyAction::Use && navigationAction->navigationType() != NavigationType::Reload && !isPolicyDataStore) {
         bool isSubstituteWebArchive = navigation->substituteData() && MIMETypeRegistry::isWebArchiveMIMEType(navigation->substituteData()->MIMEType);
         auto webarchiveURL = isSubstituteWebArchive ? URL { navigation->substituteData()->baseURL } : navigation->currentRequest().url();
-        if (isSubstituteWebArchive || (webarchiveURL.protocolIsFile() && webarchiveURL.string().endsWith(".webarchive"_s))) {
+        if (isSubstituteWebArchive || (webarchiveURL.protocolIsFile() && webarchiveURL.fileSystemPath().endsWith(".webarchive"_s))) {
             WEBPAGEPROXY_RELEASE_LOG(Loading, "receivedNavigationActionPolicyDecision: Swapping in non-persistent websiteDataStore for web archive.");
             if (navigation->targetItem() && navigation->targetItem()->dataStoreForWebArchive())
                 websiteDataStore = *navigation->targetItem()->dataStoreForWebArchive();


### PR DESCRIPTION
#### 11494e67729152123b351f836d98b94eb6f8bd65
<pre>
Improve matching webarchive file extension when loading in ephemeral datastore
<a href="https://bugs.webkit.org/show_bug.cgi?id=279226">https://bugs.webkit.org/show_bug.cgi?id=279226</a>
<a href="https://rdar.apple.com/135302982">rdar://135302982</a>

Reviewed by Darin Adler.

This change ensures we only look at the file path instead of the entire URL
string.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):

Originally-landed-as: 280938.309@safari-7619-branch (61f89b532694). <a href="https://rdar.apple.com/138934659">rdar://138934659</a>
Canonical link: <a href="https://commits.webkit.org/285963@main">https://commits.webkit.org/285963@main</a>
</pre>
----------------------------------------------------------------------
#### 4729b99658a7b2befac1a317971bee4d0bc16066
<pre>
Honor the connect-src value for &lt;a ping=&quot;&quot;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=278765">https://bugs.webkit.org/show_bug.cgi?id=278765</a>
<a href="https://rdar.apple.com/131054895">rdar://131054895</a>

Reviewed by Chris Dumez.

At the moment, even though connect-src is set to one origin, cross origin pings
originating from the ping attribute of HTMLAnchorElement are not blocked. They should be.
This adds that check using CSP and adds a +/- tests to validate the same.

* LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-allowed.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/connect-src-ping-blocked.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/sample.html: Added.
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendPing):

Originally-landed-as: 280938.286@safari-7619-branch (03fe2d2f0fa8). <a href="https://rdar.apple.com/138934062">rdar://138934062</a>
Canonical link: <a href="https://commits.webkit.org/285962@main">https://commits.webkit.org/285962@main</a>
</pre>
----------------------------------------------------------------------
#### 8b4839b1659b79ac1713978a9a94b24340a64935
<pre>
GraphicsLayerCA: when changing layer type, disown the old layer after copying to new layer
<a href="https://rdar.apple.com/132717696">rdar://132717696</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278567">https://bugs.webkit.org/show_bug.cgi?id=278567</a>

Reviewed by Simon Fraser.

In GraphicsLayerCA::changeLayerTypeTo, after copying from the current (old)
layer to the new layer, we neglect to set the owner of the old layer to nullptr.
Even if the owner (a GraphicsLayerCA) later gets destroyed, the old layer still keeps a
reference to the dead owner, and accessing the owner leads to a use-after-free.
Fix this by setting the owner of the old layer to nullptr, once we&apos;ve done using it.

* LayoutTests/compositing/tiling/crash-when-unapplying-mask-border-expected.txt: Added.
* LayoutTests/compositing/tiling/crash-when-unapplying-mask-border.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::changeLayerTypeTo):

Originally-landed-as: 280938.281@safari-7619-branch (294250ca449f). <a href="https://rdar.apple.com/138933594">rdar://138933594</a>
Canonical link: <a href="https://commits.webkit.org/285961@main">https://commits.webkit.org/285961@main</a>
</pre>
----------------------------------------------------------------------
#### aaa488b390797c343e905ba494ba8a7592e96b3e
<pre>
Cherry-pick libvpx 634e1f8fb196f0e04c0dceae7043e8a12a0d31f9
<a href="https://rdar.apple.com/133438454">rdar://133438454</a>

Reviewed by Brent Fulgham.

We cherry-pick this overflow change after resolving a small conflict.

* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_ratectrl.c:
(vp9_calc_iframe_target_size_one_pass_cbr):

Originally-landed-as: 280938.279@safari-7619-branch (e52aabe54a9b). <a href="https://rdar.apple.com/138933397">rdar://138933397</a>
Canonical link: <a href="https://commits.webkit.org/285960@main">https://commits.webkit.org/285960@main</a>
</pre>
----------------------------------------------------------------------
#### cfe38930db92bdf1fecc71b3c014c861bf4033df
<pre>
Race condition in CloneSerializer::dumpIfTerminal allows for injecting arbitrary deserialization data
<a href="https://bugs.webkit.org/show_bug.cgi?id=278657">https://bugs.webkit.org/show_bug.cgi?id=278657</a>
<a href="https://rdar.apple.com/132388209">rdar://132388209</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Fix the exploit by using consistent byteLength fetched from the array buffer.

This is part 1 of security fix. In part 2, we&apos;ll introduce a new write method for std::span and consistently use that in all cases of std::span&lt;const uint8_t&gt;. This requires for changing the byte format and need more code.

* LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer-expected.txt: Added.
* LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html: Added.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneSerializer::writeResizableArrayBuffer):

Originally-landed-as: 280938.277@safari-7619-branch (22e102ecb215). <a href="https://rdar.apple.com/138933194">rdar://138933194</a>
Canonical link: <a href="https://commits.webkit.org/285959@main">https://commits.webkit.org/285959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/228ab447a7c34d3b62b7f799ae1484f2e8dc0771

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1454 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58353 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23811 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67377 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80134 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73498 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66653 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65929 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8033 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4309 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->