### PR TITLE
ViewTransition::updatePseudoElementStyles repeatedly flushes layout.

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1909,6 +1909,7 @@ compositing/repaint/copy-forward-dirty-region.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html [ Pass ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-stay.html [ Pass ImageOnlyFailure ]
 
 http/tests/login-status/login-status-api-getter-setter-functions.html [ Failure ]
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -523,6 +523,28 @@ ExceptionOr<void> ViewTransition::captureOldState()
     return { };
 }
 
+bool ViewTransition::updatePropertiesForRenderer(CapturedElement& capturedElement, RenderBoxModelObject* renderer, const AtomString& name)
+{
+    RefPtr<MutableStyleProperties> properties;
+    if (renderer) {
+        properties = copyElementBaseProperties(*renderer, capturedElement.newSize);
+        capturedElement.newOverflowRect = captureOverflowRect(*renderer);
+    } else
+        properties = capturedElement.oldProperties;
+
+    bool changed = false;
+    if (properties) {
+        // group styles rule
+        if (!capturedElement.groupStyleProperties) {
+            capturedElement.groupStyleProperties = properties;
+            protectedDocument()->styleScope().resolver().setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
+            changed = true;
+        } else
+            changed |= capturedElement.groupStyleProperties->mergeAndOverrideOnConflict(*properties);
+    }
+    return changed;
+}
+
 // https://drafts.csswg.org/css-view-transitions/#capture-new-state-algorithm
 ExceptionOr<void> ViewTransition::captureNewState()
 {
@@ -546,6 +568,8 @@ ExceptionOr<void> ViewTransition::captureNewState()
                 auto namedElement = m_namedElements.find(name);
                 namedElement->classList = effectiveViewTransitionClassList(renderer, styleable->element, document()->styleScope());
                 namedElement->newElement = *styleable;
+
+                updatePropertiesForRenderer(*namedElement, dynamicDowncast<RenderBoxModelObject>(renderer), name);
             }
             return { };
         }, *view->layer());
@@ -674,6 +698,8 @@ void ViewTransition::activateViewTransition()
         return;
     }
 
+    setupTransitionPseudoElements();
+
     for (auto& [name, capturedElement] : m_namedElements.map()) {
         if (auto newStyleable = capturedElement->newElement.styleable()) {
             if (CheckedPtr renderer = newStyleable->renderer())
@@ -681,14 +707,12 @@ void ViewTransition::activateViewTransition()
         }
     }
 
-    setupTransitionPseudoElements();
-    checkFailure = updatePseudoElementStyles();
-    if (checkFailure.hasException()) {
-        skipViewTransition(checkFailure.releaseException());
-        return;
-    }
-
     m_phase = ViewTransitionPhase::Animating;
+
+    // No need to update pseudo element styles, since we did it as part
+    // of capture new state.
+    updatePseudoElementSizes();
+
     m_ready.second->resolve();
 }
 
@@ -741,6 +765,7 @@ void ViewTransition::handleTransitionFrame()
     }
 
     updatePseudoElementStyles();
+    updatePseudoElementSizes();
 }
 
 // https://drafts.csswg.org/css-view-transitions/#clear-view-transition-algorithm
@@ -828,54 +853,67 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles
-ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
+void ViewTransition::updatePseudoElementStyles()
 {
-    Ref resolver = protectedDocument()->styleScope().resolver();
+    RefPtr document = this->document();
+    if (!document)
+        return;
+
     bool changed = false;
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
-        RefPtr<MutableStyleProperties> properties;
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
+            CheckedPtr renderer = dynamicDowncast<RenderBoxModelObject>(newStyleable->renderer());
+            changed |= updatePropertiesForRenderer(*capturedElement, renderer.get(), name);
+        } else
+            changed |= updatePropertiesForRenderer(*capturedElement, nullptr, name);
+    }
+
+    if (changed)
+        protectedDocument()->styleScope().didChangeStyleSheetContents();
+}
+
+ExceptionOr<void> ViewTransition::updatePseudoElementSizes()
+{
+    RefPtr document = this->document();
+    if (!document)
+        return { };
+
+    RefPtr documentElement = document->documentElement();
+    if (!documentElement)
+        return { };
+
+    bool changed = false;
+    for (auto& [name, capturedElement] : m_namedElements.map()) {
         if (auto newStyleable = capturedElement->newElement.styleable()) {
             // FIXME: Also check fragmented content here.
             CheckedPtr renderer = dynamicDowncast<RenderBoxModelObject>(newStyleable->renderer());
             if (!renderer || renderer->isSkippedContent())
                 return Exception { ExceptionCode::InvalidStateError, "One of the transitioned elements has become hidden."_s };
 
-            LayoutSize boxSize;
-            properties = copyElementBaseProperties(*renderer, boxSize);
-            LayoutRect overflowRect = captureOverflowRect(*renderer);
+            Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
+            if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer())) {
+                if (viewTransitionCapture->setCapturedSize(capturedElement->newSize, capturedElement->newOverflowRect, layerToLayoutOffset(*renderer)))
+                    viewTransitionCapture->setNeedsLayout();
 
-            if (RefPtr documentElement = document()->documentElement()) {
-                Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
-                if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer())) {
-                    if (viewTransitionCapture->setCapturedSize(boxSize, overflowRect, layerToLayoutOffset(*renderer)))
-                        viewTransitionCapture->setNeedsLayout();
-
-                    RefPtr<ImageBuffer> image;
-                    if (RefPtr frame = document()->frame(); !viewTransitionCapture->canUseExistingLayers()) {
-                        image = snapshotElementVisualOverflowClippedToViewport(*frame, *renderer, overflowRect);
-                        changed = true;
-                    } else if (CheckedPtr layer = renderer->isDocumentElementRenderer() ? renderer->view().layer() : renderer->layer())
-                        layer->setNeedsCompositingGeometryUpdate();
-                    viewTransitionCapture->setImage(image);
-                }
+                RefPtr<ImageBuffer> image;
+                if (RefPtr frame = document->frame(); !viewTransitionCapture->canUseExistingLayers()) {
+                    document->updateLayout();
+                    image = snapshotElementVisualOverflowClippedToViewport(*frame, *renderer, capturedElement->newOverflowRect);
+                } else if (CheckedPtr layer = renderer->isDocumentElementRenderer() ? renderer->view().layer() : renderer->layer())
+                    layer->setNeedsCompositingGeometryUpdate();
+                viewTransitionCapture->setImage(image);
             }
-        } else
-            properties = capturedElement->oldProperties;
-
-        if (properties) {
-            // group styles rule
-            if (!capturedElement->groupStyleProperties) {
-                capturedElement->groupStyleProperties = properties;
-                resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
-                changed = true;
-            } else
-                changed |= capturedElement->groupStyleProperties->mergeAndOverrideOnConflict(*properties);
+        } else if (!capturedElement->groupStyleProperties) {
+            // If we haven't yet initialized the properties for a transition without
+            // a new element, do it now.
+            changed |= updatePropertiesForRenderer(*capturedElement, nullptr, name);
         }
     }
 
     if (changed)
-        protectedDocument()->styleScope().didChangeStyleSheetContents();
+        document->styleScope().didChangeStyleSheetContents();
+
     return { };
 }
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -67,9 +67,12 @@ public:
     LayoutPoint oldLayerToLayoutOffset;
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
-    WeakStyleable newElement;
-    Vector<AtomString> classList;
 
+    WeakStyleable newElement;
+    LayoutRect newOverflowRect;
+    LayoutSize newSize;
+
+    Vector<AtomString> classList;
     RefPtr<MutableStyleProperties> groupStyleProperties;
 };
 
@@ -196,6 +199,7 @@ private:
     ViewTransition(Document&, Vector<AtomString>&&);
 
     Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&);
+    bool updatePropertiesForRenderer(CapturedElement&, RenderBoxModelObject*, const AtomString&);
 
     // Setup view transition sub-algorithms.
     ExceptionOr<void> captureOldState();
@@ -205,7 +209,8 @@ private:
 
     void callUpdateCallback();
 
-    ExceptionOr<void> updatePseudoElementStyles();
+    void updatePseudoElementStyles();
+    ExceptionOr<void> updatePseudoElementSizes();
     ExceptionOr<void> checkForViewportSizeChange();
 
     void clearViewTransition();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -310,6 +310,15 @@ void RenderBox::styleWillChange(StyleDifference diff, const RenderStyle& newStyl
     RenderBoxModelObject::styleWillChange(diff, newStyle);
 }
 
+void RenderBox::invalidateAncestorBackgroundObscurationStatus()
+{
+    auto parentToInvalidate = parent();
+    for (unsigned i = 0; i < backgroundObscurationTestMaxDepth && parentToInvalidate; ++i) {
+        parentToInvalidate->invalidateBackgroundObscurationStatus();
+        parentToInvalidate = parentToInvalidate->parent();
+    }
+}
+
 void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     // Horizontal writing mode definition is updated in RenderBoxModelObject::updateFromStyle,
@@ -368,13 +377,8 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
 #endif
 
     // Our opaqueness might have changed without triggering layout.
-    if (diff >= StyleDifference::Repaint && diff <= StyleDifference::RepaintLayer) {
-        auto parentToInvalidate = parent();
-        for (unsigned i = 0; i < backgroundObscurationTestMaxDepth && parentToInvalidate; ++i) {
-            parentToInvalidate->invalidateBackgroundObscurationStatus();
-            parentToInvalidate = parentToInvalidate->parent();
-        }
-    }
+    if (diff >= StyleDifference::Repaint && diff <= StyleDifference::RepaintLayer)
+        invalidateAncestorBackgroundObscurationStatus();
 
     bool isBodyRenderer = isBody();
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -650,6 +650,8 @@ public:
     bool includeVerticalScrollbarSize() const;
     bool includeHorizontalScrollbarSize() const;
 
+    void invalidateAncestorBackgroundObscurationStatus();
+
 protected:
     RenderBox(Type, Element&, RenderStyle&&, OptionSet<TypeFlag> = { }, TypeSpecificFlags = { });
     RenderBox(Type, Document&, RenderStyle&&, OptionSet<TypeFlag> = { }, TypeSpecificFlags = { });

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1844,6 +1844,9 @@ void RenderObject::setCapturedInViewTransition(bool captured)
             // Invalidate transform applied by `RenderLayerBacking::updateTransform`.
             layerToInvalidate->setNeedsCompositingGeometryUpdate();
         }
+
+        if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*this))
+            renderBox->invalidateAncestorBackgroundObscurationStatus();
     }
 }
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -46,6 +46,10 @@ RenderViewTransitionCapture::~RenderViewTransitionCapture() = default;
 void RenderViewTransitionCapture::setImage(RefPtr<ImageBuffer> oldImage)
 {
     m_oldImage = oldImage;
+    if (hasLayer())
+        layer()->contentChanged(ContentChangeType::Image);
+    if (parent())
+        repaint();
 }
 
 bool RenderViewTransitionCapture::setCapturedSize(const LayoutSize& size, const LayoutRect& overflowRect, const LayoutPoint& layerToLayoutOffset)


### PR DESCRIPTION
#### 77c5d13c77da630c7b7a13f2af704378ba8e9866
<pre>
ViewTransition::updatePseudoElementStyles repeatedly flushes layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282448">https://bugs.webkit.org/show_bug.cgi?id=282448</a>
&lt;<a href="https://rdar.apple.com/139082479">rdar://139082479</a>&gt;

Reviewed by Tim Nguyen.

This code copies computed style properties which depend on layout, but also
marks renderers as needing layout and does so in a loop.

Split it into two steps, one that reads the style and sets the resulting values
as ::view-transition-group, and another which mutates the
RenderViewTransitionCapture renderer.

It also makes the style update an implicit part of captureNewState, so that we
can avoid a second iteration during activateViewTransition. Previously
updatePseudoElementStyles was blocked on a style flush from updating the dynamic
style sheet, even though it didn&apos;t read any related style data.

This results in less invalidation (since we no longer unconditionally call
didChangeStyleSheetContents on the initial update), and exposes a few bugs where
we weren&apos;t invalidating the individual changes correctly.

One fix is to make sure setting the image on a RenderViewTransitionCapture
correctly requests a repaint and layer contents change.

Also fixes an existing bug (that got exposed and started causing WPT failures
due to this change) where capturing an element into a view transition didn&apos;t
notify ancestors that the background would no longer be painted and obscuration
status needs to be computed.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePropertiesForRenderer):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::updatePseudoElementStyles):
(WebCore::ViewTransition::updatePseudoElementSizes):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::setImage):

Canonical link: <a href="https://commits.webkit.org/286209@main">https://commits.webkit.org/286209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aefdfeac4b06d4012148b719c39e382ff02c92c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75206 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/54645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28046 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2430 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/79665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78273 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64596 "Build is in progress. Recent messages:") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2536 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/81147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2686 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10505 "Build is in progress. Recent messages:") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11601 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2497 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2522 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->