### PR TITLE
Refactor URLPattern's canonical and tokenizers modules to preemptively support URLPattern parser module

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -163,7 +163,7 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         result.password = canonicalizePassword(init.password, type);
 
     if (!init.hostname.isNull()) {
-        auto hostResult = canonicalizeHost(init.hostname, type);
+        auto hostResult = canonicalizeHostname(init.hostname, type);
 
         if (hostResult.hasException())
             return hostResult.releaseException();
@@ -190,7 +190,7 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             if (slashIndex != notFound)
                 result.pathname = makeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
 
-            auto pathResult = canonicalizePath(result.pathname, baseURL.protocol(), type);
+            auto pathResult = processPathname(result.pathname, baseURL.protocol(), type);
 
             if (pathResult.hasException())
                 return pathResult.releaseException();

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
@@ -28,16 +28,17 @@
 namespace WebCore {
 
 enum class BaseURLStringType : bool;
+enum class EncodingCallbackType : uint8_t { Protocol, Username, Password, Host, IPv6Host, Port, Path, Search, Hash };
 
 bool isAbsolutePathname(StringView input, BaseURLStringType inputType);
-ExceptionOr<String> canonicalizeProtocol(const String& value, BaseURLStringType valueType);
-String canonicalizeUsername(const String& value, BaseURLStringType valueType);
-String canonicalizePassword(const String& value, BaseURLStringType valueType);
-ExceptionOr<String> canonicalizeHost(const String& value, BaseURLStringType valueType);
-ExceptionOr<String> canonicalizeIPv6Host(const String& value, BaseURLStringType valueType);
-ExceptionOr<String> canonicalizePort(const String& portValue, std::optional<StringView> protocolValue, BaseURLStringType portValueType);
-ExceptionOr<String> canonicalizePath(const String& pathnameValue, StringView protocolValue, BaseURLStringType pathnameValueType);
-ExceptionOr<String> canonicalizeSearch(const String& value, BaseURLStringType valueType);
-ExceptionOr<String> canonicalizeHash(const String& value, BaseURLStringType valueType);
-
+ExceptionOr<String> canonicalizeProtocol(StringView, BaseURLStringType valueType);
+String canonicalizeUsername(StringView value, BaseURLStringType valueType);
+String canonicalizePassword(StringView value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeHostname(StringView value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeIPv6Hostname(StringView value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizePort(StringView portValue, const std::optional<StringView> protocolValue, BaseURLStringType portValueType);
+ExceptionOr<String> processPathname(StringView pathnameValue, const StringView protocolValue, BaseURLStringType pathnameValueType);
+ExceptionOr<String> canonicalizeSearch(StringView value, BaseURLStringType valueType);
+ExceptionOr<String> canonicalizeHash(StringView value, BaseURLStringType valueType);
+ExceptionOr<String> callEncodingCallback(EncodingCallbackType, StringView input);
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -45,7 +45,11 @@ static bool isValidNameCodepoint(UChar codepoint, bool first)
 
 bool Token::isNull() const
 {
-    return type == TokenType::Open && !index && !value;
+    if (!index) {
+        ASSERT(value.isNull());
+        return true;
+    }
+    return false;
 }
 
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -33,7 +33,7 @@ enum class TokenizePolicy : bool { Strict, Lenient };
 
 struct Token {
     TokenType type;
-    size_t index;
+    std::optional<size_t> index;
     StringView value;
 
     bool isNull() const;


### PR DESCRIPTION
#### 65cb4e7a01154f36a4f3ed69ac0b08c55e892480
<pre>
Refactor URLPattern&apos;s canonical and tokenizers modules to preemptively support URLPattern parser module
<a href="https://bugs.webkit.org/show_bug.cgi?id=282418">https://bugs.webkit.org/show_bug.cgi?id=282418</a>
<a href="https://rdar.apple.com/139054089">rdar://139054089</a>

Reviewed by Sihui Liu and Chris Dumez.

Both URLPatternCanonical.cpp and URLPatternTokenizer.cpp both need to be updated to support the incoming URLPatternParser changes.

* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizePath):
(WebCore::canonicalizePathWrapper):
(WebCore::callEncodingCallback):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.h:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Token::isNull const):
(WebCore::URLPatternUtilities::Token::isInitialized const):
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h:

Canonical link: <a href="https://commits.webkit.org/286066@main">https://commits.webkit.org/286066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65ea868711693283fb6ab531e4b6a2a2678385ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21608 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80476 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16448 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8248 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1848 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4635 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->