### PR TITLE
Enable -Wunsafe-buffer-usage in WebCore

### DIFF
--- a/Source/WebCore/Configurations/Base.xcconfig
+++ b/Source/WebCore/Configurations/Base.xcconfig
@@ -87,7 +87,7 @@ GCC_WARN_SIGN_COMPARE = YES;
 GCC_WARN_UNINITIALIZED_AUTOS = YES;
 GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
-WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wno-unknown-warning-option -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled;
+WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wno-unknown-warning-option -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wunsafe-buffer-usage $(WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL);
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;


### PR DESCRIPTION
#### 67602317a9642dce33a46bbe4ff849fe1a97e88d
<pre>
Enable -Wunsafe-buffer-usage in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=282406">https://bugs.webkit.org/show_bug.cgi?id=282406</a>
<a href="https://rdar.apple.com/137810622">rdar://137810622</a>

Reviewed by David Kilzer.

* Source/WebCore/Configurations/Base.xcconfig:

Canonical link: <a href="https://commits.webkit.org/286031@main">https://commits.webkit.org/286031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a89f6f1a1c123860de06f031565910da266b046b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78991 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25794 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76673 "Found 89 Binding test failures: JSTestPluginInterface.cpp, JSTestNode.cpp, JSTestCEReactions.cpp, JSTestStringifierReadWriteAttribute.cpp, JSTestNamedDeleterNoIdentifier.cpp, JSTestIndexedSetterThrowingException.cpp, JSTestNamedAndIndexedSetterWithIdentifier.cpp, JSTestDefaultToJSONFilteredByExposed.cpp, JSTestEventTarget.cpp, JSShadowRealmGlobalScope.cpp, JSTestStringifierOperationImplementedAs.cpp, JSTestOverloadedConstructorsWithSequence.cpp, JSTestCallTracer.cpp, JSTestNamedSetterWithIndexedGetter.cpp, JSTestInterface.cpp, JSSharedWorkerGlobalScope.cpp, JSTestCEReactionsStringifier.cpp, JSTestPromiseRejectionEvent.cpp, JSTestScheduledAction.cpp, JSTestStringifierOperationNamedToString.cpp, JSTestNamedSetterWithLegacyUnforgeableProperties.cpp, JSTestOverloadedConstructors.cpp, JSTestSetLikeWithOverriddenOperations.cpp, JSTestSetLike.cpp, JSTestLegacyOverrideBuiltIns.cpp, JSTestIndexedSetterWithIdentifier.cpp, JSServiceWorkerGlobalScope.cpp, JSTestConditionallyReadWrite.cpp, JSTestNamedGetterWithIdentifier.cpp, JSExposedStar.cpp, JSTestMapLike.cpp, JSTestNamedDeleterThrowingException.cpp, JSTestNamedGetterCallWith.cpp, JSWorkletGlobalScope.cpp, JSTestDefaultToJSON.cpp, JSTestGenerateAddOpaqueRoot.cpp, JSTestSerializedScriptValueInterface.cpp, JSTestObj.cpp, JSTestIndexedSetterNoIdentifier.cpp, JSTestStringifier.cpp, JSTestInterfaceLeadingUnderscore.cpp, JSTestReadOnlyMapLike.cpp, JSTestEnabledBySetting.cpp, JSTestGlobalObject.cpp, JSTestNamedAndIndexedSetterNoIdentifier.cpp, JSTestReportExtraMemoryCost.cpp, JSTestException.cpp, JSTestStringifierReadOnlyAttribute.cpp, JSTestJSBuiltinConstructor.cpp, JSTestNamespaceObject.cpp, JSTestIterable.cpp, JSTestNamedSetterThrowingException.cpp, JSTestOperationConditional.cpp, JSTestReadOnlySetLike.cpp, JSTestClassWithJSBuiltinConstructor.cpp, JSTestDomainSecurity.cpp, JSTestDefaultToJSONIndirectInheritance.cpp, JSTestDelegateToSharedSyntheticAttribute.cpp, JSTestLegacyFactoryFunction.cpp, JSTestDOMJIT.cpp, JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp, JSTestNamedDeleterWithIdentifier.cpp, JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp, JSDOMWindow.cpp, JSTestGenerateIsReachable.cpp, JSTestNamespaceConst.cpp, JSTestNamedSetterNoIdentifier.cpp, JSPaintWorkletGlobalScope.cpp, JSTestNamedAndIndexedSetterThrowingException.cpp, JSTestMapLikeWithOverriddenOperations.cpp, JSTestNamedSetterWithIndexedGetterAndSetter.cpp, JSTestTypedefs.cpp, JSTestEnabledForContext.cpp, JSWorkerGlobalScope.cpp, JSExposedToWorkerAndWindow.cpp, JSDedicatedWorkerGlobalScope.cpp, JSTestDefaultToJSONInheritFinal.cpp, JSTestLegacyNoInterfaceObject.cpp, JSTestNamedSetterWithIdentifier.cpp, JSTestNamedDeleterWithIndexedGetter.cpp, JSTestAsyncIterable.cpp, JSTestStringifierAnonymousOperation.cpp, JSTestNamedGetterNoIdentifier.cpp, JSTestStringifierNamedOperation.cpp, JSTestAsyncKeyValueIterable.cpp, JSTestTaggedWrapper.cpp, JSTestEventConstructor.cpp, JSTestConditionalIncludes.cpp, JSTestDefaultToJSONInherit.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1770 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64102 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24127 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66139 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10088 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11508 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1838 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4625 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1866 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->