### PR TITLE
[Navigation] Fix cross-window replace navigations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT A traversal that redirects from same-origin to cross-origin fires the navigate event Test timed out
+PASS A traversal that redirects from same-origin to cross-origin fires the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after replace assert_equals: expected 1 but got 2
+PASS navigation.activation after replace
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
@@ -1,9 +1,8 @@
-CONSOLE MESSAGE: Error: assert_equals: Expected redirectStart to be 0. expected 0 but got 4
 Description
 
 This test validates the values of the window.performance.getEntriesByType("navigation")[0].redirectCount and the window.performance.getEntriesByType("navigation")[0].redirectStart/End times for a cross-origin server side redirect navigation.
 
 
 
-FAIL Navigation Timing 2 WPT Error: assert_equals: Expected redirectStart to be 0. expected 0 but got 4
+PASS Navigation Timing 2 WPT
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/test_timing_xserver_redirect-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/test_timing_xserver_redirect-expected.txt
@@ -6,9 +6,9 @@ This test validates the values of the window.performance.redirectCount and the w
 PASS window.performance is defined
 PASS window.performance.navigation is defined
 PASS timing.navigation.type is TYPE_NAVIGATE
-FAIL navigation.redirectCount == 0 on a cross-origin server redirected navigation assert_equals: navigation.redirectCount == 0 on a cross-origin server redirected navigation expected 0 but got 1
+PASS navigation.redirectCount == 0 on a cross-origin server redirected navigation
 PASS window.performance.timing.navigationStart > 0
-FAIL timing.redirectStart == 0 on a server redirected navigation from another domain assert_equals: timing.redirectStart == 0 on a server redirected navigation from another domain expected 0 but got 1688433422136
-FAIL timing.redirectEnd == 0 on a server redirected navigation from another domain assert_equals: timing.redirectEnd == 0 on a server redirected navigation from another domain expected 0 but got 1688433422166
+PASS timing.redirectStart == 0 on a server redirected navigation from another domain
+PASS timing.redirectEnd == 0 on a server redirected navigation from another domain
 
 


### PR DESCRIPTION
#### e2da0c499986dc9703d22df4b7b1a15020087306
<pre>
[Navigation] Fix cross-window replace navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=282398">https://bugs.webkit.org/show_bug.cgi?id=282398</a>

Reviewed by Alex Christensen.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/test_timing_xserver_redirect-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

Canonical link: <a href="https://commits.webkit.org/286115@main">https://commits.webkit.org/286115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c2693d81c81fe7d76bdbfd130f3b11c28de2838

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58787 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17053 "20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67027 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8415 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4892 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->