### PR TITLE
Nullptr crash under ContainerQueryEvaluator::featureEvaluationContextForQuery computing style for disconnected <title>

### DIFF
--- a/LayoutTests/fast/dom/disconnected-title-style-crash.html
+++ b/LayoutTests/fast/dom/disconnected-title-style-crash.html
@@ -1,0 +1,15 @@
+<style>
+@container style(--foo) {
+    title { color: blue; }
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+document.head.offsetLeft;
+const title = document.createElement("title");
+document.head.appendChild(title);
+getComputedStyle(title).color;
+document.firstChild.remove();
+title.innerText = "This test passes if it doesn't crash.";
+</script>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -151,6 +151,9 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
 
     ASSERT(effect.target());
     auto& element = *effect.target();
+    if (!element.isConnected())
+        return;
+
     auto& styleResolver = element.styleResolver();
 
     // We need to establish which properties are implicit for 0% and 100%.

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -747,7 +747,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
     };
 
     auto styleProperties = MutableStyleProperties::create();
-    if (m_animationType == WebAnimationType::CSSAnimation) {
+    if (m_animationType == WebAnimationType::CSSAnimation && m_target->isConnected()) {
         auto matchingRules = m_target->styleResolver().pseudoStyleRulesForElement(target, m_pseudoElementIdentifier, Style::Resolver::AllCSSRules);
         for (auto& matchedRule : matchingRules)
             styleProperties->mergeAndOverrideOnConflict(matchedRule->properties());

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1360,6 +1360,10 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
 static Ref<MutableStyleProperties> styleFromMatchedRulesForElement(Element& element, unsigned rulesToInclude)
 {
     Ref style = MutableStyleProperties::create();
+
+    if (!element.isConnected())
+        return style;
+
     for (auto& matchedRule : element.styleResolver().styleRulesForElement(&element, rulesToInclude))
         style->mergeAndOverrideOnConflict(matchedRule->protectedProperties());
     

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -104,6 +104,8 @@ public:
         : m_element(&element)
         , m_parentStyle(parentStyle)
     {
+        ASSERT(element.isConnected());
+
         auto& document = element.document();
         auto* documentElement = document.documentElement();
         if (!documentElement || documentElement == &element)


### PR DESCRIPTION
#### bf84b98bc5aef1198e82fba20d18f77d06df1052
<pre>
Nullptr crash under ContainerQueryEvaluator::featureEvaluationContextForQuery computing style for disconnected &lt;title&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282385">https://bugs.webkit.org/show_bug.cgi?id=282385</a>
<a href="https://rdar.apple.com/137177847">rdar://137177847</a>

Reviewed by Ryosuke Niwa.

We crash with null documentElement() because it is possible to enter style resolution
with a disconnected element via HTMLTitleElement::childrenChanged.

* LayoutTests/fast/dom/disconnected-title-style-crash.html: Added.
* Source/WebCore/html/HTMLTitleElement.cpp:
(WebCore::HTMLTitleElement::insertedIntoAncestor):

Update title on insertion when connected.

(WebCore::HTMLTitleElement::removedFromAncestor):
(WebCore::HTMLTitleElement::childrenChanged):

Only update the title if we are connected.

(WebCore::HTMLTitleElement::computedTextWithDirection):

Remove the style resolution path used when disconnected.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::State):

Assert we only compute style for connected elements.

Canonical link: <a href="https://commits.webkit.org/286078@main">https://commits.webkit.org/286078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ba68c79bfe034669075dbe92516b6603fb30cbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58742 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8391 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4857 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->