### PR TITLE
scrollbar-width update doesn't correctly relayout

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-expected.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-expected.html
@@ -1,0 +1,21 @@
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!doctype html>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+    .container {
+        background-color: orange;
+        overflow: auto;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+
+    .content {
+        background-color: green;
+        height: 300px;
+        width: 100%;
+    }
+</style>
+    <div id="box" class="container" style="scrollbar-width: none;">
+        <div class="content"></div>
+    </div>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!doctype html>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+    .container {
+        background-color: orange;
+        overflow: auto;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+
+    .content {
+        background-color: green;
+        height: 300px;
+        width: 100%;
+    }
+</style>
+    <div id="box" class="container" style="scrollbar-width: thin;">
+        <div class="content"></div>
+    </div>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        document.getElementById('box').style.scrollbarWidth = 'none';
+        testRunner.notifyDone();
+    }));
+</script>

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -465,6 +465,9 @@ private:
 
     void paintDebugBoxShadowIfApplicable(GraphicsContext&, const LayoutRect&) const;
 
+    bool contentBoxLogicalWidthChanged(const RenderStyle&, const RenderStyle&);
+    bool scrollbarWidthDidChange(const RenderStyle&, const RenderStyle&, ScrollbarOrientation);
+
 protected:
     void dirtyForLayoutFromPercentageHeightDescendants();
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -647,6 +647,9 @@ public:
 
     LayoutUnit computeIntrinsicLogicalWidthUsing(Length logicalWidthLength, LayoutUnit availableLogicalWidth, LayoutUnit borderAndPadding) const;
 
+    bool includeVerticalScrollbarSize() const;
+    bool includeHorizontalScrollbarSize() const;
+
 protected:
     RenderBox(Type, Element&, RenderStyle&&, OptionSet<TypeFlag> = { }, TypeSpecificFlags = { });
     RenderBox(Type, Document&, RenderStyle&&, OptionSet<TypeFlag> = { }, TypeSpecificFlags = { });
@@ -729,9 +732,6 @@ private:
     bool fixedElementLaysOutRelativeToFrame(const LocalFrameView&) const;
 
     template<typename Function> LayoutUnit computeOrTrimInlineMargin(const RenderBlock& containingBlock, MarginTrimType marginSide, const Function& computeInlineMargin) const;
-
-    bool includeVerticalScrollbarSize() const;
-    bool includeHorizontalScrollbarSize() const;
 
     bool isScrollableOrRubberbandableBox() const override;
 


### PR DESCRIPTION
#### 944510f440466ebcb886926141ba8c7c65ec0c56
<pre>
scrollbar-width update doesn&apos;t correctly relayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=278820">https://bugs.webkit.org/show_bug.cgi?id=278820</a>
<a href="https://rdar.apple.com/134894732">rdar://134894732</a>

Reviewed by Simon Fraser.

Prevent RenderBlock::styleDidChange from overwriting the needs layout bit set via
RenderLayerScrollableArea::availableContentSizeChanged by taking into account if the scrollbar width
changed. This progressed some test cases in css-scrollbars/scrollbar-width-paint* but didn&apos;t lead to
any new passes. This needs a follow up to fix going from scrollbar-width:none to auto/thin.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::scrollbarWidthDidChange):
(WebCore::RenderBlock::borderOrPaddingLogicalWidthChanged):
(WebCore::borderOrPaddingLogicalWidthChanged): Deleted.
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/286042@main">https://commits.webkit.org/286042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54a29c4435906ece56fdaecc878a427bb1805300

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1783 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16892 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1112 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66861 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/content-visibility-auto-shared-element.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66148 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8246 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1851 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4638 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1879 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->