### PR TITLE
[WebAudio] Potential out of bounds read in copyDataFromBusesToJSArray()

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -54,6 +54,15 @@ static unsigned busChannelCount(const AudioBus& bus)
     return bus.numberOfChannels();
 }
 
+template<typename ArrayType>
+static ArrayType* getArrayAtIndex(JSArray& jsArray, JSGlobalObject& globalObject, unsigned index)
+{
+    // We call getDirectIndex() instead of getIndex() since we only want to consider the values
+    // we populated the array with, not the ones the worklet might have set on the Array prototype.
+    auto item = jsArray.getDirectIndex(&globalObject, index);
+    return item ? jsDynamicCast<ArrayType*>(item) : nullptr;
+}
+
 static unsigned busChannelCount(const AudioBus* bus)
 {
     return bus ? busChannelCount(*bus) : 0;
@@ -122,20 +131,20 @@ static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, con
     return array;
 }
 
-static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, const JSArray& jsArray, Vector<Ref<AudioBus>>& buses)
+static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, JSArray& jsArray, Vector<Ref<AudioBus>>& buses)
 {
     // We can safely make assumptions about the structure of the JSArray since we use frozen arrays.
     for (unsigned i = 0; i < buses.size(); ++i) {
         auto& bus = buses[i];
-        auto* channelsArray = jsDynamicCast<JSArray*>(jsArray.getIndex(&globalObject, i));
+        auto* channelsArray = getArrayAtIndex<JSArray>(jsArray, globalObject, i);
         if (UNLIKELY(!channelsArray)) {
             bus->zero();
             continue;
         }
         for (unsigned j = 0; j < bus->numberOfChannels(); ++j) {
             auto* channel = bus->channel(j);
-            auto* jsChannelData = jsDynamicCast<JSFloat32Array*>(channelsArray->getIndex(&globalObject, j));
-            if (LIKELY(jsChannelData && jsChannelData->length() == channel->length()))
+            auto* jsChannelData = getArrayAtIndex<JSFloat32Array>(*channelsArray, globalObject, j);
+            if (LIKELY(jsChannelData && !jsChannelData->isShared() && jsChannelData->length() == channel->length()))
                 memcpy(channel->mutableData(), jsChannelData->typedVector(), sizeof(float) * channel->length());
             else
                 channel->zero();
@@ -150,14 +159,14 @@ static bool copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vecto
 
     for (size_t busIndex = 0; busIndex < buses.size(); ++busIndex) {
         auto& bus = buses[busIndex];
-        auto* jsChannelsArray = jsDynamicCast<JSArray*>(jsArray->getIndex(&globalObject, busIndex));
+        auto* jsChannelsArray = getArrayAtIndex<JSArray>(*jsArray, globalObject, busIndex);
         unsigned numberOfChannels = busChannelCount(bus.get());
         if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
             return false;
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
             auto* channel = bus->channel(channelIndex);
-            auto* jsChannelArray = jsDynamicCast<JSFloat32Array*>(jsChannelsArray->getIndex(&globalObject, channelIndex));
-            if (!jsChannelArray || jsChannelArray->length() != channel->length())
+            auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
+            if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
             memcpy(jsChannelArray->typedVector(), channel->mutableData(), sizeof(float) * jsChannelArray->length());
         }
@@ -189,14 +198,14 @@ static bool zeroJSArray(JSGlobalObject& globalObject, const Vector<Ref<AudioBus>
 
     for (size_t busIndex = 0; busIndex < outputs.size(); ++busIndex) {
         auto& bus = outputs[busIndex];
-        auto* jsChannelsArray = jsDynamicCast<JSArray*>(jsArray->getIndex(&globalObject, busIndex));
+        auto* jsChannelsArray = getArrayAtIndex<JSArray>(*jsArray, globalObject, busIndex);
         unsigned numberOfChannels = busChannelCount(bus.get());
         if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
             return false;
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
             auto* channel = bus->channel(channelIndex);
-            auto* jsChannelArray = jsDynamicCast<JSFloat32Array*>(jsChannelsArray->getIndex(&globalObject, channelIndex));
-            if (!jsChannelArray || jsChannelArray->length() != channel->length())
+            auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
+            if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
             memset(jsChannelArray->typedVector(), 0, sizeof(float) * jsChannelArray->length());
         }


### PR DESCRIPTION
#### a790f14404a5bedb5411f2cd4847b35d642ccf5c
<pre>
[WebAudio] Potential out of bounds read in copyDataFromBusesToJSArray()
<a href="https://bugs.webkit.org/show_bug.cgi?id=277639">https://bugs.webkit.org/show_bug.cgi?id=277639</a>
<a href="https://rdar.apple.com/132984512">rdar://132984512</a>

Reviewed by Yusuke Suzuki.

The AudioWorkletProcessor constructs a JSArray of JSFloat32Arrays that is frozen.
Then it passes the JSArray to arbitrary JavaScript so it can modify the data in
the JSFloat32Arrays. Finally, we memcpy the data from the JSFloat32Arrays to our
audio buses. Because the array is frozen, we expected that the arrays couldn&apos;t
change. However, one could set a shared array buffer at a particular index by
modifying Array.prototype. This would render our memcpy logic unsafe since the
size of the array could change on the main thread while we memcpy on the audio
worklet thread.

To address the issue, I now call `getDirectIndex()` instead of `getIndex()` to
ignore values set on the Array prototype and only consider the ones I populated
the array with. I&apos;m also adding validation to make sure the the JSFloat32Arrays
are not shared since I&apos;m constructing unshared ones.

* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::getArrayAtIndex):
(WebCore::copyDataFromJSArrayToBuses):
(WebCore::copyDataFromBusesToJSArray):
(WebCore::zeroJSArray):

Originally-landed-as: 280938.195@safari-7619-branch (1bac059fd67b). <a href="https://rdar.apple.com/138871121">rdar://138871121</a>
Canonical link: <a href="https://commits.webkit.org/285940@main">https://commits.webkit.org/285940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/902cf94da0f5a903ba5b21748a130884f9e972df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8037 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1536 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->