### PR TITLE
RenderViewTransitionCapture should be able to use its ImageBuffer directly as layer contents.

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -70,6 +70,7 @@ class GraphicsLayerContentsDisplayDelegate;
 class GraphicsLayerAsyncContentsDisplayDelegate;
 class HTMLVideoElement;
 class Image;
+class ImageBuffer;
 class Model;
 class Settings;
 class TiledBacking;
@@ -534,6 +535,11 @@ public:
     // Layer contents
     virtual void setContentsToImage(Image*) { }
     virtual bool shouldDirectlyCompositeImage(Image*) const { return true; }
+
+    // FIXME: Merge this with setContentsToImage once we can efficiently convert an
+    // ImageBuffer to NativeImage without GPUP readback.
+    virtual void setContentsToImageBuffer(ImageBuffer*) { }
+    virtual bool shouldDirectlyCompositeImageBuffer(ImageBuffer*) const { return false; }
 #if PLATFORM(IOS_FAMILY)
     virtual PlatformLayer* contentsLayerForMedia() const { return 0; }
 #endif

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -150,6 +150,7 @@ public:
     WEBCORE_EXPORT void removeAnimation(const String& animationName, std::optional<AnimatedProperty>) override;
     WEBCORE_EXPORT void transformRelatedPropertyDidChange() override;
     WEBCORE_EXPORT void setContentsToImage(Image*) override;
+    WEBCORE_EXPORT void setContentsToImageBuffer(ImageBuffer*) override;
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT PlatformLayer* contentsLayerForMedia() const override;
 #endif
@@ -288,6 +289,8 @@ private:
     virtual Ref<PlatformCALayer> createPlatformCALayerHost(LayerHostingContextIdentifier, PlatformCALayerClient*);
     WEBCORE_EXPORT virtual Ref<PlatformCALayer> createPlatformVideoLayer(HTMLVideoElement&, PlatformCALayerClient* owner);
     virtual Ref<PlatformCAAnimation> createPlatformCAAnimation(PlatformCAAnimation::AnimationType, const String& keyPath);
+
+    virtual void setLayerContentsToImageBuffer(PlatformCALayer*, ImageBuffer*) { }
 
     PlatformCALayer* primaryLayer() const { return m_structuralLayer.get() ? m_structuralLayer.get() : m_layer.get(); }
     PlatformCALayer* hostLayerForSublayers() const;
@@ -682,8 +685,8 @@ private:
 
     TileCoverage m_tileCoverage;
 
-    RefPtr<NativeImage> m_uncorrectedContentsImage;
     RefPtr<NativeImage> m_pendingContentsImage;
+    RefPtr<ImageBuffer> m_pendingContentsImageBuffer;
 
 #if ENABLE(MODEL_ELEMENT)
     RefPtr<Model> m_contentsModel;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -49,12 +49,16 @@ public:
     // Rect covered by the captured contents, in RenderLayer coordinates of the captured renderer
     LayoutRect captureOverflowRect() const { return m_overflowRect; }
 
+    LayoutRect captureLocalOverflowRect() const { return m_localOverflowRect; }
+
     // Inset of the scaled capture from the visualOverflowRect()
     LayoutPoint captureContentInset() const;
 
     bool canUseExistingLayers() const { return !hasNonVisibleOverflow(); }
 
     bool paintsContent() const final;
+
+    RefPtr<ImageBuffer> image() { return m_oldImage; }
 
 private:
     ASCIILiteral renderName() const override { return "RenderViewTransitionCapture"_s; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -110,7 +110,7 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
         return;
 
     m_parameters = parameters;
-    clearBackingStore();
+    m_cleared = true;
     if (m_bufferSet) {
         auto renderingMode = type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
         auto renderingPurpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -63,6 +63,9 @@ private:
     // PlatformCALayerRemote can't currently proxy directly composited image contents, so opt out of this optimization.
     bool shouldDirectlyCompositeImage(WebCore::Image*) const override { return false; }
 
+    bool shouldDirectlyCompositeImageBuffer(WebCore::ImageBuffer*) const override;
+    void setLayerContentsToImageBuffer(WebCore::PlatformCALayer*, WebCore::ImageBuffer*) override;
+
     WebCore::Color pageTiledBackingBorderColor() const override;
 
     RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(WebCore::GraphicsLayerAsyncContentsDisplayDelegate*) final;


### PR DESCRIPTION
#### 66eb479d335a74770f939936286a48ae68dca5a7
<pre>
RenderViewTransitionCapture should be able to use its ImageBuffer directly as layer contents.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282424">https://bugs.webkit.org/show_bug.cgi?id=282424</a>
&lt;<a href="https://rdar.apple.com/139050217">rdar://139050217</a>&gt;

Reviewed by Kimmo Kinnunen.

The existing setContentsToImage path is disabled for UI-side compositing, due to
lack of support for a remote NativeImage.  Adds a new option that is supported
with UI-side compositing, setContentsToImageBuffer.

Change RenderLayerBacking to detect RenderViewTransitionCapture as a suitable
image source, and pass the ImageBuffer through to the GraphicsLayer.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setContentsToImageBuffer):
(WebCore::GraphicsLayer::shouldDirectlyCompositeImageBuffer const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setContentsToImage):
(WebCore::GraphicsLayerCA::setContentsToImageBuffer):
(WebCore::GraphicsLayerCA::platformCALayerDelegatesDisplay const):
(WebCore::GraphicsLayerCA::platformCALayerLayerDisplay):
(WebCore::GraphicsLayerCA::updateContentsImage):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::setLayerContentsToImageBuffer):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
(WebCore::RenderLayerBacking::updateImageContents):
(WebCore::RenderLayerBacking::contentsBox const):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::shouldDirectlyCompositeImageBuffer const):
(WebKit::GraphicsLayerCARemote::setLayerContentsToImageBuffer):

Canonical link: <a href="https://commits.webkit.org/286139@main">https://commits.webkit.org/286139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fedbeafa5409927f6183cd498ccc83b7c2aa7559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54373 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27760 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17113 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21881 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80859 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67098 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66398 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16501 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10336 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8494 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5014 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->