### PR TITLE
Dynamically switching from scrollbar-width:none to scrollbar-width:auto/thin doesn't bring back scrollbar

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto-expected.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto-expected.html
@@ -1,0 +1,23 @@
+<!doctype html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+    .container {
+        background-color: orange;
+        overflow: auto;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+
+    .content {
+        background-color: green;
+        height: 300px;
+        width: 100%;
+    }
+</style>
+    <div id="box" class="container">
+        <div class="content"></div>
+    </div>
+<script>
+    internals.setUsesOverlayScrollbars(false);
+</script>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto.html
@@ -1,0 +1,33 @@
+<!doctype html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+    .container {
+        background-color: orange;
+        overflow: auto;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+        scrollbar-width: none;
+    }
+
+    .content {
+        background-color: green;
+        height: 300px;
+        width: 100%;
+    }
+    body.changed .container {
+        scrollbar-width: auto;
+    }
+</style>
+    <div id="box" class="container">
+        <div class="content"></div>
+    </div>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    internals.setUsesOverlayScrollbars(false);
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        document.body.classList.add('changed');
+        testRunner.notifyDone();
+    }));
+</script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1631,7 +1631,8 @@ http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html [ Pass ]
 
 webkit.org/b/264266 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/264306 [ Sonoma+ ] fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html [ Pass ImageOnlyFailure Timeout ]
+webkit.org/b/264306 fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html [ Pass ImageOnlyFailure Timeout ]
+[ Ventura ] fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto.html [ ImageOnlyFailure ]
 
 webkit.org/b/265599 [ Sonoma+ Debug x86_64 ] imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html [ Pass Crash ]
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -61,6 +61,8 @@ public:
     void updateScrollbarStyle();
     void updatePairScrollerImps();
 
+    void setHiddenByStyle(NativeScrollbarVisibility);
+
     void updateValues();
     
     String scrollbarState() const;
@@ -80,6 +82,7 @@ private:
 
     bool m_isEnabled { false };
     bool m_isVisible { false };
+    bool m_isHiddenByStyle { false };
 
     ScrollerPairMac& m_pair;
     const ScrollbarOrientation m_orientation;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -350,6 +350,20 @@ void ScrollerMac::setHostLayer(CALayer *layer)
     updatePairScrollerImps();
 }
 
+void ScrollerMac::setHiddenByStyle(NativeScrollbarVisibility visibility)
+{
+    m_isHiddenByStyle = visibility != NativeScrollbarVisibility::Visible;
+    if (m_isHiddenByStyle) {
+        detach();
+        setScrollerImp(nullptr);
+    } else {
+        attach();
+        [m_scrollerImp setLayer:m_hostLayer.get()];
+        updateValues();
+    }
+    updatePairScrollerImps();
+}
+
 void ScrollerMac::updateValues()
 {
     auto values = m_pair.valuesForOrientation(m_orientation);
@@ -372,7 +386,7 @@ void ScrollerMac::updateScrollbarStyle()
 
 void ScrollerMac::updatePairScrollerImps()
 {
-    NSScrollerImp *scrollerImp = m_hostLayer ? m_scrollerImp.get() : nil;
+    NSScrollerImp *scrollerImp = m_scrollerImp.get();
     if (m_orientation == ScrollbarOrientation::Vertical)
         m_pair.setVerticalScrollerImp(scrollerImp);
     else
@@ -438,6 +452,8 @@ void ScrollerMac::updateMinimumKnobLength(int minimumKnobLength)
 
 void ScrollerMac::setScrollerImp(NSScrollerImp *imp)
 {
+    if (m_isHiddenByStyle && imp)
+        return;
     m_scrollerImp = imp;
     updateMinimumKnobLength([m_scrollerImp knobMinLength]);
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -70,17 +70,15 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarHoverState))
         m_scrollerPair->mouseIsInScrollbar(scrollingStateNode.scrollbarHoverState());
     
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer) && scrollingNode().horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
         m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
     
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer) && scrollingNode().verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
         m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
-        if (scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->horizontalScroller().setHostLayer(nullptr);
-        if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->verticalScroller().setHostLayer(nullptr);
+        m_scrollerPair->horizontalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility);
+        m_scrollerPair->verticalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility);
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarEnabledState)) {


### PR DESCRIPTION
#### 6115517674045ec83c36c570bf353e30718d5499
<pre>
Dynamically switching from scrollbar-width:none to scrollbar-width:auto/thin doesn&apos;t bring back scrollbar
<a href="https://bugs.webkit.org/show_bug.cgi?id=282419">https://bugs.webkit.org/show_bug.cgi?id=282419</a>
<a href="https://rdar.apple.com/139040042">rdar://139040042</a>

Reviewed by Simon Fraser.

Previously, scrollbar-width:none was implemented by nulling out the host layer on the
NSScrollerImp. When switching from scrollbar-width:none to scrollbar-width:auto/thin,
we wouldn&apos;t keep around the old scrollbar layer, which would cause the scrollbar to not
appear. We fix this by implementing scrollbar-width:none as nulling out the NSScrollerImp
when hidden by style, and keeping around the previous scrollbar layer on m_hostLayer to
be re-attached when switching back to scrollbar-width:auto/thin.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::setHiddenByStyle):
(WebCore::ScrollerMac::updateScrollbarStyle):
(WebCore::ScrollerMac::updatePairScrollerImps):
(WebCore::ScrollerMac::updateMinimumKnobLength):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):

Canonical link: <a href="https://commits.webkit.org/286057@main">https://commits.webkit.org/286057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e2aff9b92b87a600e5854da38fdfd7b653ac81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58665 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66217 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8311 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11525 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1967 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1995 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->