### PR TITLE
`pointerevent_capture_suppressing_mouse` WPT is timing out

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt
@@ -1,7 +1,5 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Validate pointer events track pointer movement without pointer capture. Test timed out
-NOTRUN Test pointer capture.
+PASS Validate pointer events track pointer movement without pointer capture.
+FAIL Test pointer capture. assert_equals: Check after hover on capture target: Unexpected events pointerout@target0, pointerleave@target0 expected 0 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_styles.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_styles.css
@@ -83,7 +83,7 @@ color: white;
 
 div {
 margin: 0em;
-padding: 2em;
+padding: 1.2em;
 }
 
 #complete-notice {

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt
@@ -9,5 +9,5 @@ Click left mouse button again.
 Test passes if the proper behavior of the events is observed.
 
 
-FAIL mouse Test pointerevent coordinates when pointer is locked assert_equals: clientX expected 172 but got 314
+FAIL mouse Test pointerevent coordinates when pointer is locked assert_equals: clientX expected 146 but got 275
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Validate pointer events track pointer movement without pointer capture.
+FAIL Test pointer capture. assert_equals: Check after button hover: Unexpected events pointermove@captureButton expected 0 but got 1
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1356,7 +1356,6 @@ imported/w3c/web-platform-tests/pointerevents/pointerevent_auxclick_is_a_pointer
 imported/w3c/web-platform-tests/pointerevents/pointerevent_auxclick_is_a_pointerevent.html?pen [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_boundary_events_in_capturing.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_boundary_events_in_capturing.html?touch [ Skip ]
-imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent.html?mouse [ Pass ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent.html?pen [ Skip ]


### PR DESCRIPTION
#### 689e5c6c2e69624049ec7e761f85d36b05944d85
<pre>
`pointerevent_capture_suppressing_mouse` WPT is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=282454">https://bugs.webkit.org/show_bug.cgi?id=282454</a>
<a href="https://rdar.apple.com/139086989">rdar://139086989</a>

Reviewed by Abrar Rahman Protyasha.

The content used to test pointer events in `pointerevent_capture_suppressing_mouse`
is not fully in the viewport, at the default viewport size used by Safari/WebKit
of 800x600.

This results in a timeout when using `test_driver.Actions` with a `pointermove` to
an element outside the viewport. The pointer never actually moves over the element
since it is offscreen.

The issue is not observed in Chrome and Firefox, as their default viewport size
when running this test is larger than Safari/WebKit. However, as 800x600 is the minimum
size, the test should work at that size.

Note that Chromium&apos;s `testdriver-vendor.js` also has logic to scroll an element into
view in this scenario. However, that is not backed by the WebDriver spec or documention
of WPT Actions, which only prescribe scrolling into view for `click` and `send_keys`.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_styles.css:
(div):

Reduce padding between `div`s in pointerevents tests to ensure content is in the viewport.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt:

Rebaseline existing failure to reflect updated coordinates.

* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_suppressing_mouse-expected.txt: Added.
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/286050@main">https://commits.webkit.org/286050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f9d2027112d4f585709e0b389e260525d6b74dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16913 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21639 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66181 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10120 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1919 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1947 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->