### PR TITLE
Make SWServerToContextConnection RefCounted

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -53,9 +53,8 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
-class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr<SWServerToContextConnection>, public Identified<SWServerToContextConnectionIdentifier> {
+class SWServerToContextConnection: public RefCountedAndCanMakeWeakPtr<SWServerToContextConnection>, public Identified<SWServerToContextConnectionIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(SWServerToContextConnection);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerToContextConnection);
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -102,7 +102,7 @@ void SWServerWorker::updateAppInitiatedValue(LastNavigationWasAppInitiated lastN
     if (!isRunning())
         return;
 
-    if (CheckedPtr connection = contextConnection())
+    if (RefPtr connection = contextConnection())
         connection->updateAppInitiatedValue(identifier(), lastNavigationWasAppInitiated);
 }
 
@@ -131,7 +131,7 @@ void SWServerWorker::whenTerminated(CompletionHandler<void()>&& callback)
 
 void SWServerWorker::startTermination(CompletionHandler<void()>&& callback)
 {
-    CheckedPtr contextConnection = this->contextConnection();
+    RefPtr contextConnection = this->contextConnection();
     ASSERT(contextConnection);
     if (!contextConnection) {
         RELEASE_LOG_ERROR(ServiceWorker, "Request to terminate a worker %" PRIu64 " whose context connection does not exist", identifier().toUInt64());
@@ -166,7 +166,8 @@ void SWServerWorker::callTerminationCallbacks()
 void SWServerWorker::terminationTimerFired()
 {
     ASSERT(isTerminating());
-    contextConnection()->terminateDueToUnresponsiveness();
+    if (RefPtr contextConnection = this->contextConnection())
+        contextConnection->terminateDueToUnresponsiveness();
 }
 
 const ClientOrigin& SWServerWorker::origin() const
@@ -272,7 +273,7 @@ void SWServerWorker::setScriptResource(URL&& url, ServiceWorkerContextData::Impo
 void SWServerWorker::didSaveScriptsToDisk(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)
 {
     // Send mmap'd version of the scripts to the ServiceWorker process so we can save dirty memory.
-    if (CheckedPtr contextConnection = this->contextConnection())
+    if (RefPtr contextConnection = this->contextConnection())
         contextConnection->didSaveScriptsToDisk(identifier(), mainScript, importedScripts);
 
     // The scripts were saved to disk, replace our scripts with the mmap'd version to save dirty memory.

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -491,7 +491,7 @@ private:
     bool m_captureExtraNetworkLoadMetricsEnabled { false };
 
     WeakPtr<WebSWServerConnection> m_swConnection;
-    std::unique_ptr<WebSWServerToContextConnection> m_swContextConnection;
+    RefPtr<WebSWServerToContextConnection> m_swContextConnection;
     WeakPtr<WebSharedWorkerServerConnection> m_sharedWorkerConnection;
     RefPtr<WebSharedWorkerServerToContextConnection> m_sharedWorkerContextConnection;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -130,7 +130,7 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
 ServiceWorkerFetchTask::~ServiceWorkerFetchTask()
 {
     SWFETCH_RELEASE_LOG("~ServiceWorkerFetchTask:");
-    if (CheckedPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
+    if (RefPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
         serviceWorkerConnection->unregisterFetch(*this);
 
     cancelPreloadIfNecessary();
@@ -161,7 +161,7 @@ void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorker
 
 void ServiceWorkerFetchTask::workerClosed()
 {
-    if (CheckedPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
+    if (RefPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
         serviceWorkerConnection->unregisterFetch(*this);
     contextClosed();
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -153,28 +153,28 @@ void WebSWServerConnection::startScriptFetchInClient(ServiceWorkerJobIdentifier 
 void WebSWServerConnection::updateRegistrationStateInClient(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerRegistrationState state, const std::optional<ServiceWorkerData>& serviceWorkerData)
 {
     send(Messages::WebSWClientConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));
-    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (RefPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));
 }
 
 void WebSWServerConnection::fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier identifier)
 {
     send(Messages::WebSWClientConnection::FireUpdateFoundEvent(identifier));
-    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (RefPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::FireUpdateFoundEvent(identifier));
 }
 
 void WebSWServerConnection::setRegistrationLastUpdateTime(ServiceWorkerRegistrationIdentifier identifier, WallTime lastUpdateTime)
 {
     send(Messages::WebSWClientConnection::SetRegistrationLastUpdateTime(identifier, lastUpdateTime));
-    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (RefPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::SetRegistrationLastUpdateTime(identifier, lastUpdateTime));
 }
 
 void WebSWServerConnection::setRegistrationUpdateViaCache(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerUpdateViaCache updateViaCache)
 {
     send(Messages::WebSWClientConnection::SetRegistrationUpdateViaCache(identifier, updateViaCache));
-    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (RefPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::SetRegistrationUpdateViaCache(identifier, updateViaCache));
 }
 
@@ -186,7 +186,7 @@ void WebSWServerConnection::notifyClientsOfControllerChange(const HashSet<Script
 void WebSWServerConnection::updateWorkerStateInClient(ServiceWorkerIdentifier worker, ServiceWorkerState state)
 {
     send(Messages::WebSWClientConnection::UpdateWorkerState(worker, state));
-    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (RefPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::UpdateWorkerState(worker, state));
 }
 
@@ -456,7 +456,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
         return contextOrigin != origin.clientOrigin;
     });
     RefPtr server = protectedServer();
-    CheckedPtr contextConnection = isNewOrigin ? server->contextConnectionForRegistrableDomain(RegistrableDomain { contextOrigin }) : nullptr;
+    RefPtr contextConnection = isNewOrigin ? server->contextConnectionForRegistrableDomain(RegistrableDomain { contextOrigin }) : nullptr;
 
     m_clientOrigins.add(data.identifier, clientOrigin);
 
@@ -498,7 +498,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
     if (isDeletedOrigin) {
         RegistrableDomain potentiallyRemovedDomain { clientOrigin.clientOrigin };
         if (!hasMatchingClient(potentiallyRemovedDomain)) {
-            if (CheckedPtr contextConnection = protectedServer()->contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
+            if (RefPtr contextConnection = protectedServer()->contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
                 auto& connection = static_cast<WebSWServerToContextConnection&>(*contextConnection);
                 protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
             }
@@ -534,7 +534,7 @@ void WebSWServerConnection::updateThrottleState()
         origins.add(origin.clientOrigin);
 
     for (auto& origin : origins) {
-        if (CheckedPtr contextConnection = protectedServer()->contextConnectionForRegistrableDomain(RegistrableDomain { origin })) {
+        if (RefPtr contextConnection = protectedServer()->contextConnectionForRegistrableDomain(RegistrableDomain { origin })) {
             auto& connection = static_cast<WebSWServerToContextConnection&>(*contextConnection);
 
             if (connection.isThrottleable() == m_isThrottleable)


### PR DESCRIPTION
#### 3d0e7ad3913b69dcde692cd57f9919e2d88b478c
<pre>
Make SWServerToContextConnection RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=282390">https://bugs.webkit.org/show_bug.cgi?id=282390</a>
<a href="https://rdar.apple.com/problem/138999597">rdar://problem/138999597</a>

Reviewed by Chris Dumez.

By moving to RefCounted, we align with WebSharedWorkerServerToContextConnection.
We remove some CheckedPtr and are able to take a Ref to the connection when no longer needing it, which is safer.
In the future, we might also close it at the time we send a message to terminate unresponsive service workers, which will be made easier with this patch.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::tryInstallContextData):
(WebCore::SWServer::terminateContextConnectionWhenPossible):
(WebCore::SWServer::installContextData):
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::runServiceWorker):
(WebCore::SWServer::fireInstallEvent):
(WebCore::SWServer::unregisterServiceWorkerClient):
(WebCore::SWServer::removeContextConnectionIfPossible):
(WebCore::SWServer::contextConnectionForRegistrableDomain):
(WebCore::SWServer::setInspectable):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::updateAppInitiatedValue):
(WebCore::SWServerWorker::startTermination):
(WebCore::SWServerWorker::contextConnection):
(WebCore::SWServerWorker::didSaveScriptsToDisk):
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didClose):
(WebKit::NetworkConnectionToWebProcess::establishSWContextConnection):
(WebKit::NetworkConnectionToWebProcess::closeSWContextConnection):
(WebKit::NetworkConnectionToWebProcess::serviceWorkerServerToContextConnectionNoLongerNeeded):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::ServiceWorkerDownloadTask):
(WebKit::ServiceWorkerDownloadTask::startListeningForIPC):
(WebKit::ServiceWorkerDownloadTask::close):
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::~ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::workerClosed):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::updateRegistrationStateInClient):
(WebKit::WebSWServerConnection::fireUpdateFoundEvent):
(WebKit::WebSWServerConnection::setRegistrationLastUpdateTime):
(WebKit::WebSWServerConnection::setRegistrationUpdateViaCache):
(WebKit::WebSWServerConnection::updateWorkerStateInClient):
(WebKit::WebSWServerConnection::registerServiceWorkerClientInternal):
(WebKit::WebSWServerConnection::unregisterServiceWorkerClient):
(WebKit::WebSWServerConnection::updateThrottleState):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::WebSWServerToContextConnection):
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):
(WebKit::WebSWServerToContextConnection::stop):
(WebKit::WebSWServerToContextConnection::protectedConnection const):
(WebKit::WebSWServerToContextConnection::networkProcess):
(WebKit::WebSWServerToContextConnection::protectedIPCConnection const):
(WebKit::WebSWServerToContextConnection::ipcConnection const):
(WebKit::WebSWServerToContextConnection::messageSenderConnection const):
(WebKit::WebSWServerToContextConnection::firePushEvent):
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
(WebKit::WebSWServerToContextConnection::connectionIsNoLongerNeeded):
(WebKit::WebSWServerToContextConnection::navigate):
(WebKit::WebSWServerToContextConnection::webProcessIdentifier const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/286161@main">https://commits.webkit.org/286161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e961e226ab5a726c4caf30779ce00f938c5dc1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58886 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21938 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67139 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8541 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2295 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->