### PR TITLE
Ensure SQLiteStorageArea does not use SQLiteStatement after it's been freed

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteStatement.h
+++ b/Source/WebCore/platform/sql/SQLiteStatement.h
@@ -35,9 +35,10 @@ struct sqlite3_stmt;
 
 namespace WebCore {
 
-class SQLiteStatement {
+class SQLiteStatement : public CanMakeThreadSafeCheckedPtr<SQLiteStatement> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SQLiteStatement, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(SQLiteStatement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteStatement);
 public:
     WEBCORE_EXPORT ~SQLiteStatement();
     WEBCORE_EXPORT SQLiteStatement(SQLiteStatement&&);

--- a/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp
@@ -39,17 +39,8 @@ SQLiteStatementAutoResetScope::SQLiteStatementAutoResetScope(SQLiteStatement *st
 {
 }
 
-SQLiteStatementAutoResetScope::SQLiteStatementAutoResetScope(SQLiteStatementAutoResetScope&& other)
-    : m_statement(other.m_statement)
-{
-    other.m_statement = nullptr;
-}
-
-SQLiteStatementAutoResetScope& SQLiteStatementAutoResetScope::operator=(SQLiteStatementAutoResetScope&& other)
-{
-    std::swap(m_statement, other.m_statement);
-    return *this;
-}
+SQLiteStatementAutoResetScope::SQLiteStatementAutoResetScope(SQLiteStatementAutoResetScope&&) = default;
+SQLiteStatementAutoResetScope& SQLiteStatementAutoResetScope::operator=(SQLiteStatementAutoResetScope&&) = default;
 
 SQLiteStatementAutoResetScope::~SQLiteStatementAutoResetScope()
 {

--- a/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
+++ b/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -36,18 +37,18 @@ class SQLiteStatementAutoResetScope {
     WTF_MAKE_NONCOPYABLE(SQLiteStatementAutoResetScope);
 public:
     WEBCORE_EXPORT explicit SQLiteStatementAutoResetScope(SQLiteStatement* = nullptr);
-    WEBCORE_EXPORT SQLiteStatementAutoResetScope(SQLiteStatementAutoResetScope&& other);
-    WEBCORE_EXPORT SQLiteStatementAutoResetScope& operator=(SQLiteStatementAutoResetScope&& other);
+    WEBCORE_EXPORT SQLiteStatementAutoResetScope(SQLiteStatementAutoResetScope&&);
+    WEBCORE_EXPORT SQLiteStatementAutoResetScope& operator=(SQLiteStatementAutoResetScope&&);
     WEBCORE_EXPORT ~SQLiteStatementAutoResetScope();
 
-    explicit operator bool() const { return m_statement; }
+    explicit operator bool() const { return !!m_statement; }
     bool operator!() const { return !m_statement; }
 
-    SQLiteStatement* get() { return m_statement; }
-    SQLiteStatement* operator->() { return m_statement; }
+    SQLiteStatement* get() { return m_statement.get(); }
+    SQLiteStatement* operator->() { return m_statement.get(); }
 
 private:
-    SQLiteStatement* m_statement;
+    CheckedPtr<SQLiteStatement> m_statement;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9cfacd819f89639031bcef018ee6955f0824a95f
<pre>
Ensure SQLiteStorageArea does not use SQLiteStatement after it&apos;s been freed
<a href="https://bugs.webkit.org/show_bug.cgi?id=278538">https://bugs.webkit.org/show_bug.cgi?id=278538</a>
<a href="https://rdar.apple.com/127866416">rdar://127866416</a>

Reviewed by Chris Dumez, Geoffrey Garen, and Sihui Liu.

SQLiteStorageArea::getItemFromDatabase() holds a SQLiteStatementAutoResetScope
statement variable. This goes out of scope at the end of getItemFromDatabase()
and so it&apos;s destructor is called. There is a crash occurring here. It turns out
that SQLiteStatementAutoResetScope holds a raw pointer to a SQLiteStatement.
A series of function calls: getItemFromDatabase() -&gt; handleDatabaseErrorIfNeeded()
-&gt; close() results in this SQLiteStatement object being destroyed
(SQLiteStorageArea holds a unique pointer to this SQLiteStatement object which is
destroyed in close()). After this destruction, the SQLiteStatementAutoResetScope
statement variable goes out of scope and it&apos;s destructor attempts to access the
raw pointer to the now-destroyed SQLiteStatement object. This use-after-free
causes the crash.

We fix this problem by using a block-scope to ensure the SQLiteStatementAutoResetScope
statement variable is destroyed before handleDatabaseErrorIfNeeded() is called. Although
the crash was only in getItemFromDatabase(), there are other functions in SQLiteStorageArea
that follow this same pattern and could potentially have a use-after-free. We make this
block-scope change there as well. Additionally, we change the SQLiteStatement raw pointer
in SQLiteStatementAutoResetScope to a CheckedPtr.

We use a block-scope rather than declare a new function SQLiteStatementAutoResetScope that
could call reset on the SQLiteStatement object because we want the object to live and be
reset in sync with the scope&apos;s lifetime.

* Source/WebCore/platform/sql/SQLiteStatement.h:
* Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.cpp:
(WebCore::SQLiteStatementAutoResetScope::operator=): Deleted.
* Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h:
(WebCore::SQLiteStatementAutoResetScope::operator bool const):
(WebCore::SQLiteStatementAutoResetScope::get):
(WebCore::SQLiteStatementAutoResetScope::operator-&gt;):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::getItemFromDatabase):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):

Originally-landed-as: 280938.269@safari-7619-branch (d76a8be1ba40). <a href="https://rdar.apple.com/138875969">rdar://138875969</a>
Canonical link: <a href="https://commits.webkit.org/285939@main">https://commits.webkit.org/285939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/577f46533a98e51898719d45f53d385b65c5150c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58364 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16704 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80146 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65935 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8030 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1533 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->