### PR TITLE
Fix smart pointer warnings in MediaSource.cpp, ScopedRenderingResourcesRequestCocoa.mm, WebExtensionContextCocoa.mm, and RemoteDeviceProxy.cpp

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -918,7 +918,7 @@ ExceptionOr<Ref<SourceBuffer>> MediaSource::addSourceBuffer(const String& type)
     if (type.isEmpty())
         return Exception { ExceptionCode::TypeError };
 
-    auto context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return Exception { ExceptionCode::NotAllowedError };
 
@@ -1021,28 +1021,28 @@ void MediaSource::removeSourceBufferWithOptionalDestruction(SourceBuffer& buffer
 
             // 5.3 For each AudioTrack object in the SourceBuffer audioTracks list, run the following steps:
             for (ssize_t index = audioTracks->length() - 1; index >= 0; index--) {
-                auto& track = *audioTracks->item(index);
+                Ref track = *audioTracks->item(index);
 
                 if (withDestruction) {
                     // 5.3.1 Set the sourceBuffer attribute on the AudioTrack object to null.
-                    track.setSourceBuffer(nullptr);
+                    track->setSourceBuffer(nullptr);
                 }
 
                 // 5.3.2 If the enabled attribute on the AudioTrack object is true, then set the removed enabled
                 // audio track flag to true.
-                if (track.enabled())
+                if (track->enabled())
                     removedEnabledAudioTrack = true;
 
                 // 5.3.3 Remove the AudioTrack object from the HTMLMediaElement audioTracks list.
                 // 5.3.4 Queue a task to fire a trusted event named removetrack, that does not bubble and is not
                 // cancelable, and that uses the TrackEvent interface, at the HTMLMediaElement audioTracks list.
                 if (isMainThread()) {
-                    ensureWeakOnHTMLMediaElementContext([track = Ref { track }](auto& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([track = track](auto& mediaElement) mutable {
                         // FIXME: Need to send a mirror when we are in a worker.
                         mediaElement.removeAudioTrack(WTFMove(track));
                     });
                 } else {
-                    ensureWeakOnHTMLMediaElementContext([trackID = track.trackId()](auto& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([trackID = track->trackId()](auto& mediaElement) mutable {
                         mediaElement.removeAudioTrack(trackID);
                     });
                 }
@@ -1076,28 +1076,28 @@ void MediaSource::removeSourceBufferWithOptionalDestruction(SourceBuffer& buffer
 
             // 7.3 For each VideoTrack object in the SourceBuffer videoTracks list, run the following steps:
             for (ssize_t index = videoTracks->length() - 1; index >= 0; index--) {
-                auto& track = *videoTracks->item(index);
+                Ref track = *videoTracks->item(index);
 
                 if (withDestruction) {
                     // 7.3.1 Set the sourceBuffer attribute on the VideoTrack object to null.
-                    track.setSourceBuffer(nullptr);
+                    track->setSourceBuffer(nullptr);
                 }
 
                 // 7.3.2 If the selected attribute on the VideoTrack object is true, then set the removed selected
                 // video track flag to true.
-                if (track.selected())
+                if (track->selected())
                     removedSelectedVideoTrack = true;
 
                 // 7.3.3 Remove the VideoTrack object from the HTMLMediaElement videoTracks list.
                 // 7.3.4 Queue a task to fire a trusted event named removetrack, that does not bubble and is not
                 // cancelable, and that uses the TrackEvent interface, at the HTMLMediaElement videoTracks list.
                 if (isMainThread()) {
-                    ensureWeakOnHTMLMediaElementContext([track = Ref { track }](auto& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([track = track](auto& mediaElement) mutable {
                         // FIXME: Need to send a mirror when we are in a worker.
                         mediaElement.removeVideoTrack(WTFMove(track));
                     });
                 } else {
-                    ensureWeakOnHTMLMediaElementContext([trackID = track.trackId()](auto& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([trackID = track->trackId()](auto& mediaElement) mutable {
                         mediaElement.removeVideoTrack(trackID);
                     });
                 }
@@ -1131,27 +1131,27 @@ void MediaSource::removeSourceBufferWithOptionalDestruction(SourceBuffer& buffer
 
             // 9.3 For each TextTrack object in the SourceBuffer textTracks list, run the following steps:
             for (ssize_t index = textTracks->length() - 1; index >= 0; index--) {
-                auto& track = *textTracks->lastItem();
+                Ref track = *textTracks->lastItem();
 
                 if (withDestruction) {
                     // 9.3.1 Set the sourceBuffer attribute on the TextTrack object to null.
-                    track.setSourceBuffer(nullptr);
+                    track->setSourceBuffer(nullptr);
                 }
 
                 // 9.3.2 If the mode attribute on the TextTrack object is set to "showing" or "hidden", then
                 // set the removed enabled text track flag to true.
-                if (track.mode() == TextTrack::Mode::Showing || track.mode() == TextTrack::Mode::Hidden)
+                if (track->mode() == TextTrack::Mode::Showing || track->mode() == TextTrack::Mode::Hidden)
                     removedEnabledTextTrack = true;
 
                 // 9.3.3 Remove the TextTrack object from the HTMLMediaElement textTracks list.
                 // 9.3.4 Queue a task to fire a trusted event named removetrack, that does not bubble and is not
                 // cancelable, and that uses the TrackEvent interface, at the HTMLMediaElement textTracks list.
                 if (isMainThread()) {
-                    ensureWeakOnHTMLMediaElementContext([track = Ref { track }](HTMLMediaElement& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([track = track](HTMLMediaElement& mediaElement) mutable {
                         mediaElement.removeTextTrack(WTFMove(track));
                     });
                 } else {
-                    ensureWeakOnHTMLMediaElementContext([trackID = track.trackId()](auto& mediaElement) mutable {
+                    ensureWeakOnHTMLMediaElementContext([trackID = track->trackId()](auto& mediaElement) mutable {
                         mediaElement.removeTextTrack(trackID);
                     });
                 }
@@ -1608,7 +1608,7 @@ WTFLogChannel& MediaSource::logChannel() const
 
 void MediaSource::failedToCreateRenderer(RendererType type)
 {
-    if (auto context = scriptExecutionContext())
+    if (RefPtr context = scriptExecutionContext())
         context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource "_s, type == RendererType::Video ? "video"_s : "audio"_s, " renderer creation failed."_s));
 }
 

--- a/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm
+++ b/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm
@@ -48,7 +48,7 @@ void ScopedRenderingResourcesRequest::scheduleFreeRenderingResources()
 {
     if (didScheduleFreeRenderingResources)
         return;
-    RunLoop::main().dispatchAfter(freeRenderingResourcesTimeout, freeRenderingResources);
+    RunLoop::protectedMain()->dispatchAfter(freeRenderingResourcesTimeout, freeRenderingResources);
     didScheduleFreeRenderingResources = true;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3506,7 +3506,7 @@ void WebExtensionContext::loadBackgroundWebView()
     Ref backgroundProcess = backgroundPage->protectedLegacyMainFrameProcess();
 
     // Use foreground activity to keep background content responsive to events.
-    m_backgroundWebViewActivity = backgroundProcess->throttler().foregroundActivity("Web Extension background content"_s);
+    m_backgroundWebViewActivity = backgroundProcess->protectedThrottler()->foregroundActivity("Web Extension background content"_s);
 
     if (!protectedExtension()->backgroundContentIsServiceWorker()) {
         backgroundPage->protectedLegacyMainFrameProcess()->send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageIDInMainFrameProcess()), identifier());
@@ -4135,7 +4135,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         Ref process = inspectorBackgroundWebView._page->legacyMainFrameProcess();
 
         // Use foreground activity to keep background content responsive to events.
-        Ref inspectorBackgroundWebViewActivity = process->throttler().foregroundActivity("Web Extension Inspector background content"_s);
+        Ref inspectorBackgroundWebViewActivity = process->protectedThrottler()->foregroundActivity("Web Extension Inspector background content"_s);
 
         InspectorContext inspectorContext {
             tab->identifier(),

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -358,7 +358,7 @@ RefPtr<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteCommandEncoderProxy::create(root(), protectedConvertToBackingContext(), identifier);
+    auto result = RemoteCommandEncoderProxy::create(protectedRoot(), protectedConvertToBackingContext(), identifier);
     if (convertedDescriptor)
         result->setLabel(WTFMove(convertedDescriptor->label));
     return result;


### PR DESCRIPTION
#### 18a54579d3ec27227b5097f34b37a7d856bcd572
<pre>
Fix smart pointer warnings in MediaSource.cpp, ScopedRenderingResourcesRequestCocoa.mm, WebExtensionContextCocoa.mm, and RemoteDeviceProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282407">https://bugs.webkit.org/show_bug.cgi?id=282407</a>

Reviewed by Geoffrey Garen.

(WebCore::MediaSource::addSourceBuffer):
(WebCore::MediaSource::removeSourceBufferWithOptionalDestruction):
(WebCore::MediaSource::failedToCreateRenderer):
* Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm:
(WebKit::ScopedRenderingResourcesRequest::scheduleFreeRenderingResources):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createCommandEncoder):

Canonical link: <a href="https://commits.webkit.org/285982@main">https://commits.webkit.org/285982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb4f1c4b7e6fe51fa478f29aadf8ed7c761364ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27197 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78767 "Hash bb4f1c4b for PR 36015 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1600 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/78767 "Hash bb4f1c4b for PR 36015 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16783 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63977 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/78767 "Hash bb4f1c4b for PR 36015 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21472 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23957 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/984 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63995 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8126 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1667 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1696 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->