### PR TITLE
Prevent pathological case when tiling coverage rect

### DIFF
--- a/LayoutTests/media/modern-media-controls/css/transformed-media-crash-expected.txt
+++ b/LayoutTests/media/modern-media-controls/css/transformed-media-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/media/modern-media-controls/css/transformed-media-crash.html
+++ b/LayoutTests/media/modern-media-controls/css/transformed-media-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script>
+  if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+  }
+  function notifyDone() {
+      requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+              if (window.testRunner) {
+                  testRunner.notifyDone();
+              }
+          });
+      });
+  }
+</script>
+<p>PASS if no crash.</p>
+<video style="height: 10px; width: 10px;
+              transform: matrix(1, 0, 986610, 1, 0, 0);"
+       onerror="notifyDone()" controls src="about:blank"></video>

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -596,7 +596,16 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& 
             TileIndex tileIndex(x, y);
 
             IntRect tileRect = rectForTileIndex(tileIndex);
-            TileInfo& tileInfo = m_tiles.add(tileIndex, TileInfo()).iterator->value;
+
+            UncheckedKeyHashMap<TileIndex, TileInfo>::iterator it;
+            constexpr size_t kMaxTileCountPerGrid = 8 * 1024;
+            if (UNLIKELY(m_tiles.size() >= kMaxTileCountPerGrid)) {
+                it = m_tiles.find(tileIndex);
+                if (it == m_tiles.end())
+                    continue;
+            } else
+                it = m_tiles.add(tileIndex, TileInfo()).iterator;
+            TileInfo& tileInfo = it->value;
 
             coverageRect.unite(tileRect);
 


### PR DESCRIPTION
#### ad4b5f5f026eddfd5b976d41171a35c0e28c55fd
<pre>
Prevent pathological case when tiling coverage rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=273698">https://bugs.webkit.org/show_bug.cgi?id=273698</a>
<a href="https://rdar.apple.com/127498217">rdar://127498217</a>

Reviewed by Simon Fraser.

GraphicsLayerCA::computeVisibleAndCoverageRect() calculates coverage
rect by taking the bounding box of a planar quad with inverse
accumulated transforms applied. For some transforms (e.g. skewing along
an axis by a close-to-90° angle) this bounding box can become very large
while at the same time the dimension of tiles returned by
TileController::computeTileSize() is upper-bounded by some constant.
As a consequence, TileGrid::ensureTilesForRect() can generate a very
large number of tiled-backing-tile layers. Committing these layer
creations/changes can lead to sending a message that exceeds the
limit of the low-level IPC library (cf MACH_SEND_TOO_LARGE error code).
To work around that, we impose a limit over the number of tiles.

* LayoutTests/media/modern-media-controls/css/transformed-media-crash-expected.txt: Added.
* LayoutTests/media/modern-media-controls/css/transformed-media-crash.html: Added.
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::ensureTilesForRect): Introduce a maximum number of tiles.

Originally-landed-as: 280938.3@webkit-2024.7-embargoed (4505ee60c56b). <a href="https://rdar.apple.com/138937272">rdar://138937272</a>
Canonical link: <a href="https://commits.webkit.org/286291@main">https://commits.webkit.org/286291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b4a8533211dd6ffc6f00690a65bbf60e89855eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75335 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77452 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2567 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59129 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17351 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78402 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39491 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24927 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1682 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67377 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden.html media/modern-media-controls/css/transformed-media-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66654 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8770 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11655 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5453 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->