### PR TITLE
[WebKit] Fix actor-isolation warnings in Swift overlay

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -117,7 +117,7 @@ SUPPORTS_MACCATALYST = YES;
 // Can't enable objcxx mode until rdar://135979809 is resolved.
 SWIFT_OBJC_INTEROP_MODE = objc;
 SWIFT_VERSION = 5.0;
-OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400)) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports -Xfrontend -enable-experimental-concurrency $(OTHER_SWIFT_FLAGS_AVAILABILITY_$(USE_INTERNAL_SDK));
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400)) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports -Xfrontend -enable-experimental-concurrency -enable-upcoming-feature IsolatedDefaultValues $(OTHER_SWIFT_FLAGS_AVAILABILITY_$(USE_INTERNAL_SDK));
 OTHER_SWIFT_FLAGS_AVAILABILITY_YES = @$(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/Scripts/availability-definitions.txt;
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -444,7 +444,7 @@ If the data is written to a file the resulting file is a valid PDF document.
 It can be used to represent web content on a pasteboard, loaded into a WKWebView directly, and saved to a file for later use.
 The uniform type identifier kUTTypeWebArchive can be used get the related pasteboard type and MIME type.
 */
-- (void)createWebArchiveDataWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *, NSError *))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)createWebArchiveDataWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable, NSError * _Nullable))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /*! @abstract A Boolean value indicating whether horizontal swipe gestures
  will trigger back-forward list navigations.

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -39,23 +39,25 @@ extension WKPDFConfiguration {
 
 @available(iOS 14.0, macOS 10.16, *)
 extension WKWebView {
-    public func callAsyncJavaScript(_ functionBody: String, arguments: [String:Any] = [:], in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil) {
-        __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld, completionHandler: completionHandler.map(ObjCBlockConversion.boxingNilAsAnyForCompatibility))
+    @preconcurrency public func callAsyncJavaScript(_ functionBody: String, arguments: [String:Any] = [:], in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil) {
+        let thunk = completionHandler.map { ObjCBlockConversion.boxingNilAsAnyForCompatibility($0) }
+        __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
-    public func createPDF(configuration: WKPDFConfiguration = .init(), completionHandler: @escaping (Result<Data, Error>) -> Void) {
+    @preconcurrency public func createPDF(configuration: WKPDFConfiguration = .init(), completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
         __createPDF(with: configuration, completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
-    public func createWebArchiveData(completionHandler: @escaping (Result<Data, Error>) -> Void) {
+    @preconcurrency public func createWebArchiveData(completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
         __createWebArchiveData(completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
-    public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil) {
-        __evaluateJavaScript(javaScript, inFrame: frame, in: contentWorld, completionHandler: completionHandler.map(ObjCBlockConversion.boxingNilAsAnyForCompatibility))
+    @preconcurrency public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil) {
+        let thunk = completionHandler.map { ObjCBlockConversion.boxingNilAsAnyForCompatibility($0) }
+        __evaluateJavaScript(javaScript, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
-    public func find(_ string: String, configuration: WKFindConfiguration = .init(), completionHandler: @escaping (WKFindResult) -> Void) {
+    @preconcurrency public func find(_ string: String, configuration: WKFindConfiguration = .init(), completionHandler: @MainActor @escaping (WKFindResult) -> Void) {
         __find(string, with: configuration, completionHandler: completionHandler)
     }
 }


### PR DESCRIPTION
#### 967f1ef0f0c879e16d0e2140336e023c82c95172
<pre>
[WebKit] Fix actor-isolation warnings in Swift overlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=280924">https://bugs.webkit.org/show_bug.cgi?id=280924</a>
<a href="https://rdar.apple.com/problem/137317585">rdar://problem/137317585</a>

Reviewed by Geoffrey Garen.

In <a href="https://commits.webkit.org/278930@main">https://commits.webkit.org/278930@main</a>, we annotated WebKit&apos;s ObjC
API to mark main-thread-only classes and callback blocks. Refactor the
Swift overlays of these APIs to match.

* Source/WebKit/Configurations/Base.xcconfig: Enable the
  &quot;IsolatedDefaultValues&quot; feature, which makes default values of
  functions initialize in the same isolation domain. This means that in
  an async function like

      public func pdf(configuration: WKPDFConfiguration = .init()) async throws -&gt; Data

  a caller using the default value must either be in the same isolation
  domain as WKPDFConfiguration (the main thread), or make the call
  asynchronously with `await webView.pdf()`.

  See also: <a href="https://github.com/swiftlang/swift-evolution/blob/main/proposals/0411-isolated-default-values.md">https://github.com/swiftlang/swift-evolution/blob/main/proposals/0411-isolated-default-values.md</a>

* Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift:
  Mark the closures returned by these `Result&lt;_,_&gt;` wrappers as
  @MainActor. Mark the higher-order static functions `nonisolated`.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h: Add missing
  nullability annotations to
  -createWebArchiveDataWithCompletionHandler:. This is not a
  source-breaking change because the method has a Swift overlay method
  with correct nullability. We never noticed this because of automatic
  optional promotion in the ObjectiveCBlockConversions funcctions.

* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
  - Add missing @MainActor annotations to completion handlers to match
    the ObjC API. Mark these as @preconcurrency to avoid source breaks
    for clients in Swift 5 mode.
  - Refactor use of Optional.map to pass an actual closure, not a
    function parameter. This is required for the return type to infer
    the @MainActor isolation of the closure returned by
    ObjectiveCBlockConversions functions.

(WKWebView.callAsyncJavaScript(_:arguments:in:in:completionHandler:Error:)):
(WKWebView.createPDF(_:completionHandler:Error:)):
(WKWebView.createWebArchiveData(_:Error:)):
(WKWebView.evaluateJavaScript(_:in:in:completionHandler:Error:)):

Canonical link: <a href="https://commits.webkit.org/286620@main">https://commits.webkit.org/286620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea700ea4331ec0fee22440c5ee6d657601a84aa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76547 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/55582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29453 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3875 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/81074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79614 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47325 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/26147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3923 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4076 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16845 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6679 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->