### PR TITLE
[WebGPU] Allow bind groups with unused external textures to be used in a shader

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_282098-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_282098-expected.txt
@@ -1,0 +1,9 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderImage {IMG} at (0,0) size 38x135
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/fast/webgpu/regression/repro_282098.html
+++ b/LayoutTests/fast/webgpu/regression/repro_282098.html
@@ -1,0 +1,117 @@
+<img id="img0" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAACHCAYAAAB6fSvlAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAJqADAAQAAAABAAAAhwAAAADJtZZ9AAAVQUlEQVR4AY2ci3bbuJJFScWrI/k18/9/ee0otmfa4pxd4KZKjLrXoJuqQj0PCwBFU2Dm/05blmXmmFrb91+ml3l6GQaXy2U+HA7L9/f3YZ5x/dMfS2NAtZuenqbT5Rz/p4U42mk7MkzTQ5SHG0c0L9M8vU/T6+trJUd0yX/8j+16LCWPP5TW48BHNE+n0/SUk9jyXC5RHeec1A2oDXhFmuaHNcD0vDwfrAi6y9OlnNUjgyeAPP0/ZY9zimKrEwuom+oBEoMOJnEiO07H42fkp+Xh6enp8OPHj0udwVoRo3ZKMAIZFB2gij4u89P0NEUXoN85oasnNvp2n5U/HI8APK3DuiTGX4n5PT1g8Pfff/+A9kZAEyvfQJ2m+WmdI9jMwVNDHcM9eHxbZeaMbFyObRgzOpfvbTpgi882lJVgVxEMBHc6nWrCUxXkozpjaDfAKFrT93i8Asmo5oRHDE0F3mkBMwCGnWeuXC4DEEPdJ6xBu/3KBzhz5Ror8oprYnytDD4c9JWhvwF2XI6H6YR4tJxdBUxFbgCjXUGsltOcqsiXLliq7ew2QBrnssMyLWBSdA+Pj49Uoia2xgbrVF6b1GROYaqhy7GB5cyRWQEpMhzsS5F9fn7mynK6fHx8lAnXsSolPRx7QAOhY/EMIMdhNwXI5ZpIv32MnpzqEAtZxQ6Yz6RFlrYEVAGHrwtsSdez6TyT9jNBjgJm3q48drQtyehu1Vi7N31iTZV8LAZtQgtcYm3DWpeLQo/VMXPlMxX5OSqBw1/f3z84TQCw+rD1zHGhoZOit4/sg/7XV4XANEdsUyc6q1/3UfbwkyvuOnELYHDhCq+DPMEERQDkJoBfQSxMvc8a908MCnREG3h8jEkcwSCXf1h+/pxjVYY6dAN4mg7yBE4pQn7O8+cAEBBVkVGP8VnOqz8+vX+PV7ZdYBVA9yD2MvpfGR6uLJ/TgUoUoFCrs8UYJ/BnVcjB1Oi54l8NWc2xvZK+AbH8Sn+aP5fjRxbD9CmQKQs7gD7o13DoA8XvXlzkNGz6NWxIx2fky0N31hB1JuyyLmXLDyj9BVLJ9yfiPBQoTgIxgPQ2f53kdD4/TTfA+nUkjgIiRg3RHgB9ZRj1JPb3MuS2w0emQb72zvkv/2/55vn38sAVd5pOSVxXXH1I4jWlLooqelWR9aoIslP9uLXiYv5x+FhO+f5NEXJSz8ty/hVzpsp1fuLD7QaghtIo/w9KMEBW0J195FVJKKpDwJzP5+mDfoozQDGPB6h+coaqoYyi+iaBYkxiFN1RGwPYxwYZfYaG+zXApI3gcOlrTxd+31del4uuRNGBaKjNXof+kGHJfF3m3xmaVAEZ4PDRXh4d7d/i4fNAVWA01qG882Fg++hraDJrn5izfNBClmmdL0NSn8bvOZq6vkm6zvzbqlTQjQhQQFw9mbxPVKci11qa5t+pSl3GxvelSXs8+X/TaWP+usDqAC0gmaSsIIZoSmXW5Yx6+Z2KpYwxG0AIJA81MMY0ZOqHZHzek2nPomEoAcFSmQ5P+SP0fK5hzcVjnbS3E1ZnQTBU+4Q96R5ot4Xf8l/5yv8AkLqC1eT9XeuzArdK9GACslL2O5i9Pf2uBwwyCsLIwCPDJnSa39+XBypTwc9ZAGUSwQqq5CuvjCA9Cf19+yc/7NYKbWCQzfP7sry9zG/TG13avN0omgwqfw+MOij6irL67O3XylyvY5VzmvgWCJJ6DJEnERVimt61q/x1uVjt/yAJ7NdSOXUwFS2AupOge1XQv2W4/itg3t44kQIwT69jDuuDXT+x7S/gfvYY6bCn6Gz60F+rs9Fc9Qv0+/v7NJ/PAcUwtaq8356UoMz3x3VsTXJz0UVmw1EQTF54ZAQ+pyovzMlM3tiHvG86/E0KLxDlXZeYl7vXMY2hNJKzegSEbAU4vWfiTpm4Ly+ZLSlKPh3eDVRPCg8okhPnn9oGzNuSbiggQY2gb/M7z6sYGuZJLaT3JSNWrYOwKoIxdrdRBlDs6UNrKAWAEL4HYq7kaeL0/kpl6oKSiqwoCtTtEBGDRgwBSIfm+qkcKii0gKyKoUhn81iyet5NnhP4Nf8CFH843KzSzSHMPnjXkRQ9Mnn6GYlKqq8Um/pKyoqZebxaQ3RdOVvsNVjNCRMYBCNlnCl97KE0daN37QsQuQCVQfPA7jV/hX1N/1NB/rdWE8YEzAGtQ9lQjbNHx9AjQ58W0bBf5SVcE248dv2IT8WAApIYGcp1opTbAESgtVtkdfyDR+BZYqPfnnZdBdl9aI9Y2+061m0dEmUa66i80/VMax4p168nNgYyDmy0d0iRbZcLDaD7QAYzwJ6aQL8eQx0+6qXmvNdPccaE7Ubw/TCoATqFx1aZtlAaOqh2yrqPOqhV25Zrd4C3GZj+Ppgyg+kjFay0y5F5IN/b1EONnlwjDUkKLyj5nqT76yfFX30/gXtx9IFW0i4woQDta0OSfQJttZFiy2HfWFLke50nUcAM3KnO/ybrQQ3Y/TyBbncPTPdZXrhUvdbXzLZce4B7gHrQDgQA3XfPN9vt+rjKtv4Kbn6pO5V8JfUgLcDNKupnJN9Bdpkx0MPv7CxCDeFr5vwbPze+zinUsH8L5etxe0TQA5kIilyqTdd3INqpj31W/WvA1LdL3U6/Zphyx7RMGbIoCkSSbJVbfxKtpz03yQnak3VgVuAOAAJvwa/8AJXfPSPiHm6c6EtAAWBut9eZDvVDCDSq8esbzL2kvULqpfjQRlXqrnUdppf5NXcouYnLrVMKs5q9ZrgirKQk50ueiS5PX1AlW4PXmAPEY8QbZ9hkpY+uVSepAyKfDNX0AhIq9P6SqcNovdSIEIOYApHvFN62fVcisBorrRtD5CMow/G2kHy9IRnDQSWykijNS54LronBU34CgRKrV6b31SOj3Uz+IarfZWCXPO061B8XqUCmbADlM2f+ikldb0byuYZprKokrjACWmNugJBzopw8IP2BzYpu9jARjmhDmvIDJKORH+vznKV0eajBmh6r6PX2Ho7gJISOENfKWCF19AGF3R4Uco8KVNMCS+ZGzZfMtZcMT87scHhdXuov6JftAcj391MB6eUnoSCQqxMQ4Wn7/pBep1H8iJ20wcK9PkAAwF9E/E9bSe0oMNHQjIoAxETq+5B0nkrQl3YdfO9jk4q9jpXEX0VBYgIAwHNYDUF1HUGUOzT2u87EHYS8YPWD1nfcAPC0rRoUApKnD28zEX15gZhQeXy3Wx9kOdHtr3BtjWu8mmNURAUAHB5lGkPRE8yzNLkJel+/bgsPUGNgg0xb49xMYpJiwOMCaAfYg6O71wSFzmRS7Tsg7QGqHnsOn8HeDJNzBQOdTWZfihzegPL39CYHCPb25btPVQxBF+qwl9nf025PEvXK97IOBFsOq6ZtlVBDAmGkcp+gJ5Lv9viZ4J4vsv1BHPw44K1mfVcaZE81xkEdMnh19v9Jv5cTi6Y/vCcDT8OnVkdPpMKAUHmCEaTL1FXE9WMPdh/TfqcdKL9hbkNpQow12ielj059DyzfQXc79LZugww7ZOr5sWy7u1DoGNuH4qicAPtAPai8NvaNoz/98If6wT93CulEcp5O51N2xHzPVTGSYkgj4OCu86qDQteTdR4d/h2Uff3m53l5rOnxSIWWQ36RWX79OpxyDeWX38PTuBmoyW8g6T7BFnRXcu324DZ5duIt/OLC1sD8oElFll/Hw7l2XKU6tfXqkFurbBMKMG8KwHHz5xsBbT2ZgJVJtUUP3+WPy+N8zu7NwMnPzfkF7xQ+v/piNvzG1kEAjf74NNfNFbgPaTcmYT8Eog06hqf6QZJKVJVqu2B26lExtw4KBIpf/57mGwcZ8W+W/r2EAhLElZJtmp6zEyAbv+b8Cs7O0tpEyTwRAP7wArEvgC4nPwe6eqIIQ0LpNfngMKYi+WU3dk/L8XjJlolzbVP4zgqqfa4n5sh10y2eJMXXeHuefMqg9JVVxXBUcA3yzKTcrjGZqtkmMV9qj2t+S2R7KVs1nLD4AUR/KDHty0P3x96W/naZKGVWEZTk2c9aupTnwI7ObJdN1ca2wW2osrr2VREAcWi9H9ubfFZLm05HxQKkWlYPoMZ8+UhS9rtuv8bWPCEYYJy0Pdie3ye2Ty5stbcP1eZBTIUoCraXnthUnbVFckAQQAecad6zjd51yO1DTaz/PaqNfvYfroD+BEBy7mZDa4h1IghA6UsNDFW+5+1Dad3OPpSYN7fWCFDQdKJiQzI+tUHv0fX3eOz2cuOrs6/dzbOLvsI06I7y6gRJf6+jz6ENE19ee/v3fMfKW4MwdDh1h+6E3D60890Pnmac0Ruf3a/L4aPbVu12HetBesIux7mDW4Ntw6Rflyvb+zWbzT+ymkpsBt5urbtjB2NgA3Vd90FPw77bKCvlnx+AAkyjx9pwuM0xAwrEPrGU9YTKuh6epm6lLal3Flixe/hz4dYnd4npf+YGcd28nV4NpWe+C1gJlBGK1vvwHAKWDsvtqaMrfa1MbWcGFHch0+Xn70NtySxQn1vOmy9xAgpyDV6Ge5m6vX1AMnl3QKo//8xG3q/TvJw+cy7ZOs3+6cvCSj1ljzAnSO5jznL4b6vAs2VZWxWpAKQrAIbIChZPNwc8w5I9/uFCeR0DUHR//+T78jpkEVXr+cFQd7ACkPYKNV4gBLIq8CsoAOTE2Y8PIsYnFAi8IyKU3KMkzXX4CUDruelvFevGGkVPFG3+AMPLBpUwH7y2E1TXCbwiMRbUg8TK4Wn2pQ6bQzGsxicywQAgSYeCgmTOZNLmHaLTKUOEwmMkMQEe8A4VfXnkfep0nX8l1X6KNdgGkj9mPhyO7Kc9ZuImf+lzC1KA8DHx6l+J/QrqOnl0HQQ8Ov2hGIzhqj+pRtLcGKZSWTU/fx6ow6hMzK4vIBDrJlgJ1g8BSO/pkKH30IZq5jv7wl/C/DGR1y8GKN6WYa4wXBjhOIbq2jcY+j4sBu9J5fc6+8aQKj9kDc3Z+U456hUeFhM8BgCQCsY+1PnR7ZD3dk8nCE8Ke+2UPVAhOvXoIAZ5VSPdUameoPM6IyOg9lJttdsnVQ/FZvjxhk2GKZX5mr7GpiMnow4Gso+jkxmZYOBH0GtlkdGQD64nHyehHFqb47N/c8jqy6n8tkcE+wQGBkQHeq+vrz49Mbx6qvHJIgvlHqJgrMax2faPIdruLnpFTNABYWwf/ZYMRZo+ndem3keiNNQl12HMV1BVHe2MAa2KsTxNKiUBTWPk8kNz1Wk3fPkGOObNjq+s9mgGAiBtJ5M4N9u59nGJU3cXzjGTjwSmv51TSg2mD/lPh6+8uwaGL8yy2iHbt8fN3ETRY/Q+fFUMAxMISqfu0O2oxGe+H6ev0yVXvqD5XN+6GUBiu+3OMzaxejNHj2v+7dYaBw1VGgT5WD2RHHP7kk6NUM2XD/htmPTp1LjSroM33/oHdvVr57AKKXNO5wGApV9jtFSlVIaSDD+OfWLn7l6uD2H6btJMKeZBybZViTHHeL2xhqZWD4ZrqxUE3xOZRBmUw3mrvSe9xiqiDx1ecOEBUr24wOT/5FY3X868vxZ9IQ4VRFECGFjeoMh7hUmCDL0HMu3hebWD52y83MKLC9rzvNa3KVKxj7y19eeEJQCNgDrKdyDIvAaqhw5vQBzGqxx5Hjv/eL7kCXVOnkc54wWPtRJl79Dj6x8jFUcA1cmHiej3ZF2Oj0ABEZAFBh8eDk95epRxInG+jn/xmCDz9zedsKOq2NJ6/ppjGAzVLZhuqN6z6j4D0DlPqQcI6xGbgMjy4U+fMbz1gtU+bo8Fj/5m8ptcQ42QK+t8vQYUMM+/f+cFPqZHrdyaN0HifK2w3b/HKOX6oQ20hlJlPxOU9F3O6zDVk0RmxxwwjzUcn5dfKwgDE+8eTzx1xu92Pf/NUHYjAvgTNN8svMH3mKni6z8Ze55i1zLufj2hPLHgtesA1XUKf1Mxq8K17Cm3tWPdYMZcHUAYIpPsE9zrdzDy9+YpScwPv80xLhu8MxdZnVlerNjmiAGhJJcSQB1yE3Y5PA07be13IMi48iPD7iFXXGSr00iKwCBSZDT70iGts62vMeQcAO322kkB0Pn3+NSCyRsVL3lvgIptBj1ZD96rZFX2AEiiz1qJm6FBv8qrKvRp5/zCcn11YMjYgbV9iXdQqB2aYXodim4nYO21ZUjkoQLivYnXH+eq7Bt7zrIzr06mBqyupVuRtvuxHgjes4cKpsuwcbh6hRCjAxxvaB3OvNaRpOvrQOsGryuodc7i09vNqhQABvJJkLzX2yDkAMEmuq0aygDzlg1wr9OPbCVlAdW7JhUyH57kVhnzlAHzbG0bMAyoQB8ebABlUqoAD111ebkkP+K+nLMfMXtaRzmiewMUrRKtsbeTHarxaV7y9PwFDAFmGHF0xz0QJur5JRWr95HKknfYCogAjLWLc/dWu+fr+W+u/IKAEtTK8A1Q1chWQLaS7lbRdjK92ia8J1Mn8N63SO0COyoWUNrXVxJv4GyCVGa73kTYA2IT31pxBkemDVQ5dvJQDu2U126ozSkT451XxVjX14lawbuzQcpq/TAG1MRdpi2yjMT2tBy5dvArsPmhMLA5kje1aKmKhqJHjAxKk78HVt2eDs+aHvWbEr4tfu3DZh+tOyMf5l+/Ltxnr5tut6QE5tDZRCaA7oeu2+iHXefpUzH2s7JFft1Dy/qtH2qjLfvtoQoOHYygejJsbPf0HYC8FL9sd84KXneNpv78+1P515aqctgR07h1ubDT6b8BUAc1cVVh7a9xqMrymoutu4yxLzBZIvohMy98fgH8QX+7jtHRCEpzqKAm7kEMLsWHHceL/zJXhuf7Kb8O11q9BYOtfsbu/e06JjAd7GOMo33OCJt9e2GncRpnF/sCY6KSJw7Upk46TvgxT+fHt8r2laQDdBjdrJo6O4NklmQ3+thXDIhUtL6m1PdYXSYvxa72b+TPqlG1tbSRb3cXGktxgq9KZXye/7Mc5mwKV19VwSjNX4bVSfcnyD+8cVx+cQnP44Cn8vtm9tc+gVFRfWso+/AYrJbzeGNhvvyd8ub7EQA6DkjXeWJfit2wrZrk716GiN0ItXliTrBtaO/lr3+CqcA8L4fX99flP4/fP54TPdvLtrsIEsS5AsFv4FcUYxiEBO1gLtN3fMZ9xvVEjIN1j5ffCA88dnvIXJkDpC5uWdbT87qU/wkIAT0Iass/Sbd96dc/JxcF/6hVT6ot/vD8m1P5i6N+XxAo9PLXMv8fofyJ/NUtt/8AAAAASUVORK5CYII=" />
+<script id="shared">
+const log = globalThis.$vm?.print ?? console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0(adapter, device) {
+let bindGroupLayout0 = device.createBindGroupLayout({
+  entries: [
+   {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE,
+      externalTexture: {}
+    },
+    
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]});
+
+let buffer1 = device.createBuffer({
+  size: 29023,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let shaderModule2 = device.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+struct S {
+@size(16) h: f16,
+}
+
+@group(0) @binding(0) var<storage, read_write> buffer14: array<array<array<S, 2>, 2>, 2>;
+@group(0) @binding(50) var<storage, read_write> buffer16: vec4f;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute2() {
+  buffer14[0][1][0].h -= vec4h(buffer16).w;
+}`,
+});
+let img0 = document.getElementById('img0');
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let pipeline0 = device.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, }});
+let externalTexture1 = device.importExternalTexture({source: videoFrame0});
+let texture8 = device.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView17 = texture8.createView({label: '\u44f3\u0d9b\ubfd3\u{1f792}\u{1f85b}\u{1fa5c}', aspect: 'depth-only'});
+let bindGroup20 = device.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 0, resource: {buffer: buffer1, offset: 1792, size: 776}},
+    {binding: 1, resource: textureView17},
+    {binding: 40, resource: externalTexture1},
+    {binding: 50, resource: {buffer: buffer1, offset: 1024, size: 8896}},
+  ],
+});
+
+let commandEncoder124 = device.createCommandEncoder({});
+let computePassEncoder127 = commandEncoder124.beginComputePass();
+computePassEncoder127.setPipeline(pipeline0);
+computePassEncoder127.setBindGroup(0, bindGroup20, new Uint32Array(826), 32, 0);
+computePassEncoder127.dispatchWorkgroups(1, 1);
+computePassEncoder127.end();
+
+let commandBuffer15 = commandEncoder124.finish();
+device.queue.submit([commandBuffer15]);
+
+videoFrame0.close();
+}
+
+onload = async () => {
+  let adapter = await navigator.gpu.requestAdapter({});
+  let device = globalThis.device = await adapter.requestDevice();
+
+  device.pushErrorScope('internal');
+  let result = await window0(adapter, device);
+  let error = await device.popErrorScope();
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    return undefined;
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 456f3c8e7e526a26a7713ae0b6e2e8ce049a920b
<pre>
[WebGPU] Allow bind groups with unused external textures to be used in a shader
<a href="https://bugs.webkit.org/show_bug.cgi?id=282098">https://bugs.webkit.org/show_bug.cgi?id=282098</a>
<a href="https://rdar.apple.com/138641833">rdar://138641833</a>

Reviewed by Mike Wyrzykowski.

When a bind group member is specified on the API side but not used by the shader
the structs generated by WGSL and the API for the bind group must match. To generate
the correct struct the WGSL compiler uses the information provided by the API, but
so far we used `unsigned&amp;` for all the missing members. The assumption was that all
members would be pointer sized, but that is not correct for texture_external, and
may also not be correct for other types in different platforms. To fix that we
actually use the type information already available to generate the structs on
the WGSL side.

* LayoutTests/fast/webgpu/regression/repro_282098-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_282098.html: Added.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::dumpMetalCodeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/286002@main">https://commits.webkit.org/286002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7741fb34b571b5535d9f6a5a330c0e9c9eccff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23907 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1653 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66718 "Found 1 new test failure: inspector/dom/getMediaStats.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8098 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1617 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->