### PR TITLE
REGRESSION (Safari 17): getRangeAt(0) returns the same JS object even after selection changes, differs from Chrome and Firefox

### DIFF
--- a/LayoutTests/editing/selection/update-selection-with-find-dissociates-range-expected.txt
+++ b/LayoutTests/editing/selection/update-selection-with-find-dissociates-range-expected.txt
@@ -1,0 +1,10 @@
+This tests calling window.find twice. getSelection().getRangeAt(0) should return distinct ranges.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS range1 != range2 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello, world

--- a/LayoutTests/editing/selection/update-selection-with-find-dissociates-range.html
+++ b/LayoutTests/editing/selection/update-selection-with-find-dissociates-range.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>hello, world</p>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('This tests calling window.find twice. getSelection().getRangeAt(0) should return distinct ranges.');
+
+window.find("hello");
+let range1 = getSelection().getRangeAt(0);
+window.find("world");
+let range2 = getSelection().getRangeAt(0);
+shouldBeTrue('range1 != range2');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/update-selection-with-modify-dissociates-range-expected.txt
+++ b/LayoutTests/editing/selection/update-selection-with-modify-dissociates-range-expected.txt
@@ -1,0 +1,12 @@
+This tests calling getSelection().modify to update selection. getSelection().getRangeAt(0) should return a distinct range after each modification.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS range1 != range2 is true
+PASS range2 != range3 is true
+PASS range3 != range4 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello, world

--- a/LayoutTests/editing/selection/update-selection-with-modify-dissociates-range.html
+++ b/LayoutTests/editing/selection/update-selection-with-modify-dissociates-range.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>hello, world</p>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('This tests calling getSelection().modify to update selection. getSelection().getRangeAt(0) should return a distinct range after each modification.');
+
+window.find("hello");
+let range1 = getSelection().getRangeAt(0);
+getSelection().modify('extend', 'forward', 'word');
+let range2 = getSelection().getRangeAt(0);
+shouldBeTrue('range1 != range2');
+getSelection().modify('extend', 'backward', 'word');
+let range3 = getSelection().getRangeAt(0);
+shouldBeTrue('range2 != range3');
+getSelection().modify('extend', 'forward', 'character');
+let range4 = getSelection().getRangeAt(0);
+shouldBeTrue('range3 != range4');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -142,6 +142,7 @@ public:
         ForceCenterScroll = 1 << 12,
         ForBindings = 1 << 13,
         DoNotNotifyEditorClients = 1 << 14,
+        MaintainLiveRange = 1 << 15,
     };
     static constexpr OptionSet<SetSelectionOption> defaultSetSelectionOptions(UserTriggered = UserTriggered::No);
 
@@ -350,7 +351,6 @@ private:
     std::optional<SimpleRange> rangeByAlteringCurrentSelection(Alteration, int amount) const;
 #endif
 
-    void updateAssociatedLiveRange();
     LayoutRect localCaretRect() const final { return localCaretRectWithoutUpdate(); }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;


### PR DESCRIPTION
#### d187066ee9b041caa56406b480f595e7e1dda16a
<pre>
REGRESSION (Safari 17): getRangeAt(0) returns the same JS object even after selection changes, differs from Chrome and Firefox
<a href="https://bugs.webkit.org/show_bug.cgi?id=273469">https://bugs.webkit.org/show_bug.cgi?id=273469</a>
&lt;<a href="https://rdar.apple.com/problem/127314280">rdar://problem/127314280</a>&gt;

Reviewed by Wenson Hsieh.

This PR makes WebKit&apos;s behavior match Gecko&apos;s and Blink&apos;s behaviors by dissociating live ranges when updating selection except
when we&apos;re updating as a result of DOM mutation or via manipulation of live ranges.

* LayoutTests/editing/selection/update-selection-with-find-dissociates-range-expected.txt: Added.
* LayoutTests/editing/selection/update-selection-with-find-dissociates-range.html: Added.
* LayoutTests/editing/selection/update-selection-with-modify-dissociates-range-expected.txt: Added.
* LayoutTests/editing/selection/update-selection-with-modify-dissociates-range.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance):
(WebCore::FrameSelection::respondToNodeModification):
(WebCore::FrameSelection::textWasReplaced):
(WebCore::FrameSelection::updateFromAssociatedLiveRange):
(WebCore::FrameSelection::updateAssociatedLiveRange): Deleted.
* Source/WebCore/editing/FrameSelection.h:

Canonical link: <a href="https://commits.webkit.org/285996@main">https://commits.webkit.org/285996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ace649f746f5e837f4125738bce1e769d4df6864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21514 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1027 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66071 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10006 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4518 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->