### PR TITLE
REGRESSION(286001@main): [macOS] 3 pdf tests are constant timeout

### DIFF
--- a/LayoutTests/pdf/annotations/radio-buttons-select-second-expected.html
+++ b/LayoutTests/pdf/annotations/radio-buttons-select-second-expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
-<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-25" />
+<meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-311" />
 <script src="../../resources/ui-helper.js"></script>
 <body>
 <embed style="width: 100%; height: 100vh;" id="plugin" src="../resources/annotation-two-radio-buttons-second-active.pdf"></embed>

--- a/LayoutTests/pdf/annotations/radio-buttons-select-second.html
+++ b/LayoutTests/pdf/annotations/radio-buttons-select-second.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
-<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-25" />
+<meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-311" />
 <script src="../../resources/ui-helper.js"></script>
 <body>
 <embed style="width: 100%; height: 100vh;" id="plugin" src="../resources/annotation-two-radio-buttons-first-active.pdf"></embed>

--- a/LayoutTests/pdf/two-pages-continuous-to-discrete.html
+++ b/LayoutTests/pdf/two-pages-continuous-to-discrete.html
@@ -15,7 +15,7 @@
         window.internals.registerPDFTest(async () => {
             internals.setPDFDisplayModeForTesting(pluginElement, "TwoUpContinuous");
             internals.setPDFDisplayModeForTesting(pluginElement, "TwoUpDiscrete");
-            await UIHelper.renderingUpdate();
+            await UIHelper.ensureStablePresentationUpdate();
             testRunner.notifyDone();
         }, pluginElement);
     });

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -50,6 +50,7 @@
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "SubframeLoader.h"
+#include "VoidCallback.h"
 #include "Widget.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -72,6 +73,7 @@ HTMLPlugInElement::HTMLPlugInElement(const QualifiedName& tagName, Document& doc
 HTMLPlugInElement::~HTMLPlugInElement()
 {
     ASSERT(!m_instance); // cleared in detach()
+    ASSERT(!m_pendingPDFTestCallback);
 }
 
 bool HTMLPlugInElement::willRespondToMouseClickEventsWithEditability(Editability) const
@@ -459,6 +461,19 @@ bool HTMLPlugInElement::canLoadScriptURL(const URL&) const
 {
     // FIXME: Probably want to at least check canAddSubframe.
     return true;
+}
+
+void HTMLPlugInElement::pluginDestroyedWithPendingPDFTestCallback(RefPtr<VoidCallback>&& callback)
+{
+    ASSERT(!m_pendingPDFTestCallback);
+    m_pendingPDFTestCallback = WTFMove(callback);
+}
+
+RefPtr<VoidCallback> HTMLPlugInElement::takePendingPDFTestCallback()
+{
+    if (!m_pendingPDFTestCallback)
+        return nullptr;
+    return WTFMove(m_pendingPDFTestCallback);
 }
 
 }

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class PluginReplacement;
 class PluginViewBase;
 class RenderWidget;
+class VoidCallback;
 
 class HTMLPlugInElement : public HTMLFrameOwnerElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLPlugInElement);
@@ -74,6 +75,9 @@ public:
     WEBCORE_EXPORT bool setReplacement(RenderEmbeddedObject::PluginUnavailabilityReason, const String& unavailabilityDescription);
 
     WEBCORE_EXPORT bool isReplacementObscured();
+
+    WEBCORE_EXPORT void pluginDestroyedWithPendingPDFTestCallback(RefPtr<VoidCallback>&&);
+    WEBCORE_EXPORT RefPtr<VoidCallback> takePendingPDFTestCallback();
 
 protected:
     HTMLPlugInElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
@@ -112,6 +116,8 @@ private:
     RefPtr<PluginReplacement> m_pluginReplacement;
     bool m_isCapturingMouseEvents { false };
     DisplayState m_displayState { Playing };
+
+    RefPtr<VoidCallback> m_pendingPDFTestCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -125,6 +125,8 @@ PDFPluginBase::~PDFPluginBase()
     if (auto* page = m_frame ? m_frame->page() : nullptr)
         page->removePDFHUD(*this);
 #endif
+
+    ASSERT(!m_pdfTestCallback);
 }
 
 void PDFPluginBase::teardown()
@@ -159,6 +161,9 @@ void PDFPluginBase::teardown()
 
     if (isLocked())
         teardownPasswordEntryForm();
+
+    if (m_pdfTestCallback && m_element)
+        m_element->pluginDestroyedWithPendingPDFTestCallback(WTFMove(m_pdfTestCallback));
 }
 
 Page* PDFPluginBase::page() const
@@ -1235,6 +1240,8 @@ void PDFPluginBase::incrementalLoaderLog(const String& message)
 
 void PDFPluginBase::registerPDFTest(RefPtr<WebCore::VoidCallback>&& callback)
 {
+    ASSERT(!m_pdfTestCallback);
+
     if (m_pdfDocument && callback)
         callback->handleEvent();
     else

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -314,10 +314,13 @@ void UnifiedPDFPlugin::installPDFDocument()
 
     revealFragmentIfNeeded();
 
-    if (m_pdfTestCallback) {
-        m_pdfTestCallback->handleEvent();
-        m_pdfTestCallback = nullptr;
+    if (m_element) {
+        if (RefPtr callback = m_element->takePendingPDFTestCallback())
+            registerPDFTest(WTFMove(callback));
     }
+
+    if (m_pdfTestCallback)
+        std::exchange(m_pdfTestCallback, nullptr)->handleEvent();
 }
 
 void UnifiedPDFPlugin::incrementalLoadingDidProgress()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -230,7 +230,7 @@ private:
     Vector<WebCore::FloatRect> pdfAnnotationRectsForTesting() const override;
     void unlockPDFDocumentForTesting(const String& password) final;
     void setPDFTextAnnotationValueForTesting(unsigned pageIndex, unsigned annotationIndex, const String& value) final;
-    void registerPDFTestCallback(RefPtr<WebCore::VoidCallback> &&) final;
+    void registerPDFTestCallback(RefPtr<WebCore::VoidCallback>&&) final;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 174df3556cf36905bad666b764c61efdd335dc2d
<pre>
REGRESSION(286001@main): [macOS] 3 pdf tests are constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=282447">https://bugs.webkit.org/show_bug.cgi?id=282447</a>
<a href="https://rdar.apple.com/139078186">rdar://139078186</a>

Reviewed by Wenson Hsieh.

Tests with embedded PDF objects that use the registerPDFTest callback
mechanism now timeout because said callback is never fulfilled (the
plugin dies during render invalidation and throws away the callback when
it does so).

To fix this, we can leverage the corresponding HTMLPlugInElement. Its
lifetime can be treated as an invariant for test purposes, so if a
plugin has any unfulfilled testing callbacks during teardown, we store
said callback on plugin element, and make sure to propagate them back
down to any newly constructed plugin.

* LayoutTests/pdf/annotations/radio-buttons-select-second-expected.html:
* LayoutTests/pdf/annotations/radio-buttons-select-second.html:
* LayoutTests/pdf/two-pages-continuous-to-discrete.html:
  Wait for a stable presentation update after asking for a display mode
  change. This makes the test less flaky.

* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::~HTMLPlugInElement):
(WebCore::HTMLPlugInElement::pluginDestroyedWithPendingPDFTestCallback):
(WebCore::HTMLPlugInElement::takePendingPDFTestCallback):
* Source/WebCore/html/HTMLPlugInElement.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::~PDFPluginBase):
(WebKit::PDFPluginBase::teardown):
(WebKit::PDFPluginBase::registerPDFTest):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:

Canonical link: <a href="https://commits.webkit.org/286017@main">https://commits.webkit.org/286017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27b7ba48e82000dc76d3aa3e431d87635ab4aa8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77582 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/38964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/45779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24086 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/21919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80423 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1832 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1980 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66119 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4584 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->