### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PAL

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -91,9 +91,11 @@
 		465005D82CD2840A00950C5F /* MallocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 465005D72CD2840A00950C5F /* MallocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46BEB6EB22FFE24900269868 /* RefTrackerMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */; };
 		46CEA3FA2CC2D39B00FE325C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */; };
+		46E915222CD2E26C00C437B7 /* UnicodeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46E915212CD2E26C00C437B7 /* UnicodeExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46E93049271F1205005BA6E5 /* SafeStrerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E43647271F10AA00C88C90 /* SafeStrerror.cpp */; };
 		4BF93AD32C8B53C100F0E06C /* RefTrackerMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD50026DEAD /* RefTrackerMixin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		50DE35F5215BB01500B979C7 /* ExternalStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */; };
@@ -1225,6 +1227,7 @@
 		465005D72CD2840A00950C5F /* MallocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocSpan.h; sourceTree = "<group>"; };
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
+		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269867 /* RefCounted.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounted.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefTrackerMixin.cpp; sourceTree = "<group>"; };
@@ -1232,6 +1235,7 @@
 		46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpanCocoa.mm; sourceTree = "<group>"; };
 		46E43646271F10AA00C88C90 /* SafeStrerror.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SafeStrerror.h; sourceTree = "<group>"; };
 		46E43647271F10AA00C88C90 /* SafeStrerror.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SafeStrerror.cpp; sourceTree = "<group>"; };
+		46E915212CD2E26C00C437B7 /* UnicodeExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnicodeExtras.h; sourceTree = "<group>"; };
 		50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExternalStringImpl.cpp; sourceTree = "<group>"; };
 		50DE35F4215BB01500B979C7 /* ExternalStringImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExternalStringImpl.h; sourceTree = "<group>"; };
 		513E170A1CD7D5BF00E3650B /* LoggingAccumulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggingAccumulator.h; sourceTree = "<group>"; };
@@ -1959,6 +1963,8 @@
 			isa = PBXGroup;
 			children = (
 				1CCDB14D1E566898006C73C0 /* TextBreakIteratorICU.h */,
+				467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */,
+				46E915212CD2E26C00C437B7 /* UnicodeExtras.h */,
 				1C181C891D307AB800F5FA16 /* UTextProvider.cpp */,
 				1C181C8A1D307AB800F5FA16 /* UTextProvider.h */,
 				1C181C8B1D307AB800F5FA16 /* UTextProviderLatin1.cpp */,
@@ -3651,6 +3657,7 @@
 				FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */,
 				DD3DC8C927A4BF8E007E5B61 /* UnalignedAccess.h in Headers */,
 				DD3DC86A27A4BF8E007E5B61 /* Unexpected.h in Headers */,
+				46E915222CD2E26C00C437B7 /* UnicodeExtras.h in Headers */,
 				DD28468829248DDA0009A61D /* UnifiedWebPreferences.yaml in Headers */,
 				DD3DC8A627A4BF8E007E5B61 /* UnionFind.h in Headers */,
 				DD3DC98727A4BF8E007E5B61 /* UniqueArray.h in Headers */,
@@ -4220,6 +4227,7 @@
 				0F66B2901DC97BAB004A1D3F /* TimeWithDynamicClockType.cpp in Sources */,
 				0F7075F51FBF53CD00489AF0 /* TimingScope.cpp in Sources */,
 				521CC6B424A27809004377D6 /* TranslatedProcess.cpp in Sources */,
+				467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */,
 				0FA6F39520CCACE900A03DCD /* UniqueArray.cpp in Sources */,
 				5CC0EE7621629F1900A1A842 /* URL.cpp in Sources */,
 				5C1F0595216437B30039302C /* URLCF.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -467,6 +467,7 @@ set(WTF_PUBLIC_HEADERS
     text/WTFString.h
 
     text/icu/TextBreakIteratorICU.h
+    text/icu/UnicodeExtras.h
     text/icu/UTextProvider.h
     text/icu/UTextProviderLatin1.h
     text/icu/UTextProviderUTF16.h
@@ -621,6 +622,7 @@ set(WTF_SOURCES
     text/TextStream.cpp
     text/WTFString.cpp
 
+    text/icu/UnicodeExtras.cpp
     text/icu/UTextProvider.cpp
     text/icu/UTextProviderLatin1.cpp
     text/icu/UTextProviderUTF16.cpp

--- a/Source/WTF/wtf/text/icu/UnicodeExtras.cpp
+++ b/Source/WTF/wtf/text/icu/UnicodeExtras.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UnicodeExtras.h"
+
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+std::span<const UCharsetMatch*> ucsdet_detectAll_span(UCharsetDetector* detector, UErrorCode* status)
+{
+    int32_t matchesCount = 0;
+    auto* matches = ucsdet_detectAll(detector, &matchesCount, status);
+    return unsafeMakeSpan(matches, std::max(matchesCount, 0));
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/text/icu/UnicodeExtras.h
+++ b/Source/WTF/wtf/text/icu/UnicodeExtras.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <unicode/ucsdet.h>
+
+namespace WTF {
+
+WTF_EXPORT_PRIVATE std::span<const UCharsetMatch*> ucsdet_detectAll_span(UCharsetDetector*, UErrorCode* status);
+
+} // namespace WTF
+
+using WTF::ucsdet_detectAll_span;

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -34,8 +34,6 @@
 #include <wtf/Assertions.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 // See <http://en.wikipedia.org/wiki/Percent-encoding#Non-standard_implementations>.
@@ -104,18 +102,17 @@ struct URLEscapeSequence {
         // a valid escape sequence, but there may be characters between the sequences.
         Vector<uint8_t, 512> buffer;
         buffer.grow(run.length()); // Unescaping hex sequences only makes the length smaller.
-        uint8_t* p = buffer.data();
+        size_t bufferIndex = 0;
         while (!run.isEmpty()) {
             if (run[0] == '%') {
-                *p++ = (toASCIIHexValue(run[1]) << 4) | toASCIIHexValue(run[2]);
+                buffer[bufferIndex++] = (toASCIIHexValue(run[1]) << 4) | toASCIIHexValue(run[2]);
                 run = run.substring(SequenceSize);
             } else {
-                *p++ = run[0];
+                buffer[bufferIndex++] = run[0];
                 run = run.substring(1);
             }
         }
-        ASSERT(buffer.size() >= static_cast<size_t>(p - buffer.data())); // Prove buffer not overrun.
-        buffer.shrink(p - buffer.data());
+        buffer.shrink(bufferIndex);
         return buffer;
     }
 
@@ -188,5 +185,3 @@ inline Vector<uint8_t> decodeURLEscapeSequencesAsData(StringView string)
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -31,11 +31,9 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
-static const UChar latin1ConversionTable[256] = {
+static constexpr std::array<UChar, 256> latin1ConversionTable = {
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, // 00-07
     0x0008, 0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x000E, 0x000F, // 08-0F
     0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017, // 10-17
@@ -98,6 +96,8 @@ void TextCodecLatin1::registerCodecs(TextCodecRegistrar registrar)
         return makeUnique<TextCodecLatin1>();
     });
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 String TextCodecLatin1::decode(std::span<const uint8_t> bytes, bool, bool, bool& sawException)
 {
@@ -208,6 +208,8 @@ useLookupTable16:
     return result16;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, UnencodableHandling handling)
 {
     Vector<uint8_t> result;
@@ -233,6 +235,8 @@ static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, Unencodable
     return result;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling handling) const
 {
     {
@@ -254,6 +258,6 @@ Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling h
     return encodeComplexWindowsLatin1(string, handling);
 }
 
-} // namespace PAL
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+} // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -32,8 +32,6 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecUserDefined);
@@ -77,6 +75,8 @@ static Vector<uint8_t> encodeComplexUserDefined(StringView string, UnencodableHa
     return result;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandling handling) const
 {
     {
@@ -98,6 +98,6 @@ Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandl
     return encodeComplexUserDefined(string, handling);
 }
 
-} // namespace PAL
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+} // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextEncoding.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.cpp
@@ -39,11 +39,11 @@ namespace PAL {
 
 static const TextEncoding& UTF7Encoding()
 {
-    static NeverDestroyed<TextEncoding> globalUTF7Encoding("UTF-7");
+    static NeverDestroyed<TextEncoding> globalUTF7Encoding("UTF-7"_s);
     return globalUTF7Encoding;
 }
 
-TextEncoding::TextEncoding(const char* name)
+TextEncoding::TextEncoding(ASCIILiteral name)
     : m_name(atomCanonicalTextEncodingName(name))
     , m_backslashAsCurrencySymbol(backslashAsCurrencySymbol())
 {
@@ -93,7 +93,7 @@ ASCIILiteral TextEncoding::domName() const
     // FIXME: This is not thread-safe. At the moment, this function is
     // only accessed in a single thread, but eventually has to be made
     // thread-safe along with usesVisualOrdering().
-    static const ASCIILiteral windows949 = atomCanonicalTextEncodingName("windows-949");
+    static const ASCIILiteral windows949 = atomCanonicalTextEncodingName("windows-949"_s);
     if (m_name == windows949)
         return "EUC-KR"_s;
     return m_name;
@@ -104,7 +104,7 @@ bool TextEncoding::usesVisualOrdering() const
     if (noExtendedTextEncodingNameUsed())
         return false;
 
-    static const ASCIILiteral iso88598 = atomCanonicalTextEncodingName("ISO-8859-8");
+    static const ASCIILiteral iso88598 = atomCanonicalTextEncodingName("ISO-8859-8"_s);
     return m_name == iso88598;
 }
 
@@ -152,38 +152,38 @@ const TextEncoding& TextEncoding::encodingForFormSubmissionOrURLParsing() const
 
 const TextEncoding& ASCIIEncoding()
 {
-    static NeverDestroyed<TextEncoding> globalASCIIEncoding("ASCII");
+    static NeverDestroyed<TextEncoding> globalASCIIEncoding("ASCII"_s);
     return globalASCIIEncoding;
 }
 
 const TextEncoding& Latin1Encoding()
 {
-    static NeverDestroyed<TextEncoding> globalLatin1Encoding("latin1");
+    static NeverDestroyed<TextEncoding> globalLatin1Encoding("latin1"_s);
     return globalLatin1Encoding;
 }
 
 const TextEncoding& UTF16BigEndianEncoding()
 {
-    static NeverDestroyed<TextEncoding> globalUTF16BigEndianEncoding("UTF-16BE");
+    static NeverDestroyed<TextEncoding> globalUTF16BigEndianEncoding("UTF-16BE"_s);
     return globalUTF16BigEndianEncoding;
 }
 
 const TextEncoding& UTF16LittleEndianEncoding()
 {
-    static NeverDestroyed<TextEncoding> globalUTF16LittleEndianEncoding("UTF-16LE");
+    static NeverDestroyed<TextEncoding> globalUTF16LittleEndianEncoding("UTF-16LE"_s);
     return globalUTF16LittleEndianEncoding;
 }
 
 const TextEncoding& UTF8Encoding()
 {
-    static NeverDestroyed<TextEncoding> globalUTF8Encoding("UTF-8");
+    static NeverDestroyed<TextEncoding> globalUTF8Encoding("UTF-8"_s);
     ASSERT(globalUTF8Encoding.get().isValid());
     return globalUTF8Encoding;
 }
 
 const TextEncoding& WindowsLatin1Encoding()
 {
-    static NeverDestroyed<TextEncoding> globalWindowsLatin1Encoding("WinLatin-1");
+    static NeverDestroyed<TextEncoding> globalWindowsLatin1Encoding("WinLatin-1"_s);
     return globalWindowsLatin1Encoding;
 }
 

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -36,7 +36,7 @@ enum class NFCNormalize : bool { No, Yes };
 class TextEncoding : public WTF::URLTextEncoding {
 public:
     TextEncoding() = default;
-    PAL_EXPORT TextEncoding(const char* name);
+    PAL_EXPORT TextEncoding(ASCIILiteral name);
     PAL_EXPORT TextEncoding(StringView name);
     PAL_EXPORT TextEncoding(const String& name);
 

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetector.h
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetector.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <span>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace PAL {
 
@@ -40,6 +41,6 @@ class TextEncoding;
 // hintEncodingName, detect the most likely character encoding.
 // The way hintEncodingName is used is up to an implementation.
 // Currently, the only caller sets it to the parent frame encoding.
-bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingName, TextEncoding* detectedEncoding);
+bool detectTextEncoding(std::span<const uint8_t> data, ASCIILiteral hintEncodingName, TextEncoding* detectedEncoding);
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -48,59 +48,64 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/StringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
-const size_t maxEncodingNameLength = 63;
+constexpr size_t maxEncodingNameLength = 63;
 
 // Hash for all-ASCII strings that does case folding.
 struct TextEncodingNameHash {
-    static bool equal(const char* s1, const char* s2)
+    static bool equal(std::span<const LChar> s1, std::span<const LChar> s2)
     {
-        char c1;
-        char c2;
-        do {
-            c1 = *s1++;
-            c2 = *s2++;
-            if (toASCIILower(c1) != toASCIILower(c2))
+        if (s1.size() != s2.size())
+            return false;
+
+        for (size_t i = 0; i < s1.size(); ++i) {
+            if (toASCIILower(s1[i]) != toASCIILower(s2[i]))
                 return false;
-        } while (c1 && c2);
-        return !c1 && !c2;
+        }
+
+        return true;
+    }
+
+    static bool equal(ASCIILiteral s1, ASCIILiteral s2)
+    {
+        return equal(s1.span8(), s2.span8());
     }
 
     // This algorithm is the one-at-a-time hash from:
     // http://burtleburtle.net/bob/hash/hashfaq.html
     // http://burtleburtle.net/bob/hash/doobs.html
-    static unsigned hash(const char* s)
+    static unsigned hash(std::span<const LChar> s)
     {
         unsigned h = WTF::stringHashingStartValue;
-        for (;;) {
-            char c = *s++;
-            if (!c) {
-                h += (h << 3);
-                h ^= (h >> 11);
-                h += (h << 15);
-                return h;
-            }
+        for (char c : s) {
             h += toASCIILower(c);
             h += (h << 10);
             h ^= (h >> 6);
         }
+        h += (h << 3);
+        h ^= (h >> 11);
+        h += (h << 15);
+        return h;
+    }
+
+    static unsigned hash(ASCIILiteral s)
+    {
+        return hash(s.span8());
     }
 
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
 
 struct HashTranslatorTextEncodingName {
-    static unsigned hash(const char* literal)
+    static unsigned hash(std::span<const LChar> literal)
     {
         return TextEncodingNameHash::hash(literal);
     }
 
-    static bool equal(const ASCIILiteral& a, const char* b)
+    static bool equal(const ASCIILiteral& a, std::span<const LChar> b)
     {
-        return TextEncodingNameHash::equal(a.characters(), b);
+        return TextEncodingNameHash::equal(a.span8(), b);
     }
 };
 
@@ -284,9 +289,9 @@ std::unique_ptr<TextCodec> newTextCodec(const TextEncoding& encoding)
     return result->value();
 }
 
-ASCIILiteral atomCanonicalTextEncodingName(const char* name)
+static ASCIILiteral atomCanonicalTextEncodingName(std::span<const LChar> name)
 {
-    if (!name || !name[0])
+    if (name.empty())
         return { };
 
     Locker locker { encodingRegistryLock };
@@ -304,17 +309,21 @@ ASCIILiteral atomCanonicalTextEncodingName(const char* name)
     return textEncodingNameMap->get<HashTranslatorTextEncodingName>(name);
 }
 
-template<typename CharacterType> static ASCIILiteral atomCanonicalTextEncodingName(std::span<const CharacterType> characters)
+static ASCIILiteral atomCanonicalTextEncodingName(std::span<const UChar> characters)
 {
-    char buffer[maxEncodingNameLength + 1];
-    size_t j = 0;
-    for (auto character : characters) {
-        if (j == maxEncodingNameLength)
-            return { };
-        buffer[j++] = character;
-    }
-    buffer[j] = 0;
-    return atomCanonicalTextEncodingName(buffer);
+    if (characters.size() > maxEncodingNameLength)
+        return { };
+
+    std::array<LChar, maxEncodingNameLength> buffer;
+    for (size_t i = 0; i < characters.size(); ++i)
+        buffer[i] = characters[i];
+
+    return atomCanonicalTextEncodingName(std::span { buffer }.first(characters.size()));
+}
+
+ASCIILiteral atomCanonicalTextEncodingName(ASCIILiteral name)
+{
+    return atomCanonicalTextEncodingName(name.span8());
 }
 
 ASCIILiteral atomCanonicalTextEncodingName(StringView alias)
@@ -359,5 +368,3 @@ String defaultTextEncodingNameForSystemLanguage()
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.h
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.h
@@ -42,7 +42,7 @@ class TextEncoding;
 PAL_EXPORT std::unique_ptr<TextCodec> newTextCodec(const TextEncoding&);
 
 // Only TextEncoding should use the following functions directly.
-ASCIILiteral atomCanonicalTextEncodingName(const char* alias);
+ASCIILiteral atomCanonicalTextEncodingName(ASCIILiteral alias);
 ASCIILiteral atomCanonicalTextEncodingName(StringView);
 bool noExtendedTextEncodingNameUsed();
 bool isJapaneseEncoding(ASCIILiteral canonicalEncodingName);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1424,7 +1424,7 @@ Ref<TextResourceDecoder> InspectorNetworkAgent::createTextDecoder(const String& 
         return TextResourceDecoder::create("text/plain"_s, textEncodingName);
 
     if (MIMETypeRegistry::isTextMIMEType(mimeType))
-        return TextResourceDecoder::create(mimeType, "UTF-8");
+        return TextResourceDecoder::create(mimeType, "UTF-8"_s);
 
     if (MIMETypeRegistry::isXMLMIMEType(mimeType)) {
         auto decoder = TextResourceDecoder::create("application/xml"_s);
@@ -1432,7 +1432,7 @@ Ref<TextResourceDecoder> InspectorNetworkAgent::createTextDecoder(const String& 
         return decoder;
     }
 
-    return TextResourceDecoder::create("text/plain"_s, "UTF-8");
+    return TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);
 }
 
 std::optional<String> InspectorNetworkAgent::textContentForCachedResource(CachedResource& cachedResource)

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -32,6 +32,7 @@
 #include <pal/text/TextEncodingDetector.h>
 #include <pal/text/TextEncodingRegistry.h>
 #include <wtf/ASCIICType.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -72,12 +73,9 @@ static int find(const uint8_t* subject, size_t subjectLength, const char* target
     return -1;
 }
 
-static PAL::TextEncoding findTextEncoding(const uint8_t* encodingName, int length)
+static PAL::TextEncoding findTextEncoding(std::span<const LChar> encodingName)
 {
-    Vector<char, 64> buffer(length + 1);
-    memcpy(buffer.data(), encodingName, length);
-    buffer[length] = '\0';
-    return buffer.data();
+    return StringView { encodingName };
 }
 
 class KanjiCode {
@@ -331,7 +329,7 @@ static inline bool shouldPrependBOM(std::span<const uint8_t> data)
 // https://encoding.spec.whatwg.org/#utf-8-decode
 String TextResourceDecoder::textFromUTF8(std::span<const uint8_t> data)
 {
-    auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8");
+    auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);
     if (shouldPrependBOM(data)) {
         constexpr std::array<uint8_t, 3> bom = { 0xEF, 0xBB, 0xBF };
         decoder->decode(bom);
@@ -351,7 +349,7 @@ void TextResourceDecoder::setEncoding(const PAL::TextEncoding& encoding, Encodin
     // When encoding comes from meta tag (i.e. it cannot be XML files sent via XHR),
     // treat x-user-defined as windows-1252 (bug 18270)
     if (source == EncodingFromMetaTag && equalLettersIgnoringASCIICase(encoding.name(), "x-user-defined"_s))
-        m_encoding = "windows-1252";
+        m_encoding = "windows-1252"_s;
     else if (source == EncodingFromMetaTag || source == EncodingFromXMLHeader || source == EncodingFromCSSCharset)        
         m_encoding = encoding.closestByteBasedEquivalent();
     else
@@ -466,26 +464,27 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
     if (m_buffer.size() <= 13) // strlen('@charset "x";') == 13
         return false;
 
-    const uint8_t* dataStart = m_buffer.data();
-    const uint8_t* dataEnd = dataStart + m_buffer.size();
+    data = m_buffer.span();
 
-    if (bytesEqual(dataStart, '@', 'c', 'h', 'a', 'r', 's', 'e', 't', ' ', '"')) {
-        dataStart += 10;
-        const uint8_t* pos = dataStart;
+    static constexpr std::array<uint8_t, 10> charsetPrefix { '@', 'c', 'h', 'a', 'r', 's', 'e', 't', ' ', '"' };
+    if (equalSpans(data.first(10), std::span { charsetPrefix })) {
+        data = data.subspan(10);
 
-        while (pos < dataEnd && *pos != '"')
-            ++pos;
-        if (pos == dataEnd)
+        size_t index = 0;
+        while (index < data.size() && data[index] != '"')
+            ++index;
+
+        if (index == data.size())
             return false;
 
-        int encodingNameLength = pos - dataStart;
+        auto encodingName = data.first(index);
         
-        ++pos;
-        if (pos == dataEnd)
+        ++index;
+        if (index == data.size())
             return false;
 
-        if (*pos == ';')
-            setEncoding(findTextEncoding(dataStart, encodingNameLength), EncodingFromCSSCharset);
+        if (data[index] == ';')
+            setEncoding(findTextEncoding(encodingName), EncodingFromCSSCharset);
     }
 
     m_checkedForCSSCharset = true;
@@ -512,31 +511,33 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
     if (m_charsetParser)
         return checkForMetaCharset(data);
 
-    const uint8_t* ptr = m_buffer.data();
-    const uint8_t* pEnd = ptr + m_buffer.size();
+    auto bufferData = m_buffer.span();
 
     // Is there enough data available to check for XML declaration?
-    if (m_buffer.size() < 8)
+    if (bufferData.size() < 8)
         return false;
 
     // Handle XML declaration, which can have encoding in it. This encoding is honored even for HTML documents.
     // It is an error for an XML declaration not to be at the start of an XML document, and it is ignored in HTML documents in such case.
-    if (bytesEqual(ptr, '<', '?', 'x', 'm', 'l')) {
-        const uint8_t* xmlDeclarationEnd = ptr;
-        while (xmlDeclarationEnd != pEnd && *xmlDeclarationEnd != '>')
-            ++xmlDeclarationEnd;
-        if (xmlDeclarationEnd == pEnd)
+    static constexpr std::array<uint8_t, 5> xmlPrefix { '<', '?', 'x', 'm', 'l' };
+    static constexpr std::array<uint8_t, 6> xmlPrefixLittleEndian { '<', 0, '?', 0, 'x', 0 };
+    static constexpr std::array<uint8_t, 6> xmlPrefixBigEndian { 0, '<', 0, '?', 0, 'x' };
+    if (equalSpans(bufferData.first(5), std::span { xmlPrefix })) {
+        auto xmlDeclarationEnd = bufferData;
+        while (!xmlDeclarationEnd.empty() && xmlDeclarationEnd[0] != '>')
+            xmlDeclarationEnd = xmlDeclarationEnd.subspan(1);
+        if (xmlDeclarationEnd.empty())
             return false;
         // No need for +1, because we have an extra "?" to lose at the end of XML declaration.
         int len = 0;
-        int pos = findXMLEncoding(ptr, xmlDeclarationEnd - ptr, len);
+        int pos = findXMLEncoding(bufferData.data(), xmlDeclarationEnd.data() - bufferData.data(), len);
         if (pos != -1)
-            setEncoding(findTextEncoding(ptr + pos, len), EncodingFromXMLHeader);
+            setEncoding(findTextEncoding(bufferData.subspan(pos, len)), EncodingFromXMLHeader);
         // continue looking for a charset - it may be specified in an HTTP-Equiv meta
-    } else if (bytesEqual(ptr, '<', 0, '?', 0, 'x', 0)) {
+    } else if (equalSpans(bufferData.first(6), std::span { xmlPrefixLittleEndian })) {
         setEncoding(PAL::UTF16LittleEndianEncoding(), AutoDetectedEncoding);
         return true;
-    } else if (bytesEqual(ptr, 0, '<', 0, '?', 0, 'x')) {
+    } else if (equalSpans(bufferData.first(6), std::span { xmlPrefixBigEndian })) {
         setEncoding(PAL::UTF16BigEndianEncoding(), AutoDetectedEncoding);
         return true;
     }
@@ -564,13 +565,13 @@ void TextResourceDecoder::detectJapaneseEncoding(std::span<const uint8_t> data)
 {
     switch (KanjiCode::judge(data)) {
         case KanjiCode::JIS:
-            setEncoding("ISO-2022-JP", AutoDetectedEncoding);
+            setEncoding("ISO-2022-JP"_s, AutoDetectedEncoding);
             break;
         case KanjiCode::EUC:
-            setEncoding("EUC-JP", AutoDetectedEncoding);
+            setEncoding("EUC-JP"_s, AutoDetectedEncoding);
             break;
         case KanjiCode::SJIS:
-            setEncoding("Shift_JIS", AutoDetectedEncoding);
+            setEncoding("Shift_JIS"_s, AutoDetectedEncoding);
             break;
         case KanjiCode::ASCII:
         case KanjiCode::UTF16:

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -86,7 +86,7 @@ private:
     std::unique_ptr<PAL::TextCodec> m_codec;
     std::unique_ptr<HTMLMetaCharsetParser> m_charsetParser;
     EncodingSource m_source { DefaultEncoding };
-    const char* m_parentFrameAutoDetectedEncoding { nullptr };
+    ASCIILiteral m_parentFrameAutoDetectedEncoding;
     Vector<uint8_t> m_buffer;
     bool m_checkedForBOM { false };
     bool m_checkedForCSSCharset { false };

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -78,7 +78,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
     bool allowFallbackNamespaceOutsideManifestPath = equalLettersIgnoringASCIICase(manifestMIMEType, cacheManifestMIMEType);
     auto manifestPath = WebCore::manifestPath(manifestURL);
 
-    auto manifestString = TextResourceDecoder::create(cacheManifestMIMEType, "UTF-8")->decodeAndFlush(data);
+    auto manifestString = TextResourceDecoder::create(cacheManifestMIMEType, "UTF-8"_s)->decodeAndFlush(data);
 
     return readCharactersForParsing(manifestString, [&]<typename CharacterType> (StringParsingBuffer<CharacterType> buffer) -> std::optional<ApplicationCacheManifest> {
         ApplicationCacheManifest manifest;

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -62,7 +62,7 @@ inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url,
     : ActiveDOMObject(&context)
     , m_url(url)
     , m_withCredentials(eventSourceInit.withCredentials)
-    , m_decoder(TextResourceDecoder::create("text/plain"_s, "UTF-8"))
+    , m_decoder(TextResourceDecoder::create("text/plain"_s, "UTF-8"_s))
 {
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -290,7 +290,7 @@ void WorkerScriptLoader::didReceiveData(const SharedBuffer& buffer)
 #endif
 
     if (!m_decoder)
-        m_decoder = TextResourceDecoder::create("text/javascript"_s, "UTF-8");
+        m_decoder = TextResourceDecoder::create("text/javascript"_s, "UTF-8"_s);
 
     if (buffer.isEmpty())
         return;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1033,14 +1033,14 @@ Ref<TextResourceDecoder> XMLHttpRequest::createDecoder() const
         FALLTHROUGH;
     case ResponseType::Text:
     case ResponseType::Json: {
-        auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8");
+        auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);
         if (responseType() == ResponseType::Json)
             decoder->setAlwaysUseUTF8();
         return decoder;
     }
     case ResponseType::Document: {
         if (equalLettersIgnoringASCIICase(responseMIMEType(), "text/html"_s))
-            return TextResourceDecoder::create("text/html"_s, "UTF-8");
+            return TextResourceDecoder::create("text/html"_s, "UTF-8"_s);
         auto decoder = TextResourceDecoder::create("application/xml"_s);
         // Don't stop on encoding errors, unlike it is done for other kinds of XML resources. This matches the behavior of previous WebKit versions, Firefox and Opera.
         decoder->useLenientXMLDecoding();
@@ -1051,7 +1051,7 @@ Ref<TextResourceDecoder> XMLHttpRequest::createDecoder() const
         ASSERT_NOT_REACHED();
         break;
     }
-    return TextResourceDecoder::create("text/plain"_s, "UTF-8");
+    return TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);
 }
 
 void XMLHttpRequest::didReceiveData(const SharedBuffer& buffer)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -182,7 +182,7 @@ void ServiceWorkerSoftUpdateLoader::didReceiveBuffer(const WebCore::FragmentedSh
         if (!m_responseEncoding.isEmpty())
             m_decoder = TextResourceDecoder::create("text/javascript"_s, m_responseEncoding);
         else
-            m_decoder = TextResourceDecoder::create("text/javascript"_s, "UTF-8");
+            m_decoder = TextResourceDecoder::create("text/javascript"_s, "UTF-8"_s);
     }
 
     buffer.forEachSegment([&](auto segment) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
@@ -85,7 +85,7 @@ static const char* escapeNonASCIIPrintableCharacters(StringView string)
     return resultBuffer.data();
 }
 
-static const char* testDecode(const char* encodingName, std::initializer_list<const char*> inputs)
+static const char* testDecode(ASCIILiteral encodingName, std::initializer_list<const char*> inputs)
 {
     StringBuilder resultBuilder;
     auto codec = newTextCodec(PAL::TextEncoding { encodingName });
@@ -103,138 +103,138 @@ static const char* testDecode(const char* encodingName, std::initializer_list<co
 
 TEST(TextCodec, UTF8)
 {
-    EXPECT_STREQ("", testDecode("UTF-8", { "" }));
+    EXPECT_STREQ("", testDecode("UTF-8"_s, { "" }));
 
-    EXPECT_STREQ("{0}", testDecode("UTF-8", { "00" }));
+    EXPECT_STREQ("{0}", testDecode("UTF-8"_s, { "00" }));
 
-    EXPECT_STREQ("a", testDecode("UTF-8", { "61" }));
-    EXPECT_STREQ("a", testDecode("UTF-8", { "", "61" }));
-    EXPECT_STREQ("a", testDecode("UTF-8", { "61", "" }));
-    EXPECT_STREQ("a", testDecode("UTF-8", { "", "61", "" }));
+    EXPECT_STREQ("a", testDecode("UTF-8"_s, { "61" }));
+    EXPECT_STREQ("a", testDecode("UTF-8"_s, { "", "61" }));
+    EXPECT_STREQ("a", testDecode("UTF-8"_s, { "61", "" }));
+    EXPECT_STREQ("a", testDecode("UTF-8"_s, { "", "61", "" }));
 
-    EXPECT_STREQ("{B6}", testDecode("UTF-8", { "C2 B6" }));
-    EXPECT_STREQ("{B6}", testDecode("UTF-8", { "C2", "B6" }));
-    EXPECT_STREQ("{B6}", testDecode("UTF-8", { "", "C2", "", "B6", "" }));
-    EXPECT_STREQ("x{B6}", testDecode("UTF-8", { "78 C2 B6" }));
-    EXPECT_STREQ("{B6}x", testDecode("UTF-8", { "C2 B6 78" }));
+    EXPECT_STREQ("{B6}", testDecode("UTF-8"_s, { "C2 B6" }));
+    EXPECT_STREQ("{B6}", testDecode("UTF-8"_s, { "C2", "B6" }));
+    EXPECT_STREQ("{B6}", testDecode("UTF-8"_s, { "", "C2", "", "B6", "" }));
+    EXPECT_STREQ("x{B6}", testDecode("UTF-8"_s, { "78 C2 B6" }));
+    EXPECT_STREQ("{B6}x", testDecode("UTF-8"_s, { "C2 B6 78" }));
 
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "E2 98 83" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "E2", "98", "83" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "", "E2", "", "98", "83" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "E2 98", "83" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "", "E2 98", "", "83", "" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "E2", "9883" }));
-    EXPECT_STREQ("{2603}", testDecode("UTF-8", { "", "E2", "", "9883", "" }));
-    EXPECT_STREQ("x{2603}", testDecode("UTF-8", { "78 E2 98 83" }));
-    EXPECT_STREQ("{2603}x", testDecode("UTF-8", { "E2 98 83 78" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "E2 98 83" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "E2", "98", "83" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "", "E2", "", "98", "83" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "E2 98", "83" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "", "E2 98", "", "83", "" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "E2", "9883" }));
+    EXPECT_STREQ("{2603}", testDecode("UTF-8"_s, { "", "E2", "", "9883", "" }));
+    EXPECT_STREQ("x{2603}", testDecode("UTF-8"_s, { "78 E2 98 83" }));
+    EXPECT_STREQ("{2603}x", testDecode("UTF-8"_s, { "E2 98 83 78" }));
 
-    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8", { "F0 9F 92 A9" }));
-    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8", { "F0", "9F", "92", "A9" }));
-    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8", { "", "F0", "", "9F", "", "92", "" , "A9", "" }));
-    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8", { "F09F92", "A9" }));
-    EXPECT_STREQ("x{1F4A9}", testDecode("UTF-8", { "78 F0 9F 92 A9" }));
-    EXPECT_STREQ("{1F4A9}x", testDecode("UTF-8", { "F0 9F 92 A9 78" }));
+    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8"_s, { "F0 9F 92 A9" }));
+    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8"_s, { "F0", "9F", "92", "A9" }));
+    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8"_s, { "", "F0", "", "9F", "", "92", "" , "A9", "" }));
+    EXPECT_STREQ("{1F4A9}", testDecode("UTF-8"_s, { "F09F92", "A9" }));
+    EXPECT_STREQ("x{1F4A9}", testDecode("UTF-8"_s, { "78 F0 9F 92 A9" }));
+    EXPECT_STREQ("{1F4A9}x", testDecode("UTF-8"_s, { "F0 9F 92 A9 78" }));
 }
 
 TEST(TextCodec, UTF8InvalidSequences)
 {
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0 A5 3F" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0 A5", "3F" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0", "A5 3F" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0", "A5", "3F" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0", "", "A5", "", "3F" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "E0", "", "A5", "", "3F", "" }));
-    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8", { "", "E0", "", "A5", "", "3F", "" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0 A5 3F" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0 A5", "3F" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0", "A5 3F" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0", "A5", "3F" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0", "", "A5", "", "3F" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "E0", "", "A5", "", "3F", "" }));
+    EXPECT_STREQ("{FFFD}? ERROR", testDecode("UTF-8"_s, { "", "E0", "", "A5", "", "3F", "" }));
 
-    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8", { "61 E0 A5 3F" }));
-    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8", { "61 E0 A5", "3F" }));
-    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8", { "61 E0", "A5 3F" }));
-    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8", { "61 E0", "A5", "3F" }));
+    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8"_s, { "61 E0 A5 3F" }));
+    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8"_s, { "61 E0 A5", "3F" }));
+    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8"_s, { "61 E0", "A5 3F" }));
+    EXPECT_STREQ("a{FFFD}? ERROR", testDecode("UTF-8"_s, { "61 E0", "A5", "3F" }));
 
-    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8", { "C2 B6 E0 A5 3F" }));
-    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8", { "C2 B6 E0 A5", "3F" }));
-    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8", { "C2 B6 E0", "A5 3F" }));
-    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8", { "C2 B6 E0", "A5", "3F" }));
+    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8"_s, { "C2 B6 E0 A5 3F" }));
+    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8"_s, { "C2 B6 E0 A5", "3F" }));
+    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8"_s, { "C2 B6 E0", "A5 3F" }));
+    EXPECT_STREQ("{B6}{FFFD}? ERROR", testDecode("UTF-8"_s, { "C2 B6 E0", "A5", "3F" }));
 
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "C2" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "E2" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "E2 98" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0 9F" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0 9F 92" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "C2" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "E2" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "E2 98" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 9F" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 9F 92" }));
 
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "E2", "98" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0", "9F" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0 9F", "92" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0", "9F92" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "F0", "9F", "92" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "E2", "98" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0", "9F" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 9F", "92" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0", "9F92" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "F0", "9F", "92" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "C0 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "E0 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "C0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "E0 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 80 80 80" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "C1 BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "E0 81 BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 80 81 BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 80 81 BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 80 81 BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "C1 BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "E0 81 BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 80 81 BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 80 81 BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 80 81 BF" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "E0 82 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 80 82 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 80 82 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 80 82 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "E0 82 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 80 82 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 80 82 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 80 82 80" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "E0 9F BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 80 9F BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 80 9F BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 80 9F BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "E0 9F BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 80 9F BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 80 9F BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 80 9F BF" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 80 A0 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 80 A0 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 80 A0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 80 A0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 80 A0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 80 A0 80" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 8F BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 8F BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 8F BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 8F BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 8F BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 8F BF BF" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 80 90 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 80 90 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 80 90 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 80 90 80 80" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 84 8F BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 84 8F BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 84 8F BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 84 8F BF BF" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F4 90 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FB BF BF BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FD BF BF BF BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "ED A0 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "ED BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "ED A0 BD ED B2 A9" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F4 90 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FB BF BF BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FD BF BF BF BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "ED A0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "ED BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "ED A0 BD ED B2 A9" }));
 
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F8 84 90 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FC 80 84 90 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 8D A0 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 8D BF BF" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "F0 8D A0 BD F0 8D B2 A9" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F8 84 90 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FC 80 84 90 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 8D A0 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 8D BF BF" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 8D A0 BD F0 8D B2 A9" }));
 
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "80" }));
-    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80 80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80 80 80 80 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "80 80 80 80 80 80 80" }));
-    EXPECT_STREQ("{B6}{FFFD} ERROR", testDecode("UTF-8", { "C2 B6 80" }));
-    EXPECT_STREQ("{2603}{FFFD} ERROR", testDecode("UTF-8", { "E2 98 83 80" }));
-    EXPECT_STREQ("{1F4A9}{FFFD} ERROR", testDecode("UTF-8", { "F0 9F 92 A9 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FB BF BF BF BF 80" }));
-    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FD BF BF BF BF BF 80" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "80" }));
+    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80 80 80 80 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "80 80 80 80 80 80 80" }));
+    EXPECT_STREQ("{B6}{FFFD} ERROR", testDecode("UTF-8"_s, { "C2 B6 80" }));
+    EXPECT_STREQ("{2603}{FFFD} ERROR", testDecode("UTF-8"_s, { "E2 98 83 80" }));
+    EXPECT_STREQ("{1F4A9}{FFFD} ERROR", testDecode("UTF-8"_s, { "F0 9F 92 A9 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FB BF BF BF BF 80" }));
+    EXPECT_STREQ("{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FD BF BF BF BF BF 80" }));
 
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "FE" }));
-    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FE 80" }));
-    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8", { "FF" }));
-    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8", { "FF 80" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "FE" }));
+    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FE 80" }));
+    EXPECT_STREQ("{FFFD} ERROR", testDecode("UTF-8"_s, { "FF" }));
+    EXPECT_STREQ("{FFFD}{FFFD} ERROR", testDecode("UTF-8"_s, { "FF 80" }));
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/URLParserTextEncoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/URLParserTextEncoding.cpp
@@ -142,7 +142,7 @@ TEST_F(URLParserTextEncodingTest, QueryEncoding)
 {
     checkURL(utf16String(u"http://host?ß😍#ß😍"), nullptr, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, "%C3%9F%F0%9F%98%8D"_s, "%C3%9F%F0%9F%98%8D"_s, utf16String(u"http://host/?%C3%9F%F0%9F%98%8D#%C3%9F%F0%9F%98%8D")}, testTabsValueForSurrogatePairs);
 
-    PAL::TextEncoding latin1("latin1");
+    PAL::TextEncoding latin1("latin1"_s);
     checkURL("http://host/?query with%20spaces"_s, &latin1, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, "query%20with%20spaces"_s, emptyString(), "http://host/?query%20with%20spaces"_s});
     checkURL("http://host/?query"_s, &latin1, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, "query"_s, emptyString(), "http://host/?query"_s});
     checkURL("http://host/?\tquery"_s, &latin1, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, "query"_s, emptyString(), "http://host/?query"_s});
@@ -154,7 +154,7 @@ TEST_F(URLParserTextEncodingTest, QueryEncoding)
     checkURL("http://host/?query"_s, &unrecognized, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, emptyString(), emptyString(), "http://host/?"_s});
     checkURL("http://host/?"_s, &unrecognized, {"http"_s, emptyString(), emptyString(), "host"_s, 0, "/"_s, emptyString(), emptyString(), "http://host/?"_s});
 
-    PAL::TextEncoding iso88591("ISO-8859-1");
+    PAL::TextEncoding iso88591("ISO-8859-1"_s);
     String withUmlauts = utf16String<4>({0xDC, 0x430, 0x451, '\0'});
     checkURL(makeString("ws://host/path?"_s, withUmlauts), &iso88591, {"ws"_s, emptyString(), emptyString(), "host"_s, 0, "/path"_s, "%C3%9C%D0%B0%D1%91"_s, emptyString(), "ws://host/path?%C3%9C%D0%B0%D1%91"_s});
     checkURL(makeString("wss://host/path?"_s, withUmlauts), &iso88591, {"wss"_s, emptyString(), emptyString(), "host"_s, 0, "/path"_s, "%C3%9C%D0%B0%D1%91"_s, emptyString(), "wss://host/path?%C3%9C%D0%B0%D1%91"_s});


### PR DESCRIPTION
#### 3798bfb9a809f6d40f35c6ea29226183c07c17d8
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PAL
<a href="https://bugs.webkit.org/show_bug.cgi?id=282370">https://bugs.webkit.org/show_bug.cgi?id=282370</a>

Reviewed by Darin Adler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/icu/UnicodeExtras.h: Added.
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::URLEscapeSequence::decodeRun):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
* Source/WebCore/PAL/pal/text/TextEncoding.cpp:
(PAL::UTF7Encoding):
(PAL::TextEncoding::TextEncoding):
(PAL::TextEncoding::domName const):
(PAL::TextEncoding::usesVisualOrdering const):
(PAL::ASCIIEncoding):
(PAL::Latin1Encoding):
(PAL::UTF16BigEndianEncoding):
(PAL::UTF16LittleEndianEncoding):
(PAL::UTF8Encoding):
(PAL::WindowsLatin1Encoding):
* Source/WebCore/PAL/pal/text/TextEncoding.h:
* Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp:
(PAL::detectTextEncoding):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::TextEncodingNameHash::equal):
(PAL::TextEncodingNameHash::hash):
(PAL::HashTranslatorTextEncodingName::hash):
(PAL::HashTranslatorTextEncodingName::equal):
(PAL::atomCanonicalTextEncodingName):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.h:

Canonical link: <a href="https://commits.webkit.org/285998@main">https://commits.webkit.org/285998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cedc392bae4363c3feab5ebf4566e0fcac93703e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74447 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58498 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21515 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24018 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67584 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80348 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73705 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66784 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10004 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8164 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95486 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1728 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4516 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20966 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->