### PR TITLE
Allow speculative parsing for poster attribute in `video` tag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/video-poster.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/video-poster.tentative.sub-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
     <!-- speculative case in document.write -->
     <video poster="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=f5db0934-1d0b-4012-b025-76987af46874&amp;encodingcheck=&Gbreve;"></video>
 
 
-FAIL Speculative parsing, document.write(): video-poster Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+PASS Speculative parsing, document.write(): video-poster
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/video-poster.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/video-poster.tentative-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
 
-FAIL Speculative parsing, page load: video-poster Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, page load: video-poster
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.h
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.h
@@ -54,6 +54,7 @@ private:
         Script,
         Meta,
         Source,
+        Video,
 
         // These tags are not scanned by the StartTagScanner.
         Unknown,


### PR DESCRIPTION
#### fb4ed0edb9d286926ab71d53b7b0ce53c7588f8c
<pre>
Allow speculative parsing for poster attribute in `video` tag

<a href="https://bugs.webkit.org/show_bug.cgi?id=282434">https://bugs.webkit.org/show_bug.cgi?id=282434</a>
<a href="https://rdar.apple.com/139067803">rdar://139067803</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch allows our preload scanner to scan `poster` attribute with video tag
and respect it accordingly to `speculative parsing` specification [1]:

[1] <a href="https://html.spec.whatwg.org/#speculative-html-parsing">https://html.spec.whatwg.org/#speculative-html-parsing</a>

* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::tagIdFor):
(WebCore::TokenPreloadScanner::initiatorFor):
(WebCore::TokenPreloadScanner::StartTagScanner::processVideoAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::resourceType const):
* Source/WebCore/html/parser/HTMLPreloadScanner.h:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/video-poster.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/video-poster.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/286008@main">https://commits.webkit.org/286008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bd79f2956d2c970f1dbe021cbc3698b5aa2f5e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27308 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1711 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77564 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24068 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1962 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11491 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4566 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1807 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/1814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->