### PR TITLE
Renamed unsafeForgeSpan to unsafeMakeSpan

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -89,7 +89,7 @@ Vector<String> IntlCollator::sortLocaleData(const String& locale, RelevantExtens
             int32_t length = 0;
             while ((pointer = uenum_next(enumeration.get(), &length, &status)) && U_SUCCESS(status)) {
                 // 10.2.3 "The values "standard" and "search" must not be used as elements in any [[sortLocaleData]][locale].co and [[searchLocaleData]][locale].co array."
-                String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+                String collation(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
                 if (collation == "standard"_s || collation == "search"_s)
                     continue;
                 if (auto mapped = mapICUCollationKeywordToBCP47(collation))

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -158,7 +158,7 @@ Vector<String> IntlDateTimeFormat::localeData(const String& locale, RelevantExte
         int32_t nameLength;
         while (const char* availableName = uenum_next(calendars, &nameLength, &status)) {
             ASSERT(U_SUCCESS(status));
-            String calendar = String(unsafeForgeSpan(availableName, static_cast<size_t>(nameLength)));
+            String calendar = String(unsafeMakeSpan(availableName, static_cast<size_t>(nameLength)));
             keyLocaleData.append(calendar);
             // Adding "islamicc" candidate for backward compatibility.
             if (calendar == "islamic-civil"_s)

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -600,7 +600,7 @@ JSArray* IntlLocale::calendars(JSGlobalObject* globalObject)
     const char* pointer;
     int32_t length = 0;
     while ((pointer = uenum_next(calendars.get(), &length, &status)) && U_SUCCESS(status)) {
-        String calendar(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+        String calendar(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
         if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
             elements.append(WTFMove(mapped.value()));
         else
@@ -638,7 +638,7 @@ JSArray* IntlLocale::collations(JSGlobalObject* globalObject)
     const char* pointer;
     int32_t length = 0;
     while ((pointer = uenum_next(enumeration.get(), &length, &status)) && U_SUCCESS(status)) {
-        String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+        String collation(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
         // 1.1.3 step 4, The values "standard" and "search" must be excluded from list.
         if (collation == "standard"_s || collation == "search"_s)
             continue;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1633,7 +1633,7 @@ const Vector<String>& intlAvailableCalendars()
             int32_t length = 0;
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
-            String calendar(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+            String calendar(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
             if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
                 return createImmortalThreadSafeString(WTFMove(mapped.value()));
             return createImmortalThreadSafeString(WTFMove(calendar));
@@ -1704,7 +1704,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
             throwTypeError(globalObject, scope, "failed to enumerate available collations"_s);
             return { };
         }
-        String collation(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+        String collation(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
         if (collation == "standard"_s || collation == "search"_s)
             continue;
         if (auto mapped = mapICUCollationKeywordToBCP47(collation))
@@ -1761,7 +1761,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
             throwTypeError(globalObject, scope, "failed to enumerate available currencies"_s);
             return { };
         }
-        String currency(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+        String currency(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
         if (currency == "EQE"_s)
             continue;
         if (currency == "LSM"_s)
@@ -1870,7 +1870,7 @@ const Vector<String>& intlAvailableTimeZones()
             int32_t length = 0;
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
-            String timeZone(unsafeForgeSpan(pointer, static_cast<size_t>(length)));
+            String timeZone(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
             if (isValidTimeZoneNameFromICUTimeZone(timeZone)) {
                 if (auto mapped = canonicalizeTimeZoneNameFromICUTimeZone(WTFMove(timeZone)))
                     temporary.append(WTFMove(mapped.value()));

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -190,7 +190,7 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
     unsigned index = 0;
     while (const char* result = uenum_next(keywords.get(), &resultLength, &status)) {
         ASSERT(U_SUCCESS(status));
-        categories->putDirectIndex(globalObject, index++, jsNontrivialString(vm, String(unsafeForgeSpan(result, static_cast<size_t>(resultLength)))));
+        categories->putDirectIndex(globalObject, index++, jsNontrivialString(vm, String(unsafeMakeSpan(result, static_cast<size_t>(resultLength)))));
         RETURN_IF_EXCEPTION(scope, { });
     }
     options->putDirect(vm, Identifier::fromString(vm, "pluralCategories"_s), categories);

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -72,7 +72,7 @@ FunctionAllowlist::FunctionAllowlist(const char* filename)
         if (!length)
             continue;
         
-        m_entries.add(String(unsafeForgeSpan(line, length)));
+        m_entries.add(String(unsafeMakeSpan(line, length)));
     }
 
     int result = fclose(f);

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -222,7 +222,7 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
         FAIL_WITH_ERROR(SYNTAX_ERROR, ("Missing { after '", keyword, "' clause start delimiter:\n", line, "\n"));
 
     size_t delimiterLength = delimiterEnd - delimiterStart;
-    String delimiter(unsafeForgeSpan(delimiterStart, delimiterLength));
+    String delimiter(unsafeMakeSpan(delimiterStart, delimiterLength));
 
     if (hasDisallowedCharacters(delimiterStart, delimiterLength))
         FAIL_WITH_ERROR(SYNTAX_ERROR, ("Delimiter '", delimiter, "' cannot have '{', '}', or whitespace:\n", line, "\n"));

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -144,8 +144,8 @@ public:
 
     constexpr size_t storageLengthInBytes() { return sizeof(bits); }
 
-    std::span<uint8_t> storageBytes() { return unsafeForgeSpan(reinterpret_cast<uint8_t*>(storage()), storageLengthInBytes()); }
-    std::span<const uint8_t> storageBytes() const { return unsafeForgeSpan(reinterpret_cast<const uint8_t*>(storage()), storageLengthInBytes()); }
+    std::span<uint8_t> storageBytes() { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(storage()), storageLengthInBytes()); }
+    std::span<const uint8_t> storageBytes() const { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(storage()), storageLengthInBytes()); }
 
 private:
     void cleanseLastWord();

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -93,14 +93,14 @@ public:
 
     void realloc(size_t newSize)
     {
-        m_span = unsafeForgeSpan(static_cast<T*>(Malloc::realloc(m_span.data(), newSize)), newSize);
+        m_span = unsafeMakeSpan(static_cast<T*>(Malloc::realloc(m_span.data(), newSize)), newSize);
     }
 
 private:
     template<typename U, typename OtherMalloc> friend MallocSpan<U, OtherMalloc> adoptMallocSpan(U*, size_t);
 
     explicit MallocSpan(T* ptr, size_t size)
-        : m_span(unsafeForgeSpan(ptr, size))
+        : m_span(unsafeMakeSpan(ptr, size))
     {
     }
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -764,7 +764,7 @@ template<typename OptionalType> auto valueOrDefault(OptionalType&& optionalValue
 // Use this when we can't edit the imported API and it doesn't offer
 // begin() / end() or a span accessor.
 template<typename T, std::size_t Extent = std::dynamic_extent>
-inline constexpr auto unsafeForgeSpan(T* ptr, size_t size)
+inline constexpr auto unsafeMakeSpan(T* ptr, size_t size)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return std::span<T, Extent> { ptr, size };
@@ -810,27 +810,27 @@ std::span<uint8_t, Extent == std::dynamic_extent ? std::dynamic_extent: Extent *
 template<typename T>
 std::span<const uint8_t> asByteSpan(const T& input)
 {
-    return unsafeForgeSpan(reinterpret_cast<const uint8_t*>(&input), sizeof(input));
+    return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(&input), sizeof(input));
 }
 
 template<typename T, std::size_t Extent>
 std::span<const uint8_t> asByteSpan(std::span<T, Extent> input)
 {
-    return unsafeForgeSpan(reinterpret_cast<const uint8_t*>(input.data()), input.size_bytes());
+    return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(input.data()), input.size_bytes());
 }
 
 template<typename T>
 std::span<uint8_t> asMutableByteSpan(T& input)
 {
     static_assert(!std::is_const_v<T>);
-    return unsafeForgeSpan(reinterpret_cast<uint8_t*>(&input), sizeof(input));
+    return unsafeMakeSpan(reinterpret_cast<uint8_t*>(&input), sizeof(input));
 }
 
 template<typename T, std::size_t Extent>
 std::span<uint8_t> asMutableByteSpan(std::span<T, Extent> input)
 {
     static_assert(!std::is_const_v<T>);
-    return unsafeForgeSpan(reinterpret_cast<uint8_t*>(input.data()), input.size_bytes());
+    return unsafeMakeSpan(reinterpret_cast<uint8_t*>(input.data()), input.size_bytes());
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1126,7 +1126,7 @@ using WTF::safeCast;
 using WTF::spanConstCast;
 using WTF::spanReinterpretCast;
 using WTF::tryBinarySearch;
-using WTF::unsafeForgeSpan;
+using WTF::unsafeMakeSpan;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
 using WTF::toTwosComplement;

--- a/Source/WTF/wtf/cocoa/SpanCocoa.mm
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.mm
@@ -35,7 +35,7 @@ namespace WTF {
 bool dispatch_data_apply_span(dispatch_data_t data, const Function<bool(std::span<const uint8_t>)>& applier)
 {
     return dispatch_data_apply(data, makeBlockPtr([&applier](dispatch_data_t, size_t, const void* data, size_t size) {
-        return applier(unsafeForgeSpan(static_cast<const uint8_t*>(data), size));
+        return applier(unsafeMakeSpan(static_cast<const uint8_t*>(data), size));
     }).get());
 }
 

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -71,7 +71,7 @@ inline std::span<const uint8_t> span(GBytes* bytes)
 {
     size_t size = 0;
     const auto* ptr = static_cast<const uint8_t*>(g_bytes_get_data(bytes, &size));
-    return unsafeForgeSpan<const uint8_t>(ptr, size);
+    return unsafeMakeSpan<const uint8_t>(ptr, size);
 }
 
 inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes)
@@ -81,7 +81,7 @@ inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes)
 
 inline std::span<const uint8_t> span(GByteArray* array)
 {
-    return unsafeForgeSpan<const uint8_t>(array->data, array->len);
+    return unsafeMakeSpan<const uint8_t>(array->data, array->len);
 }
 
 inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array)
@@ -93,7 +93,7 @@ inline std::span<const uint8_t> span(GVariant* variant)
 {
     const auto* ptr = static_cast<const uint8_t*>(g_variant_get_data(variant));
     size_t size = g_variant_get_size(variant);
-    return unsafeForgeSpan<const uint8_t>(ptr, size);
+    return unsafeMakeSpan<const uint8_t>(ptr, size);
 }
 
 inline std::span<const uint8_t> span(const GRefPtr<GVariant>& variant)

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -53,7 +53,7 @@ public:
     static constexpr ASCIILiteral fromLiteralUnsafe(const char* string)
     {
         ASSERT_UNDER_CONSTEXPR_CONTEXT(string);
-        return ASCIILiteral { unsafeForgeSpan(string, std::char_traits<char>::length(string) + 1) };
+        return ASCIILiteral { unsafeMakeSpan(string, std::char_traits<char>::length(string) + 1) };
     }
 
     WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
@@ -150,7 +150,7 @@ constexpr ASCIILiteral operator""_s(const char* characters, size_t)
 
 constexpr std::span<const LChar> operator""_span(const char* characters, size_t n)
 {
-    auto span = byteCast<LChar>(unsafeForgeSpan(characters, n));
+    auto span = byteCast<LChar>(unsafeMakeSpan(characters, n));
 #if ASSERT_ENABLED
     for (size_t i = 0, size = span.size(); i < size; ++i)
         ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -42,33 +42,33 @@ namespace WTF {
 
 inline std::span<const LChar> span(const LChar& character)
 {
-    return unsafeForgeSpan(&character, 1);
+    return unsafeMakeSpan(&character, 1);
 }
 
 inline std::span<const UChar> span(const UChar& character)
 {
-    return unsafeForgeSpan(&character, 1);
+    return unsafeMakeSpan(&character, 1);
 }
 
 inline std::span<const LChar> span8(const char* string)
 {
-    return unsafeForgeSpan(byteCast<LChar>(string), string ? strlen(string) : 0);
+    return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) : 0);
 }
 
 inline std::span<const LChar> span8IncludingNullTerminator(const char* string)
 {
-    return unsafeForgeSpan(byteCast<LChar>(string), string ? strlen(string) + 1 : 0);
+    return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) + 1 : 0);
 }
 
 inline std::span<const char> span(const char* string)
 {
-    return unsafeForgeSpan(string, string ? strlen(string) : 0);
+    return unsafeMakeSpan(string, string ? strlen(string) : 0);
 }
 
 #if !HAVE(MISSING_U8STRING)
 inline std::span<const char8_t> span(const std::u8string& string)
 {
-    return unsafeForgeSpan(string.data(), string.length());
+    return unsafeMakeSpan(string.data(), string.length());
 }
 #endif
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -191,7 +191,7 @@ template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninit
     if (length > maxInternalLength<CharacterType>())
         CRASH();
     StringImpl* string = static_cast<StringImpl*>(StringImplMalloc::malloc(allocationSize<CharacterType>(length)));
-    data = unsafeForgeSpan(string->tailPointer<CharacterType>(), length);
+    data = unsafeMakeSpan(string->tailPointer<CharacterType>(), length);
     return constructInternal<CharacterType>(*string, length);
 }
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -39,7 +39,7 @@ namespace WebGPU {
 
 static inline auto span(id<MTLBuffer> buffer)
 {
-    return unsafeForgeSpan(static_cast<uint8_t*>(buffer.contents), static_cast<size_t>(buffer.length));
+    return unsafeMakeSpan(static_cast<uint8_t*>(buffer.contents), static_cast<size_t>(buffer.length));
 }
 
 static bool validateDescriptor(const Device& device, const WGPUBufferDescriptor& descriptor)

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -545,7 +545,7 @@ void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEnco
 
 void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, const uint32_t* dynamicOffsets)
 {
-    WebGPU::protectedFromAPI(computePassEncoder)->setBindGroup(groupIndex, WebGPU::protectedFromAPI(group), unsafeForgeSpan(dynamicOffsets, dynamicOffsetCount));
+    WebGPU::protectedFromAPI(computePassEncoder)->setBindGroup(groupIndex, WebGPU::protectedFromAPI(group), unsafeMakeSpan(dynamicOffsets, dynamicOffsetCount));
 }
 
 void wgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline)

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -1090,7 +1090,7 @@ void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue queue, WGPUQueueWorkDoneBlo
 void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuffer* commands)
 {
     Vector<Ref<WebGPU::CommandBuffer>> commandsToForward;
-    for (auto& command : unsafeForgeSpan(commands, commandCount))
+    for (auto& command : unsafeMakeSpan(commands, commandCount))
         commandsToForward.append(WebGPU::protectedFromAPI(command));
     WebGPU::protectedFromAPI(queue)->submit(WTFMove(commandsToForward));
 }

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -300,7 +300,7 @@ static std::span<T> makeSpanFromBuffer(id<MTLBuffer> buffer, size_t byteOffset =
     if (UNLIKELY(bufferLength < byteOffset || (bufferLength - byteOffset < sizeof(T))))
         return { };
 
-    return unsafeForgeSpan(static_cast<T*>(buffer.contents), (bufferLength - byteOffset) / sizeof(T));
+    return unsafeMakeSpan(static_cast<T*>(buffer.contents), (bufferLength - byteOffset) / sizeof(T));
 }
 
 bool RenderBundleEncoder::executePreDrawCommands(bool passWasSplit, uint32_t firstInstance, uint32_t instanceCount)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1416,7 +1416,7 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder)
 void wgpuRenderPassEncoderExecuteBundles(WGPURenderPassEncoder renderPassEncoder, size_t bundlesCount, const WGPURenderBundle* bundles)
 {
     Vector<Ref<WebGPU::RenderBundle>> bundlesToForward;
-    for (auto& bundle : unsafeForgeSpan(bundles, bundlesCount))
+    for (auto& bundle : unsafeMakeSpan(bundles, bundlesCount))
         bundlesToForward.append(WebGPU::protectedFromAPI(bundle));
     WebGPU::protectedFromAPI(renderPassEncoder)->executeBundles(WTFMove(bundlesToForward));
 }
@@ -1438,7 +1438,7 @@ void wgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder
 
 void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, const uint32_t* dynamicOffsets)
 {
-    WebGPU::protectedFromAPI(renderPassEncoder)->setBindGroup(groupIndex, WebGPU::protectedFromAPI(group), unsafeForgeSpan(dynamicOffsets, dynamicOffsetCount));
+    WebGPU::protectedFromAPI(renderPassEncoder)->setBindGroup(groupIndex, WebGPU::protectedFromAPI(group), unsafeMakeSpan(dynamicOffsets, dynamicOffsetCount));
 }
 
 void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, const WGPUColor* color)

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -919,7 +919,7 @@ typedef struct WGPUPipelineLayoutDescriptor {
     size_t bindGroupLayoutCount;
     WGPUBindGroupLayout const * bindGroupLayouts;
 
-    auto bindGroupLayoutsSpan() const { return unsafeForgeSpan(bindGroupLayouts, bindGroupLayoutCount); }
+    auto bindGroupLayoutsSpan() const { return unsafeMakeSpan(bindGroupLayouts, bindGroupLayoutCount); }
 } WGPUPipelineLayoutDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 // Can be chained in WGPUPrimitiveState
@@ -963,7 +963,7 @@ typedef struct WGPURenderBundleEncoderDescriptor {
     WGPUBool depthReadOnly;
     WGPUBool stencilReadOnly;
 
-    auto colorFormatsSpan() const { return unsafeForgeSpan(colorFormats, colorFormatCount); }
+    auto colorFormatsSpan() const { return unsafeMakeSpan(colorFormats, colorFormatCount); }
 } WGPURenderBundleEncoderDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDepthStencilAttachment {
@@ -1163,7 +1163,7 @@ typedef struct WGPUBindGroupDescriptor {
     size_t entryCount;
     WGPUBindGroupEntry const * entries;
 
-    auto entriesSpan() const { return unsafeForgeSpan(entries, entryCount); }
+    auto entriesSpan() const { return unsafeMakeSpan(entries, entryCount); }
 } WGPUBindGroupDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUBindGroupLayoutEntry {
@@ -1233,7 +1233,7 @@ typedef struct WGPUProgrammableStageDescriptor {
     size_t constantCount;
     WGPUConstantEntry const * constants;
 
-    auto constantsSpan() const { return unsafeForgeSpan(constants, constantCount); }
+    auto constantsSpan() const { return unsafeMakeSpan(constants, constantCount); }
 } WGPUProgrammableStageDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassColorAttachment {
@@ -1259,7 +1259,7 @@ typedef struct WGPUShaderModuleDescriptor {
     size_t hintCount;
     WGPUShaderModuleCompilationHint const * hints;
 
-    auto hintsSpan() const { return unsafeForgeSpan(hints, hintCount); }
+    auto hintsSpan() const { return unsafeMakeSpan(hints, hintCount); }
 } WGPUShaderModuleDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUSupportedLimits {
@@ -1279,7 +1279,7 @@ typedef struct WGPUTextureDescriptor {
     size_t viewFormatCount;
     WGPUTextureFormat const * viewFormats;
 
-    auto viewFormatsSpan() const { return unsafeForgeSpan(viewFormats, viewFormatCount); }
+    auto viewFormatsSpan() const { return unsafeMakeSpan(viewFormats, viewFormatCount); }
 } WGPUTextureDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexBufferLayout {
@@ -1288,7 +1288,7 @@ typedef struct WGPUVertexBufferLayout {
     size_t attributeCount;
     WGPUVertexAttribute const * attributes;
 
-    auto attributesSpan() const { return unsafeForgeSpan(attributes, attributeCount); }
+    auto attributesSpan() const { return unsafeMakeSpan(attributes, attributeCount); }
 } WGPUVertexBufferLayout WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUBindGroupLayoutDescriptor {
@@ -1297,7 +1297,7 @@ typedef struct WGPUBindGroupLayoutDescriptor {
     size_t entryCount;
     WGPUBindGroupLayoutEntry const * entries;
 
-    auto entriesSpan() const { return unsafeForgeSpan(entries, entryCount); }
+    auto entriesSpan() const { return unsafeMakeSpan(entries, entryCount); }
 } WGPUBindGroupLayoutDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUColorTargetState {
@@ -1324,7 +1324,7 @@ typedef struct WGPUDeviceDescriptor {
     WGPUDeviceLostCallback deviceLostCallback;
     void * deviceLostUserdata;
 
-    auto requiredFeaturesSpan() const { return unsafeForgeSpan(requiredFeatures, requiredFeatureCount); }
+    auto requiredFeaturesSpan() const { return unsafeMakeSpan(requiredFeatures, requiredFeatureCount); }
 } WGPUDeviceDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDescriptor {
@@ -1336,7 +1336,7 @@ typedef struct WGPURenderPassDescriptor {
     WGPU_NULLABLE WGPUQuerySet occlusionQuerySet;
     WGPU_NULLABLE WGPURenderPassTimestampWrites const * timestampWrites;
 
-    auto colorAttachmentsSpan() const { return unsafeForgeSpan(colorAttachments, colorAttachmentCount); }
+    auto colorAttachmentsSpan() const { return unsafeMakeSpan(colorAttachments, colorAttachmentCount); }
 } WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexState {
@@ -1348,8 +1348,8 @@ typedef struct WGPUVertexState {
     size_t bufferCount;
     WGPUVertexBufferLayout const * buffers;
 
-    auto buffersSpan() const { return unsafeForgeSpan(buffers, bufferCount); }
-    auto constantsSpan() const { return unsafeForgeSpan(constants, constantCount); }
+    auto buffersSpan() const { return unsafeMakeSpan(buffers, bufferCount); }
+    auto constantsSpan() const { return unsafeMakeSpan(constants, constantCount); }
 } WGPUVertexState WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUFragmentState {
@@ -1361,8 +1361,8 @@ typedef struct WGPUFragmentState {
     size_t targetCount;
     WGPUColorTargetState const * targets;
 
-    auto targetsSpan() const { return unsafeForgeSpan(targets, targetCount); }
-    auto constantsSpan() const { return unsafeForgeSpan(constants, constantCount); }
+    auto targetsSpan() const { return unsafeMakeSpan(targets, targetCount); }
+    auto constantsSpan() const { return unsafeMakeSpan(constants, constantCount); }
 } WGPUFragmentState WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPipelineDescriptor {

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -344,14 +344,14 @@ void LibWebRTCCodecsProxy::createEncoder(VideoEncoderIdentifier identifier, WebC
             protectedThis->notifyEncoderResult(identifier, result);
     });
     auto newFrameBlock = makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, queue = m_queue, connection = m_connection, identifier](const uint8_t* buffer, size_t size, const webrtc::WebKitEncodedFrameInfo& info) {
-        connection->send(Messages::LibWebRTCCodecs::CompletedEncoding { identifier, unsafeForgeSpan(buffer, size), info }, 0);
+        connection->send(Messages::LibWebRTCCodecs::CompletedEncoding { identifier, unsafeMakeSpan(buffer, size), info }, 0);
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->notifyEncoderResult(identifier, true);
     });
     auto newConfigurationBlock = makeBlockPtr([connection = m_connection, identifier](const uint8_t* buffer, size_t size) {
         // Current encoders are limited to this configuration. We might want in the future to let encoders notify which colorSpace they are selecting.
         PlatformVideoColorSpace colorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Bt709, true };
-        connection->send(Messages::LibWebRTCCodecs::SetEncodingConfiguration { identifier, unsafeForgeSpan(buffer, size), colorSpace }, 0);
+        connection->send(Messages::LibWebRTCCodecs::SetEncodingConfiguration { identifier, unsafeMakeSpan(buffer, size), colorSpace }, 0);
     });
 
     webrtc::LocalEncoderScalabilityMode rtcScalabilityMode;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -57,7 +57,7 @@ std::span<const uint8_t> Data::span() const
         const void* data = nullptr;
         size_t size = 0;
         m_dispatchData = adoptOSObject(dispatch_data_create_map(m_dispatchData.get(), &data, &size));
-        m_data = unsafeForgeSpan(static_cast<const uint8_t*>(data), size);
+        m_data = unsafeMakeSpan(static_cast<const uint8_t*>(data), size);
     }
     return m_data;
 }

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -51,7 +51,7 @@ public:
         std::span<uint8_t> copiedBytes;
 
         if (!bytes.empty()) {
-            copiedBytes = unsafeForgeSpan(static_cast<uint8_t*>(fastMalloc(bytes.size())), bytes.size());
+            copiedBytes = unsafeMakeSpan(static_cast<uint8_t*>(fastMalloc(bytes.size())), bytes.size());
             memcpySpan(copiedBytes, bytes);
         }
 
@@ -70,7 +70,7 @@ public:
     {
         auto bufferSize = buffer.size();
         auto bufferPointer = buffer.releaseBuffer().leakPtr();
-        return createWithoutCopying(unsafeForgeSpan(bufferPointer, bufferSize), [] (uint8_t* bytes, const void*) {
+        return createWithoutCopying(unsafeMakeSpan(bufferPointer, bufferSize), [] (uint8_t* bytes, const void*) {
             if (bytes)
                 WTF::VectorMalloc::free(bytes);
         }, nullptr);

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -598,7 +598,7 @@ static NSString *escapeKey(NSString *key)
 
 - (void)encodeBytes:(const uint8_t *)bytes length:(NSUInteger)length forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Data::create(unsafeForgeSpan(bytes, length)));
+    _currentDictionary->set(escapeKey(key), API::Data::create(unsafeMakeSpan(bytes, length)));
 }
 
 - (void)encodeBool:(BOOL)value forKey:(NSString *)key

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
@@ -123,7 +123,7 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
     unsigned methodCount;
     struct objc_method_description *rawMethods = protocol_copyMethodDescriptionList(protocol, requiredMethods, true, &methodCount);
 
-    auto methods = unsafeForgeSpan(rawMethods, methodCount);
+    auto methods = unsafeMakeSpan(rawMethods, methodCount);
     for (auto& method : methods) {
         SEL selector = method.name;
 
@@ -146,7 +146,7 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
 {
     unsigned conformingProtocolCount;
     auto rawConformingProtocols = protocol_copyProtocolList(protocol, &conformingProtocolCount);
-    auto conformingProtocols = unsafeForgeSpan(rawConformingProtocols, conformingProtocolCount);
+    auto conformingProtocols = unsafeMakeSpan(rawConformingProtocols, conformingProtocolCount);
 
     for (auto& conformingProtocol : conformingProtocols) {
         if (conformingProtocol == @protocol(NSObject))

--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -37,7 +37,7 @@ WKTypeID WKArrayGetTypeID()
 
 WKArrayRef WKArrayCreate(WKTypeRef* rawValues, size_t numberOfValues)
 {
-    auto values = unsafeForgeSpan(rawValues, numberOfValues);
+    auto values = unsafeMakeSpan(rawValues, numberOfValues);
     Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) -> RefPtr<API::Object> {
         return WebKit::toImpl(values[i]);
     });
@@ -46,7 +46,7 @@ WKArrayRef WKArrayCreate(WKTypeRef* rawValues, size_t numberOfValues)
 
 WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* rawValues, size_t numberOfValues)
 {
-    auto values = unsafeForgeSpan(rawValues, numberOfValues);
+    auto values = unsafeMakeSpan(rawValues, numberOfValues);
     Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) {
         return adoptRef(WebKit::toImpl(values[i]));
     });

--- a/Source/WebKit/Shared/API/c/WKData.cpp
+++ b/Source/WebKit/Shared/API/c/WKData.cpp
@@ -37,7 +37,7 @@ WKTypeID WKDataGetTypeID()
 
 WKDataRef WKDataCreate(const unsigned char* bytes, size_t size)
 {
-    return WebKit::toAPI(&API::Data::create(unsafeForgeSpan(bytes, size)).leakRef());
+    return WebKit::toAPI(&API::Data::create(unsafeMakeSpan(bytes, size)).leakRef());
 }
 
 const unsigned char* WKDataGetBytes(WKDataRef dataRef)
@@ -52,5 +52,5 @@ size_t WKDataGetSize(WKDataRef dataRef)
 
 std::span<const uint8_t> WKDataGetSpan(WKDataRef dataRef)
 {
-    return unsafeForgeSpan(byteCast<uint8_t>(WKDataGetBytes(dataRef)), WKDataGetSize(dataRef));
+    return unsafeMakeSpan(byteCast<uint8_t>(WKDataGetBytes(dataRef)), WKDataGetSize(dataRef));
 }

--- a/Source/WebKit/Shared/API/c/WKDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKDictionary.cpp
@@ -37,8 +37,8 @@ WKTypeID WKDictionaryGetTypeID()
 
 WK_EXPORT WKDictionaryRef WKDictionaryCreate(const WKStringRef* rawKeys, const WKTypeRef* rawValues, size_t numberOfValues)
 {
-    auto keys = unsafeForgeSpan(rawKeys, numberOfValues);
-    auto values = unsafeForgeSpan(rawValues, numberOfValues);
+    auto keys = unsafeMakeSpan(rawKeys, numberOfValues);
+    auto values = unsafeMakeSpan(rawValues, numberOfValues);
 
     API::Dictionary::MapType map;
     map.reserveInitialCapacity(numberOfValues);

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -46,7 +46,7 @@ WKStringRef WKStringCreateWithUTF8CString(const char* string)
 
 WKStringRef WKStringCreateWithUTF8CStringWithLength(const char* string, size_t stringLength)
 {
-    return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8(unsafeForgeSpan(string, stringLength))).leakRef());
+    return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8(unsafeMakeSpan(string, stringLength))).leakRef());
 }
 
 bool WKStringIsEmpty(WKStringRef stringRef)
@@ -85,7 +85,7 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
 
     auto string = WebKit::toImpl(stringRef)->stringView();
 
-    auto target = unsafeForgeSpan(byteCast<char8_t>(buffer), bufferSize);
+    auto target = unsafeMakeSpan(byteCast<char8_t>(buffer), bufferSize);
     WTF::Unicode::ConversionResult<char8_t> result;
     if (string.is8Bit())
         result = WTF::Unicode::convert(string.span8(), target.first(bufferSize - 1));

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -124,7 +124,7 @@ static void connectionRemoved(xpc_connection_t connection)
 
 int PCMDaemonMain(int argc, const char** argv)
 {
-    auto arguments = unsafeForgeSpan(argv, argc);
+    auto arguments = unsafeMakeSpan(argv, argc);
     if (arguments.size() < 5 || strcmp(arguments[1], "--machServiceName") || strcmp(arguments[3], "--storageLocation")) {
         NSLog(@"Usage: %s --machServiceName <name> --storageLocation <location> [--startActivity]", arguments[0]);
         return -1;

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -431,8 +431,8 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
     cacheFile.append(asByteSpan(cachedHeader));
     cacheFile.append(info.header.span());
     if (haveBuiltin)
-        cacheFile.append(unsafeForgeSpan(sandboxProfile->builtin, cachedHeader.builtinSize));
-    cacheFile.append(unsafeForgeSpan(sandboxProfile->data, cachedHeader.dataSize));
+        cacheFile.append(unsafeMakeSpan(sandboxProfile->builtin, cachedHeader.builtinSize));
+    cacheFile.append(unsafeMakeSpan(sandboxProfile->data, cachedHeader.dataSize));
 
     if (!writeSandboxDataToCacheFile(info, cacheFile))
         WTFLogAlways("%s: Unable to cache compiled sandbox\n", getprogname());

--- a/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
+++ b/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
@@ -67,7 +67,7 @@ SystemMallocStats WebMemorySampler::sampleSystemMalloc() const
     mallocStats.purgeableMallocZoneStats = stats;
     
     malloc_get_all_zones(mach_task_self(), 0, &rawZones, &count);
-    auto zones = unsafeForgeSpan(rawZones, count);
+    auto zones = unsafeMakeSpan(rawZones, count);
     for (auto& zone : zones) {
         if (const char* name = malloc_get_zone_name(reinterpret_cast<malloc_zone_t*>(zone))) {
             stats.blocks_in_use = 0;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -878,7 +878,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_addTrackingRects:(NSRect *)rawRects owner:(id)owner userDataList:(void **)userDataList assumeInsideList:(BOOL *)assumeInsideList trackingNums:(NSTrackingRectTag *)trackingNums count:(int)count
 {
-    auto nsRects = unsafeForgeSpan(rawRects, count);
+    auto nsRects = unsafeMakeSpan(rawRects, count);
     auto cgRects = WTF::map(nsRects, [](auto& nsRect) {
         return NSRectToCGRect(nsRect);
     });
@@ -896,7 +896,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if (!_impl)
         return;
-    _impl->removeTrackingRects(unsafeForgeSpan(tags, count));
+    _impl->removeTrackingRects(unsafeMakeSpan(tags, count));
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -357,7 +357,7 @@ static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
     Vector<uint8_t> pngData;
     cairo_surface_write_to_png_stream(surface, [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
         auto* pngData = static_cast<Vector<uint8_t>*>(userData);
-        pngData->append(unsafeForgeSpan<const uint8_t>(data, length));
+        pngData->append(unsafeMakeSpan<const uint8_t>(data, length));
         return CAIRO_STATUS_SUCCESS;
     }, &pngData);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -53,7 +53,7 @@ static void reportReceived(void* context, IOReturn status, void*, IOHIDReportTyp
     ASSERT(reportID == kHidReportId);
     ASSERT(reportLength == kHidMaxPacketSize);
 
-    connection->receiveReport(unsafeForgeSpan(report, reportLength));
+    connection->receiveReport(unsafeMakeSpan(report, reportLength));
 }
 #endif // HAVE(SECURITY_KEY_API)
 

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -518,7 +518,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
     auto mallocBuffer = MallocPtr<uint8_t, HistoryEntryDataEncoderMalloc>::tryMalloc(bufferSize);
     if (!mallocBuffer)
         return nullptr;
-    auto buffer = unsafeForgeSpan(mallocBuffer.leakPtr(), bufferSize);
+    auto buffer = unsafeMakeSpan(mallocBuffer.leakPtr(), bufferSize);
 
     // Put the session state version number at the start of the buffer
     buffer[0] = (sessionStateDataVersion & 0xff000000) >> 24;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -193,7 +193,7 @@ static JSValueRef createUUID(JSContextRef context, JSObjectRef function, JSObjec
 static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
     // This is using the JSC C API so we cannot take a std::span in argument directly.
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     ASSERT(arguments.size() == 4);
     ASSERT(JSValueIsNumber(context, arguments[0]));

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -492,7 +492,7 @@ EOF
 
             my $lastParameter = $specifiedParameters[$#specifiedParameters];
 
-            push(@contents, "\n    auto arguments = unsafeForgeSpan(unsafeArguments, argumentCount);\n\n") if scalar @specifiedParameters;
+            push(@contents, "\n    auto arguments = unsafeMakeSpan(unsafeArguments, argumentCount);\n\n") if scalar @specifiedParameters;
             my $needsScriptContext = $function->extendedAttributes->{"NeedsScriptContext"};
 
             my $needsFrame = $function->extendedAttributes->{"NeedsFrame"};

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -243,7 +243,7 @@ void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
 
 
         auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
-        auto buffers = unsafeForgeSpan(ioData->mBuffers, numberOfBuffers);
+        auto buffers = unsafeMakeSpan(ioData->mBuffers, numberOfBuffers);
 
         // Associate the destination data array with the output bus then fill the FIFO.
         for (UInt32 i = 0; i < numberOfBuffers; ++i) {

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -153,7 +153,7 @@ static int32_t releaseVideoDecoder(webrtc::WebKitVideoDecoder::Value decoder)
 
 static int32_t decodeVideoFrame(webrtc::WebKitVideoDecoder::Value decoder, uint32_t timeStamp, const uint8_t* data, size_t size, uint16_t width,  uint16_t height)
 {
-    return WebProcess::singleton().libWebRTCCodecs().decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, unsafeForgeSpan(data, size), width, height);
+    return WebProcess::singleton().libWebRTCCodecs().decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, unsafeMakeSpan(data, size), width, height);
 }
 
 static int32_t registerDecodeCompleteCallback(webrtc::WebKitVideoDecoder::Value decoder, void* decodedImageCallback)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -121,7 +121,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
     if (m_isSuspended)
         return size;
 
-    auto data = unsafeForgeSpan(static_cast<const uint8_t*>(value), size);
+    auto data = unsafeMakeSpan(static_cast<const uint8_t*>(value), size);
     connection->send(Messages::NetworkRTCProvider::SendToSocket { identifier(), data, RTCNetwork::SocketAddress { address }, RTCPacketOptions { options } }, 0);
 
     return size;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -574,13 +574,13 @@ void PDFIncrementalLoader::requestDidCompleteWithAccumulatedData(ByteRangeReques
 static void dataProviderGetByteRangesCallback(void* info, CFMutableArrayRef buffers, const CFRange* ranges, size_t count)
 {
     RefPtr loader = reinterpret_cast<PDFIncrementalLoader*>(info);
-    loader->dataProviderGetByteRanges(buffers, unsafeForgeSpan(ranges, count));
+    loader->dataProviderGetByteRanges(buffers, unsafeMakeSpan(ranges, count));
 }
 
 static size_t dataProviderGetBytesAtPositionCallback(void* info, void* buffer, off_t position, size_t count)
 {
     RefPtr loader = reinterpret_cast<PDFIncrementalLoader*>(info);
-    return loader->dataProviderGetBytesAtPosition(unsafeForgeSpan(static_cast<uint8_t*>(buffer), count), position);
+    return loader->dataProviderGetBytesAtPosition(unsafeMakeSpan(static_cast<uint8_t*>(buffer), count), position);
 }
 
 static void dataProviderReleaseInfoCallback(void* info)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
@@ -124,7 +124,7 @@ static bool pdfDocumentContainsPrintScript(RetainPtr<CGPDFDocumentRef> pdfDocume
             CGPDFStringRef string = nullptr;
             if (!CGPDFDictionaryGetString(javaScriptAction, "JS", &string))
                 return nullptr;
-            return scriptFromBytes(unsafeForgeSpan(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string)));
+            return scriptFromBytes(unsafeMakeSpan(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string)));
         };
 
         if (RetainPtr<CFStringRef> script = scriptFromStream() ?: scriptFromString(); script && isPrintScript({ script.get() }))

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -847,7 +847,7 @@ JSValueRef JSIPCConnection::invalidate(JSContextRef context, JSObjectRef, JSObje
 
 JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -872,7 +872,7 @@ JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObj
 
 JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -910,7 +910,7 @@ JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef
 
 JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -931,7 +931,7 @@ JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, J
 
 JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -951,7 +951,7 @@ JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JS
 
 JSValueRef JSIPCConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1073,7 +1073,7 @@ JSValueRef JSIPCStreamClientConnection::streamBuffer(JSContextRef context, JSObj
 
 JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
@@ -1141,7 +1141,7 @@ bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(uint64_t desti
 
 JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1161,7 +1161,7 @@ JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObje
 
 JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1200,7 +1200,7 @@ JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context,
 
 JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1223,7 +1223,7 @@ JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JS
 // FIXME(http://webkit.org/b/237197): Cannot send arbitrary messages, so we hard-code this one to be able to send it.
 JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
@@ -1269,7 +1269,7 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
 
 JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1289,7 +1289,7 @@ JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSO
 
 JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -1539,7 +1539,7 @@ const JSStaticFunction* JSSharedMemory::staticFunctions()
 
 JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsSharedMemory = toWrapped(context, thisObject);
     if (!jsSharedMemory) {
@@ -1609,12 +1609,12 @@ static std::span<const uint8_t> arrayBufferSpanFromValueRef(JSContextRef context
     else
         length = JSObjectGetTypedArrayByteLength(context, objectRef, exception);
 
-    return unsafeForgeSpan(static_cast<const uint8_t*>(buffer), length);
+    return unsafeMakeSpan(static_cast<const uint8_t*>(buffer), length);
 }
 
 JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsSharedMemory = toWrapped(context, thisObject);
     if (!jsSharedMemory) {
@@ -1713,7 +1713,7 @@ JSValueRef JSIPCStreamConnectionBuffer::readDataBytes(JSContextRef context, JSOb
 
 JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception, std::span<uint8_t> span)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     size_t offset = 0;
     size_t length = span.size();
@@ -1795,7 +1795,7 @@ JSValueRef JSIPCStreamConnectionBuffer::writeDataBytes(JSContextRef context, JSO
 
 JSValueRef JSIPCStreamConnectionBuffer::writeBytes(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception, std::span<uint8_t> span)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     auto type = arguments.size() > 0 ? JSValueGetTypedArrayType(context, arguments[0], exception) : kJSTypedArrayTypeNone;
     if (type == kJSTypedArrayTypeNone) {
@@ -1960,7 +1960,7 @@ RefPtr<JSIPCConnection> JSIPC::processTargetFromArgument(JSC::JSGlobalObject* gl
 
 void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef context, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -2523,7 +2523,7 @@ JSValueRef JSIPC::connectionForProcessTarget(JSContextRef context, JSObjectRef, 
 
 JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -2551,7 +2551,7 @@ JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thi
 
 JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -2576,7 +2576,7 @@ JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef 
 
 JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
@@ -2628,7 +2628,7 @@ JSValueRef JSIPC::createConnectionPair(JSContextRef context, JSObjectRef, JSObje
 
 JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    auto arguments = unsafeForgeSpan(rawArguments, rawArgumentCount);
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
 
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());


### PR DESCRIPTION
#### f687b57a0a69304a15a8689a9609bcf493981887
<pre>
Renamed unsafeForgeSpan to unsafeMakeSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=282411">https://bugs.webkit.org/show_bug.cgi?id=282411</a>
<a href="https://rdar.apple.com/139032153">rdar://139032153</a>

Reviewed by Simon Fraser and Chris Dumez.

People found &quot;forge&quot; to be awkward.

* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::sortLocaleData):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::localeData):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::calendars):
(JSC::IntlLocale::collations):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlAvailableCalendars):
(JSC::availableCollations):
(JSC::availableCurrencies):
(JSC::intlAvailableTimeZones):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::FunctionAllowlist):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause):
* Source/WTF/wtf/BitSet.h:
* Source/WTF/wtf/MallocSpan.h:
(WTF::MallocSpan::realloc):
(WTF::MallocSpan::MallocSpan):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::unsafeMakeSpan):
(WTF::asByteSpan):
(WTF::asMutableByteSpan):
(WTF::unsafeForgeSpan): Deleted.
* Source/WTF/wtf/cocoa/SpanCocoa.mm:
(WTF::dispatch_data_apply_span):
* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::span):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator_span):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::span):
(WTF::span8):
(WTF::span8IncludingNullTerminator):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createUninitializedInternalNonEmpty):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::span):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(wgpuComputePassEncoderSetBindGroup):
* Source/WebGPU/WebGPU/Queue.mm:
(wgpuQueueSubmit):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::makeSpanFromBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(wgpuRenderPassEncoderExecuteBundles):
(wgpuRenderPassEncoderSetBindGroup):
* Source/WebGPU/WebGPU/WebGPU.h:
(WGPUPipelineLayoutDescriptor::bindGroupLayoutsSpan const):
(WGPURenderBundleEncoderDescriptor::colorFormatsSpan const):
(WGPUBindGroupDescriptor::entriesSpan const):
(WGPUProgrammableStageDescriptor::constantsSpan const):
(WGPUShaderModuleDescriptor::hintsSpan const):
(WGPUTextureDescriptor::viewFormatsSpan const):
(WGPUVertexBufferLayout::attributesSpan const):
(WGPUBindGroupLayoutDescriptor::entriesSpan const):
(WGPUDeviceDescriptor::requiredFeaturesSpan const):
(WGPURenderPassDescriptor::colorAttachmentsSpan const):
(WGPUVertexState::buffersSpan const):
(WGPUVertexState::constantsSpan const):
(WGPUFragmentState::targetsSpan const):
(WGPUFragmentState::constantsSpan const):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createEncoder):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::span const):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::create):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectEncoder encodeBytes:length:forKey:]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
(initializeMethods):
* Source/WebKit/Shared/API/c/WKArray.cpp:
(WKArrayCreate):
(WKArrayCreateAdoptingValues):
* Source/WebKit/Shared/API/c/WKData.cpp:
(WKDataCreate):
(WKDataGetSpan):
* Source/WebKit/Shared/API/c/WKDictionary.cpp:
(WKDictionaryCreate):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringCreateWithUTF8CStringWithLength):
(WKStringGetUTF8CStringImpl):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::PCMDaemonMain):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndCacheSandboxProfile):
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
(WebKit::WebMemorySampler::sampleSystemMalloc const):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _addTrackingRects:owner:userDataList:assumeInsideList:trackingNums:count:]):
(-[WKWebView _removeTrackingRects:count:]):
* Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp:
(WebKit::base64EncodedPNGData):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::reportReceived):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeLegacySessionState):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::renderAudio):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::decodeVideoFrame):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::SendTo):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::dataProviderGetByteRangesCallback):
(WebKit::dataProviderGetBytesAtPositionCallback):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm:
(WebKit::PDFScriptEvaluation::pdfDocumentContainsPrintScript):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::setSemaphores):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSSharedMemory::readBytes):
(WebKit::IPCTestingAPI::arrayBufferSpanFromValueRef):
(WebKit::IPCTestingAPI::JSSharedMemory::writeBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::writeBytes):
(WebKit::IPCTestingAPI::JSIPC::addMessageListener):
(WebKit::IPCTestingAPI::JSIPC::sendMessage):
(WebKit::IPCTestingAPI::JSIPC::waitForMessage):
(WebKit::IPCTestingAPI::JSIPC::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPC::createStreamClientConnection):

Canonical link: <a href="https://commits.webkit.org/285985@main">https://commits.webkit.org/285985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc8e1b26082928242b2e5bc4d7caf230c9b8f26d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1605 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63989 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21484 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/23962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67528 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80290 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73649 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/990 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64007 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9975 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1672 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1701 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->