### PR TITLE
Use a HashTable for animationRareData.

### DIFF
--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -35,8 +35,7 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ElementAnimationRareData);
 
-ElementAnimationRareData::ElementAnimationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
-    : m_pseudoElementIdentifier(pseudoElementIdentifier)
+ElementAnimationRareData::ElementAnimationRareData()
 {
 }
 

--- a/Source/WebCore/animation/ElementAnimationRareData.h
+++ b/Source/WebCore/animation/ElementAnimationRareData.h
@@ -41,10 +41,8 @@ class ElementAnimationRareData {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ElementAnimationRareData);
     WTF_MAKE_NONCOPYABLE(ElementAnimationRareData);
 public:
-    explicit ElementAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
+    explicit ElementAnimationRareData();
     ~ElementAnimationRareData();
-
-    const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier() { return m_pseudoElementIdentifier; }
 
     KeyframeEffectStack* keyframeEffectStack() { return m_keyframeEffectStack.get(); }
     KeyframeEffectStack& ensureKeyframeEffectStack();
@@ -69,7 +67,6 @@ private:
     CSSAnimationCollection m_animationsCreatedByMarkup;
     AnimatableCSSPropertyToTransitionMap m_completedTransitionsByProperty;
     AnimatableCSSPropertyToTransitionMap m_runningTransitionsByProperty;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { };
     bool m_hasPendingKeyframesUpdate { false };
     bool m_hasPropertiesOverridenAfterAnimation { false };
 };

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -38,7 +38,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     int m_tabIndex;
     uint8_t contentRelevancy;
     IntPoint savedLayerScrollPosition;
-    Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
+    HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
     void* pointers[17];
     void* intersectionObserverData;
     void* typedOMData[2];

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -42,6 +42,7 @@
 #include "StylePropertyMap.h"
 #include "StylePropertyMapReadOnly.h"
 #include "VisibilityAdjustment.h"
+#include <wtf/HashMap.h>
 #include <wtf/Markable.h>
 
 namespace WebCore {
@@ -241,7 +242,7 @@ private:
     Markable<LayoutUnit, LayoutUnitMarkableTraits> m_lastRememberedLogicalWidth;
     Markable<LayoutUnit, LayoutUnitMarkableTraits> m_lastRememberedLogicalHeight;
 
-    Vector<std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
+    HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
 
     RefPtr<PseudoElement> m_beforePseudoElement;
     RefPtr<PseudoElement> m_afterPseudoElement;
@@ -306,11 +307,7 @@ inline void ElementRareData::setUnusualTabIndex(int tabIndex)
 
 inline ElementAnimationRareData* ElementRareData::animationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
-    for (auto& animationRareData : m_animationRareData) {
-        if (animationRareData->pseudoElementIdentifier() == pseudoElementIdentifier)
-            return animationRareData.get();
-    }
-    return nullptr;
+    return m_animationRareData.get(pseudoElementIdentifier);
 }
 
 inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
@@ -318,8 +315,9 @@ inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const 
     if (auto* animationRareData = this->animationRareData(pseudoElementIdentifier))
         return *animationRareData;
 
-    m_animationRareData.append(makeUnique<ElementAnimationRareData>(pseudoElementIdentifier));
-    return *m_animationRareData.last().get();
+    auto result = m_animationRareData.add(pseudoElementIdentifier, makeUnique<ElementAnimationRareData>());
+    ASSERT(result.isNewEntry);
+    return *result.iterator->value.get();
 }
 
 inline ElementRareData* Element::elementRareData() const

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -80,12 +80,16 @@ struct HashTraits<std::optional<WebCore::Style::PseudoElementIdentifier>> : Gene
 
     static constexpr bool emptyValueIsZero = false;
     static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::AfterLastInternalPseudoId, nullAtom() }; }
+
+    static void constructDeletedValue(std::optional<WebCore::Style::PseudoElementIdentifier>& pseudoElementIdentifier) { pseudoElementIdentifier = WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
+    static bool isDeletedValue(const std::optional<WebCore::Style::PseudoElementIdentifier>& pseudoElementIdentifier) { return pseudoElementIdentifier == WebCore::Style::PseudoElementIdentifier { WebCore::PseudoId::None, nullAtom() }; }
 };
 
 template<>
 struct DefaultHash<std::optional<WebCore::Style::PseudoElementIdentifier>> {
     static unsigned hash(const std::optional<WebCore::Style::PseudoElementIdentifier>& data) { return computeHash(data); }
     static bool equal(const std::optional<WebCore::Style::PseudoElementIdentifier>& a, const std::optional<WebCore::Style::PseudoElementIdentifier>& b) { return a == b; }
+
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
 


### PR DESCRIPTION
#### c51ed1c168eb02036f575c667400d4ed26c99c6e
<pre>
Use a HashTable for animationRareData.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282375">https://bugs.webkit.org/show_bug.cgi?id=282375</a>
&lt;<a href="https://rdar.apple.com/138980396">rdar://138980396</a>&gt;

Reviewed by Tim Nguyen.

ViewTransitions can add a lot of pseudo elements to the document node, we should
use a hash table instead of iterating a list.

* Source/WebCore/animation/ElementAnimationRareData.cpp:
(WebCore::ElementAnimationRareData::ElementAnimationRareData):
* Source/WebCore/animation/ElementAnimationRareData.h:
(WebCore::ElementAnimationRareData::pseudoElementIdentifier): Deleted.
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::animationRareData const):
(WebCore::ElementRareData::ensureAnimationRareData):
* Source/WebCore/style/PseudoElementIdentifier.h:
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::constructDeletedValue):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::isDeletedValue):

Canonical link: <a href="https://commits.webkit.org/285997@main">https://commits.webkit.org/285997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c512d9a9457be4d82c3ef812c9fbb2b53ec609a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38895 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80327 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16411 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8150 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4495 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->