### PR TITLE
Have Timer protect the object it is calling the timeout function on when possible

### DIFF
--- a/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
@@ -99,10 +99,6 @@ void GeoNotifier::timerFired()
 {
     m_timer.stop();
 
-    // Protect this GeoNotifier object, since it
-    // could be deleted by a call to clearWatch in a callback.
-    Ref<GeoNotifier> protectedThis(*this);
-
     // Test for fatal error first. This is required for the case where the Frame is
     // disconnected and requests are cancelled.
     Ref geolocation = m_geolocation;

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -431,8 +431,6 @@ void CSSFontFace::fontLoadEventOccurred()
 
 void CSSFontFace::timeoutFired()
 {
-    Ref<CSSFontFace> protectedThis(*this);
-    
     switch (status()) {
     case Status::Loading:
         setStatus(Status::TimedOut);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7978,7 +7978,6 @@ void Document::postTask(Task&& task)
 
 void Document::pendingTasksTimerFired()
 {
-    Ref protectedThis { *this };
     auto pendingTasks = std::exchange(m_pendingTasks, Vector<Task> { });
     for (auto& task : pendingTasks)
         task.performTask(*this);
@@ -8350,7 +8349,6 @@ void Document::loadEventDelayTimerFired()
     // FIXME: Should this also call DocumentLoader::checkLoadComplete?
     // FIXME: Not obvious why checkCompleted needs to go first. The order these are called is
     // visible to WebKit clients, but it's more like a race than a well-defined relationship.
-    Ref protectedThis { *this };
     checkCompleted();
     if (RefPtr frame = this->frame())
         frame->protectedLoader()->checkLoadComplete();

--- a/Source/WebCore/dom/ScriptableDocumentParser.cpp
+++ b/Source/WebCore/dom/ScriptableDocumentParser.cpp
@@ -59,8 +59,6 @@ void ScriptableDocumentParser::scriptsWaitingForStylesheetsExecutionTimerFired()
 {
     ASSERT(!isDetached());
 
-    Ref protectedThis { *this };
-
     RefPtr document = this->document();
     if (!document->styleScope().hasPendingSheets())
         executeScriptsWaitingForStylesheets();

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -254,7 +254,6 @@ void HTMLPlugInElement::swapRendererTimerFired()
     
     // Create a shadow root, which will trigger the code to add a snapshot container
     // and reattach, thus making a new Renderer.
-    Ref protectedThis { *this };
     ensureUserAgentShadowRoot();
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2514,7 +2514,6 @@ void LocalFrameView::scrollToFocusedElementImmediatelyIfNeeded()
 
 void LocalFrameView::scrollToFocusedElementTimerFired()
 {
-    Ref protectedThis { *this };
     scrollToFocusedElementInternal();
 }
 
@@ -2555,8 +2554,6 @@ void LocalFrameView::scrollToFocusedElementInternal()
 
 void LocalFrameView::textFragmentIndicatorTimerFired()
 {
-    Ref protectedThis { *this };
-    
     ASSERT(m_frame->document());
     auto& document = *m_frame->document();
     
@@ -3780,7 +3777,6 @@ bool LocalFrameView::updateEmbeddedObjects()
 
 void LocalFrameView::updateEmbeddedObjectsTimerFired()
 {
-    Ref protectedThis { *this };
     m_updateEmbeddedObjectsTimer.stop();
     for (unsigned i = 0; i < maxUpdateEmbeddedObjectsIterations; ++i) {
         if (updateEmbeddedObjects())


### PR DESCRIPTION
#### e6d75cd60444c7975ce4f18e9c643417d6a92f5d
<pre>
Have Timer protect the object it is calling the timeout function on when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=282421">https://bugs.webkit.org/show_bug.cgi?id=282421</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Have Timer protect the object it is calling the timeout function on when possible.
Otherwise, people have to remember to add a `protectedThis` protector at the
beginning out of `timerFired()` functions, which is error prone.

* Source/WTF/wtf/RunLoop.h:
* Source/WebCore/Modules/geolocation/GeoNotifier.cpp:
(WebCore::GeoNotifier::timerFired):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::timeoutFired):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::pendingTasksTimerFired):
(WebCore::Document::loadEventDelayTimerFired):
* Source/WebCore/dom/ScriptableDocumentParser.cpp:
(WebCore::ScriptableDocumentParser::scriptsWaitingForStylesheetsExecutionTimerFired):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::swapRendererTimerFired):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFocusedElementTimerFired):
(WebCore::LocalFrameView::textFragmentIndicatorTimerFired):
(WebCore::LocalFrameView::updateEmbeddedObjectsTimerFired):
* Source/WebCore/platform/Timer.h:
(WebCore::Timer::Timer):

Canonical link: <a href="https://commits.webkit.org/286015@main">https://commits.webkit.org/286015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/145b1ab686470ef8fdafa431235e09a5251d9f7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58522 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16821 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24023 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67589 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80353 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73710 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66795 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64039 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66078 "Found 101 new API test failures: /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.DocumentStartUserScriptAlertCrashTest, /TestWebKit:WebKit.WKPageCopySessionStateWithFiltering, /TestWebKit:WebKit.ParentFrame, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit2UserMessageRoundTripTest.WKString, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.FocusedFrameAfterCrash, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8166 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95491 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11498 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4521 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20968 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->