### PR TITLE
Use-after-free in FormDataConsumer::consume

### DIFF
--- a/LayoutTests/fetch/fetch-empty-blob-crash-expected.txt
+++ b/LayoutTests/fetch/fetch-empty-blob-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Consuming form data with empty blob
+

--- a/LayoutTests/fetch/fetch-empty-blob-crash.html
+++ b/LayoutTests/fetch/fetch-empty-blob-crash.html
@@ -1,0 +1,65 @@
+<html>
+<head>
+<title>Consuming form data with empty blob</title>
+</head>
+<body>
+<script src="../resources/gc.js"></script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script>
+function sleep(ms)
+{
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function createClonedBlobWithIndexedDB()
+{
+    return new Promise(resolve => {
+        const request = indexedDB.open('db' + Math.random(), 1);
+
+        request.onupgradeneeded = e => {
+            const db = e.target.result;
+
+            db.createObjectStore('storage', {keyPath: 'id'});
+        };
+
+        request.onsuccess = e => {
+            const db = e.target.result;
+            const transaction = db.transaction(['storage'], 'readwrite');
+            const objectStore = transaction.objectStore('storage');
+
+            const storeRequest = objectStore.put({
+                id: 1,
+                data: new Blob(['aa'])
+            });
+
+            storeRequest.onsuccess = () => {
+                objectStore.get(1).onsuccess = e => {
+                    gc();
+
+                    resolve(e.target.result.data);
+                };
+            };
+        };
+    });
+}
+
+promise_test(async () => {
+    const blob = await createClonedBlobWithIndexedDB();
+    await sleep(100);
+
+    const formData = new FormData();
+    formData.append('a', blob);
+
+    let response = new Response(formData);
+    Object.prototype.__defineGetter__('then', () => {
+        response = null;
+
+        gc();
+    });
+
+    response.arrayBuffer();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -124,14 +124,16 @@ void FormDataConsumer::consume(std::span<const uint8_t> content)
     if (!m_callback)
         return;
 
-    bool result = m_callback(WTFMove(content));
-    if (!result) {
-        cancel();
-        return;
-    }
+    if (!content.empty()) {
+        bool result = m_callback(WTFMove(content));
+        if (!result) {
+            cancel();
+            return;
+        }
 
-    if (!m_callback)
-        return;
+        if (!m_callback)
+            return;
+    }
 
     read();
 }


### PR DESCRIPTION
#### 8f96cc81ef906ace167b247fe77a20461e9dc1f4
<pre>
Use-after-free in FormDataConsumer::consume
<a href="https://rdar.apple.com/134411748">rdar://134411748</a>

Reviewed by Chris Dumez.

FormDataConsumer is notifying of end of load with an empty span.
Form datas can be using blobs as element, the blobs having zero data.
In this case, FormDataConsumer will send an empty span for the zero data and then an empty span for the end of load.
This confuses FetchBodyConsumer which then triggers a UAF.

To prevent this, we update FormDataConsumer to execute the callback when receiving data only if data is not empty.
An empty span is solely used to convey the end of the load.

* LayoutTests/fetch/fetch-empty-blob-crash-expected.txt: Added.
* LayoutTests/fetch/fetch-empty-blob-crash.html: Added.
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::consume):

Originally-landed-as: 280938.254@safari-7619-branch (76167250cbca). <a href="https://rdar.apple.com/138929706">rdar://138929706</a>
Canonical link: <a href="https://commits.webkit.org/285945@main">https://commits.webkit.org/285945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003e309c77d6455265871f8bbd183b1ea8d3bd56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16701 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21360 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23821 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65940 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9877 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8028 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1531 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->