### PR TITLE
MediaRecorder shouldn't perform memory allocation on the thread it is receiving audio samples

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -32,8 +32,8 @@
 
 struct AudioBuffer;
 struct AudioBufferList;
-typedef struct OpaqueCMBlockBuffer *CMBlockBufferRef;
-typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
+typedef struct OpaqueCMBlockBuffer* CMBlockBufferRef;
+typedef struct opaqueCMSampleBuffer* CMSampleBufferRef;
 
 namespace WebCore {
 
@@ -45,6 +45,8 @@ public:
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&, size_t sampleCount);
     WebAudioBufferList(const CAAudioStreamDescription&, CMSampleBufferRef);
     WEBCORE_EXPORT virtual ~WebAudioBufferList();
+
+    static std::optional<std::pair<UniqueRef<WebAudioBufferList>, RetainPtr<CMBlockBufferRef>>> createWebAudioBufferListWithBlockBuffer(const CAAudioStreamDescription&, size_t sampleCount);
 
     void reset();
     WEBCORE_EXPORT void setSampleCount(size_t);
@@ -63,6 +65,8 @@ public:
 
 private:
     Kind kind() const { return Kind::WebAudioBufferList; }
+    void initializeList(std::span<uint8_t>, size_t);
+    RetainPtr<CMBlockBufferRef> setSampleCountWithBlockBuffer(size_t);
 
     size_t m_listBufferSize { 0 };
     uint32_t m_bytesPerFrame { 0 };


### PR DESCRIPTION
#### cb76829ab268a109558cca5efdce6ca18913e643
<pre>
MediaRecorder shouldn&apos;t perform memory allocation on the thread it is receiving audio samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=282374">https://bugs.webkit.org/show_bug.cgi?id=282374</a>
<a href="https://rdar.apple.com/problem/138978311">rdar://problem/138978311</a>

Reviewed by Youenn Fablet.

We used to create a CMSampleBuffer in the audio thread before sending it to the AudioSampleBufferCompressor
for encoding.

We now instead allocate an InProcessCARingBuffer when we receive the first audio sample.
From that point, we push the new audio in the ringbuffer and send a message to the encoder&apos;s WorkQueue
to retrieve the data where the CMSampleBuffer will be created.
This reduces the number of memory allocation to once only.
The CARingBuffer is made to allow for 2s of audio. This is the same size used by the GPU process
to capture the audio and send it to the content process in its own ringbuffer.

No change in observable behaviour. Covered by existing tests.

* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::setSampleCount):
(WebCore::WebAudioBufferList::createWebAudioBufferListWithBlockBuffer):
(WebCore::WebAudioBufferList::setSampleCountWithBlockBuffer):
(WebCore::WebAudioBufferList::initializeList):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h: We add a new method to create an AudioBufferList backed by a CMBlockBoffer.
This allows to directly copy the data from the CARingBuffer to the CMSampleBuffer without an intermediary.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::appendAudioSampleBuffer):
(WebCore::MediaRecorderPrivateEncoder::audioSamplesAvailableStarted):
(WebCore::MediaRecorderPrivateEncoder::audioSamplesAvailable):
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame): Fly-By: check if recorder is stopped before enqueuing. So that even in-flight video frames
at the time the recorder was stopped will be processed and converted.
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::maybeStartWriter):
(WebCore::MediaRecorderPrivateEncoder::stopRecording):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
(WebCore::MediaRecorderPrivateEncoder::hasAudio const): Deleted.
(WebCore::MediaRecorderPrivateEncoder::hasVideo const): Deleted.
(WebCore::MediaRecorderPrivateEncoder::WTF_GUARDED_BY_CAPABILITY): Deleted.

Canonical link: <a href="https://commits.webkit.org/286083@main">https://commits.webkit.org/286083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ccee3969e209d074774273e7094510346337c8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2016 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17037 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77868 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46179 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80714 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1271 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10249 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2084 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2112 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->