### PR TITLE
delayedRenderingUpdateDetectionTimer should hold a weak pointer to the current RemoteLayerTreeEventDispatcher

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -484,7 +484,11 @@ void RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTime
     ASSERT(ScrollingThread::isCurrentThread());
 
     if (!m_delayedRenderingUpdateDetectionTimer)
-        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired);
+        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }] {
+            auto strongThis = weakThis.get();
+            if (strongThis)
+                strongThis->delayedRenderingUpdateDetectionTimerFired();
+        });
 
     m_delayedRenderingUpdateDetectionTimer->startOneShot(delay);
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -39,7 +39,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WebCore {
@@ -65,7 +65,9 @@ class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 
 // This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
-class RemoteLayerTreeEventDispatcher : public ThreadSafeRefCounted<RemoteLayerTreeEventDispatcher>, public MomentumEventDispatcher::Client {
+class RemoteLayerTreeEventDispatcher
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteLayerTreeEventDispatcher>
+    , public MomentumEventDispatcher::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeEventDispatcher);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeEventDispatcher);
     friend class RemoteLayerTreeEventDispatcherDisplayLinkClient;


### PR DESCRIPTION
#### a753a1d21c3368a763b9e9a50dca5e7d93f72f59
<pre>
delayedRenderingUpdateDetectionTimer should hold a weak pointer to the current RemoteLayerTreeEventDispatcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=278943">https://bugs.webkit.org/show_bug.cgi?id=278943</a>
<a href="https://rdar.apple.com/133813795">rdar://133813795</a>

Reviewed by Simon Fraser.

m_delayedRenderingUpdateDetectionTimer invokes
RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired
on the current RemoteLayerTreeEventDispatcher object (`this`) when fired. However,
a race condition between when the timer is fired and when `this` is destroyed
can lead to a use-after-free:

1. RemoteLayerTreeEventDispatcherDisplayLinkClient::displayLinkFired is called
on the display link callback thread.
2. Previous method dispatch calls to RemoteLayerTreeEventDispatcher::didRefreshDisplay
in the scrolling thread. Once in the scrolling thread, it calls
RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTimer,
which schedules a one-shot timer to call
RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired
within the context of `this`. The timer runs on the same thread as the
thread where it&apos;s scheduled - that is, the scrolling thread.
3. The timer is fired and RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired
is called in the scrolling thread.
4. Just after the timer is fired and before the method accesses `this`, `this` is
destroyed in another thread.
5. In the scrolling thread, RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired
executes without knowing `this` is destroyed. Eventually it accesses one of its
member and causes a UAF.

Fix this by making the timer function hold a weak pointer to `this`.
When fired, it checks if the weak pointer is still valid before using it.

Due to the race condition nature, the original fuzzer test case is flaky,
hence no tests.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTimer):
Make the timer function hold a weak pointer to `this`.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:

Originally-landed-as: 280938.303@safari-7619-branch (c54b231c174f). <a href="https://rdar.apple.com/138934262">rdar://138934262</a>
Canonical link: <a href="https://commits.webkit.org/285942@main">https://commits.webkit.org/285942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1df38ec747c0e315d0df58656b7ced44cdf4f3f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16702 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45468 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23825 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65936 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8036 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1535 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->