### PR TITLE
REGRESSION (283084@main): Document::visibilityStateChanged does not hold reference to callback clients

### DIFF
--- a/LayoutTests/fast/dom/view-transition-lifetime-crash-expected.txt
+++ b/LayoutTests/fast/dom/view-transition-lifetime-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/dom/view-transition-lifetime-crash.html
+++ b/LayoutTests/fast/dom/view-transition-lifetime-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src="../../resources/gc.js"></script>
+</head>
+
+<body>
+  <p>This test passes if it does not crash.</p>
+
+  <script>
+    // This allocates a bunch of ViewTransition objects, but nothing references them,
+    // so they should be garbage collected (below).
+    for (let i = 0; i < 100; i++) {
+      let vt = document.startViewTransition();
+
+      // Repeatedly starting new view transitions will cancel the previous view transition and
+      // reject the `ready` promise. If the document visibility is hidden, the view transition
+      // is skipped and the promise is also rejected too.
+      // In any case, we don't want the unhandled promise rejection to show up in the
+      // test output, so catch them but do nothing.
+      vt.ready.catch(e => { });
+    }
+
+    // Trigger GC to deallocate the ViewTransition objects (hopefully)
+    window.gc();
+
+    document.addEventListener("visibilitychange", () => {
+      testRunner.notifyDone();
+    });
+
+    window.internals.setPageVisibility(false);
+
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+  </script>
+</body>
+
+</html>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -47,6 +47,16 @@ WakeLockManager::~WakeLockManager()
     m_document.unregisterForVisibilityStateChangedCallbacks(*this);
 }
 
+void WakeLockManager::ref() const
+{
+    m_document.ref();
+}
+
+void WakeLockManager::deref() const
+{
+    m_document.deref();
+}
+
 void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, std::optional<PageIdentifier> pageID)
 {
     auto type = lock->type();

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -45,6 +45,9 @@ public:
     explicit WakeLockManager(Document&);
     ~WakeLockManager();
 
+    void ref() const final;
+    void deref() const final;
+
     void addWakeLock(Ref<WakeLockSentinel>&&, std::optional<PageIdentifier>);
     void removeWakeLock(WakeLockSentinel&);
 

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -46,8 +46,10 @@ WakeLockSentinel::WakeLockSentinel(Document& document, WakeLockType type)
 void WakeLockSentinel::release(Ref<DeferredPromise>&& promise)
 {
     if (!m_wasReleased) {
-        if (RefPtr document = downcast<Document>(scriptExecutionContext()))
-            Ref { *this }->release(document->wakeLockManager());
+        if (RefPtr document = downcast<Document>(scriptExecutionContext())) {
+            Ref wakeLockManagerRef { document->wakeLockManager() };
+            Ref { *this }->release(wakeLockManagerRef.get());
+        }
     }
     promise->resolve();
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2340,7 +2340,7 @@ void Document::visibilityStateChanged()
     // https://w3c.github.io/page-visibility/#reacting-to-visibilitychange-changes
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().visibilitychangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
     m_visibilityStateCallbackClients.forEach([](auto& client) {
-        client.visibilityStateChanged();
+        Ref { client }->visibilityStateChanged();
     });
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
@@ -2408,7 +2408,7 @@ String Document::nodeName() const
 WakeLockManager& Document::wakeLockManager()
 {
     if (!m_wakeLockManager)
-        m_wakeLockManager = makeUnique<WakeLockManager>(*this);
+        m_wakeLockManager = makeUniqueWithoutRefCountedCheck<WakeLockManager>(*this);
     return *m_wakeLockManager;
 }
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -212,6 +212,11 @@ void ViewTransition::skipViewTransition(ExceptionOr<JSC::JSValue>&& reason)
     });
 }
 
+bool ViewTransition::virtualHasPendingActivity() const
+{
+    return m_phase != ViewTransitionPhase::Done;
+}
+
 // https://drafts.csswg.org/css-view-transitions/#ViewTransition-skipTransition
 void ViewTransition::skipTransition()
 {

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -215,6 +215,7 @@ private:
 
     // ActiveDOMObject.
     void stop() final;
+    bool virtualHasPendingActivity() const final;
 
     bool isCrossDocument() { return m_isCrossDocument; }
 

--- a/Source/WebCore/dom/VisibilityChangeClient.h
+++ b/Source/WebCore/dom/VisibilityChangeClient.h
@@ -25,20 +25,15 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 class VisibilityChangeClient;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::VisibilityChangeClient> : std::true_type { };
-}
-
 namespace WebCore {
 
-class VisibilityChangeClient : public CanMakeWeakPtr<VisibilityChangeClient> {
+class VisibilityChangeClient : public AbstractRefCountedAndCanMakeWeakPtr<VisibilityChangeClient> {
 public:
     virtual ~VisibilityChangeClient() = default;
 


### PR DESCRIPTION
#### c8d323b1851ec55adde59e1c5ccaa61d9effc0a9
<pre>
REGRESSION (283084@main): Document::visibilityStateChanged does not hold reference to callback clients
<a href="https://rdar.apple.com/138799302">rdar://138799302</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282360">https://bugs.webkit.org/show_bug.cgi?id=282360</a>

Reviewed by Tim Nguyen, Ryosuke Niwa, and Chris Dumez.

Document::visibilityStateChanged() invokes visibility state callback clients, but does not
hold a reference to them before invoking. The client could then accidentally free itself
and cause an UAF. One possible route that leads to an UAF is through ViewTransition,
which the test case demonstrates:

* The ViewTransition C++ objects are allocated by document.startViewTransition().
  After the call, each object has a ref count of at least 2 (one in the JS wrapper
  that wraps the C++ object, one in Document::m_activeViewTransition)
* The GC is invoked, which releases the JS wrappers and decreases the ref count to 1
* The document visibility state is changed. This invokes ViewTransition::visibilityStateChanged
  on each object, which calls ::skipViewTransition, which calls ::clearViewTransition.
  ::clearViewTransition sets Document::m_activeViewTransition to null, so the object ref
  count is 0 and it&apos;s deallocated. ::clearViewTransition then continues to modify the
  (already deallocated) object, leading to an UAF.

Fix this by holding a reference to the callback clients before invoking it. This involves
making VisibilityChangeClient ref counted. Then Document::visibilityStateChanged()
would hold a reference to the client before invoking it. As WakeLockManager
(which inherits VisibilityChangeClient) wasn&apos;t ref counted, this patch also makes it
ref counted.

It&apos;s also observed that the JS wrapper should not be deallocated by the GC before the
view transition has completed. This commit fixes this by implementing
ViewTransition::virtualHasPendingActivity(), which the GC consults to determine whether
to deallocate the wrapper or not.

* LayoutTests/fast/dom/view-transition-lifetime-crash-expected.txt: Added.
* LayoutTests/fast/dom/view-transition-lifetime-crash.html: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp:
(WebCore::WakeLockManager::ref const): Delegated ref() to the document.
(WebCore::WakeLockManager::deref const): Delegated deref() to the document.
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h: Made WakeLockManager ref counted by declaring ref() and deref().
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
(WebCore::WakeLockSentinel::release): Hold a reference to the document&apos;s WakeLockManager before using it.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::visibilityStateChanged): Hold a reference to the visibility state callback client before calling it.
(WebCore::Document::wakeLockManager): Used makeUniqueWithoutRefCountedCheck to create new WakeLockManager.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::virtualHasPendingActivity const): Added implementation.
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/dom/VisibilityChangeClient.h: Made VisibilityChangeClient ref counted.

Canonical link: <a href="https://commits.webkit.org/286136@main">https://commits.webkit.org/286136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/998ef19dd556bc5b70315e1b07e1d4bd97803406

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58828 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17107 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46290 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21867 "Found 1 new test failure: svg/custom/text-tref-03-b-tref-removal.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67435 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22211 "Found 1 new test failure: media/media-vp8-webm-with-poster.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8481 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4993 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->