### PR TITLE
[WebGPU] Add tooling to selectively enable shader validation for debugging

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
@@ -44,8 +44,8 @@ struct GPUComputePassTimestampWrites {
     }
 
     WeakPtr<GPUQuerySet> querySet;
-    GPUSize32 beginningOfPassWriteIndex { UINT32_MAX };
-    GPUSize32 endOfPassWriteIndex { UINT32_MAX };
+    GPUSize32 beginningOfPassWriteIndex { 0 };
+    GPUSize32 endOfPassWriteIndex { 1 };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
@@ -44,8 +44,8 @@ struct GPURenderPassTimestampWrites {
     }
 
     WeakPtr<GPUQuerySet> querySet;
-    GPUSize32 beginningOfPassWriteIndex { UINT32_MAX };
-    GPUSize32 endOfPassWriteIndex { UINT32_MAX };
+    GPUSize32 beginningOfPassWriteIndex { 0 };
+    GPUSize32 endOfPassWriteIndex { 1 };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
@@ -37,7 +37,7 @@ class QuerySet;
 struct ComputePassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
-    Size32 endOfPassWriteIndex { 0 };
+    Size32 endOfPassWriteIndex { 1 };
 
     RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
@@ -38,7 +38,7 @@ class QuerySet;
 struct RenderPassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
-    Size32 endOfPassWriteIndex { 0 };
+    Size32 endOfPassWriteIndex { 1 };
 
     RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -139,10 +139,7 @@ private:
     id<MTLSharedEvent> m_abortCommandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
     id<MTLCommandEncoder> m_existingCommandEncoder { nil };
-    struct PendingTimestampWrites {
-        Ref<QuerySet> querySet;
-        uint32_t queryIndex;
-    };
+
     uint64_t m_debugGroupStackSize { 0 };
     WeakPtr<CommandBuffer> m_cachedCommandBuffer;
     NSString* m_lastErrorString { nil };

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -94,10 +94,6 @@ private:
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 
-    struct PendingTimestampWrites {
-        Ref<QuerySet> querySet;
-        uint32_t queryIndex;
-    };
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -35,11 +35,13 @@
 
 namespace WebGPU {
 
-static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const MTLSize& size, NSString *label)
+static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const MTLSize& size, NSString *label, GPUShaderValidation validationState)
 {
     auto computePipelineDescriptor = [MTLComputePipelineDescriptor new];
 #if ENABLE(WEBGPU_BY_DEFAULT)
-    computePipelineDescriptor.shaderValidation = MTLShaderValidationEnabled;
+    computePipelineDescriptor.shaderValidation = validationState;
+#else
+    UNUSED_PARAM(validationState);
 #endif
 
     computePipelineDescriptor.computeFunction = function;
@@ -125,11 +127,11 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         auto generatedPipelineLayout = generatePipelineLayout(bindGroupEntries);
         if (!generatedPipelineLayout->isValid())
             return returnInvalidComputePipeline(*this, isAsync);
-        auto computePipelineState = createComputePipelineState(m_device, function, generatedPipelineLayout, size, label);
+        auto computePipelineState = createComputePipelineState(m_device, function, generatedPipelineLayout, size, label, shaderValidationState());
         return std::make_pair(ComputePipeline::create(computePipelineState, WTFMove(generatedPipelineLayout), size, WTFMove(minimumBufferSizes), *this), nil);
     }
 
-    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label);
+    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label, shaderValidationState());
     return std::make_pair(ComputePipeline::create(computePipelineState, WTFMove(pipelineLayout), size, WTFMove(minimumBufferSizes), *this), nil);
 }
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -81,8 +81,6 @@ static HardwareCapabilities::BaseCapabilities baseCapabilities(id<MTLDevice> dev
             statisticCounterSet = counterSet;
     }
 
-    timestampCounterSet = nil;
-
     return {
         .argumentBuffersTier = [device argumentBuffersSupport],
         .supportsNonPrivateDepthStencilTextures = false, // To be filled in by the caller.
@@ -119,6 +117,9 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
     if (device.supports32BitFloatFiltering)
         features.append(WGPUFeatureName_Float32Filterable);
 #endif
+
+    if (baseCapabilities.timestampCounterSet)
+        features.append(WGPUFeatureName_TimestampQuery);
 
     return features;
 }

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -83,7 +83,6 @@ private:
     QuerySet(Device&);
 
     const Ref<Device> m_device;
-    // FIXME: Can we use a variant for these two resources?
     id<MTLBuffer> m_visibilityBuffer { nil };
     id<MTLCounterSampleBuffer> m_timestampBuffer { nil };
     uint32_t m_count { 0 };

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -97,10 +97,12 @@ void Queue::finalizeBlitCommandEncoder()
 void Queue::endEncoding(id<MTLCommandEncoder> commandEncoder, id<MTLCommandBuffer> commandBuffer) const
 {
     id<MTLCommandEncoder> currentEncoder = encoderForBuffer(commandBuffer);
-    if (currentEncoder != commandEncoder)
+    if (!currentEncoder || currentEncoder != commandEncoder)
         return;
 
     [currentEncoder endEncoding];
+    if (RefPtr device = m_device.get())
+        device->resolveTimestampsForBuffer(commandBuffer);
     [m_openCommandEncoders removeObjectForKey:commandBuffer];
 }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -141,10 +141,6 @@ private:
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 
     uint64_t m_debugGroupStackSize { 0 };
-    struct PendingTimestampWrites {
-        Ref<QuerySet> querySet;
-        uint32_t queryIndex;
-    };
 
     const Ref<Device> m_device;
     RefPtr<Buffer> m_indexBuffer;
@@ -179,7 +175,6 @@ private:
     WGPURenderPassDescriptor m_descriptor;
     Vector<WGPURenderPassColorAttachment> m_descriptorColorAttachments;
     WGPURenderPassDepthStencilAttachment m_descriptorDepthStencilAttachment;
-    WGPURenderPassTimestampWrites m_descriptorTimestampWrites;
     Vector<RefPtr<TextureView>> m_colorAttachmentViews;
     RefPtr<TextureView> m_depthStencilView;
     struct BufferAndOffset {

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -74,7 +74,6 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     , m_descriptor(descriptor)
     , m_descriptorColorAttachments(descriptor.colorAttachmentCount ? Vector<WGPURenderPassColorAttachment>(std::span { descriptor.colorAttachments, descriptor.colorAttachmentCount }) : Vector<WGPURenderPassColorAttachment>())
     , m_descriptorDepthStencilAttachment(descriptor.depthStencilAttachment ? *descriptor.depthStencilAttachment : WGPURenderPassDepthStencilAttachment())
-    , m_descriptorTimestampWrites(descriptor.timestampWrites ? *descriptor.timestampWrites : WGPURenderPassTimestampWrites())
 #if CPU(X86_64)
     , m_metalDescriptor(metalDescriptor)
 #endif
@@ -87,8 +86,6 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
         m_descriptor.colorAttachments = &m_descriptorColorAttachments[0];
     if (descriptor.depthStencilAttachment)
         m_descriptor.depthStencilAttachment = &m_descriptorDepthStencilAttachment;
-    if (descriptor.timestampWrites)
-        m_descriptor.timestampWrites = &m_descriptorTimestampWrites;
     auto colorAttachments = descriptor.colorAttachmentsSpan();
     for (auto& attachment : colorAttachments)
         m_colorAttachmentViews.append(RefPtr { static_cast<TextureView*>(attachment.view) });

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1313,7 +1313,7 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
 
     MTLRenderPipelineDescriptor* mtlRenderPipelineDescriptor = [MTLRenderPipelineDescriptor new];
 #if ENABLE(WEBGPU_BY_DEFAULT)
-    mtlRenderPipelineDescriptor.shaderValidation = MTLShaderValidationEnabled;
+    mtlRenderPipelineDescriptor.shaderValidation = shaderValidationState();
 #endif
 
     auto label = fromAPI(descriptor.label);

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h
@@ -38,7 +38,7 @@ namespace WebKit::WebGPU {
 struct ComputePassTimestampWrites {
     WebGPUIdentifier querySet;
     WebCore::WebGPU::Size32 beginningOfPassWriteIndex { 0 };
-    WebCore::WebGPU::Size32 endOfPassWriteIndex { 0 };
+    WebCore::WebGPU::Size32 endOfPassWriteIndex { 1 };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h
@@ -38,7 +38,7 @@ namespace WebKit::WebGPU {
 struct RenderPassTimestampWrites {
     WebGPUIdentifier querySet;
     WebCore::WebGPU::Size32 beginningOfPassWriteIndex { 0 };
-    WebCore::WebGPU::Size32 endOfPassWriteIndex { 0 };
+    WebCore::WebGPU::Size32 endOfPassWriteIndex { 1 };
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 1f8f2770f44982e1bb1640a15b7c2a0b6b492d29
<pre>
[WebGPU] Add tooling to selectively enable shader validation for debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=282402">https://bugs.webkit.org/show_bug.cgi?id=282402</a>
<a href="https://rdar.apple.com/139020869">rdar://139020869</a>

Reviewed by Dan Glastonbury.

Add a method of running with shader validation for debugging
does it selectively enabled for certain pipelines.

* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::createComputePipelineState):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::shaderValidationState const):
(WebGPU::Device::enableEncoderTimestamps const):
(WebGPU::Device::timestampsBuffer):
(WebGPU::Device::resolveTimestampsForBuffer):
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseCapabilities):
(WebGPU::baseFeatures):
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::endEncoding const):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
* Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h:

Canonical link: <a href="https://commits.webkit.org/286025@main">https://commits.webkit.org/286025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5b8bdf45c4fddf9367a1818043ce6ebbe729e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1713 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21559 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8206 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4568 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->