### PR TITLE
Unreviewed, reverting 285965@main (b2e420a36ecb)

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -75,8 +75,6 @@ public:
     KeyIDs& keyIDs() { return m_keyIDs; }
 #endif
 
-    static bool isCMSampleBufferNonDisplaying(CMSampleBufferRef);
-
 protected:
     WEBCORE_EXPORT MediaSampleAVFObjC(RetainPtr<CMSampleBufferRef>&&);
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -183,7 +183,7 @@ static bool isCMSampleBufferAttachmentNonDisplaying(CFDictionaryRef attachmentDi
     return CFDictionaryContainsKey(attachmentDict, PAL::kCMSampleAttachmentKey_DoNotDisplay);
 }
 
-bool MediaSampleAVFObjC::isCMSampleBufferNonDisplaying(CMSampleBufferRef sample)
+static bool isCMSampleBufferNonDisplaying(CMSampleBufferRef sample)
 {
     CFArrayRef attachments = PAL::CMSampleBufferGetSampleAttachmentsArray(sample, false);
     if (!attachments)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1099,7 +1099,7 @@ void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
     attachContentKeyToSampleIfNeeded(sample);
     WebSampleBufferVideoRendering *renderer = nil;
     if (m_videoRenderer) {
-        m_videoRenderer->enqueueSample(sample);
+        m_videoRenderer->enqueueSample(sample.platformSample().sample.cmSampleBuffer, !sample.isNonDisplaying());
 
         // Enqueuing a sample for display my synchronously fire an error, which can cause m_videoRenderer to become null.
         if (!m_videoRenderer)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -977,7 +977,7 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
         if (!m_videoRenderer)
             return;
 
-        m_videoRenderer->enqueueSample(sample);
+        m_videoRenderer->enqueueSample(platformSample.sample.cmSampleBuffer, !sample->isNonDisplaying());
         WebSampleBufferVideoRendering *renderer = m_videoRenderer->renderer();
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY)
         if (AVSampleBufferDisplayLayer *displayLayer = m_videoRenderer->displayLayer()) {
@@ -2035,8 +2035,6 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
         return;
 
     m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
-    m_videoRenderer->setPrefersDecompressionSession(true);
-    m_videoRenderer->setTimebase([m_synchronizer timebase]);
     configureVideoRenderer(*m_videoRenderer);
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -26,7 +26,6 @@
 #import "config.h"
 #import "VideoMediaSampleRenderer.h"
 
-#import "MediaSampleAVFObjC.h"
 #import "WebCoreDecompressionSession.h"
 #import "WebSampleBufferVideoRendering.h"
 #import <AVFoundation/AVFoundation.h>
@@ -36,7 +35,6 @@
 
 #pragma mark - Soft Linking
 
-#import "CoreVideoSoftLink.h"
 #import "VideoToolboxSoftLink.h"
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -48,121 +46,35 @@
 
 namespace WebCore {
 
-static constexpr CMItemCount CompressedSampleQueueHighWaterMark = 30;
-static constexpr CMItemCount CompressedSampleQueueLowWaterMark = 15;
-
-VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering *renderering)
-    : m_workQueue(WorkQueue::create("VideoMediaSampleRenderer Queue"_s))
+VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering *renderer)
+    : m_renderer(renderer)
 {
-    if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderering, PAL::getAVSampleBufferDisplayLayerClass()))
-        m_displayLayer = displayLayer;
-    else if (auto *renderer = dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderering, PAL::getAVSampleBufferVideoRendererClass()))
-        m_renderer = renderer;
 }
 
 VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
 {
-    assertIsMainThread();
-
-    if (m_displayLayer) {
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [m_displayLayer flush];
-        [m_displayLayer stopRequestingMediaData];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-        m_displayLayer = nil;
-    }
-
-    if (m_renderer) {
-        [m_renderer flush];
-        [m_renderer stopRequestingMediaData];
-        m_renderer = nil;
-    }
-
-    if (m_decompressionSession) {
+    [m_renderer flush];
+    [m_renderer stopRequestingMediaData];
+    if (m_decompressionSession)
         m_decompressionSession->invalidate();
-        m_decompressionSession = nullptr;
-    }
-
-    setTimebase(nullptr);
 }
 
 bool VideoMediaSampleRenderer::isReadyForMoreMediaData() const
 {
-    assertIsMainThread();
-
-    if (m_compressedSampleQueue && PAL::CMBufferQueueGetBufferCount(m_compressedSampleQueue.get()) >= CompressedSampleQueueHighWaterMark)
-        return false;
-
-    return [renderer() isReadyForMoreMediaData];
-}
-
-void VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData()
-{
-    assertIsMainThread();
-
-    if (![renderer() isReadyForMoreMediaData])
-        return;
-
-    if (m_compressedSampleQueue && PAL::CMBufferQueueGetBufferCount(m_compressedSampleQueue.get()) >= CompressedSampleQueueLowWaterMark)
-        return;
-
-    if (m_readyForMoreSampleFunction)
-        m_readyForMoreSampleFunction();
+    return (!m_decompressionSession || m_decompressionSession->isReadyForMoreMediaData()) && [m_renderer isReadyForMoreMediaData];
 }
 
 void VideoMediaSampleRenderer::stopRequestingMediaData()
 {
-    assertIsMainThread();
-    [renderer() stopRequestingMediaData];
-
-    m_readyForMoreSampleFunction = nil;
+    [m_renderer stopRequestingMediaData];
 }
 
-void VideoMediaSampleRenderer::setPrefersDecompressionSession(bool prefers)
+void VideoMediaSampleRenderer::enqueueSample(CMSampleBufferRef sample, bool displaying)
 {
-    if (m_prefersDecompressionSession == prefers)
-        return;
-
-    m_prefersDecompressionSession = prefers;
-    if (!m_prefersDecompressionSession && m_decompressionSession) {
-        m_decompressionSession->invalidate();
-        m_decompressionSession = nullptr;
-    }
-}
-
-void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
-{
-    if (m_timebase) {
-        PAL::CMTimebaseRemoveTimerDispatchSource(m_timebase.get(), m_timerSource.get());
-        dispatch_source_cancel(m_timerSource.get());
-        m_timerSource = nullptr;
-    }
-
-    m_timebase = WTFMove(timebase);
-
-    if (m_timebase) {
-        m_timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_workQueue->dispatchQueue()));
-        dispatch_source_set_event_handler(m_timerSource.get(), [weakThis = ThreadSafeWeakPtr { *this }] {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->purgeDecodedSampleQueue();
-        });
-        dispatch_activate(m_timerSource.get());
-        PAL::CMTimebaseAddTimerDispatchSource(m_timebase.get(), m_timerSource.get());
-    }
-}
-
-void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
-{
-    ASSERT(sample.platformSampleType() == PlatformSample::Type::CMSampleBufferType);
-    if (sample.platformSampleType() != PlatformSample::Type::CMSampleBufferType)
-        return;
-
-    auto cmSampleBuffer = sample.platformSample().sample.cmSampleBuffer;
-
 #if PLATFORM(IOS_FAMILY)
     if (!m_decompressionSession && !m_currentCodec) {
         // Only use a decompression session for vp8 or vp9 when software decoded.
-        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(cmSampleBuffer);
+        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
         auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
         if (fourCC == 'vp08' || (fourCC == 'vp09' && !(canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9))))
             initializeDecompressionSession();
@@ -170,285 +82,107 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
     }
 #endif
 
-    if (!m_decompressionSession && prefersDecompressionSession() && !sample.isProtected())
-        initializeDecompressionSession();
-
     if (!m_decompressionSession) {
-        [renderer() enqueueSampleBuffer:cmSampleBuffer];
+        [m_renderer enqueueSampleBuffer:sample];
         return;
     }
-
-    PAL::CMBufferQueueEnqueue(ensureCompressedSampleQueue(), cmSampleBuffer);
-    m_workQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->decodeNextSample();
-    });
-}
-
-void VideoMediaSampleRenderer::decodeNextSample()
-{
-    assertIsCurrent(m_workQueue);
-
-    if (!m_compressedSampleQueue)
+    m_decompressionSession->enqueueSample(sample, displaying);
+    ++m_decodePending;
+    m_wasNotDisplaying |= !displaying;
+    if (m_requestMediaDataWhenReadySet)
         return;
-
-    if (m_isDecodingSample)
-        return;
-
-    auto sample = adoptCF(checked_cf_cast<CMSampleBufferRef>(PAL::CMBufferQueueDequeueAndRetain(m_compressedSampleQueue.get())));
-    if (!sample)
-        return;
-
-    bool displaying = !MediaSampleAVFObjC::isCMSampleBufferNonDisplaying(sample.get());
-    auto decodePromise = m_decompressionSession->decodeSample(sample.get(), displaying);
-    m_isDecodingSample = true;
-    decodePromise->whenSettled(m_workQueue, [weakThis = ThreadSafeWeakPtr { *this }, displaying] (auto&& result) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
-        protectedThis->m_isDecodingSample = false;
-
-        if (!result) {
-            ensureOnMainThread([protectedThis = WTFMove(protectedThis), status = result.error()] {
-                assertIsMainThread();
-
-                // Simulate AVSBDL decoding error.
-                RetainPtr error = [NSError errorWithDomain:@"com.apple.WebKit" code:status userInfo:nil];
-                NSDictionary *userInfoDict = @{ (__bridge NSString *)AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey: (__bridge NSError *)error.get() };
-                [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferDisplayLayerFailedToDecodeNotification object:protectedThis->renderer() userInfo:userInfoDict];
-                [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferVideoRendererDidFailToDecodeNotification object:protectedThis->renderer() userInfo:userInfoDict];
-            });
-            return;
+    m_requestMediaDataWhenReadySet = true;
+    // We set requestMediaDataWhenReady only after calling enqueueSample once, to avoid having the callback
+    // being called immediately.
+    m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (!--m_decodePending && m_minimumUpcomingPresentationTime) {
+                expectMinimumUpcomingSampleBufferPresentationTime(*m_minimumUpcomingPresentationTime);
+                m_minimumUpcomingPresentationTime.reset();
+            }
+            if (!m_wasNotDisplaying)
+                return;
+            m_wasNotDisplaying = false;
+            if (m_readyForMoreSampleFunction)
+                m_readyForMoreSampleFunction();
         }
-
-        if (displaying && *result) {
-            RetainPtr<CMSampleBufferRef> retainedResult = *result;
-            protectedThis->decodedFrameAvailable(WTFMove(retainedResult));
-        }
-
-        protectedThis->decodeNextSample();
-    });
-
-    callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->maybeBecomeReadyForMoreMediaData();
     });
 }
 
 void VideoMediaSampleRenderer::initializeDecompressionSession()
 {
-    assertIsMainThread();
     if (m_decompressionSession)
         m_decompressionSession->invalidate();
-
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
-    m_decompressionSession->setTimebase(m_timebase.get());
+    m_decompressionSession->setTimebase([m_renderer timebase]);
     m_decompressionSession->setResourceOwner(m_resourceOwner);
+    m_decompressionSession->decodedFrameWhenAvailable([weakThis = ThreadSafeWeakPtr { *this }](RetainPtr<CMSampleBufferRef>&& sample) {
+        if (RefPtr protectedThis = weakThis.get())
+            [protectedThis->m_renderer enqueueSampleBuffer:sample.get()];
+    });
+    m_decompressionSession->setErrorListener([weakThis = ThreadSafeWeakPtr { *this }, this](OSStatus status) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            // Simulate AVSBDL decoding error.
+            RetainPtr error = [NSError errorWithDomain:@"com.apple.WebKit" code:status userInfo:nil];
+            NSDictionary *userInfoDict = @{ (__bridge NSString *)AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey: (__bridge NSError *)error.get() };
+            [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferDisplayLayerFailedToDecodeNotification object:m_renderer.get() userInfo:userInfoDict];
+            [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferVideoRendererDidFailToDecodeNotification object:m_renderer.get() userInfo:userInfoDict];
+        }
+    });
 
     resetReadyForMoreSample();
 }
 
-void VideoMediaSampleRenderer::decodedFrameAvailable(RetainPtr<CMSampleBufferRef>&& sample)
-{
-    assertIsCurrent(m_workQueue);
-
-    assignResourceOwner(sample.get());
-
-    if (m_timebase) {
-        purgeDecodedSampleQueue();
-        PAL::CMBufferQueueEnqueue(ensureDecodedSampleQueue(), sample.get());
-    }
-
-    if (m_renderer)
-        [m_renderer enqueueSampleBuffer:sample.get()];
-    else if (m_displayLayer) {
-        callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, sample = sample] {
-            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            if (RefPtr protectedThis = weakThis.get())
-                [protectedThis->m_displayLayer enqueueSampleBuffer:sample.get()];
-            ALLOW_DEPRECATED_DECLARATIONS_END
-        });
-    }
-}
-
-void VideoMediaSampleRenderer::flushCompressedSampleQueue()
-{
-    assertIsCurrent(m_workQueue);
-    if (!m_compressedSampleQueue)
-        return;
-
-    PAL::CMBufferQueueReset(m_compressedSampleQueue.get());
-    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), PAL::kCMTimeInvalid, 0);
-}
-
-void VideoMediaSampleRenderer::flushDecodedSampleQueue()
-{
-    assertIsCurrent(m_workQueue);
-    if (!m_decodedSampleQueue)
-        return;
-
-    PAL::CMBufferQueueReset(m_decodedSampleQueue.get());
-    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), PAL::kCMTimeInvalid, 0);
-}
-
-void VideoMediaSampleRenderer::purgeDecodedSampleQueue()
-{
-    assertIsCurrent(m_workQueue);
-    if (!m_decodedSampleQueue)
-        return;
-
-    if (!m_timebase)
-        return;
-
-    CMTime currentTime = PAL::CMTimebaseGetTime(m_timebase.get());
-    CMTime nextPurgeTime = PAL::kCMTimeInvalid;
-
-    while (RetainPtr nextSample = (CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueGetHead(m_decodedSampleQueue.get()))) {
-        CMTime presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
-        CMTime duration = PAL::CMSampleBufferGetOutputDuration(nextSample.get());
-        CMTime presentationEndTime = PAL::CMTimeAdd(presentationTime, duration);
-        if (PAL::CMTimeCompare(presentationEndTime, currentTime) >= 0) {
-            nextPurgeTime = presentationEndTime;
-            break;
-        }
-
-        RetainPtr sampleToBePurged = adoptCF(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get()));
-        sampleToBePurged = nil;
-    }
-
-    if (!CMTIME_IS_VALID(nextPurgeTime))
-        return;
-
-    PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), nextPurgeTime, 0);
-}
-
-CMBufferQueueRef VideoMediaSampleRenderer::ensureCompressedSampleQueue()
-{
-    assertIsMainThread();
-    if (!m_compressedSampleQueue)
-        m_compressedSampleQueue = WebCoreDecompressionSession::createBufferQueue();
-    return m_compressedSampleQueue.get();
-}
-
-CMBufferQueueRef VideoMediaSampleRenderer::ensureDecodedSampleQueue()
-{
-    assertIsCurrent(m_workQueue);
-    if (!m_decodedSampleQueue)
-        m_decodedSampleQueue = WebCoreDecompressionSession::createBufferQueue();
-    return m_decodedSampleQueue.get();
-}
-
 void VideoMediaSampleRenderer::flush()
 {
-    assertIsMainThread();
-    [renderer() flush];
-
+    [m_renderer flush];
     if (m_decompressionSession)
         m_decompressionSession->flush();
-
-    m_workQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] () mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
-        protectedThis->flushCompressedSampleQueue();
-        protectedThis->flushDecodedSampleQueue();
-
-        callOnMainThread([weakThis = WTFMove(weakThis)] {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->maybeBecomeReadyForMoreMediaData();
-        });
-    });
 }
 
 void VideoMediaSampleRenderer::requestMediaDataWhenReady(Function<void()>&& function)
 {
-    assertIsMainThread();
     m_readyForMoreSampleFunction = WTFMove(function);
     resetReadyForMoreSample();
 }
 
 void VideoMediaSampleRenderer::resetReadyForMoreSample()
 {
-    assertIsMainThread();
     ThreadSafeWeakPtr weakThis { *this };
-    [renderer() requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->maybeBecomeReadyForMoreMediaData();
+    [m_renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_readyForMoreSampleFunction)
+            protectedThis->m_readyForMoreSampleFunction();
     }];
 }
 
 void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime& time)
 {
-    assertIsMainThread();
     if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
         return;
-    [renderer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
+    if (!m_decodePending)
+        [m_renderer expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
+    else
+        m_minimumUpcomingPresentationTime = time;
 }
 
 void VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations()
 {
-    assertIsMainThread();
     if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(resetUpcomingSampleBufferPresentationTimeExpectations)])
         return;
-
-    [renderer() resetUpcomingSampleBufferPresentationTimeExpectations];
-}
-
-WebSampleBufferVideoRendering *VideoMediaSampleRenderer::renderer() const
-{
-    assertIsMainThread();
-    if (m_displayLayer)
-        return m_displayLayer.get();
-#if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
-    return m_renderer.get();
-#else
-    return nil;
-#endif
+    [m_renderer resetUpcomingSampleBufferPresentationTimeExpectations];
+    m_minimumUpcomingPresentationTime.reset();
 }
 
 AVSampleBufferDisplayLayer *VideoMediaSampleRenderer::displayLayer() const
 {
-    assertIsMainThread();
-    return m_displayLayer.get();
+    return dynamic_objc_cast<AVSampleBufferDisplayLayer>(m_renderer.get(), PAL::getAVSampleBufferDisplayLayerClass());
 }
 
-RetainPtr<CVPixelBufferRef> VideoMediaSampleRenderer::copyDisplayedPixelBuffer()
-{
-    assertIsMainThread();
-
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
-    if (auto buffer = adoptCF([renderer() copyDisplayedPixelBuffer]))
-        return buffer;
-#endif
 
-    RetainPtr<CVPixelBufferRef> imageBuffer;
-
-    m_workQueue->dispatchSync([&] {
-        if (!m_timebase)
-            return;
-
-        purgeDecodedSampleQueue();
-
-        CMTime currentTime = PAL::CMTimebaseGetTime(m_timebase.get());
-        auto nextSample = (CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueGetHead(m_decodedSampleQueue.get()));
-        CMTime presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample);
-
-        if (PAL::CMTimeCompare(presentationTime, currentTime) > 0)
-            return;
-
-        RetainPtr sampleToBePurged = adoptCF((CMSampleBufferRef)const_cast<void*>(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get())));
-        imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(sampleToBePurged.get());
-    });
-
-    if (!imageBuffer)
-        return nullptr;
-
-    ASSERT(CFGetTypeID(imageBuffer.get()) == CVPixelBufferGetTypeID());
-    if (CFGetTypeID(imageBuffer.get()) != CVPixelBufferGetTypeID())
-        return nullptr;
-    return imageBuffer;
+RetainPtr<CVPixelBufferRef> VideoMediaSampleRenderer::copyDisplayedPixelBuffer() const
+{
+    return adoptCF([m_renderer copyDisplayedPixelBuffer]);
 }
 
 CGRect VideoMediaSampleRenderer::bounds() const
@@ -456,52 +190,6 @@ CGRect VideoMediaSampleRenderer::bounds() const
     return [displayLayer() bounds];
 }
 
-unsigned VideoMediaSampleRenderer::totalVideoFrames() const
-{
-    if (m_decompressionSession)
-        return m_decompressionSession->totalVideoFrames();
-    return [renderer() videoPerformanceMetrics].totalNumberOfVideoFrames;
-}
-
-unsigned VideoMediaSampleRenderer::droppedVideoFrames() const
-{
-    if (m_decompressionSession)
-        return m_decompressionSession->droppedVideoFrames();
-    return [renderer() videoPerformanceMetrics].numberOfDroppedVideoFrames;
-}
-
-unsigned VideoMediaSampleRenderer::corruptedVideoFrames() const
-{
-    if (m_decompressionSession)
-        return m_decompressionSession->corruptedVideoFrames();
-    return [renderer() videoPerformanceMetrics].numberOfCorruptedVideoFrames;
-}
-
-MediaTime VideoMediaSampleRenderer::totalFrameDelay() const
-{
-    if (m_decompressionSession)
-        return m_decompressionSession->totalFrameDelay();
-    return MediaTime::createWithDouble([renderer() videoPerformanceMetrics].totalFrameDelay);
-}
-
-void VideoMediaSampleRenderer::setResourceOwner(const ProcessIdentity& resourceOwner)
-{
-    m_resourceOwner = resourceOwner;
-}
-
-void VideoMediaSampleRenderer::assignResourceOwner(CMSampleBufferRef sampleBuffer)
-{
-    assertIsCurrent(m_workQueue);
-    if (!m_resourceOwner || !sampleBuffer)
-        return;
-
-    RetainPtr<CVPixelBufferRef> imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(sampleBuffer);
-    if (!imageBuffer || CFGetTypeID(imageBuffer.get()) != CVPixelBufferGetTypeID())
-        return;
-
-    if (auto surface = CVPixelBufferGetIOSurface(imageBuffer.get()))
-        IOSurface::setOwnershipIdentity(surface, m_resourceOwner);
-}
-
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -74,9 +74,6 @@ public:
 
     RetainPtr<CVPixelBufferRef> decodeSampleSync(CMSampleBufferRef);
 
-    using DecodingPromise = NativePromise<RetainPtr<CMSampleBufferRef>, OSStatus>;
-    Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
-
     void setTimebase(CMTimebaseRef);
     RetainPtr<CMTimebaseRef> timebase() const;
 
@@ -97,8 +94,6 @@ public:
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
-    static RetainPtr<CMBufferQueueRef> createBufferQueue();
-
 private:
     enum Mode {
         OpenGL,
@@ -110,7 +105,8 @@ private:
 
     void setTimebaseWithLockHeld(CMTimebaseRef);
     void enqueueCompressedSample(CMSampleBufferRef, bool displaying, uint32_t flushId);
-    Ref<DecodingPromise> decodeSampleInternal(CMSampleBufferRef, bool displaying);
+    using DecodingPromise = NativePromise<RetainPtr<CMSampleBufferRef>, OSStatus>;
+    Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
     void enqueueDecodedSample(CMSampleBufferRef);
     void maybeDecodeNextSample();
     void handleDecompressionOutput(bool displaying, OSStatus, VTDecodeInfoFlags, CVImageBufferRef, CMTime presentationTimeStamp, CMTime presentationDuration);

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -200,9 +200,6 @@ VideoFrameLibWebRTC::VideoFrameLibWebRTC(MediaTime presentationTime, bool isMirr
     case webrtc::VideoFrameBuffer::Type::kI420:
         m_videoPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
         break;
-    case webrtc::VideoFrameBuffer::Type::kI444:
-        m_videoPixelFormat = kCVPixelFormatType_444YpCbCr8BiPlanarFullRange;
-        break;
     case webrtc::VideoFrameBuffer::Type::kI010:
         m_videoPixelFormat = kCVPixelFormatType_420YpCbCr10BiPlanarFullRange;
         break;


### PR DESCRIPTION
#### 762b03dd4107d0981ed225a37d8ea4c1e210affd
<pre>
Unreviewed, reverting 285965@main (b2e420a36ecb)
<a href="https://rdar.apple.com/139016139">rdar://139016139</a>

Broke Internal watchOS Builds

Reverted change:

    Refactor VideoMediaSampleRenderer to support enqueuing decoded samples
    <a href="https://bugs.webkit.org/show_bug.cgi?id=281497">https://bugs.webkit.org/show_bug.cgi?id=281497</a>
    <a href="https://rdar.apple.com/137964106">rdar://137964106</a>
    285965@main (b2e420a36ecb)

Canonical link: <a href="https://commits.webkit.org/285972@main">https://commits.webkit.org/285972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16f513bbfb1c14454c4461e291cfb4b31450d8b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74365 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27176 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/63969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1682 "Failed to checkout and rebase branch from PR 36011") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/80264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/1830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/63987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11479 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/1646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/1682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->