### PR TITLE
bestbuy.com: [iPad] Cannot adjust page zoom on Bestbuy.com

### DIFF
--- a/LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale-expected.txt
+++ b/LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale-expected.txt
@@ -1,0 +1,46 @@
+setViewScale(0.50)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(0.75)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(1.00)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(1.25)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(1.50)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(1.25)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(1.00)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(0.75)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+setViewScale(0.50)
+PASS:  window size scaled correctly
+PASS:  square size scaled correctly
+PASS:  zoom scale accounts for both target scale and initial scale
+
+

--- a/LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale.html
+++ b/LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ShouldIgnoreMetaViewport=true contentMode=desktop ] -->
+<html>
+<head>
+    <meta name="viewport">
+    <style>
+        #square {
+            position: absolute;
+            width: 10vw;
+            height: 10vh;
+            border: 2px solid black;
+        }
+
+        #output {
+            width: 100%;
+            height: 100%;
+            overflow: scroll;
+        }
+
+        body {
+            margin: 0;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+
+    const metaViewportWidth = 390;
+
+    const viewportWidthBaseline = innerWidth;
+    const viewportHeightBaseline = innerHeight;
+    const initialScale = viewportWidthBaseline / metaViewportWidth;
+
+    document.querySelector('meta').setAttribute("content","width=" + metaViewportWidth);
+
+    function valuesAreClose(num1, num2, maxDiff = 0.5) {
+        return Math.abs(num1 - num2) <= maxDiff;
+    }
+    
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function runTest() {
+        const appendOutput = message => {
+            output.appendChild(document.createTextNode(message));
+            output.appendChild(document.createElement("br"));
+        };
+
+        for (let targetScale of [0.5, 0.75, 1, 1.25, 1.5, 1.25, 1, 0.75, 0.5]) {
+            appendOutput(`setViewScale(${targetScale.toFixed(2)})`);
+
+            await UIHelper.setViewScale(targetScale);
+            await UIHelper.ensurePresentationUpdate();
+
+            const actualZoomScale = (await UIHelper.zoomScale());
+            const expectedZoomScale = targetScale * initialScale;
+
+            const expectedWindowWidth = metaViewportWidth / targetScale;
+            const expectedWindowHeight = viewportHeightBaseline / expectedZoomScale;
+
+            const expectedSquareWidth = expectedWindowWidth / 10;
+            const expectedSquareHeight = expectedWindowHeight / 10;
+
+            if (valuesAreClose(expectedWindowWidth, innerWidth) && valuesAreClose(expectedWindowHeight, innerHeight))
+                appendOutput(`PASS:  window size scaled correctly`);
+            else
+                appendOutput(`FAIL:  window size should be within 0.5 of [${expectedWindowWidth}, ${expectedWindowHeight}], but was [${innerWidth}, ${innerHeight}]`);
+
+            if (valuesAreClose(square.clientWidth, expectedSquareWidth) && valuesAreClose(square.clientHeight, expectedSquareHeight))
+                appendOutput(`PASS:  square size scaled correctly`);
+            else 
+                appendOutput(`FAIL:  square size should be within 0.5 of [${expectedSquareWidth}, ${expectedSquareHeight}], but was [${square.clientWidth}, ${square.clientHeight}]`);
+
+            if (actualZoomScale.toFixed(2) == expectedZoomScale.toFixed(2))
+                appendOutput(`PASS:  zoom scale accounts for both target scale and initial scale`);
+            else 
+                appendOutput(`FAIL:  zoom scale should be ${expectedZoomScale.toFixed(2)}, but was ${actualZoomScale.toFixed(2)}`);
+
+            appendOutput("");
+        }
+
+        testRunner.notifyDone();
+    }
+    </script>
+</head>
+
+<body onload="runTest()">
+    <div id="square"></div>
+    <pre id="output"></pre>
+</body>
+</html>

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -548,8 +548,12 @@ void ViewportConfiguration::updateConfiguration()
     else if (booleanViewportArgumentIsSet(m_viewportArguments.shrinkToFit))
         m_configuration.allowsShrinkToFit = m_viewportArguments.shrinkToFit != 0.;
 
-    if (canOverrideConfigurationParameters() && !viewportArgumentsOverridesWidth)
-        m_configuration.width = m_minimumLayoutSize.width();
+    if (canOverrideConfigurationParameters()) {
+        if (!viewportArgumentsOverridesWidth)
+            m_configuration.width = m_minimumLayoutSize.width();
+        else if (layoutSizeIsExplicitlyScaled())
+            m_configuration.width /= effectiveLayoutScale;
+    }
 
     m_configuration.avoidsUnsafeArea = m_viewportArguments.viewportFit != ViewportFit::Cover;
     m_configuration.initialScaleIgnoringLayoutScaleFactor = m_configuration.initialScale;


### PR DESCRIPTION
#### 965304e0df2a41aab964bbd33ea5ebddcbeffdc9
<pre>
bestbuy.com: [iPad] Cannot adjust page zoom on Bestbuy.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=282372">https://bugs.webkit.org/show_bug.cgi?id=282372</a>
<a href="https://rdar.apple.com/100570236">rdar://100570236</a>

Reviewed by Wenson Hsieh.

ViewportConfiguration::updateConfiguration now checks for the case where both the
layout size is scaled and an explicit width has been set by the meta viewport. When
both are true, the configuration width is scaled accordingly.

* LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale-expected.txt: Added.
* LayoutTests/fast/viewport/ios/constant-width-viewport-with-no-scale-after-changing-view-scale.html: Added.
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::updateConfiguration):

Canonical link: <a href="https://commits.webkit.org/286043@main">https://commits.webkit.org/286043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378521b09f0e38a2bf56c59801ad9ae2836798d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25799 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76678 "Found 89 Binding test failures: JSTestPluginInterface.cpp, JSTestNode.cpp, JSTestCEReactions.cpp, JSTestStringifierReadWriteAttribute.cpp, JSTestNamedDeleterNoIdentifier.cpp, JSTestIndexedSetterThrowingException.cpp, JSTestNamedAndIndexedSetterWithIdentifier.cpp, JSTestDefaultToJSONFilteredByExposed.cpp, JSTestEventTarget.cpp, JSShadowRealmGlobalScope.cpp, JSTestStringifierOperationImplementedAs.cpp, JSTestOverloadedConstructorsWithSequence.cpp, JSTestCallTracer.cpp, JSTestNamedSetterWithIndexedGetter.cpp, JSTestInterface.cpp, JSSharedWorkerGlobalScope.cpp, JSTestCEReactionsStringifier.cpp, JSTestPromiseRejectionEvent.cpp, JSTestScheduledAction.cpp, JSTestStringifierOperationNamedToString.cpp, JSTestNamedSetterWithLegacyUnforgeableProperties.cpp, JSTestOverloadedConstructors.cpp, JSTestSetLikeWithOverriddenOperations.cpp, JSTestSetLike.cpp, JSTestLegacyOverrideBuiltIns.cpp, JSTestIndexedSetterWithIdentifier.cpp, JSServiceWorkerGlobalScope.cpp, JSTestConditionallyReadWrite.cpp, JSTestNamedGetterWithIdentifier.cpp, JSExposedStar.cpp, JSTestMapLike.cpp, JSTestNamedDeleterThrowingException.cpp, JSTestNamedGetterCallWith.cpp, JSWorkletGlobalScope.cpp, JSTestDefaultToJSON.cpp, JSTestGenerateAddOpaqueRoot.cpp, JSTestSerializedScriptValueInterface.cpp, JSTestObj.cpp, JSTestIndexedSetterNoIdentifier.cpp, JSTestStringifier.cpp, JSTestInterfaceLeadingUnderscore.cpp, JSTestReadOnlyMapLike.cpp, JSTestEnabledBySetting.cpp, JSTestGlobalObject.cpp, JSTestNamedAndIndexedSetterNoIdentifier.cpp, JSTestReportExtraMemoryCost.cpp, JSTestException.cpp, JSTestStringifierReadOnlyAttribute.cpp, JSTestJSBuiltinConstructor.cpp, JSTestNamespaceObject.cpp, JSTestIterable.cpp, JSTestNamedSetterThrowingException.cpp, JSTestOperationConditional.cpp, JSTestReadOnlySetLike.cpp, JSTestClassWithJSBuiltinConstructor.cpp, JSTestDomainSecurity.cpp, JSTestDefaultToJSONIndirectInheritance.cpp, JSTestDelegateToSharedSyntheticAttribute.cpp, JSTestLegacyFactoryFunction.cpp, JSTestDOMJIT.cpp, JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp, JSTestNamedDeleterWithIdentifier.cpp, JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp, JSDOMWindow.cpp, JSTestGenerateIsReachable.cpp, JSTestNamespaceConst.cpp, JSTestNamedSetterNoIdentifier.cpp, JSPaintWorkletGlobalScope.cpp, JSTestNamedAndIndexedSetterThrowingException.cpp, JSTestMapLikeWithOverriddenOperations.cpp, JSTestNamedSetterWithIndexedGetterAndSetter.cpp, JSTestTypedefs.cpp, JSTestEnabledForContext.cpp, JSWorkerGlobalScope.cpp, JSExposedToWorkerAndWindow.cpp, JSDedicatedWorkerGlobalScope.cpp, JSTestDefaultToJSONInheritFinal.cpp, JSTestLegacyNoInterfaceObject.cpp, JSTestNamedSetterWithIdentifier.cpp, JSTestNamedDeleterWithIndexedGetter.cpp, JSTestAsyncIterable.cpp, JSTestStringifierAnonymousOperation.cpp, JSTestNamedGetterNoIdentifier.cpp, JSTestStringifierNamedOperation.cpp, JSTestAsyncKeyValueIterable.cpp, JSTestTaggedWrapper.cpp, JSTestEventConstructor.cpp, JSTestConditionalIncludes.cpp, JSTestDefaultToJSONInherit.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16884 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24132 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66856 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66142 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8244 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11516 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1843 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4630 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1871 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->