### PR TITLE
[css-masonry] Revert Rows 005 Fix

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1777,6 +1777,7 @@ webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html [ ImageOnlyFailure ]
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
@@ -11,11 +11,6 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
-@font-face {
-  font-family: Ahem;
-  src: url(/fonts/Ahem.ttf);
-}
-
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -25,15 +20,13 @@ grid {
   padding: 0 1px 0 2px;
   vertical-align: top;
 }
-
 item {
   writing-mode: vertical-lr;
-  font-family: Ahem;
-  font-size: 9px;
 }
 </style>
 
 <body>
+
 <grid style="grid-template-rows: repeat(4, 3ch)">
   <item style="height:3ch">1</item>
   <item>2</item>
@@ -44,7 +37,6 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
 <grid style="grid-template-rows: repeat(4,3ch)">
@@ -57,32 +49,29 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
   <item style="height:3ch; grid-row:1">5 5</item>
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: 3ch repeat(3,1ch)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:2; grid-row: 1;">5 5</item>
+  <item style="height:3ch; grid-column:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
@@ -11,11 +11,6 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
-@font-face {
-  font-family: Ahem;
-  src: url(/fonts/Ahem.ttf);
-}
-
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -25,15 +20,13 @@ grid {
   padding: 0 1px 0 2px;
   vertical-align: top;
 }
-
 item {
   writing-mode: vertical-lr;
-  font-family: Ahem;
-  font-size: 9px;
 }
 </style>
 
 <body>
+
 <grid style="grid-template-rows: repeat(4, 3ch)">
   <item style="height:3ch">1</item>
   <item>2</item>
@@ -44,7 +37,6 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
 <grid style="grid-template-rows: repeat(4,3ch)">
@@ -57,32 +49,29 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
   <item style="height:3ch; grid-row:1">5 5</item>
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: 3ch repeat(3,1ch)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:2; grid-row: 1;">5 5</item>
+  <item style="height:3ch; grid-column:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
-  <item style="visibility: hidden; grid-column: 4; grid-row: 1; width: calc(1ch - 2px);"></item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
@@ -13,11 +13,6 @@
 
 @import "support/masonry-intrinsic-sizing-visual.css";
 
-@font-face {
-  font-family: Ahem;
-  src: url(/fonts/Ahem.ttf);
-}
-
 grid {
   display: inline-grid;
   gap: 1px 2px;
@@ -30,8 +25,6 @@ grid {
 
 item {
   writing-mode: vertical-lr;
-  font-family: Ahem;
-  font-size: 9px;
 }
 </style>
 


### PR DESCRIPTION
#### 9517efe03711bfecaa84e3aa3ec8174b75666698
<pre>
[css-masonry] Revert Rows 005 Fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=282397">https://bugs.webkit.org/show_bug.cgi?id=282397</a>
<a href="https://rdar.apple.com/problem/139013428">rdar://problem/139013428</a>

Reviewed by Sammy Gill.

Based on discussions with Sammy and Elika I believe my updates to the rows 005 test case are not correct.
The width sizing was correct, and we should not be adding the extra padding at the end.

Reverts: <a href="https://github.com/WebKit/WebKit/commit/b79f7439f9580da79e784a83279751fecbb1e401">https://github.com/WebKit/WebKit/commit/b79f7439f9580da79e784a83279751fecbb1e401</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html:

Canonical link: <a href="https://commits.webkit.org/285975@main">https://commits.webkit.org/285975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2970da99c97647e7e199e8391fe3a727513cd493

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25586 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16761 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38847 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23919 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80246 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1665 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66725 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8106 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1629 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->