### PR TITLE
Add parser support for URLPattern API

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -182,14 +182,14 @@ static ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL opaque path string."_s };
 
-    return value.toString();
+    return dummyURL.path().toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname
 static ExceptionOr<String> canonicalizePathname(StringView pathnameValue)
 {
-    if (!pathnameValue)
-        return Exception { ExceptionCode::TypeError, "Null input to canonicalize a URL path string."_s };
+    if (pathnameValue.isEmpty())
+        return pathnameValue.toString();
 
     bool hasLeadingSlash = pathnameValue[0] == '/';
     auto maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue : makeString("/-"_s, pathnameValue);

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "URLPatternParser.h"
+
+#include "URLPatternTokenizer.h"
+
+namespace WebCore {
+namespace URLPatternUtilities {
+
+URLPatternParser::URLPatternParser(EncodingCallbackType type, String&& segmentWildcardRegexp)
+    : m_callbackType(type)
+    , m_segmentWildcardRegexp(WTFMove(segmentWildcardRegexp))
+{
+}
+
+ExceptionOr<void> URLPatternParser::performParse(const URLPatternStringOptions& options)
+{
+    ExceptionOr<void> maybeFunctionException;
+
+    while (m_index < m_tokenList.size()) {
+        auto charToken = tryToConsumeToken(TokenType::Char);
+        auto nameToken = tryToConsumeToken(TokenType::Name);
+        auto regexOrWildcardToken = tryToConsumeRegexOrWildcardToken(nameToken);
+
+        if (!nameToken.isNull() || !regexOrWildcardToken.isNull()) {
+            String prefix;
+
+            if (!charToken.isNull())
+                prefix = charToken.value.toString();
+
+            if (!prefix.isEmpty() && prefix != options.prefixCodepoint)
+                m_pendingFixedValue.append(std::exchange(prefix, { }));
+
+            maybeFunctionException = maybeAddPartFromPendingFixedValue();
+            if (maybeFunctionException.hasException())
+                return maybeFunctionException.releaseException();
+
+            auto modifierToken = tryToConsumeModifierToken();
+
+            maybeFunctionException = addPart(WTFMove(prefix), nameToken, regexOrWildcardToken, { }, modifierToken);
+            if (maybeFunctionException.hasException())
+                return maybeFunctionException.releaseException();
+
+            continue;
+        }
+
+        auto fixedToken = charToken;
+
+        if (fixedToken.isNull())
+            fixedToken = tryToConsumeToken(TokenType::EscapedChar);
+
+        if (!fixedToken.isNull()) {
+            m_pendingFixedValue.append(WTFMove(fixedToken.value));
+
+            continue;
+        }
+
+        auto openToken = tryToConsumeToken(TokenType::Open);
+        if (!openToken.isNull()) {
+            String prefix = consumeText();
+            nameToken = tryToConsumeToken(TokenType::Name);
+            regexOrWildcardToken = tryToConsumeRegexOrWildcardToken(nameToken);
+            String suffix = consumeText();
+            consumeRequiredToken(TokenType::Close);
+            auto modifierToken = tryToConsumeModifierToken();
+
+            maybeFunctionException = addPart(WTFMove(prefix), nameToken, regexOrWildcardToken, WTFMove(suffix), modifierToken);
+            if (maybeFunctionException.hasException())
+                return maybeFunctionException.releaseException();
+
+            continue;
+        }
+
+        maybeFunctionException = maybeAddPartFromPendingFixedValue();
+        if (maybeFunctionException.hasException())
+            return maybeFunctionException.releaseException();
+
+        consumeRequiredToken(TokenType::End);
+    }
+
+    return { };
+}
+
+// https://urlpattern.spec.whatwg.org/#try-to-consume-a-token
+Token URLPatternParser::tryToConsumeToken(TokenType type)
+{
+    auto& nextToken = m_tokenList[m_index];
+
+    if (nextToken.type != type)
+        return { };
+
+    ++m_index;
+
+    return nextToken;
+}
+
+// https://urlpattern.spec.whatwg.org/#try-to-consume-a-regexp-or-wildcard-token
+Token URLPatternParser::tryToConsumeRegexOrWildcardToken(const Token& token)
+{
+    auto tokenResult = tryToConsumeToken(TokenType::Regexp);
+
+    if (tokenResult.isNull() && token.isNull())
+        tokenResult = tryToConsumeToken(TokenType::Asterisk);
+
+    return tokenResult;
+}
+
+// https://urlpattern.spec.whatwg.org/#try-to-consume-a-modifier-token
+Token URLPatternParser::tryToConsumeModifierToken()
+{
+    auto token = tryToConsumeToken(TokenType::OtherModifier);
+    if (!token.isNull())
+        return token;
+
+    return tryToConsumeToken(TokenType::Asterisk);
+}
+
+// https://urlpattern.spec.whatwg.org/#consume-text
+String URLPatternParser::consumeText()
+{
+    StringBuilder result;
+
+    while (true) {
+        auto consumedToken = tryToConsumeToken(TokenType::Char);
+
+        if (consumedToken.isNull())
+            consumedToken = tryToConsumeToken(TokenType::EscapedChar);
+
+        if (consumedToken.isNull())
+            break;
+
+        result.append(consumedToken.value);
+    }
+
+    return result.toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#consume-a-required-token
+ExceptionOr<Token> URLPatternParser::consumeRequiredToken(TokenType type)
+{
+    auto result = tryToConsumeToken(type);
+
+    if (result.isNull())
+        return Exception { ExceptionCode::TypeError, "Null token was produced when consuming a required token."_s };
+
+    return result;
+}
+
+// https://urlpattern.spec.whatwg.org/#maybe-add-a-part-from-the-pending-fixed-value
+ExceptionOr<void> URLPatternParser::maybeAddPartFromPendingFixedValue()
+{
+    if (m_pendingFixedValue.isEmpty())
+        return { };
+
+    auto encodedValue = callEncodingCallback(m_callbackType, m_pendingFixedValue.toString());
+    m_pendingFixedValue.clear();
+
+    if (encodedValue.hasException())
+        return encodedValue.releaseException();
+
+    m_partList.append(Part { .type = PartType::FixedText, .value = encodedValue.releaseReturnValue(), .modifier = Modifier::None });
+
+    return { };
+}
+
+// https://urlpattern.spec.whatwg.org/#add-a-part
+ExceptionOr<void> URLPatternParser::addPart(String&& prefix, const Token& nameToken, const Token& regexpOrWildcardToken, String&& suffix, const Token& modifierToken)
+{
+    Modifier modifier = Modifier::None;
+
+    if (!modifierToken.isNull()) {
+        if (modifierToken.value == "?"_s)
+            modifier = Modifier::Optional;
+        else if (modifierToken.value == "*"_s)
+            modifier = Modifier::ZeroOrMore;
+        else if (modifierToken.value == "+"_s)
+            modifier = Modifier::OneOrMore;
+    }
+
+    if (nameToken.isNull() && regexpOrWildcardToken.isNull() && modifier == Modifier::None) {
+        m_pendingFixedValue.append(WTFMove(prefix));
+
+        return { };
+    }
+
+    auto maybeFunctionException = maybeAddPartFromPendingFixedValue();
+    if (maybeFunctionException.hasException())
+        return maybeFunctionException.releaseException();
+
+    if (nameToken.isNull() && regexpOrWildcardToken.isNull()) {
+        ASSERT(suffix.isEmpty());
+
+        if (prefix.isEmpty())
+            return { };
+
+        auto encodedValue = callEncodingCallback(m_callbackType, WTFMove(prefix));
+        if (encodedValue.hasException())
+            return encodedValue.releaseException();
+
+        m_partList.append(Part { .type = PartType::FixedText, .value = encodedValue.releaseReturnValue(), .modifier = modifier });
+
+        return { };
+    }
+
+    String regexValue;
+
+    if (regexpOrWildcardToken.isNull())
+        regexValue = m_segmentWildcardRegexp;
+    else if (regexpOrWildcardToken.type == TokenType::Asterisk)
+        regexValue = ".*"_s;
+    else
+        regexValue = regexpOrWildcardToken.value.toString();
+
+    PartType type = PartType::Regexp;
+
+    if (regexValue == m_segmentWildcardRegexp) {
+        type = PartType::SegmentWildcard;
+        regexValue = { };
+    } else if (regexValue == ".*"_s) {
+        type = PartType::FullWildcard;
+        regexValue = { };
+    }
+
+    String name;
+
+    if (!nameToken.isNull())
+        name = nameToken.value.toString();
+    else if (regexpOrWildcardToken.isNull()) {
+        name = String::number(m_nextNumericName);
+        ++m_nextNumericName;
+    }
+
+    if (isDuplicateName(name))
+        return Exception { ExceptionCode::TypeError, "Duplicate name token produced when adding to parser part list."_s };
+
+    auto encodedPrefix = callEncodingCallback(m_callbackType, WTFMove(prefix));
+    if (encodedPrefix.hasException())
+        return encodedPrefix.releaseException();
+
+    auto encodedSuffix = callEncodingCallback(m_callbackType, WTFMove(suffix));
+    if (encodedSuffix.hasException())
+        return encodedSuffix.releaseException();
+
+    m_partList.append(Part { type, WTFMove(regexValue), modifier, WTFMove(name), encodedPrefix.releaseReturnValue(), encodedSuffix.releaseReturnValue() });
+
+    return { };
+}
+
+// https://urlpattern.spec.whatwg.org/#is-a-duplicate-name
+bool URLPatternParser::isDuplicateName(StringView name) const
+{
+    return m_partList.containsIf([&](auto& part) {
+        return part.name == name;
+    });
+}
+
+// https://urlpattern.spec.whatwg.org/#parse-a-pattern-string
+ExceptionOr<const Vector<Part>&> parse(StringView patternStringInput, const URLPatternStringOptions& options, EncodingCallbackType type)
+{
+    URLPatternParser tokenParser { type, generateSegmentWildcardRegexp(options) };
+
+    auto maybeParserTokenList = Tokenizer(patternStringInput, TokenizePolicy::Strict).tokenize();
+    if (maybeParserTokenList.hasException())
+        return maybeParserTokenList.releaseException();
+
+    tokenParser.setTokenList(maybeParserTokenList.releaseReturnValue());
+
+    tokenParser.performParse(options);
+
+    return tokenParser.getPartList();
+}
+
+// https://urlpattern.spec.whatwg.org/#generate-a-segment-wildcard-regexp
+String generateSegmentWildcardRegexp(const URLPatternStringOptions& options)
+{
+    return makeString("[^"_s, escapeRegexString(options.delimiterCodepoint), "]+?"_s);
+}
+
+template<typename CharacterType>
+static String escapeRegexStringForCharacters(std::span<const CharacterType> characters)
+{
+    static constexpr std::array regexEscapeCharacters { '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '/', '\\' }; // NOLINT
+
+    StringBuilder result;
+    result.reserveCapacity(characters.size());
+
+    for (auto character : characters) {
+        if (std::find(regexEscapeCharacters.begin(), regexEscapeCharacters.end(), character) != regexEscapeCharacters.end())
+            result.append('\\');
+
+        result.append(character);
+    }
+
+    return result.toString();
+}
+
+// https://urlpattern.spec.whatwg.org/#escape-a-regexp-string
+String escapeRegexString(StringView input)
+{
+    ASSERT(input.containsOnlyASCII());
+
+    if (input.is8Bit())
+        return escapeRegexStringForCharacters(input.span8());
+
+    return escapeRegexStringForCharacters(input.span16());
+}
+
+} // namespace URLPatternUtilities
+} // namespace WebCore

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+namespace URLPatternUtilities {
+
+struct Token;
+enum class TokenType : uint8_t;
+
+enum class PartType : uint8_t { FixedText, Regexp, SegmentWildcard, FullWildcard };
+enum class Modifier : uint8_t { None, Optional, ZeroOrMore, OneOrMore };
+
+struct Part {
+    PartType type;
+    String value;
+    Modifier modifier;
+    String name { };
+    String prefix { };
+    String suffix { };
+};
+
+struct URLPatternStringOptions {
+    String delimiterCodepoint;
+    String prefixCodepoint;
+    bool ignoreCase { false };
+};
+
+class URLPatternParser {
+public:
+    URLPatternParser(EncodingCallbackType, String&& segmentWildcardRegexp);
+    ExceptionOr<void> performParse(const URLPatternStringOptions&);
+
+    void setTokenList(Vector<Token>&& tokenList) { m_tokenList = WTFMove(tokenList); }
+    const Vector<Part>& getPartList() const { return m_partList; }
+
+private:
+    Token tryToConsumeToken(TokenType);
+    Token tryToConsumeRegexOrWildcardToken(const Token&);
+    Token tryToConsumeModifierToken();
+
+    String consumeText();
+    ExceptionOr<Token> consumeRequiredToken(TokenType);
+
+    ExceptionOr<void> maybeAddPartFromPendingFixedValue();
+    ExceptionOr<void> addPart(String&& prefix, const Token& nameToken, const Token& regexpOrWildcardToken, String&& suffix, const Token& modifierToken);
+
+    bool isDuplicateName(StringView) const;
+
+    Vector<Token> m_tokenList;
+    Vector<Part> m_partList;
+    EncodingCallbackType m_callbackType;
+    String m_segmentWildcardRegexp;
+    StringBuilder m_pendingFixedValue;
+    size_t m_index { 0 };
+    int m_nextNumericName { 0 };
+};
+
+ExceptionOr<const Vector<Part>&> parse(StringView, const URLPatternStringOptions&, EncodingCallbackType);
+
+// FIXME: Consider moving functions to somewhere generic, perhaps refactor Part to its own class.
+String generateSegmentWildcardRegexp(const URLPatternStringOptions&);
+String escapeRegexString(StringView);
+
+} // namespace URLPatternUtilities
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -371,6 +371,7 @@ Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp
 Modules/url-pattern/URLPatternCanonical.cpp
+Modules/url-pattern/URLPatternParser.cpp
 Modules/url-pattern/URLPatternTokenizer.cpp
 Modules/web-locks/WebLock.cpp
 Modules/web-locks/WebLockManager.cpp


### PR DESCRIPTION
#### 781f0cd0ee913678fcca6360aea3b85d14a9f246
<pre>
Add parser support for URLPattern API
<a href="https://bugs.webkit.org/show_bug.cgi?id=282413">https://bugs.webkit.org/show_bug.cgi?id=282413</a>
<a href="https://rdar.apple.com/139032626">rdar://139032626</a>

Reviewed by Chris Dumez and Sihui Liu.

Implement parser support for URL Pattern API, see <a href="https://urlpattern.spec.whatwg.org/#pattern-parser">https://urlpattern.spec.whatwg.org/#pattern-parser</a>

* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeOpaquePathname):
(WebCore::canonicalizePathname):
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp: Added.
(WebCore::URLPatternUtilities::URLPatternParser::URLPatternParser):
(WebCore::URLPatternUtilities::URLPatternParser::performParse):
(WebCore::URLPatternUtilities::URLPatternParser::tryToConsumeToken):
(WebCore::URLPatternUtilities::URLPatternParser::tryToConsumeRegexOrWildcardToken):
(WebCore::URLPatternUtilities::URLPatternParser::tryToConsumeModifierToken):
(WebCore::URLPatternUtilities::URLPatternParser::consumeText):
(WebCore::URLPatternUtilities::URLPatternParser::consumeRequiredToken):
(WebCore::URLPatternUtilities::URLPatternParser::maybeAddPartFromPendingFixedValue):
(WebCore::URLPatternUtilities::URLPatternParser::addPart):
(WebCore::URLPatternUtilities::URLPatternParser::isDuplicateName const):
(WebCore::URLPatternUtilities::parse):
(WebCore::URLPatternUtilities::generateSegmentWildcardRegexp):
(WebCore::URLPatternUtilities::escapeRegexStringForCharacters):
(WebCore::URLPatternUtilities::escapeRegexString):
* Source/WebCore/Modules/url-pattern/URLPatternParser.h: Added.
(WebCore::URLPatternUtilities::URLPatternParser::setTokenList):
(WebCore::URLPatternUtilities::URLPatternParser::getPartList):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/286362@main">https://commits.webkit.org/286362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28b6d5f33ed84a76edfe23b653a5a0687f9afa7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75783 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/54812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77899 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/63954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78850 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/63954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39789 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/63954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25376 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/63954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81744 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/3133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1978 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3276 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10913 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3081 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5907 "Failed to build and analyze WebKit") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/4045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/3130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->