### PR TITLE
Timer lambdas should protect this before calling timeout function

### DIFF
--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -113,7 +113,7 @@ MediaRecorder::MediaRecorder(Document& document, Ref<MediaStream>&& stream, Opti
     : ActiveDOMObject(document)
     , m_options(WTFMove(options))
     , m_stream(WTFMove(stream))
-    , m_timeSliceTimer([this] { requestData(); })
+    , m_timeSliceTimer([this] { Ref { *this }->requestData(); })
 {
     computeInitialBitRates();
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -611,7 +611,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_creationURL(url)
     , m_domTreeVersion(++s_globalTreeVersion)
     , m_styleScope(makeUniqueRef<Style::Scope>(*this))
-    , m_styleRecalcTimer([this] { updateStyleIfNeeded(); })
+    , m_styleRecalcTimer([this] { Ref { *this }->updateStyleIfNeeded(); })
 #if !LOG_DISABLED
     , m_documentCreationTime(MonotonicTime::now())
 #endif
@@ -10505,7 +10505,7 @@ void Document::setPaintWorkletGlobalScopeForName(const String& name, Ref<PaintWo
 ContentChangeObserver& Document::contentChangeObserver()
 {
     if (!m_contentChangeObserver)
-        m_contentChangeObserver = makeUnique<ContentChangeObserver>(*this);
+        m_contentChangeObserver = makeUniqueWithoutRefCountedCheck<ContentChangeObserver>(*this);
     return *m_contentChangeObserver;
 }
 

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -76,7 +76,7 @@ static bool isHiddenBehindFullscreenElement(const Node& descendantCandidate)
 
 bool ContentChangeObserver::isContentChangeObserverEnabled()
 {
-    return m_document.settings().contentChangeObserverEnabled();
+    return m_document->settings().contentChangeObserverEnabled();
 }
 
 bool ContentChangeObserver::isVisuallyHidden(const Node& node)
@@ -185,7 +185,7 @@ bool ContentChangeObserver::isConsideredActionableContent(const Element& candida
 
 ContentChangeObserver::ContentChangeObserver(Document& document)
     : m_document(document)
-    , m_contentObservationTimer([this] { completeDurationBasedContentObservation(); })
+    , m_contentObservationTimer([this] { Ref { *this }->completeDurationBasedContentObservation(); })
 {
 }
 
@@ -317,7 +317,7 @@ void ContentChangeObserver::didInstallDOMTimer(const DOMTimer& timer, Seconds ti
         return;
     if (hasVisibleChangeState())
         return;
-    if (m_document.activeDOMObjectsAreSuspended())
+    if (m_document->activeDOMObjectsAreSuspended())
         return;
     if (timeout > maximumDelayForTimers || !singleShot)
         return;
@@ -585,9 +585,9 @@ void ContentChangeObserver::adjustObservedState(Event event)
             setHasNoChangeState();
 
         LOG_WITH_STREAM(ContentObservation, stream << "notifyClientIfNeeded: sending observedContentChange ->" << observedContentChange());
-        ASSERT(m_document.page());
-        ASSERT(m_document.frame());
-        m_document.page()->chrome().client().didFinishContentChangeObserving(*m_document.frame(), observedContentChange());
+        ASSERT(m_document->page());
+        ASSERT(m_document->frame());
+        m_document->page()->chrome().client().didFinishContentChangeObserving(*m_document->protectedFrame(), observedContentChange());
         stopContentObservation();
     };
 
@@ -604,7 +604,7 @@ void ContentChangeObserver::adjustObservedState(Event event)
             return;
         }
         if (event == Event::StartedMouseMovedEventDispatching) {
-            ASSERT(!m_document.hasPendingStyleRecalc());
+            ASSERT(!m_document->hasPendingStyleRecalc());
             if (!isBetweenTouchEndAndMouseMoved())
                 resetToStartObserving();
             setIsBetweenTouchEndAndMouseMoved(false);
@@ -648,7 +648,7 @@ void ContentChangeObserver::adjustObservedState(Event event)
             return;
         }
         if (event == Event::EndedDOMTimerExecution) {
-            if (m_document.hasPendingStyleRecalc()) {
+            if (m_document->hasPendingStyleRecalc()) {
                 setShouldObserveNextStyleRecalc(true);
                 return;
             }
@@ -658,7 +658,7 @@ void ContentChangeObserver::adjustObservedState(Event event)
         if (event == Event::EndedTransitionButFinalStyleIsNotDefiniteYet) {
             // onAnimationEnd can be called while in the middle of resolving the document (synchronously) or
             // asynchronously right before the style update is issued. It also means we don't know whether this animation ends up producing visible content yet. 
-            if (m_document.inStyleRecalc()) {
+            if (m_document->inStyleRecalc()) {
                 // We need to start observing this style change synchronously.
                 m_isInObservedStyleRecalc = true;
                 return;
@@ -667,7 +667,7 @@ void ContentChangeObserver::adjustObservedState(Event event)
             return;
         }
         if (event == Event::CompletedTransition) {
-            if (m_document.inStyleRecalc()) {
+            if (m_document->inStyleRecalc()) {
                 m_isInObservedStyleRecalc = true;
                 return;
             }

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -35,6 +35,7 @@
 #include "Timer.h"
 #include "WKContentObservation.h"
 #include "WebAnimationTypes.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
@@ -42,11 +43,6 @@
 
 namespace WebCore {
 class ContentChangeObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ContentChangeObserver> : std::true_type { };
 }
 
 namespace WebCore {
@@ -58,7 +54,7 @@ class Element;
 class ContentChangeObserver : public CanMakeWeakPtr<ContentChangeObserver> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentChangeObserver, WEBCORE_EXPORT);
 public:
-    ContentChangeObserver(Document&);
+    explicit ContentChangeObserver(Document&);
 
     WEBCORE_EXPORT void startContentObservationForDuration(Seconds duration);
     WEBCORE_EXPORT void stopContentObservation();
@@ -68,6 +64,9 @@ public:
 
     void didInstallDOMTimer(const DOMTimer&, Seconds timeout, bool singleShot);
     void didRemoveDOMTimer(const DOMTimer&);
+
+    void ref() const { m_document->ref(); }
+    void deref() const { m_document->deref(); }
 
     void didAddTransition(const Element&, const Animation&);
     void didFinishTransition(const Element&, CSSPropertyID);
@@ -220,7 +219,7 @@ private:
     };
     void adjustObservedState(Event);
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     Timer m_contentObservationTimer;
     WeakHashSet<const DOMTimer> m_DOMTimerList;
     WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsWithTransition;


### PR DESCRIPTION
#### 945acb34cd8b1d44049a18d3f84644f7333ffcdd
<pre>
Timer lambdas should protect this before calling timeout function
<a href="https://bugs.webkit.org/show_bug.cgi?id=282439">https://bugs.webkit.org/show_bug.cgi?id=282439</a>

Reviewed by Ryosuke Niwa and Darin Adler.

* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::MediaRecorder):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::isContentChangeObserverEnabled):
(WebCore::ContentChangeObserver::ContentChangeObserver):
(WebCore::ContentChangeObserver::didInstallDOMTimer):
(WebCore::ContentChangeObserver::adjustObservedState):
* Source/WebCore/page/ios/ContentChangeObserver.h:
(WebCore::ContentChangeObserver::ref const):
(WebCore::ContentChangeObserver::deref const):

Canonical link: <a href="https://commits.webkit.org/286016@main">https://commits.webkit.org/286016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b229a446db1215ec19874d4fb7a85812282bfb85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58545 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45746 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21549 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/alignment-in-subgridded-axes-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80399 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66821 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66106 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8196 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11499 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->