### PR TITLE
Make ScrollingTreeNode::m_scrollingTree ThreadSafeWeakPtr

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -1102,6 +1102,16 @@ String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBeha
     return ts.release();
 }
 
+bool ScrollingTree::hasFixedOrSticky() const
+{
+    return !m_fixedOrStickyNodes.isEmptyIgnoringNullReferences();
+}
+
+void ScrollingTree::fixedOrStickyNodeAdded(ScrollingTreeNode& node)
+{
+    m_fixedOrStickyNodes.add(node);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -64,7 +64,7 @@ using PlatformDisplayID = uint32_t;
 
 enum class EventTargeting : uint8_t { NodeOnly, Propagate };
 
-class ScrollingTree : public ThreadSafeRefCounted<ScrollingTree> {
+class ScrollingTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingTree> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTree, WEBCORE_EXPORT);
     friend class ScrollingTreeLatchingController;
 public:
@@ -186,13 +186,8 @@ public:
     std::optional<ScrollingNodeID> latchedNodeID() const;
     WEBCORE_EXPORT void clearLatchedNode();
 
-    bool hasFixedOrSticky() const { return !!m_fixedOrStickyNodeCount; }
-    void fixedOrStickyNodeAdded() { ++m_fixedOrStickyNodeCount; }
-    void fixedOrStickyNodeRemoved()
-    {
-        ASSERT(m_fixedOrStickyNodeCount);
-        --m_fixedOrStickyNodeCount;
-    }
+    bool hasFixedOrSticky() const;
+    void fixedOrStickyNodeAdded(ScrollingTreeNode&);
 
     // A map of overflow scrolling nodes to positioned nodes which need to be updated
     // when the scroller changes, but are not descendants.
@@ -357,8 +352,8 @@ protected:
     bool m_allowLatching { true };
 
 private:
-    unsigned m_fixedOrStickyNodeCount { 0 };
-    bool m_isHandlingProgrammaticScroll { false };
+    ThreadSafeWeakHashSet<ScrollingTreeNode> m_fixedOrStickyNodes;
+    std::atomic<bool> m_isHandlingProgrammaticScroll { false };
     bool m_isMonitoringWheelEvents { false };
     bool m_scrollingPerformanceTestingEnabled { false };
     bool m_overlayScrollbarsEnabled { false };

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -46,13 +46,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFixedNode);
 ScrollingTreeFixedNode::ScrollingTreeFixedNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Fixed, nodeID)
 {
-    scrollingTree.fixedOrStickyNodeAdded();
+    scrollingTree.fixedOrStickyNodeAdded(*this);
 }
 
-ScrollingTreeFixedNode::~ScrollingTreeFixedNode()
-{
-    scrollingTree().fixedOrStickyNodeRemoved();
-}
+ScrollingTreeFixedNode::~ScrollingTreeFixedNode() = default;
 
 bool ScrollingTreeFixedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -69,20 +69,20 @@ void ScrollingTreeFrameHostingNode::setLayerHostingContextIdentifier(std::option
         removeHostedChildren();
     m_hostingContext = identifier;
     if (m_hostingContext)
-        scrollingTree().addScrollingNodeToHostedSubtreeMap(*m_hostingContext, *this);
+        scrollingTree()->addScrollingNodeToHostedSubtreeMap(*m_hostingContext, *this);
 }
 
 void ScrollingTreeFrameHostingNode::removeHostedChildren()
 {
     auto hostedChildren = std::exchange(m_hostedChildren, { });
     for (auto& children : hostedChildren)
-        scrollingTree().removeNode(children->scrollingNodeID());
+        scrollingTree()->removeNode(children->scrollingNodeID());
 }
 
 void ScrollingTreeFrameHostingNode::willBeDestroyed()
 {
     if (m_hostingContext)
-        scrollingTree().removeFrameHostingNode(*m_hostingContext);
+        scrollingTree()->removeFrameHostingNode(*m_hostingContext);
     removeHostedChildren();
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeNode);
 
 ScrollingTreeNode::ScrollingTreeNode(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
-    : m_scrollingTree(scrollingTree)
+    : m_scrollingTree(&scrollingTree)
     , m_nodeType(nodeType)
     , m_nodeID(nodeID)
 {
@@ -49,7 +49,7 @@ ScrollingTreeNode::~ScrollingTreeNode() = default;
 
 void ScrollingTreeNode::appendChild(Ref<ScrollingTreeNode>&& childNode)
 {
-    RELEASE_ASSERT(m_scrollingTree.inCommitTreeState());
+    RELEASE_ASSERT(scrollingTree()->inCommitTreeState());
 
     childNode->setParent(this);
 
@@ -58,7 +58,7 @@ void ScrollingTreeNode::appendChild(Ref<ScrollingTreeNode>&& childNode)
 
 void ScrollingTreeNode::removeChild(ScrollingTreeNode& node)
 {
-    RELEASE_ASSERT(m_scrollingTree.inCommitTreeState());
+    RELEASE_ASSERT(scrollingTree()->inCommitTreeState());
 
     size_t index = m_children.findIf([&](auto& child) {
         return &node == child.ptr();
@@ -77,14 +77,14 @@ void ScrollingTreeNode::removeChild(ScrollingTreeNode& node)
 
 void ScrollingTreeNode::removeAllChildren()
 {
-    RELEASE_ASSERT(m_scrollingTree.inCommitTreeState());
+    RELEASE_ASSERT(scrollingTree()->inCommitTreeState());
 
     m_children.clear();
 }
 
 bool ScrollingTreeNode::isRootNode() const
 {
-    return m_scrollingTree.rootNode() == this;
+    return scrollingTree()->rootNode() == this;
 }
 
 void ScrollingTreeNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -102,7 +102,7 @@ public:
 
 protected:
     ScrollingTreeNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
-    ScrollingTree& scrollingTree() const { return m_scrollingTree; }
+    RefPtr<ScrollingTree> scrollingTree() const { return m_scrollingTree.get(); }
 
     virtual void applyLayerPositions() = 0;
 
@@ -111,7 +111,7 @@ protected:
     Vector<Ref<ScrollingTreeNode>> m_children;
 
 private:
-    ScrollingTree& m_scrollingTree;
+    ThreadSafeWeakPtr<ScrollingTree> m_scrollingTree;
 
     const ScrollingNodeType m_nodeType;
     const ScrollingNodeID m_nodeID;

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -55,12 +55,12 @@ bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
         m_overflowScrollingNodeID = overflowProxyStateNode->overflowScrollingNode();
 
     if (m_overflowScrollingNodeID) {
-        auto& relatedNodes = scrollingTree().overflowRelatedNodes();
+        auto& relatedNodes = scrollingTree()->overflowRelatedNodes();
         relatedNodes.ensure(*m_overflowScrollingNodeID, [] {
             return Vector<ScrollingNodeID>();
         }).iterator->value.append(scrollingNodeID());
 
-        scrollingTree().activeOverflowScrollProxyNodes().add(*this);
+        scrollingTree()->activeOverflowScrollProxyNodes().add(*this);
     }
     
     return true;
@@ -68,7 +68,7 @@ bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
 
 FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() const
 {
-    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(m_overflowScrollingNodeID)))
+    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree()->nodeForID(m_overflowScrollingNodeID)))
         return node->scrollDeltaSinceLastCommit();
 
     return { };
@@ -77,7 +77,7 @@ FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() con
 FloatPoint ScrollingTreeOverflowScrollProxyNode::computeLayerPosition() const
 {
     FloatPoint scrollOffset;
-    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(m_overflowScrollingNodeID)))
+    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree()->nodeForID(m_overflowScrollingNodeID)))
         scrollOffset = node->currentScrollOffset();
     return scrollOffset;
 }
@@ -87,7 +87,7 @@ void ScrollingTreeOverflowScrollProxyNode::dumpProperties(TextStream& ts, Option
     ts << "overflow scroll proxy node";
     ScrollingTreeNode::dumpProperties(ts, behavior);
 
-    if (auto* relatedOverflowNode = scrollingTree().nodeForID(m_overflowScrollingNodeID)) {
+    if (auto* relatedOverflowNode = scrollingTree()->nodeForID(m_overflowScrollingNodeID)) {
         if (RefPtr scrollingNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(relatedOverflowNode))
             ts.dumpProperty("related overflow scrolling node scroll position", scrollingNode->currentScrollPosition());
     }

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
@@ -60,7 +60,7 @@ bool ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingState
         m_constraints = positionedStateNode->layoutConstraints();
 
     if (!m_relatedOverflowScrollingNodes.isEmpty())
-        scrollingTree().activePositionedNodes().add(*this);
+        scrollingTree()->activePositionedNodes().add(*this);
 
     return true;
 }
@@ -69,7 +69,7 @@ FloatSize ScrollingTreePositionedNode::scrollDeltaSinceLastCommit() const
 {
     FloatSize delta;
     for (auto nodeID : m_relatedOverflowScrollingNodes) {
-        if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(nodeID)))
+        if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree()->nodeForID(nodeID)))
             delta += node->scrollDeltaSinceLastCommit();
     }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -61,7 +61,7 @@ bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateN
         m_scrollableAreaSize = state->scrollableAreaSize();
 
     if (state->hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)) {
-        if (scrollingTree().isRubberBandInProgressForNode(scrollingNodeID()))
+        if (scrollingTree()->isRubberBandInProgressForNode(scrollingNodeID()))
             m_totalContentsSizeForRubberBand = m_totalContentsSize;
         else
             m_totalContentsSizeForRubberBand = state->totalContentsSize();
@@ -134,7 +134,7 @@ void ScrollingTreeScrollingNode::didCompleteCommitForNode()
 
 bool ScrollingTreeScrollingNode::isLatchedNode() const
 {
-    return scrollingTree().latchedNodeID() == scrollingNodeID();
+    return scrollingTree()->latchedNodeID() == scrollingNodeID();
 }
 
 bool ScrollingTreeScrollingNode::shouldRubberBand(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting) const
@@ -229,43 +229,43 @@ RectEdges<bool> ScrollingTreeScrollingNode::edgePinnedState() const
 
 bool ScrollingTreeScrollingNode::isUserScrollInProgress() const
 {
-    return scrollingTree().isUserScrollInProgressForNode(scrollingNodeID());
+    return scrollingTree()->isUserScrollInProgressForNode(scrollingNodeID());
 }
 
 void ScrollingTreeScrollingNode::setUserScrollInProgress(bool isUserScrolling)
 {
-    scrollingTree().setUserScrollInProgressForNode(scrollingNodeID(), isUserScrolling);
+    scrollingTree()->setUserScrollInProgressForNode(scrollingNodeID(), isUserScrolling);
 }
 
 bool ScrollingTreeScrollingNode::isScrollSnapInProgress() const
 {
-    return scrollingTree().isScrollSnapInProgressForNode(scrollingNodeID());
+    return scrollingTree()->isScrollSnapInProgressForNode(scrollingNodeID());
 }
 
 void ScrollingTreeScrollingNode::setScrollSnapInProgress(bool isSnapping)
 {
-    scrollingTree().setNodeScrollSnapInProgress(scrollingNodeID(), isSnapping);
+    scrollingTree()->setNodeScrollSnapInProgress(scrollingNodeID(), isSnapping);
 }
 
 void ScrollingTreeScrollingNode::willStartAnimatedScroll()
 {
-    scrollingTree().scrollingTreeNodeWillStartAnimatedScroll(*this);
+    scrollingTree()->scrollingTreeNodeWillStartAnimatedScroll(*this);
 }
 
 void ScrollingTreeScrollingNode::didStopAnimatedScroll()
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
-    scrollingTree().scrollingTreeNodeDidStopAnimatedScroll(*this);
+    scrollingTree()->scrollingTreeNodeDidStopAnimatedScroll(*this);
 }
 
 void ScrollingTreeScrollingNode::willStartWheelEventScroll()
 {
-    scrollingTree().scrollingTreeNodeWillStartWheelEventScroll(*this);
+    scrollingTree()->scrollingTreeNodeWillStartWheelEventScroll(*this);
 }
 
 void ScrollingTreeScrollingNode::didStopWheelEventScroll()
 {
-    scrollingTree().scrollingTreeNodeDidStopWheelEventScroll(*this);
+    scrollingTree()->scrollingTreeNodeDidStopWheelEventScroll(*this);
 }
 
 bool ScrollingTreeScrollingNode::startAnimatedScrollToPosition(FloatPoint destinationPosition)
@@ -287,7 +287,7 @@ void ScrollingTreeScrollingNode::serviceScrollAnimation(MonotonicTime currentTim
 
 void ScrollingTreeScrollingNode::setScrollAnimationInProgress(bool animationInProgress)
 {
-    scrollingTree().setScrollAnimationInProgressForNode(scrollingNodeID(), animationInProgress);
+    scrollingTree()->setScrollAnimationInProgressForNode(scrollingNodeID(), animationInProgress);
 }
 
 void ScrollingTreeScrollingNode::handleKeyboardScrollRequest(const RequestedKeyboardScrollData& scrollData)
@@ -298,7 +298,7 @@ void ScrollingTreeScrollingNode::handleKeyboardScrollRequest(const RequestedKeyb
 
 void ScrollingTreeScrollingNode::requestKeyboardScroll(const RequestedKeyboardScrollData& scrollData)
 {
-    scrollingTree().scrollingTreeNodeRequestsKeyboardScroll(scrollingNodeID(), scrollData);
+    scrollingTree()->scrollingTreeNodeRequestsKeyboardScroll(scrollingNodeID(), scrollData);
 }
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)
@@ -308,11 +308,11 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
     if (requestedScrollData.requestType == ScrollRequestType::CancelAnimatedScroll) {
         ASSERT(!requestedScrollData.requestedDataBeforeAnimatedScroll);
         LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest() - cancel animated scroll");
-        scrollingTree().removePendingScrollAnimationForNode(scrollingNodeID());
+        scrollingTree()->removePendingScrollAnimationForNode(scrollingNodeID());
         return;
     }
 
-    if (scrollingTree().scrollingTreeNodeRequestsScroll(scrollingNodeID(), requestedScrollData))
+    if (scrollingTree()->scrollingTreeNodeRequestsScroll(scrollingNodeID(), requestedScrollData))
         return;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest() with data " << requestedScrollData);
@@ -361,7 +361,7 @@ void ScrollingTreeScrollingNode::scrollTo(const FloatPoint& position, ScrollType
     if (position == m_currentScrollPosition)
         return;
 
-    scrollingTree().setIsHandlingProgrammaticScroll(scrollType == ScrollType::Programmatic);
+    scrollingTree()->setIsHandlingProgrammaticScroll(scrollType == ScrollType::Programmatic);
 
     if (scrollType == ScrollType::Programmatic)
         willDoProgrammaticScroll(position);
@@ -370,18 +370,18 @@ void ScrollingTreeScrollingNode::scrollTo(const FloatPoint& position, ScrollType
     
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " scrollTo " << position << " adjusted to "
         << m_currentScrollPosition << " (" << scrollType << ", " << clamp << ") (delta from last committed position " << (m_lastCommittedScrollPosition - m_currentScrollPosition) << ")"
-        << " rubberbanding " << scrollingTree().isRubberBandInProgressForNode(scrollingNodeID()));
+        << " rubberbanding " << scrollingTree()->isRubberBandInProgressForNode(scrollingNodeID()));
 
     updateViewportForCurrentScrollPosition();
     currentScrollPositionChanged(scrollType);
 
-    scrollingTree().setIsHandlingProgrammaticScroll(false);
+    scrollingTree()->setIsHandlingProgrammaticScroll(false);
 }
 
 void ScrollingTreeScrollingNode::currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction action)
 {
     m_scrolledSinceLastCommit = true;
-    scrollingTree().scrollingTreeNodeDidScroll(*this, action);
+    scrollingTree()->scrollingTreeNodeDidScroll(*this, action);
 }
 
 bool ScrollingTreeScrollingNode::scrollPositionAndLayoutViewportMatch(const FloatPoint& position, std::optional<FloatRect>)
@@ -406,9 +406,9 @@ void ScrollingTreeScrollingNode::wasScrolledByDelegatedScrolling(const FloatPoin
 
     repositionRelatedLayers();
 
-    scrollingTree().notifyRelatedNodesAfterScrollPositionChange(*this);
-    scrollingTree().scrollingTreeNodeDidScroll(*this, scrollingLayerPositionAction);
-    scrollingTree().setNeedsApplyLayerPositionsAfterCommit();
+    scrollingTree()->notifyRelatedNodesAfterScrollPositionChange(*this);
+    scrollingTree()->scrollingTreeNodeDidScroll(*this, scrollingLayerPositionAction);
+    scrollingTree()->setNeedsApplyLayerPositionsAfterCommit();
 }
 
 void ScrollingTreeScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
@@ -515,12 +515,12 @@ ScrollPropagationInfo ScrollingTreeScrollingNode::computeScrollPropagation(const
 
 void ScrollingTreeScrollingNode::scrollbarVisibilityDidChange(ScrollbarOrientation orientation, bool isVisible)
 {
-    scrollingTree().scrollingTreeNodeScrollbarVisibilityDidChange(scrollingNodeID(), orientation, isVisible);
+    scrollingTree()->scrollingTreeNodeScrollbarVisibilityDidChange(scrollingNodeID(), orientation, isVisible);
 }
 
 void ScrollingTreeScrollingNode::scrollbarMinimumThumbLengthDidChange(ScrollbarOrientation orientation, int minimumThumbLength)
 {
-    scrollingTree().scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(scrollingNodeID(), orientation, minimumThumbLength);
+    scrollingTree()->scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(scrollingNodeID(), orientation, minimumThumbLength);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
@@ -43,9 +43,9 @@ ScrollingTreeScrollingNodeDelegate::ScrollingTreeScrollingNodeDelegate(Scrolling
 
 ScrollingTreeScrollingNodeDelegate::~ScrollingTreeScrollingNodeDelegate() = default;
 
-ScrollingTree& ScrollingTreeScrollingNodeDelegate::scrollingTree() const
+RefPtr<ScrollingTree> ScrollingTreeScrollingNodeDelegate::scrollingTree() const
 {
-    return m_scrollingNode.scrollingTree();
+    return protectedScrollingNode()->scrollingTree();
 }
 
 FloatPoint ScrollingTreeScrollingNodeDelegate::lastCommittedScrollPosition() const

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -65,7 +65,7 @@ public:
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
 
 protected:
-    WEBCORE_EXPORT ScrollingTree& scrollingTree() const;
+    WEBCORE_EXPORT RefPtr<ScrollingTree> scrollingTree() const;
 
     WEBCORE_EXPORT FloatPoint lastCommittedScrollPosition() const;
     WEBCORE_EXPORT FloatSize totalContentsSize();

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -48,13 +48,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeStickyNode);
 ScrollingTreeStickyNode::ScrollingTreeStickyNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Sticky, nodeID)
 {
-    scrollingTree.fixedOrStickyNodeAdded();
+    scrollingTree.fixedOrStickyNodeAdded(*this);
 }
 
-ScrollingTreeStickyNode::~ScrollingTreeStickyNode()
-{
-    scrollingTree().fixedOrStickyNodeRemoved();
-}
+ScrollingTreeStickyNode::~ScrollingTreeStickyNode() = default;
 
 bool ScrollingTreeStickyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
@@ -94,7 +91,7 @@ FloatPoint ScrollingTreeStickyNode::computeLayerPosition() const
 
     for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (auto* overflowProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(*ancestor)) {
-            auto overflowNode = scrollingTree().nodeForID(overflowProxyNode->overflowScrollingNodeID());
+            auto overflowNode = scrollingTree()->nodeForID(overflowProxyNode->overflowScrollingNodeID());
             if (!overflowNode)
                 break;
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -62,7 +62,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::updateSnapScrollState()
     scrollingNode->setScrollSnapInProgress(m_scrollController.isScrollSnapInProgress());
 
     if (m_scrollController.activeScrollSnapIndexDidChange())
-        scrollingTree().setActiveScrollSnapIndices(scrollingNode->scrollingNodeID(), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Horizontal), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Vertical));
+        scrollingTree()->setActiveScrollSnapIndices(scrollingNode->scrollingNodeID(), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Horizontal), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Vertical));
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::updateUserScrollInProgressForEvent(const PlatformWheelEvent& wheelEvent)
@@ -95,7 +95,7 @@ std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingN
 {
     // This is only used for a scroll snap timer.
     return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::protectedCurrent(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
-        Locker locker { protectedNode->scrollingTree().treeLock() };
+        Locker locker { protectedNode->scrollingTree()->treeLock() };
         function();
     });
 }
@@ -188,20 +188,20 @@ ScrollExtents ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents() const
 
 void ThreadedScrollingTreeScrollingNodeDelegate::deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason reason) const
 {
-    if (!scrollingTree().isMonitoringWheelEvents())
+    if (!scrollingTree()->isMonitoringWheelEvents())
         return;
 
     // Just use the scrolling node ID as the identifier, since we know this is coming from a ScrollingEffectsController associated with this node.
-    scrollingTree().deferWheelEventTestCompletionForReason(scrollingNode().scrollingNodeID(), reason);
+    scrollingTree()->deferWheelEventTestCompletionForReason(scrollingNode().scrollingNodeID(), reason);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason reason) const
 {
-    if (!scrollingTree().isMonitoringWheelEvents())
+    if (!scrollingTree()->isMonitoringWheelEvents())
         return;
 
     // Just use the scrolling node ID as the identifier, since we know this is coming from a ScrollingEffectsController associated with this node.
-    scrollingTree().removeWheelEventTestCompletionDeferralForReason(scrollingNode().scrollingNodeID(), reason);
+    scrollingTree()->removeWheelEventTestCompletionDeferralForReason(scrollingNode().scrollingNodeID(), reason);
 }
 
 FloatPoint ThreadedScrollingTreeScrollingNodeDelegate::adjustedScrollPosition(const FloatPoint& position) const

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -48,7 +48,7 @@ private:
     CALayer* layer() const final { return m_layer.get(); }
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
-    void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
+    void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -72,7 +72,7 @@ void ScrollingTreeFixedNodeCocoa::applyLayerPositions()
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
         // Match the behavior of ScrollingTreeFrameScrollingNodeMac::repositionScrollingLayers().
-        if (!scrollingTree().isScrollingSynchronizedWithMainThread())
+        if (!scrollingTree()->isScrollingSynchronizedWithMainThread())
             [m_layer _web_setLayerTopLeftPosition:CGPointZero];
     }
 #endif

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -46,7 +46,7 @@ private:
     ScrollingTreeStickyNodeCocoa(ScrollingTree&, ScrollingNodeID);
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
-    void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
+    void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
     FloatPoint layerTopLeft() const final;
     CALayer* layer() const final { return m_layer.get(); }
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -67,7 +67,7 @@ void ScrollingTreeStickyNodeCocoa::applyLayerPositions()
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
         // Match the behavior of ScrollingTreeFrameScrollingNodeMac::repositionScrollingLayers().
-        if (!scrollingTree().isScrollingSynchronizedWithMainThread())
+        if (!scrollingTree()->isScrollingSynchronizedWithMainThread())
             [m_layer _web_setLayerTopLeftPosition:CGPointZero];
     }
 #endif

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -73,7 +73,7 @@ private:
     void willDoProgrammaticScroll(const FloatPoint&) final;
 
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
-    void repositionScrollingLayers() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
+    void repositionScrollingLayers() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
 
     RetainPtr<CALayer> m_rootContentsLayer;
     RetainPtr<CALayer> m_counterScrollingLayer;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -104,8 +104,8 @@ bool ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const Scrolli
     if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
         logScrollingMode = true;
 
-    if (logScrollingMode && isRootNode() && scrollingTree().scrollingPerformanceTestingEnabled())
-        scrollingTree().reportSynchronousScrollingReasonsChanged(MonotonicTime::now(), synchronousScrollingReasons());
+    if (logScrollingMode && isRootNode() && scrollingTree()->scrollingPerformanceTestingEnabled())
+        scrollingTree()->reportSynchronousScrollingReasonsChanged(MonotonicTime::now(), synchronousScrollingReasons());
 
     m_delegate->updateFromStateNode(*scrollingStateNode);
 
@@ -148,7 +148,7 @@ void ScrollingTreeFrameScrollingNodeMac::willDoProgrammaticScroll(const FloatPoi
 
 void ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFrameScrollingNodeMac " << scrollingNodeID() << " currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons() << " is animating: " << scrollingTree().isScrollAnimationInProgressForNode(scrollingNodeID()));
+    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFrameScrollingNodeMac " << scrollingNodeID() << " currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons() << " is animating: " << scrollingTree()->isScrollAnimationInProgressForNode(scrollingNodeID()));
 
     delegate().currentScrollPositionChanged();
 
@@ -157,10 +157,10 @@ void ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged(ScrollType
 
     ScrollingTreeFrameScrollingNode::currentScrollPositionChanged(scrollType, hasSynchronousScrollingReasons() ? ScrollingLayerPositionAction::Set : action);
 
-    if (scrollingTree().scrollingPerformanceTestingEnabled()) {
+    if (scrollingTree()->scrollingPerformanceTestingEnabled()) {
         unsigned unfilledArea = exposedUnfilledArea();
         if (unfilledArea || m_lastScrollHadUnfilledPixels)
-            scrollingTree().reportExposedUnfilledArea(MonotonicTime::now(), unfilledArea);
+            scrollingTree()->reportExposedUnfilledArea(MonotonicTime::now(), unfilledArea);
 
         m_lastScrollHadUnfilledPixels = unfilledArea;
     }
@@ -176,7 +176,7 @@ void ScrollingTreeFrameScrollingNodeMac::repositionScrollingLayers()
         // The main thread may already have set the same layer position, but here we need to trigger a scrolling thread commit to
         // ensure that the scroll happens even when the main thread commit is taking a long time. So make sure the layer property changes
         // when there has been a scroll position change.
-        if (!scrollingTree().isScrollingSynchronizedWithMainThread())
+        if (!scrollingTree()->isScrollingSynchronizedWithMainThread())
             layer.position = CGPointZero;
     }
 
@@ -224,7 +224,7 @@ FloatPoint ScrollingTreeFrameScrollingNodeMac::minimumScrollPosition() const
 {
     FloatPoint position = ScrollableArea::scrollPositionFromOffset(FloatPoint(), toFloatSize(scrollOrigin()));
     
-    if (isRootNode() && scrollingTree().scrollPinningBehavior() == ScrollPinningBehavior::PinToBottom)
+    if (isRootNode() && scrollingTree()->scrollPinningBehavior() == ScrollPinningBehavior::PinToBottom)
         position.setY(maximumScrollPosition().y());
 
     return position;
@@ -235,7 +235,7 @@ FloatPoint ScrollingTreeFrameScrollingNodeMac::maximumScrollPosition() const
     FloatPoint position = ScrollableArea::scrollPositionFromOffset(FloatPoint(totalContentsSizeForRubberBand() - scrollableAreaSize()), toFloatSize(scrollOrigin()));
     position = position.expandedTo(FloatPoint());
 
-    if (isRootNode() && scrollingTree().scrollPinningBehavior() == ScrollPinningBehavior::PinToTop)
+    if (isRootNode() && scrollingTree()->scrollPinningBehavior() == ScrollPinningBehavior::PinToTop)
         position.setY(minimumScrollPosition().y());
 
     return position;
@@ -244,7 +244,7 @@ FloatPoint ScrollingTreeFrameScrollingNodeMac::maximumScrollPosition() const
 void ScrollingTreeFrameScrollingNodeMac::updateMainFramePinAndRubberbandState()
 {
     ASSERT(isRootNode());
-    scrollingTree().setMainFramePinnedState(edgePinnedState());
+    scrollingTree()->setMainFramePinnedState(edgePinnedState());
 }
 
 unsigned ScrollingTreeFrameScrollingNodeMac::exposedUnfilledArea() const

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -127,7 +127,7 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
     if (wasInMomentumPhase != m_inMomentumPhase)
         m_scrollerPair->setUsePresentationValues(m_inMomentumPhase);
 
-    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 
@@ -288,7 +288,7 @@ RectEdges<bool> ScrollingTreeScrollingNodeDelegateMac::edgePinnedState() const
 bool ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide(BoxSide side) const
 {
     if (scrollingNode().isRootNode())
-        return scrollingTree().clientAllowsMainFrameRubberBandingOnSide(side);
+        return scrollingTree()->clientAllowsMainFrameRubberBandingOnSide(side);
 
     switch (side) {
     case BoxSide::Top:
@@ -309,7 +309,7 @@ void ScrollingTreeScrollingNodeDelegateMac::didStopRubberBandAnimation()
 
 void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRubberBand)
 {
-    scrollingTree().setRubberBandingInProgressForNode(scrollingNode().scrollingNodeID(), inRubberBand);
+    scrollingTree()->setRubberBandingInProgressForNode(scrollingNode().scrollingNodeID(), inRubberBand);
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
@@ -49,7 +49,7 @@ void ScrollingTreeScrollingNodeDelegateNicosia::updateVisibleLengths()
 
 bool ScrollingTreeScrollingNodeDelegateNicosia::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
-    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::DeferReason::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -462,6 +462,14 @@ bool RemoteScrollingCoordinatorProxy::isMonitoringWheelEvents()
     return false;
 }
 
+bool RemoteScrollingCoordinatorProxy::hasFixedOrSticky() const
+{
+    if (RefPtr scrollingTree = m_scrollingTree)
+        return scrollingTree->hasFixedOrSticky();
+
+    return false;
+}
+
 #undef MESSAGE_CHECK_WITH_RETURN_VALUE
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -112,7 +112,7 @@ public:
 
     std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 
-    bool hasFixedOrSticky() const { return m_scrollingTree->hasFixedOrSticky(); }
+    bool hasFixedOrSticky() const;
     bool hasScrollableMainFrame() const;
     bool hasScrollableOrZoomedMainFrame() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -113,7 +113,7 @@ FloatPoint ScrollingTreeFrameScrollingNodeRemoteIOS::minimumScrollPosition() con
 {
     FloatPoint position = ScrollableArea::scrollPositionFromOffset(FloatPoint(), toFloatSize(scrollOrigin()));
     
-    if (isRootNode() && scrollingTree().scrollPinningBehavior() == ScrollPinningBehavior::PinToBottom)
+    if (isRootNode() && scrollingTree()->scrollPinningBehavior() == ScrollPinningBehavior::PinToBottom)
         position.setY(maximumScrollPosition().y());
 
     return position;
@@ -124,7 +124,7 @@ FloatPoint ScrollingTreeFrameScrollingNodeRemoteIOS::maximumScrollPosition() con
     FloatPoint position = ScrollableArea::scrollPositionFromOffset(FloatPoint(totalContentsSizeForRubberBand() - scrollableAreaSize()), toFloatSize(scrollOrigin()));
     position = position.expandedTo(FloatPoint());
 
-    if (isRootNode() && scrollingTree().scrollPinningBehavior() == ScrollPinningBehavior::PinToTop)
+    if (isRootNode() && scrollingTree()->scrollPinningBehavior() == ScrollPinningBehavior::PinToTop)
         position.setY(minimumScrollPosition().y());
 
     return position;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -380,7 +380,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition)) {
         scrollingNode().handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
-        scrollingTree().setNeedsApplyLayerPositionsAfterCommit();
+        scrollingTree()->setNeedsApplyLayerPositionsAfterCommit();
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {
@@ -416,7 +416,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll()
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, WKBEScrollViewScrollUpdate *update, void (^completion)(BOOL handled))
 {
-    auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree())->scrollingCoordinatorProxy();
     if (scrollingCoordinatorProxy) {
         if (RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient())
             pageClient->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
@@ -438,17 +438,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollWillStart() const
 {
-    scrollingTree().scrollingTreeNodeWillStartScroll(scrollingNode().scrollingNodeID());
+    scrollingTree()->scrollingTreeNodeWillStartScroll(scrollingNode().scrollingNodeID());
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollDidEnd() const
 {
-    scrollingTree().scrollingTreeNodeDidEndScroll(scrollingNode().scrollingNodeID());
+    scrollingTree()->scrollingTreeNodeDidEndScroll(scrollingNode().scrollingNodeID());
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollViewWillStartPanGesture() const
 {
-    scrollingTree().scrollingTreeNodeWillStartPanGesture(scrollingNode().scrollingNodeID());
+    scrollingTree()->scrollingTreeNodeWillStartPanGesture(scrollingNode().scrollingNodeID());
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollViewDidScroll(const FloatPoint& scrollOffset, bool inUserInteraction)
@@ -465,7 +465,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::currentSnapPointIndicesDidChange(std
     if (m_updatingFromStateNode)
         return;
 
-    scrollingTree().currentSnapPointIndicesDidChange(scrollingNode().scrollingNodeID(), horizontal, vertical);
+    scrollingTree()->currentSnapPointIndicesDidChange(scrollingNode().scrollingNodeID(), horizontal, vertical);
 }
 
 WKBaseScrollView *ScrollingTreeScrollingNodeDelegateIOS::scrollView() const
@@ -479,7 +479,7 @@ UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent(UISc
 {
     ASSERT(scrollView == this->scrollView());
 
-    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree())->scrollingCoordinatorProxy();
     if (!scrollingCoordinatorProxy)
         return nil;
 
@@ -492,7 +492,7 @@ UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent(UISc
 
 void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    auto* scrollingCoordinatorProxy = dynamicDowncast<RemoteScrollingCoordinatorProxyIOS>(downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy());
+    auto* scrollingCoordinatorProxy = dynamicDowncast<RemoteScrollingCoordinatorProxyIOS>(downcast<RemoteScrollingTree>(scrollingTree())->scrollingCoordinatorProxy());
     if (!scrollingCoordinatorProxy)
         return;
 
@@ -506,7 +506,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureR
 
 void ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree())->scrollingCoordinatorProxy();
     if (!scrollingCoordinatorProxy)
         return;
 


### PR DESCRIPTION
#### 11da279b4983306534b4deb78ceed041027f9226
<pre>
Make ScrollingTreeNode::m_scrollingTree ThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=282401">https://bugs.webkit.org/show_bug.cgi?id=282401</a>
<a href="https://rdar.apple.com/139019595">rdar://139019595</a>

Reviewed by Simon Fraser.

ScrollingTreeNode inherits from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr and it can be accessed from different
threads, so it should not hold raw pointer to ScrollingTree or return reference to ScrollingTree in scrollingTree().
This patch fixes the issue by making ScrollingTreeNode hold a thread-safe weak pointer to ScrollingTree. Also, make
ScrollingTree::m_isHandlingProgrammaticScroll std::atomic since it can be written and read via ScrollingTreeNode on
different threads.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::hasFixedOrSticky const):
(WebCore::ScrollingTree::fixedOrStickyNodeAdded):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::hasFixedOrSticky const): Deleted.
(WebCore::ScrollingTree::fixedOrStickyNodeAdded): Deleted.
(WebCore::ScrollingTree::fixedOrStickyNodeRemoved): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::ScrollingTreeFixedNode):
(WebCore::ScrollingTreeFixedNode::~ScrollingTreeFixedNode): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
(WebCore::ScrollingTreeFrameHostingNode::setLayerHostingContextIdentifier):
(WebCore::ScrollingTreeFrameHostingNode::removeHostedChildren):
(WebCore::ScrollingTreeFrameHostingNode::willBeDestroyed):
* Source/WebCore/page/scrolling/ScrollingTreeNode.cpp:
(WebCore::ScrollingTreeNode::ScrollingTreeNode):
(WebCore::ScrollingTreeNode::appendChild):
(WebCore::ScrollingTreeNode::removeChild):
(WebCore::ScrollingTreeNode::removeAllChildren):
(WebCore::ScrollingTreeNode::isRootNode const):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::scrollingTree const):
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp:
(WebCore::ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingTreeOverflowScrollProxyNode::computeLayerPosition const):
(WebCore::ScrollingTreeOverflowScrollProxyNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp:
(WebCore::ScrollingTreePositionedNode::commitStateBeforeChildren):
(WebCore::ScrollingTreePositionedNode::scrollDeltaSinceLastCommit const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeScrollingNode::isLatchedNode const):
(WebCore::ScrollingTreeScrollingNode::isUserScrollInProgress const):
(WebCore::ScrollingTreeScrollingNode::setUserScrollInProgress):
(WebCore::ScrollingTreeScrollingNode::isScrollSnapInProgress const):
(WebCore::ScrollingTreeScrollingNode::setScrollSnapInProgress):
(WebCore::ScrollingTreeScrollingNode::willStartAnimatedScroll):
(WebCore::ScrollingTreeScrollingNode::didStopAnimatedScroll):
(WebCore::ScrollingTreeScrollingNode::willStartWheelEventScroll):
(WebCore::ScrollingTreeScrollingNode::didStopWheelEventScroll):
(WebCore::ScrollingTreeScrollingNode::setScrollAnimationInProgress):
(WebCore::ScrollingTreeScrollingNode::requestKeyboardScroll):
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
(WebCore::ScrollingTreeScrollingNode::scrollTo):
(WebCore::ScrollingTreeScrollingNode::currentScrollPositionChanged):
(WebCore::ScrollingTreeScrollingNode::wasScrolledByDelegatedScrolling):
(WebCore::ScrollingTreeScrollingNode::scrollbarVisibilityDidChange):
(WebCore::ScrollingTreeScrollingNode::scrollbarMinimumThumbLengthDidChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingTree const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::ScrollingTreeStickyNode):
(WebCore::ScrollingTreeStickyNode::computeLayerPosition const):
(WebCore::ScrollingTreeStickyNode::~ScrollingTreeStickyNode): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::updateSnapScrollState):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::createTimer):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::deferWheelEventTestCompletionForReason const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionDeferralForReason const):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
(WebCore::ScrollingTreeFixedNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged):
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionScrollingLayers):
(WebCore::ScrollingTreeFrameScrollingNodeMac::minimumScrollPosition const):
(WebCore::ScrollingTreeFrameScrollingNodeMac::maximumScrollPosition const):
(WebCore::ScrollingTreeFrameScrollingNodeMac::updateMainFramePinAndRubberbandState):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::hasFixedOrSticky const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::minimumScrollPosition const):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::maximumScrollPosition const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollWillStart const):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollDidEnd const):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollViewWillStartPanGesture const):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::currentSnapPointIndicesDidChange const):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer):

Canonical link: <a href="https://commits.webkit.org/286018@main">https://commits.webkit.org/286018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/659d89972fd9d7bceb35234223feb46796f42b09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24030 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16425 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8170 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4528 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->