### PR TITLE
Fix the open source macOS 15.1-and-above build after 284018@main

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h
@@ -90,9 +90,14 @@ typedef NS_ENUM(uint32_t, NFNdefAvailability) {
 
 @protocol NFReaderSessionDelegate;
 
+typedef NS_ENUM(NSInteger, NFReaderSessionUI) {
+    NFReaderSessionUINone
+};
+
 @interface NFReaderSession : NFSession
 @property (assign) id<NFReaderSessionDelegate> delegate;
 
+- (instancetype)initWithUIType:(NFReaderSessionUI)uiType;
 - (BOOL)startPollingWithError:(NSError **)outError;
 - (BOOL)stopPolling;
 - (BOOL)connectTag:(NFTag*)tag;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -43,16 +43,6 @@ uint8_t tagID1[] = { 0x01 };
 uint8_t tagID2[] = { 0x02 };
 }
 
-#if HAVE(NEAR_FIELD) && (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 150000) \
-    || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED > 180000) \
-    || PLATFORM(VISION) && __VISION_OS_VERSION_MIN_REQUIRED > 20000 \
-    || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED > 110000) \
-    || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED > 180000)
-#define NEED_UI_TYPE_FOR_NFC_SESSION 1
-#else
-#define NEED_UI_TYPE_FOR_NFC_SESSION 0
-#endif
-
 #if HAVE(NEAR_FIELD)
 
 @interface WKMockNFTag : NSObject <NFTag>
@@ -247,11 +237,7 @@ void MockNfcService::platformStartDiscovery()
         Method methodToSwizzle5 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(startPollingWithError:));
         method_setImplementation(methodToSwizzle5, (IMP)NFReaderSessionStartPollingWithError);
 
-#if NEED_UI_TYPE_FOR_NFC_SESSION
         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
-#else
-        auto readerSession = adoptNS([allocNFReaderSessionInstance() init]);
-#endif
         setConnection(NfcConnection::create(readerSession.get(), *this));
     }
     LOG_ERROR("No nfc authenticators is available.");
@@ -277,11 +263,7 @@ void MockNfcService::detectTags() const
         if (configuration.nfc->multiplePhysicalTags)
             [tags addObject:adoptNS([[WKMockNFTag alloc] initWithType:NFTagTypeGeneric4A tagID:adoptNS([[NSData alloc] initWithBytesNoCopy:tagID2 length:sizeof(tagID2) freeWhenDone:NO]).get()]).get()];
 
-#if NEED_UI_TYPE_FOR_NFC_SESSION
         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
-#else
-        auto readerSession = adoptNS([allocNFReaderSessionInstance() init]);
-#endif
         [globalNFReaderSessionDelegate readerSession:readerSession.get() didDetectTags:tags.get()];
     });
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), callback.get());


### PR DESCRIPTION
#### 62a6f504bf7ea2850efb3488395444d8105e6294
<pre>
Fix the open source macOS 15.1-and-above build after 284018@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=282414">https://bugs.webkit.org/show_bug.cgi?id=282414</a>
<a href="https://rdar.apple.com/139032978">rdar://139032978</a>

Reviewed by Wenson Hsieh.

284018@main fixed internal builds by not calling into
`-[NFReaderSession init]` on certain platform versions, but the fallback
SPI `-initWithUIType:` was not forward declared, so open source builds
calling into said SPI failed. Namely, the build error looks as such:

```
Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:251:70: error: instance method
      &apos;-initWithUIType:&apos; not found (return type defaults to &apos;id&apos;) [-Werror,-Wobjc-method-access]
  251 |         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
      |                                                                      ^~~~~~~~~~~~~~
Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:251:85: error: use of undeclared identifier
      &apos;NFReaderSessionUINone&apos;
  251 |         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
      |
```

This patch addresses said build failure by providing appropriate forward
declarations in NearFieldSPI.h, but also opportunistically moves away
unconditionally from `[NFReaderSession init]`, which is marked unavailable
in certain SDK versions, to `[NFReaderSession initWithUIType:]`. This is
safe to do so because the latter is part of the internal SDK on all
supported platform configurations.

* Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::platformStartDiscovery):
(WebKit::MockNfcService::detectTags const):

Canonical link: <a href="https://commits.webkit.org/285991@main">https://commits.webkit.org/285991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dfa3c51661855e9477964b24c85b92a7fc4c4d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45641 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1718 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/996 "Found 1 new test failure: http/tests/workers/service/page-caching.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66760 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66044 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8132 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11486 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->