### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.24.9

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -13,7 +13,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.24.6.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.24.9.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.9.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.9.patch
@@ -1,7 +1,7 @@
 From db93844bb1f807d7acad0384e7804d6283079fdf Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
 Date: Wed, 6 Mar 2024 12:17:24 +0000
-Subject: [PATCH] Bump to GStreamer 1.24.6
+Subject: [PATCH] Bump to GStreamer 1.24.9
 
 ---
  elements/components/gstreamer-plugins-bad.bst |  1 +
@@ -89,7 +89,7 @@ index f36b91e..2d73091 100644
    url: freedesktop:gstreamer/gstreamer.git
    track: 1.*[02468].*
 -  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
-+  ref: 1.24.6-0-g8d175ea255ea260ae4ad05175282bdfb1b975f35
++  ref: 1.24.9-0-gb309f90bfde36e6d175b70bfa0c941f2829dd6a5
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch

--- a/Tools/buildstream/patches/fdo-0011-gst-plugins-bad-webrtcbin-connect-transportreceivebi.patch
+++ b/Tools/buildstream/patches/fdo-0011-gst-plugins-bad-webrtcbin-connect-transportreceivebi.patch
@@ -110,7 +110,7 @@ new file mode 100644
 index 0000000..83557b0
 --- /dev/null
 +++ b/patches/gstreamer/gst-plugins-bad-0003-webrtcbin-connect-output-stream-on-recv-transceivers.patch
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,40 @@
 +From efa0a3ec6a5f8277d16f0cb46e3528be931f7859 Mon Sep 17 00:00:00 2001
 +From: Carlos Bentzen <cadubentzen@igalia.com>
 +Date: Fri, 2 Aug 2024 11:21:13 +0200
@@ -148,88 +148,6 @@ index 0000000..83557b0
 +   }
 + 
 +   ret = TRUE;
-+diff --git a/subprojects/gst-plugins-bad/tests/check/elements/webrtcbin.c b/subprojects/gst-plugins-bad/tests/check/elements/webrtcbin.c
-+index 1dd2ddf3c2..6ba8315f87 100644
-+--- a/subprojects/gst-plugins-bad/tests/check/elements/webrtcbin.c
-++++ b/subprojects/gst-plugins-bad/tests/check/elements/webrtcbin.c
-+@@ -4601,6 +4601,69 @@ _pad_added_harness (struct test_webrtc *t, GstElement * element,
-+   }
-+ }
-+ 
-++GST_START_TEST (test_audio_sendrecv)
-++{
-++  struct test_webrtc *t = test_webrtc_new ();
-++  GstHarness *h1, *h2;
-++
-++  t->on_negotiation_needed = NULL;
-++  t->on_ice_candidate = NULL;
-++  t->on_pad_added = _pad_added_fakesink;
-++
-++  h1 = gst_harness_new_with_element (t->webrtc1, "sink_0", NULL);
-++  add_audio_test_src_harness (h1, 0xDEADBEEF);
-++  t->harnesses = g_list_prepend (t->harnesses, h1);
-++
-++  h2 = gst_harness_new_with_element (t->webrtc2, "sink_0", NULL);
-++  add_audio_test_src_harness (h2, 0xBEEFDEAD);
-++  t->harnesses = g_list_prepend (t->harnesses, h2);
-++
-++  VAL_SDP_INIT (no_duplicate_payloads, on_sdp_media_no_duplicate_payloads,
-++      NULL, NULL);
-++  guint media_format_count[] = { 1 };
-++  VAL_SDP_INIT (media_formats, on_sdp_media_count_formats,
-++      media_format_count, &no_duplicate_payloads);
-++  VAL_SDP_INIT (count, _count_num_sdp_media, GUINT_TO_POINTER (1),
-++      &media_formats);
-++  const gchar *expected_offer_setup[] = { "actpass", };
-++  VAL_SDP_INIT (offer_setup, on_sdp_media_setup, expected_offer_setup, &count);
-++  const gchar *expected_answer_setup[] = { "active", };
-++  VAL_SDP_INIT (answer_setup, on_sdp_media_setup, expected_answer_setup,
-++      &count);
-++  const gchar *expected_offer_direction[] = { "sendrecv", };
-++  VAL_SDP_INIT (offer, on_sdp_media_direction, expected_offer_direction,
-++      &offer_setup);
-++  const gchar *expected_answer_direction[] = { "sendrecv", };
-++  VAL_SDP_INIT (answer, on_sdp_media_direction, expected_answer_direction,
-++      &answer_setup);
-++  GstWebRTCKind expected_kind = GST_WEBRTC_KIND_AUDIO;
-++
-++  g_signal_connect (t->webrtc1, "on-new-transceiver",
-++      G_CALLBACK (on_new_transceiver_expected_kind),
-++      GUINT_TO_POINTER (expected_kind));
-++  g_signal_connect (t->webrtc2, "on-new-transceiver",
-++      G_CALLBACK (on_new_transceiver_expected_kind),
-++      GUINT_TO_POINTER (expected_kind));
-++
-++  test_validate_sdp (t, &offer, &answer);
-++
-++  fail_if (gst_element_set_state (t->webrtc1,
-++          GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE);
-++  fail_if (gst_element_set_state (t->webrtc2,
-++          GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE);
-++
-++  /* Exchange a few buffers between webrtcbin1 and webrtcbin2 to check
-++     that they can handle incoming data and we get no errors on the bus. */
-++  for (int i = 0; i < 5; i++) {
-++    gst_harness_push_from_src (h1);
-++    gst_harness_push_from_src (h2);
-++  }
-++
-++  test_webrtc_free (t);
-++}
-++
-++GST_END_TEST;
-++
-+ static void
-+ new_jitterbuffer_set_fast_start (GstElement * rtpbin,
-+     GstElement * rtpjitterbuffer, guint session_id, guint ssrc,
-+@@ -6001,6 +6064,7 @@ webrtcbin_suite (void)
-+     tcase_add_test (tc, test_session_stats);
-+     tcase_add_test (tc, test_stats_with_stream);
-+     tcase_add_test (tc, test_audio);
-++    tcase_add_test (tc, test_audio_sendrecv);
-+     tcase_add_test (tc, test_ice_port_restriction);
-+     tcase_add_test (tc, test_audio_video);
-+     tcase_add_test (tc, test_media_direction);
 +-- 
 +2.45.2
 +


### PR DESCRIPTION
#### fcc904b37fc4d00b32d7670f4bfdae3b68965a18
<pre>
[Buildstream SDK] Bump to GStreamer 1.24.9
<a href="https://bugs.webkit.org/show_bug.cgi?id=282378">https://bugs.webkit.org/show_bug.cgi?id=282378</a>

Reviewed by Adrian Perez de Castro.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.9.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.6.patch.
* Tools/buildstream/patches/fdo-0011-gst-plugins-bad-webrtcbin-connect-transportreceivebi.patch: One
unit test was removed here due to diff conflicts. It&apos;s not required anyway, we don&apos;t run those tests.

Canonical link: <a href="https://commits.webkit.org/285947@main">https://commits.webkit.org/285947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86f7c1945e1e4945a7b1c62cd10cf338dc82a12f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80181 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65968 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8060 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1566 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->