### PR TITLE
[WPE][GTK] Add warning that web process sandbox may interfere with web process extension loading

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -288,6 +288,9 @@ webkit_web_context_get_tls_errors_policy            (WebKitWebContext           
  * otherwise it will not have any effect. You can connect to
  * #WebKitWebContext::initialize-web-process-extensions to call this method
  * before anything is loaded.
+ *
+ * If your web process extension is installed to an unusual location,
+ * then you may also need to call webkit_web_context_add_path_to_sandbox().
  */
 WEBKIT_API void
 webkit_web_context_set_web_process_extensions_directory (WebKitWebContext              *context,


### PR DESCRIPTION
#### 34c71b9eeed606fa76f6906afbc48586f9d0013e
<pre>
[WPE][GTK] Add warning that web process sandbox may interfere with web process extension loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=282389">https://bugs.webkit.org/show_bug.cgi?id=282389</a>

Reviewed by Adrian Perez de Castro.

In
<a href="https://discourse.gnome.org/t/webkitgtk-web-process-extension-not-loading/24809">https://discourse.gnome.org/t/webkitgtk-web-process-extension-not-loading/24809</a>
I was stumped as to why the web process extension was not being loaded.
The problem turned out to be it was installed to a directory that isn&apos;t
mounted into the web process sandbox.

* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:

Canonical link: <a href="https://commits.webkit.org/285974@main">https://commits.webkit.org/285974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d2e4be93487c3fd6103fb20717651653f08415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16743 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45550 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80202 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8079 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4375 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->