### PR TITLE
Replace more use of MallocPtr with newer MallocSpan

### DIFF
--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
 #include <wtf/IterationStatus.h>
+#include <wtf/MallocPtr.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/jit/JITCodeMap.h
+++ b/Source/JavaScriptCore/jit/JITCodeMap.h
@@ -29,6 +29,7 @@
 
 #include "BytecodeIndex.h"
 #include "CodeLocation.h"
+#include <wtf/MallocPtr.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -74,6 +74,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/HashMap.h>
 #include <wtf/LazyRef.h>
 #include <wtf/LazyUniqueRef.h>
+#include <wtf/MallocPtr.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <wtf/BlockPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/cocoa/SpanCocoa.h>
@@ -118,7 +119,16 @@ inline Vector<uint8_t> makeVector(NSData *data)
     return span(data);
 }
 
+template<typename T>
+inline RetainPtr<dispatch_data_t> makeDispatchData(Vector<T>&& vector)
+{
+    auto buffer = vector.releaseBuffer();
+    auto span = buffer.span();
+    return adoptNS(dispatch_data_create(span.data(), span.size_bytes(), dispatch_get_main_queue(), makeBlockPtr([buffer = WTFMove(buffer)] { }).get()));
+}
+
 } // namespace WTF
 
 using WTF::createNSArray;
+using WTF::makeDispatchData;
 using WTF::makeVector;

--- a/Source/WTF/wtf/glib/GSpanExtras.cpp
+++ b/Source/WTF/wtf/glib/GSpanExtras.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include <wtf/glib/GSpanExtras.h>
 
+#include <wtf/StdLibExtras.h>
+
 namespace WTF {
 
 GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile* keyFile, const char* groupName, GUniqueOutPtr<GError>& error)
@@ -29,7 +31,7 @@ GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile* keyFile, const char* g
 
     size_t keyCount = 0;
     char** keys = g_key_file_get_keys(keyFile, groupName, &keyCount, &error.outPtr());
-    return adoptGMallocSpan<char*, GMallocStrv>(keys, keyCount);
+    return adoptGMallocSpan<char*, GMallocStrv>(unsafeMakeSpan(keys, keyCount));
 }
 
 GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass* objectClass)
@@ -38,7 +40,7 @@ GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass* objectClass)
 
     unsigned propertyCount = 0;
     GParamSpec** properties = g_object_class_list_properties(objectClass, &propertyCount);
-    return adoptGMallocSpan(properties, propertyCount);
+    return adoptGMallocSpan(unsafeMakeSpan(properties, propertyCount));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -59,9 +59,9 @@ template <typename T, typename Malloc = GMalloc>
 using GMallocSpan = MallocSpan<T, Malloc>;
 
 template<typename T, typename Malloc = GMalloc>
-GMallocSpan<T, Malloc> adoptGMallocSpan(T* ptr, size_t size)
+GMallocSpan<T, Malloc> adoptGMallocSpan(std::span<T> span)
 {
-    return adoptMallocSpan<T, Malloc>(ptr, size);
+    return adoptMallocSpan<T, Malloc>(span);
 }
 
 WTF_EXPORT_PRIVATE GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile*, const char* groupName, GUniqueOutPtr<GError>&);

--- a/Source/WTF/wtf/text/StringBuffer.h
+++ b/Source/WTF/wtf/text/StringBuffer.h
@@ -32,7 +32,7 @@
 #include <unicode/utypes.h>
 #include <wtf/Assertions.h>
 #include <wtf/DebugHeap.h>
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 
 namespace WTF {
@@ -73,11 +73,9 @@ public:
 
     CharType& operator[](unsigned i) { RELEASE_ASSERT(i < m_length); return m_data[i]; }
 
-    MallocPtr<CharType, StringBufferMalloc> release()
+    MallocSpan<CharType, StringBufferMalloc> release()
     {
-        CharType* data = m_data;
-        m_data = nullptr;
-        return adoptMallocPtr<CharType, StringBufferMalloc>(data);
+        return adoptMallocSpan<CharType, StringBufferMalloc>(unsafeMakeSpan(std::exchange(m_data, nullptr), std::exchange(m_length, 0)));
     }
 
 private:

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1543,18 +1543,16 @@ std::optional<UCharDirection> StringImpl::defaultWritingDirection()
 
 Ref<StringImpl> StringImpl::adopt(StringBuffer<LChar>&& buffer)
 {
-    unsigned length = buffer.length();
-    if (!length)
+    if (!buffer.length())
         return *empty();
-    return adoptRef(*new StringImpl(buffer.release(), length));
+    return adoptRef(*new StringImpl(buffer.release()));
 }
 
 Ref<StringImpl> StringImpl::adopt(StringBuffer<UChar>&& buffer)
 {
-    unsigned length = buffer.length();
-    if (!length)
+    if (!buffer.length())
         return *empty();
-    return adoptRef(*new StringImpl(buffer.release(), length));
+    return adoptRef(*new StringImpl(buffer.release()));
 }
 
 size_t StringImpl::sizeInBytes() const

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -37,7 +37,7 @@
 #include <wtf/BlockPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakObjCPtr.h>
-#include <wtf/cocoa/SpanCocoa.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 ALLOW_COMMA_BEGIN
@@ -186,15 +186,6 @@ void NetworkRTCTCPSocketCocoa::setOption(int option, int value)
     nw_connection_reset_traffic_class(m_nwConnection.get(), *trafficClass);
 }
 
-static RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&& v)
-{
-    auto bufferSize = v.size();
-    auto rawPointer = v.releaseBuffer().leakPtr();
-    return adoptNS(dispatch_data_create(rawPointer, bufferSize, dispatch_get_main_queue(), ^{
-        fastFree(rawPointer);
-    }));
-}
-
 Vector<uint8_t> NetworkRTCTCPSocketCocoa::createMessageBuffer(std::span<const uint8_t> data)
 {
     if (data.size() >= std::numeric_limits<uint16_t>::max())
@@ -232,7 +223,7 @@ void NetworkRTCTCPSocketCocoa::sendTo(std::span<const uint8_t> data, const rtc::
     if (buffer.isEmpty())
         return;
 
-    nw_connection_send(m_nwConnection.get(), dataFromVector(WTFMove(buffer)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([identifier = m_identifier, connection = m_connection.copyRef(), options](_Nullable nw_error_t) {
+    nw_connection_send(m_nwConnection.get(), makeDispatchData(WTFMove(buffer)).get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([identifier = m_identifier, connection = m_connection.copyRef(), options](_Nullable nw_error_t) {
         connection->send(Messages::LibWebRTCNetwork::SignalSentPacket { identifier, options.packet_id, rtc::TimeMillis() }, 0);
     }).get());
 }

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -37,6 +37,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <wtf/Assertions.h>
+#include <wtf/MallocPtr.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
@@ -30,6 +30,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/ASCIILiteral.h>
 
 namespace WebKit {
@@ -79,12 +80,7 @@ void startListeningForMachServiceConnections(const char* serviceName, ASCIILiter
 
 RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&& vector)
 {
-    auto bufferSize = vector.size();
-    auto rawPointer = vector.releaseBuffer().leakPtr();
-    auto dispatchData = adoptNS(dispatch_data_create(rawPointer, bufferSize, dispatch_get_main_queue(), ^{
-        fastFree(rawPointer);
-    }));
-    return adoptNS(xpc_data_create_with_dispatch_data(dispatchData.get()));
+    return adoptNS(xpc_data_create_with_dispatch_data(makeDispatchData(WTFMove(vector)).get()));
 }
 
 OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -98,6 +98,4 @@ private:
     Connection m_connection;
 };
 
-RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&&);
-
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 static int provisionalLoadCount;
 
@@ -233,7 +234,7 @@ TEST(WebKit, LoadMoreThan4GB)
     "</script>"_s;
 
     using namespace TestWebKitAPI;
-    auto longData = dataFromVector(Vector<uint8_t>(static_cast<size_t>(0x10000000), [] (size_t) {
+    auto longData = makeDispatchData(Vector<uint8_t>(static_cast<size_t>(0x10000000), [] (size_t) {
         return static_cast<uint8_t>('a');
     }));
 


### PR DESCRIPTION
#### 469e8d288d11f72a19c28830fd431ef07fcb0567
<pre>
Replace more use of MallocPtr with newer MallocSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=282392">https://bugs.webkit.org/show_bug.cgi?id=282392</a>

Reviewed by Geoffrey Garen and Darin Adler.

Replace more use of MallocPtr with newer MallocSpan.

Also fix an issue when using MallocSpan&lt;T&gt; when sizeof(T)
is not 1. We were failing to multiply the size by sizeof(T)
before calling malloc functions.

* Source/JavaScriptCore/bytecode/ExpressionInfo.h:
* Source/JavaScriptCore/jit/JITCodeMap.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/WTF/wtf/Vector.h:
(WTF::VectorBufferBase::releaseBuffer):
(WTF::VectorBuffer::releaseBuffer):
(WTF::Malloc&gt;::releaseBuffer):
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::dispatchDataFromVector):
* Source/WTF/wtf/text/StringBuffer.h:
(WTF::StringBuffer::release):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::StringImpl):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::closeCurrentStream):
(WebCore::advanceCurrentStream):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::sendTo):
(WebKit::dataFromVector): Deleted.
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSendStreamCocoa.mm:
(WebKit::NetworkTransportSendStream::sendBytes):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::sendDatagram):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::createWithoutCopying):
(API::Data::create):
(API::Data::Data):
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::vectorToXPCData):
* Tools/TestWebKitAPI/NetworkConnection.h:
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::Connection::awaitableSend):
(TestWebKitAPI::Connection::send const):
(TestWebKitAPI::Connection::sendAndReportError const):
(TestWebKitAPI::dataFromVector): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST(WebKit, LoadMoreThan4GB)):

Canonical link: <a href="https://commits.webkit.org/286028@main">https://commits.webkit.org/286028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53588a4ce36039f69fde33b13257b3ad0f04cdc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27356 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1759 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16878 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21591 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24116 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67682 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80454 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73803 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1099 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66145 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10078 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95584 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1827 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20983 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1855 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->