### PR TITLE
[WPE] Implement theme color retrieval API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -908,6 +908,12 @@ webkit_web_view_get_web_extension_mode               (WebKitWebView             
 WEBKIT_API const gchar*
 webkit_web_view_get_default_content_security_policy  (WebKitWebView             *web_view);
 
+#if PLATFORM(WPE)
+WEBKIT_API gboolean
+webkit_web_view_get_theme_color                      (WebKitWebView             *web_view,
+                                                      WebKitColor               *color);
+#endif
+
 #if USE(GI_FINISH_FUNC_ANNOTATION)
 /**
  * webkit_web_view_run_async_javascript_function_in_world: (finish-func webkit_web_view_run_javascript_in_world_finish)

--- a/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
@@ -54,6 +54,7 @@ public:
     virtual void didChangePageID(WKWPE::View&) { }
     virtual void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&& completionHandler) { completionHandler(WebKit::UserMessage()); }
     virtual WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() { return nullptr; }
+    virtual void themeColorDidChange() { }
 
 #if ENABLE(FULLSCREEN_API)
     virtual bool enterFullScreen(WKWPE::View&) { return false; };

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -396,6 +396,11 @@ void PageClientImpl::didChangeBackgroundColor()
 {
 }
 
+void PageClientImpl::themeColorDidChange()
+{
+    m_view.themeColorDidChange();
+}
+
 void PageClientImpl::refView()
 {
 }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -153,6 +153,7 @@ private:
     void didSameDocumentNavigationForMainFrame(SameDocumentNavigationType) override;
 
     void didChangeBackgroundColor() override;
+    void themeColorDidChange() override;
     void isPlayingAudioWillChange() final { }
     void isPlayingAudioDidChange() final { }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -119,6 +119,11 @@ void View::selectionDidChange()
     }
 }
 
+void View::themeColorDidChange()
+{
+    m_client->themeColorDidChange();
+}
+
 void View::setSize(const WebCore::IntSize& size)
 {
     m_size = size;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -73,6 +73,8 @@ public:
     WebKitInputMethodContext* inputMethodContext() const;
     void setInputMethodState(std::optional<WebKit::InputMethodState>&&);
 
+    void themeColorDidChange();
+
 #if ENABLE(FULLSCREEN_API)
     bool isFullScreen() const;
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
@@ -55,6 +55,7 @@ private:
     void didChangePageID(WKWPE::View&) override;
     void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&) override;
     WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() override;
+    void themeColorDidChange() override;
 
 #if ENABLE(FULLSCREEN_API)
     bool enterFullScreen(WKWPE::View&) override;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -327,3 +327,31 @@ void webkit_web_view_toggle_inspector(WebKitWebView* webView)
         inspector->show();
 }
 #endif
+
+/**
+ * webkit_web_view_get_theme_color:
+ * @web_view: a #WebKitWebView
+ * @color: (out): a #WebKitColor to fill in with the theme color
+ *
+ * Gets the theme color that is specified by the content in the @web_view.
+ * If the @web_view doesn't have a theme color it will fill the @color
+ * with transparent black content.
+ *
+ * Returns: Whether the currently loaded page defines a theme color.
+ *
+ * Since: 2.50
+ */
+gboolean webkit_web_view_get_theme_color(WebKitWebView* webView, WebKitColor* color)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+    auto& page = webkitWebViewGetPage(webView);
+
+    if (!page.themeColor().isValid()) {
+        WebCore::Color tmpColor(WebCore::Color::transparentBlack);
+        webkitColorFillFromWebCoreColor(tmpColor, color);
+        return FALSE;
+    }
+
+    webkitColorFillFromWebCoreColor(page.themeColor(), color);
+    return TRUE;
+}

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -87,7 +87,7 @@ messages -> WebPageProxy {
     DidChangeScrollbarsForMainFrame(bool hasHorizontalScrollbar, bool hasVerticalScrollbar)
     DidChangeScrollOffsetPinningForMainFrame(WebCore::RectEdges<bool> pinnedState)
     DidChangePageCount(unsigned pageCount)
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(WPE)
     ThemeColorChanged(WebCore::Color themeColor)
 #endif
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -186,6 +186,10 @@ void LayerTreeHost::flushLayers()
     page->updateRendering();
     page->flushPendingEditorStateUpdate();
 
+#if PLATFORM(WPE)
+    page->flushPendingThemeColorChange();
+#endif
+
     if (m_overlayCompositingLayer)
         m_overlayCompositingLayer->flushCompositingState(visibleContentsRect());
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8125,7 +8125,7 @@ void WebPage::getInformationFromImageData(const Vector<uint8_t>& data, Completio
 }
 #endif
 
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(WPE)
 void WebPage::flushPendingThemeColorChange()
 {
     if (!m_pendingThemeColorChange)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1594,7 +1594,7 @@ public:
 #endif
 
     void themeColorChanged() { m_pendingThemeColorChange = true; }
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(WPE)
     void flushPendingThemeColorChange();
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -1636,6 +1636,60 @@ static void testWebViewBackgroundColor(WebViewTest* test, gconstpointer)
     // MiniBrowser --bg-color="<color-value>" for manually testing this API.
 }
 
+#if PLATFORM(WPE)
+class ThemeColorWebViewTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(ThemeColorWebViewTest);
+
+    static void themeColorChanged(GObject*, GParamSpec*, ThemeColorWebViewTest* test)
+    {
+        g_signal_handlers_disconnect_by_func(test->m_webView.get(), reinterpret_cast<void*>(themeColorChanged), test);
+        g_main_loop_quit(test->m_mainLoop);
+    }
+
+    void testThemeColorResult()
+    {
+        WebKitColor rgba;
+        g_assert_true(webkit_web_view_get_theme_color(m_webView.get(), &rgba));
+        g_assert_cmpfloat(rgba.red, ==, targetColor.red);
+        g_assert_cmpfloat(rgba.green, ==, targetColor.green);
+        g_assert_cmpfloat(rgba.blue, ==, targetColor.blue);
+        g_assert_cmpfloat(rgba.alpha, ==, targetColor.alpha);
+    }
+
+    void waitUntilThemeColorChanged()
+    {
+        g_signal_connect(m_webView.get(), "notify::theme-color", G_CALLBACK(themeColorChanged), this);
+        g_main_loop_run(m_mainLoop);
+    }
+
+    WebKitColor targetColor { 0.0, 0.0, 0.0, 0.0 };
+};
+
+static void testWebViewThemeColor(ThemeColorWebViewTest* test, gconstpointer)
+{
+    WebKitColor rgba;
+
+    test->showInWindow();
+
+    g_assert_false(webkit_web_view_get_theme_color(test->m_webView.get(), &rgba));
+
+    test->targetColor = WebKitColor(1.0, 0.0, 0.0, 1.0);
+    test->loadHtml("<html style='width: 325px; height: 615px'><meta name='theme-color' content='#FF0000' /></html>", nullptr);
+    test->waitUntilThemeColorChanged();
+    test->testThemeColorResult();
+
+    test->targetColor = WebKitColor(0.0, 1.0, 0.0, 1.0);
+    test->loadHtml("<html style='width: 325px; height: 615px'><meta name='theme-color' content='#00FF00' /></html>", nullptr);
+    test->waitUntilThemeColorChanged();
+    test->testThemeColorResult();
+
+    test->loadHtml("<html style='width: 325px; height: 615px'></html>", nullptr);
+    test->waitUntilThemeColorChanged();
+    g_assert_false(webkit_web_view_get_theme_color(test->m_webView.get(), &rgba));
+}
+#endif
+
 #if PLATFORM(GTK)
 static void testWebViewPreferredSize(WebViewTest* test, gconstpointer)
 {
@@ -2112,6 +2166,9 @@ void beforeAll()
 #endif
     IsPlayingAudioWebViewTest::add("WebKitWebView", "is-playing-audio", testWebViewIsPlayingAudio);
     WebViewTest::add("WebKitWebView", "background-color", testWebViewBackgroundColor);
+#if PLATFORM(WPE)
+    ThemeColorWebViewTest::add("WebKitWebView", "theme-color", testWebViewThemeColor);
+#endif
 #if PLATFORM(GTK)
     WebViewTest::add("WebKitWebView", "preferred-size", testWebViewPreferredSize);
 #endif


### PR DESCRIPTION
#### 2246a2aa28d527e129ebec66183569db035fdc8a
<pre>
[WPE] Implement theme color retrieval API

<a href="https://bugs.webkit.org/show_bug.cgi?id=273747">https://bugs.webkit.org/show_bug.cgi?id=273747</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

Implements a property &quot;theme-color&quot; and a getter function webkit_web_view_get_theme_color()
for retrieving the web view&apos;s page theme color, with property changes for notification.

Combined changes:

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(WebKitWebViewClient::themeColorDidChange):
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/wpe/APIViewClient.h:
(API::ViewClient::themeColorDidChange):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::themeColorDidChange):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::themeColorDidChange):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(webkit_web_view_get_theme_color):
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::flushLayers):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(ThemeColorWebViewTest::themeColorChanged):
(ThemeColorWebViewTest::testThemeColorResult):
(ThemeColorWebViewTest::waitUntilThemeColorChanged):
(testWebViewThemeColor):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/296035@main">https://commits.webkit.org/296035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da8019d4a6faee74ff52ff9bfbff1fb3d6a48492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57119 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25206 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92845 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12809 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29934 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39594 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33877 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->