### PR TITLE
Rename some of the CanMakeCheckedPtrBase member functions to make their names less generic

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -176,13 +176,13 @@ private:
     ALWAYS_INLINE void refIfNotNull()
     {
         if (T* ptr = PtrTraits::unwrap(m_ptr); LIKELY(ptr))
-            ptr->incrementPtrCount();
+            ptr->incrementCheckedPtrCount();
     }
 
     ALWAYS_INLINE void derefIfNotNull()
     {
         if (T* ptr = PtrTraits::unwrap(m_ptr); LIKELY(ptr))
-            ptr->decrementPtrCount();
+            ptr->decrementCheckedPtrCount();
     }
 
     typename PtrTraits::StorageType m_ptr;

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -629,7 +629,7 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 void operator delete(T* object, std::destroying_delete_t, size_t size) { \
     ASSERT(sizeof(T) == size); \
     object->T::~T(); \
-    if (UNLIKELY(object->ptrCountWithoutThreadCheck())) { \
+    if (UNLIKELY(object->checkedPtrCountWithoutThreadCheck())) { \
         memset(static_cast<void*>(object), 0, size); \
         return; \
     } \

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -120,7 +120,7 @@ struct HasRefPtrMethods : decltype(detail::HasRefPtrMethodsTest<T>(SFINAE_OVERLO
 namespace detail {
 
 template<class T>
-static auto HasCheckedPtrMethodsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->incrementPtrCount(), static_cast<std::remove_cv_t<T>*>(nullptr)->decrementPtrCount())>;
+static auto HasCheckedPtrMethodsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->incrementCheckedPtrCount(), static_cast<std::remove_cv_t<T>*>(nullptr)->decrementCheckedPtrCount())>;
 template<class>
 static auto HasCheckedPtrMethodsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
 

--- a/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
+++ b/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
@@ -36,10 +36,10 @@ public:
     virtual void setAppBadge(std::optional<uint64_t>) = 0;
 
     // CanMakeCheckedPtr.
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -71,10 +71,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     // RealtimeMediaSource::AudioSampleObserver
     void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -57,10 +57,10 @@ public:
     void postTaskToAudioWorklet(Function<void(AudioWorklet&)>&&);
     ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
 
-    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementCheckedPtrCount(); }
 
 private:
     explicit AudioWorkletMessagingProxy(AudioWorklet&);

--- a/Source/WebCore/dom/PendingScriptClient.h
+++ b/Source/WebCore/dom/PendingScriptClient.h
@@ -36,10 +36,10 @@ public:
     virtual ~PendingScriptClient() = default;
 
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void notifyFinished(PendingScript&) = 0;
 };

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -50,10 +50,10 @@ public:
     ~ScriptRunner();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     enum ExecutionType { ASYNC_EXECUTION, IN_ORDER_EXECUTION };
     void queueScriptForExecution(ScriptElement&, LoadableScript&, ExecutionType);

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -54,10 +54,10 @@ public:
     virtual ~HTMLDocumentParser();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -76,10 +76,10 @@ public:
     virtual Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) = 0;
 
     // CheckedPtr interface.
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 }

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -77,10 +77,10 @@ public:
     virtual ~ScrollView();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     USING_CAN_MAKE_WEAKPTR(Widget);
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -84,10 +84,10 @@ class ScrollableArea : public CanMakeWeakPtr<ScrollableArea> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollableArea);
 public:
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual bool isScrollView() const { return false; }
     virtual bool isRenderLayer() const { return false; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -68,10 +68,10 @@ public:
     virtual void removeClient(PlaybackSessionModelClient&) = 0;
 
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void play() = 0;
     virtual void pause() = 0;
@@ -155,10 +155,10 @@ public:
     virtual ~PlaybackSessionModelClient() { };
 
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void durationChanged(double) { }
     virtual void currentTimeChanged(double /* currentTime */, double /* anchorTime */) { }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -59,10 +59,10 @@ public:
     WEBCORE_EXPORT virtual ~PlaybackSessionModelMediaElement();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     WEBCORE_EXPORT void setMediaElement(HTMLMediaElement*);
     HTMLMediaElement* mediaElement() const { return m_mediaElement.get(); }

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -115,10 +115,10 @@ public:
     virtual ~VideoPresentationModelClient() = default;
 
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void hasVideoChanged(bool) { }
     virtual void videoDimensionsChanged(const FloatSize&) { }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -67,10 +67,10 @@ public:
     }
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void videoDimensionsChanged(const FloatSize& videoDimensions)
     {

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -78,10 +78,10 @@ private:
     }
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void durationChanged(double) final { }
     void currentTimeChanged(double, double) final { }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -93,10 +93,10 @@ private:
     }
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -101,10 +101,10 @@ protected:
     PlaybackSessionModel* m_playbackSessionModel { nullptr };
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final;
-    uint32_t ptrCountWithoutThreadCheck() const final;
-    void incrementPtrCount() const final;
-    void decrementPtrCount() const final;
+    uint32_t checkedPtrCount() const final;
+    uint32_t checkedPtrCountWithoutThreadCheck() const final;
+    void incrementCheckedPtrCount() const final;
+    void decrementCheckedPtrCount() const final;
 
 private:
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -132,24 +132,24 @@ WTFLogChannel& PlaybackSessionInterfaceIOS::logChannel() const
     return LogMedia;
 }
 
-uint32_t PlaybackSessionInterfaceIOS::ptrCount() const
+uint32_t PlaybackSessionInterfaceIOS::checkedPtrCount() const
 {
-    return CanMakeCheckedPtr::ptrCount();
+    return CanMakeCheckedPtr::checkedPtrCount();
 }
 
-uint32_t PlaybackSessionInterfaceIOS::ptrCountWithoutThreadCheck() const
+uint32_t PlaybackSessionInterfaceIOS::checkedPtrCountWithoutThreadCheck() const
 {
-    return CanMakeCheckedPtr::ptrCountWithoutThreadCheck();
+    return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck();
 }
 
-void PlaybackSessionInterfaceIOS::incrementPtrCount() const
+void PlaybackSessionInterfaceIOS::incrementCheckedPtrCount() const
 {
-    CanMakeCheckedPtr::incrementPtrCount();
+    CanMakeCheckedPtr::incrementCheckedPtrCount();
 }
 
-void PlaybackSessionInterfaceIOS::decrementPtrCount() const
+void PlaybackSessionInterfaceIOS::decrementCheckedPtrCount() const
 {
-    CanMakeCheckedPtr::decrementPtrCount();
+    CanMakeCheckedPtr::decrementCheckedPtrCount();
 }
 
 #endif

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -73,10 +73,10 @@ public:
     WEBCORE_EXPORT ~VideoPresentationInterfaceIOS();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceIOS& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -124,10 +124,10 @@ private:
     VideoFullscreenControllerContext() { }
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -93,10 +93,10 @@ private:
     PlaybackSessionInterfaceMac(PlaybackSessionModel&);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final;
-    uint32_t ptrCountWithoutThreadCheck() const final;
-    void incrementPtrCount() const final;
-    void decrementPtrCount() const final;
+    uint32_t checkedPtrCount() const final;
+    uint32_t checkedPtrCountWithoutThreadCheck() const final;
+    void incrementCheckedPtrCount() const final;
+    void decrementCheckedPtrCount() const final;
 
     WeakPtr<PlaybackSessionModel> m_playbackSessionModel;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -303,24 +303,24 @@ void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming(double cur
     manager.timing = [getAVValueTimingClass() valueTimingWithAnchorValue:currentTime anchorTimeStamp:effectiveAnchorTime rate:effectivePlaybackRate];
 }
 
-uint32_t PlaybackSessionInterfaceMac::ptrCount() const
+uint32_t PlaybackSessionInterfaceMac::checkedPtrCount() const
 {
-    return CanMakeCheckedPtr::ptrCount();
+    return CanMakeCheckedPtr::checkedPtrCount();
 }
 
-uint32_t PlaybackSessionInterfaceMac::ptrCountWithoutThreadCheck() const
+uint32_t PlaybackSessionInterfaceMac::checkedPtrCountWithoutThreadCheck() const
 {
-    return CanMakeCheckedPtr::ptrCountWithoutThreadCheck();
+    return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck();
 }
 
-void PlaybackSessionInterfaceMac::incrementPtrCount() const
+void PlaybackSessionInterfaceMac::incrementCheckedPtrCount() const
 {
-    CanMakeCheckedPtr::incrementPtrCount();
+    CanMakeCheckedPtr::incrementCheckedPtrCount();
 }
 
-void PlaybackSessionInterfaceMac::decrementPtrCount() const
+void PlaybackSessionInterfaceMac::decrementCheckedPtrCount() const
 {
-    CanMakeCheckedPtr::decrementPtrCount();
+    CanMakeCheckedPtr::decrementCheckedPtrCount();
 }
 
 #endif // ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -118,10 +118,10 @@ private:
     WEBCORE_EXPORT VideoPresentationInterfaceMac(PlaybackSessionInterfaceMac&);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDocumentBecameVisibleCallback(Function<void()>&& callback) { m_documentBecameVisibleCallback = WTFMove(callback); }
 
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -59,10 +59,10 @@ public:
     ~MediaRecorderPrivate();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     struct AudioVideoSelectedTracks {
         MediaStreamTrackPrivate* audioTrack { nullptr };

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -77,10 +77,10 @@ private:
     explicit AudioTrackPrivateMediaStream(MediaStreamTrackPrivate&);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     static std::unique_ptr<AudioMediaStreamTrackRenderer> createRenderer(AudioTrackPrivateMediaStream&);
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -124,10 +124,10 @@ public:
         virtual ~AudioSampleObserver() = default;
 
         // CheckedPtr interface
-        virtual uint32_t ptrCount() const = 0;
-        virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-        virtual void incrementPtrCount() const = 0;
-        virtual void decrementPtrCount() const = 0;
+        virtual uint32_t checkedPtrCount() const = 0;
+        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+        virtual void incrementCheckedPtrCount() const = 0;
+        virtual void decrementCheckedPtrCount() const = 0;
 
         // May be called on a background thread.
         virtual void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t /*numberOfFrames*/) = 0;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -552,10 +552,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void flush()
     {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
@@ -45,10 +45,10 @@ private:
     ~RealtimeOutgoingAudioSourceLibWebRTC();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -51,10 +51,10 @@ private:
     explicit MediaStreamTrackAudioSourceProviderCocoa(MediaStreamTrackPrivate&);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     // WebAudioSourceProviderCocoa
     void hasNewClient(AudioSourceProviderClient*) final;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -50,10 +50,10 @@ private:
     ~RealtimeOutgoingAudioSourceCocoa();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
@@ -32,10 +32,10 @@ namespace WebCore {
 class CurlMultipartHandleClient {
 public:
     // CheckedPtr interface
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 
     virtual void didReceiveHeaderFromMultipart(Vector<String>&&) = 0;
     virtual void didReceiveDataFromMultipart(std::span<const uint8_t>) = 0;

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -85,10 +85,10 @@ private:
     WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, CaptureNetworkLoadMetrics);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementCheckedPtrCount(); }
 
     void retain() override { ref(); }
     void release() override { deref(); }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -60,10 +60,10 @@ public:
     virtual ~RenderLayerScrollableArea();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     RenderLayer& layer() { return m_layer; }
 

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -48,10 +48,10 @@ public:
     virtual ~RenderListBox();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     HTMLSelectElement& selectElement() const;
 

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -49,10 +49,10 @@ public:
     HTMLSelectElement& selectElement() const;
 
     // CheckedPtr interface.
-    uint32_t ptrCount() const final { return RenderFlexibleBox::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return RenderFlexibleBox::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { RenderFlexibleBox::incrementPtrCount(); }
-    void decrementPtrCount() const final { RenderFlexibleBox::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return RenderFlexibleBox::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderFlexibleBox::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { RenderFlexibleBox::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { RenderFlexibleBox::decrementCheckedPtrCount(); }
 
 #if !PLATFORM(IOS_FAMILY)
     bool popupIsVisible() const { return m_popupIsVisible; }

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -47,10 +47,10 @@ public:
     WEBCORE_EXPORT std::span<const RecentSearch> recentSearches();
 
     // CheckedPtr interface.
-    uint32_t ptrCount() const final { return RenderTextControlSingleLine::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return RenderTextControlSingleLine::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { RenderTextControlSingleLine::incrementPtrCount(); }
-    void decrementPtrCount() const final { RenderTextControlSingleLine::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return RenderTextControlSingleLine::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderTextControlSingleLine::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { RenderTextControlSingleLine::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { RenderTextControlSingleLine::decrementCheckedPtrCount(); }
 
 private:
     void willBeDestroyed() override;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1520,10 +1520,10 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 #endif // ENABLE(MEDIA_STREAM)
 
     Document* contextDocument() const;

--- a/Source/WebCore/workers/WorkerDebuggerProxy.h
+++ b/Source/WebCore/workers/WorkerDebuggerProxy.h
@@ -41,10 +41,10 @@ public:
     virtual void setResourceCachingDisabledByWebInspector(bool) = 0;
 
     // CanMakeCheckedPtr.
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -58,10 +58,10 @@ public:
     virtual void postTaskToLoader(ScriptExecutionContext::Task&&) = 0;
 
     // CanMakeCheckedPtr.
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -48,10 +48,10 @@ public:
     explicit WorkerMessagingProxy(Worker&);
     virtual ~WorkerMessagingProxy();
 
-    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::decrementCheckedPtrCount(); }
 
 private:
     // Implementations of WorkerGlobalScopeProxy.

--- a/Source/WebCore/workers/WorkerReportingProxy.h
+++ b/Source/WebCore/workers/WorkerReportingProxy.h
@@ -51,10 +51,10 @@ public:
     virtual void workerGlobalScopeDestroyed() = 0;
 
     // CanMakeCheckedPtr.
-    virtual uint32_t ptrCount() const = 0;
-    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-    virtual void incrementPtrCount() const = 0;
-    virtual void decrementPtrCount() const = 0;
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -75,10 +75,10 @@ public:
     }
 
     // CanMakeCheckedPtr.
-    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
 
 private:
     void postExceptionToWorkerObject(const String&, int, int, const String&) final { };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -100,10 +100,10 @@ public:
 
     WEBCORE_EXPORT void setInspectable(bool);
 
-    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::decrementCheckedPtrCount(); }
 
 private:
     WEBCORE_EXPORT ServiceWorkerThreadProxy(Ref<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -61,10 +61,10 @@ public:
     bool isTerminatingOrTerminated() const { return m_isTerminatingOrTerminated; }
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
 
-    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::decrementCheckedPtrCount(); }
 
 private:
     WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -98,10 +98,10 @@ private:
     XMLDocumentParser(DocumentFragment&, HashMap<AtomString, AtomString>&&, const AtomString&, OptionSet<ParserContentPolicy>);
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void insert(SegmentedString&&) final;
     void append(RefPtr<StringImpl>&&) final;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -76,10 +76,10 @@ public:
         virtual ~Client() { }
 
         // CheckedPtr interface
-        virtual uint32_t ptrCount() const = 0;
-        virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-        virtual void incrementPtrCount() const = 0;
-        virtual void decrementPtrCount() const = 0;
+        virtual uint32_t checkedPtrCount() const = 0;
+        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+        virtual void incrementCheckedPtrCount() const = 0;
+        virtual void decrementCheckedPtrCount() const = 0;
 
         virtual void didCreateDownload() = 0;
         virtual void didDestroyDownload() = 0;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -148,10 +148,10 @@ public:
     static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);
     virtual ~NetworkConnectionToWebProcess();
 
-    using IPC::Connection::Client::ptrCount;
-    using IPC::Connection::Client::ptrCountWithoutThreadCheck;
-    using IPC::Connection::Client::incrementPtrCount;
-    using IPC::Connection::Client::decrementPtrCount;
+    using IPC::Connection::Client::checkedPtrCount;
+    using IPC::Connection::Client::checkedPtrCountWithoutThreadCheck;
+    using IPC::Connection::Client::incrementCheckedPtrCount;
+    using IPC::Connection::Client::decrementCheckedPtrCount;
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess); }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -156,10 +156,10 @@ public:
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Network;
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     template <typename T>
     T* supplement()

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -77,10 +77,10 @@ public:
     USING_CAN_MAKE_WEAKPTR(ResponsivenessTimer::Client);
 
     // ProcessLauncher::Client
-    uint32_t ptrCount() const final { return IPC::Connection::Client::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return IPC::Connection::Client::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { IPC::Connection::Client::incrementPtrCount(); }
-    void decrementPtrCount() const final { IPC::Connection::Client::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return IPC::Connection::Client::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return IPC::Connection::Client::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { IPC::Connection::Client::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { IPC::Connection::Client::decrementCheckedPtrCount(); }
 
     virtual ~AuxiliaryProcessProxy();
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -67,10 +67,10 @@ public:
     virtual ~PlaybackSessionModelContext();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     // PlaybackSessionModel
     void addClient(WebCore::PlaybackSessionModelClient&) final;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -306,10 +306,10 @@ private:
     }
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void sourceStopped() final
     {

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -136,10 +136,10 @@ public:
 #endif
 
         // CanMakeCheckedPtr.
-        virtual uint32_t ptrCount() const = 0;
-        virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
-        virtual void incrementPtrCount() const = 0;
-        virtual void decrementPtrCount() const = 0;
+        virtual uint32_t checkedPtrCount() const = 0;
+        virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+        virtual void incrementCheckedPtrCount() const = 0;
+        virtual void decrementCheckedPtrCount() const = 0;
     };
 
     static Ref<ProcessLauncher> create(Client* client, LaunchOptions&& launchOptions)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -273,10 +273,10 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 public:
     virtual ~Internals();
 
-    uint32_t ptrCount() const { return WebPopupMenuProxy::Client::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const { return WebPopupMenuProxy::Client::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const { WebPopupMenuProxy::Client::incrementPtrCount(); }
-    void decrementPtrCount() const { WebPopupMenuProxy::Client::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const { return WebPopupMenuProxy::Client::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return WebPopupMenuProxy::Client::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { WebPopupMenuProxy::Client::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { WebPopupMenuProxy::Client::decrementCheckedPtrCount(); }
 
     WeakRef<WebPageProxy> page;
     OptionSet<WebCore::ActivityState> activityState;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -107,10 +107,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     WeakObjCPtr<WKFullScreenViewController> m_parent;
     RefPtr<WebCore::PlaybackSessionInterfaceIOS> m_interface;

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -49,10 +49,10 @@ public:
     ~WebPopupMenuProxyWin();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void showPopupMenu(const WebCore::IntRect&, WebCore::TextDirection, double pageScaleFactor, const Vector<WebPopupItem>&, const PlatformPopupMenuData&, int32_t selectedIndex) override;
     void hidePopupMenu() override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -101,10 +101,10 @@ public:
     virtual ~PDFPluginBase();
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementCheckedPtrCount(); }
 
     void startLoading();
     void destroy();

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -90,10 +90,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void sourceStopped() final
     {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -77,10 +77,10 @@ private:
     friend class VideoPresentationInterfaceContext;
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     // PlaybackSessionModelClient
     void durationChanged(double) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -107,10 +107,10 @@ private:
     void documentVisibilityChanged(bool) override;
 
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     void videoDimensionsChanged(const WebCore::FloatSize&) override;
     void setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier>) final;

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -52,67 +52,67 @@ TEST(WTF_CheckedPtr, Basic)
 {
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedPtr ptr { checkedObject.get() };
             EXPECT_TRUE(!!ptr);
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedPtr ptr = { checkedObject.get() };
         EXPECT_TRUE(!!ptr);
         EXPECT_EQ(ptr.get(), checkedObject.get());
         EXPECT_EQ(ptr->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         ptr = nullptr;
 
         EXPECT_FALSE(!!ptr);
         EXPECT_EQ(ptr.get(), nullptr);
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedPtr ptr1 { checkedObject.get() };
         EXPECT_TRUE(!!ptr1);
         EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr1->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
         const CheckedPtr ptr2 { checkedObject.get() };
         EXPECT_TRUE(!!ptr2);
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr2->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
 
         CheckedPtr ptr3 = ptr2;
         EXPECT_TRUE(!!ptr3);
         EXPECT_EQ(ptr3.get(), checkedObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 3u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 3u);
 
         ptr1 = nullptr;
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr3.get(), checkedObject.get());
 
         ptr1 = WTFMove(ptr3);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr3.get(), nullptr);
@@ -123,70 +123,70 @@ TEST(WTF_CheckedPtr, CheckedRef)
 {
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef ref { *checkedObject };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
             CheckedPtr ptr { ref };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef<DerivedCheckedObject> ref { *checkedObject };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
             CheckedPtr<CheckedObject> ptr { ref };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef ref { *checkedObject };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
             CheckedPtr ptr { WTFMove(ref) };
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef<DerivedCheckedObject> ref { *checkedObject };
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
             CheckedPtr<CheckedObject> ptr { WTFMove(ref) };
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 }
 
@@ -194,67 +194,67 @@ TEST(WTF_CheckedPtr, DerivedClass)
 {
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedPtr ptr = { checkedObject.get() };
             EXPECT_TRUE(!!ptr);
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedPtr<CheckedObject> ptr { checkedObject.get() };
         EXPECT_TRUE(!!ptr);
         EXPECT_EQ(ptr.get(), checkedObject.get());
         EXPECT_EQ(ptr->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         ptr = nullptr;
 
         EXPECT_FALSE(!!ptr);
         EXPECT_EQ(ptr.get(), nullptr);
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedPtr<DerivedCheckedObject> ptr1 { checkedObject.get() };
         EXPECT_TRUE(!!ptr1);
         EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr1->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
         const CheckedPtr<CheckedObject> ptr2 = ptr1;
         EXPECT_TRUE(!!ptr2);
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr2->someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
 
         CheckedPtr<CheckedObject> ptr3 = ptr1;
         EXPECT_TRUE(!!ptr3);
         EXPECT_EQ(ptr3.get(), checkedObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 3u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 3u);
 
         ptr1 = nullptr;
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr3.get(), checkedObject.get());
 
         CheckedPtr<CheckedObject> ptr4 = WTFMove(ptr3);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr3.get(), nullptr);
@@ -266,53 +266,53 @@ TEST(WTF_CheckedPtr, HashSet)
 {
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedPtr ptr = { checkedObject.get() };
         EXPECT_EQ(ptr.get(), checkedObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
         set.add(ptr);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
 
         ptr = nullptr;
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
     }
 
     {
         auto object1 = makeUnique<CheckedObject>();
         auto object2 = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(object1->ptrCount(), 0u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 0u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
         set.add(object1.get());
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
 
         set.add(object1.get());
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
 
         CheckedPtr<DerivedCheckedObject> ptr { object2.get() };
         set.add(ptr);
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 2u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 2u);
         ptr = nullptr;
 
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 1u);
 
         set.remove(object1.get());
-        EXPECT_EQ(object1->ptrCount(), 0u);
-        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_EQ(object1->checkedPtrCount(), 0u);
+        EXPECT_EQ(object2->checkedPtrCount(), 1u);
     }
 
     {
         Vector<std::unique_ptr<CheckedObject>> objects;
         objects.append(makeUnique<CheckedObject>());
-        EXPECT_EQ(objects[0]->ptrCount(), 0u);
+        EXPECT_EQ(objects[0]->checkedPtrCount(), 0u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
         set.add(objects[0].get());
@@ -327,12 +327,12 @@ TEST(WTF_CheckedPtr, HashSet)
         }
 
         for (auto& object : objects)
-            EXPECT_EQ(object->ptrCount(), 1u);
+            EXPECT_EQ(object->checkedPtrCount(), 1u);
 
         auto setVector = WTF::copyToVector(set);
 
         for (auto& object : objects)
-            EXPECT_EQ(object->ptrCount(), 2u);
+            EXPECT_EQ(object->checkedPtrCount(), 2u);
     }
 }
 
@@ -342,7 +342,7 @@ TEST(WTF_CheckedPtr, ReferenceCountLimit)
     constexpr unsigned count = 256 * 1024;
     Vector<CheckedPtr<CheckedObject>> ptrs;
     ptrs.fill(object.get(), count);
-    EXPECT_EQ(object->ptrCount(), count);
+    EXPECT_EQ(object->checkedPtrCount(), count);
 }
 
 class ThreadSafeCheckedPtrObject final : public CanMakeThreadSafeCheckedPtr<ThreadSafeCheckedPtrObject> {

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
@@ -65,71 +65,71 @@ TEST(WTF_CheckedRef, Basic)
 {
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef ref = *checkedObject;
             EXPECT_EQ(&ref.get(), checkedObject.get());
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -7);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
         auto anotherObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedRef ref = *checkedObject;
         EXPECT_EQ(ref.ptr(), checkedObject.get());
         EXPECT_EQ(ref->someFunction(), -7);
         EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
         ref = *anotherObject;
         EXPECT_EQ(ref.ptr(), anotherObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
     }
 
     {
         auto checkedObject = makeUnique<CheckedObject>();
         auto anotherObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         CheckedRef ref1 = *checkedObject;
         EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), -7);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
         const CheckedRef ref2 = *checkedObject;
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref2.get().someFunction(), -7);
         EXPECT_EQ(static_cast<const CheckedObject&>(ref2).someFunction(), -7);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
 
         CheckedRef ref3 = ref2;
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 3u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 3u);
 
         ref1 = *anotherObject;
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
         EXPECT_EQ(ref1.ptr(), anotherObject.get());
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
         ref1 = WTFMove(ref3);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
         EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
     }
@@ -139,66 +139,66 @@ TEST(WTF_CheckedRef, DerivedClass)
 {
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
         {
             CheckedRef ref = *checkedObject;
             EXPECT_EQ(&ref.get(), checkedObject.get());
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(static_cast<DerivedCheckedObject&>(ref).someFunction(), -11);
             EXPECT_EQ(ref->someFunction(), -11);
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>();
         auto anotherObject = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         CheckedRef<CheckedObject> ref = *checkedObject;
         EXPECT_EQ(ref.ptr(), checkedObject.get());
         EXPECT_EQ(ref->someFunction(), -11);
         EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -11);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         ref = *anotherObject;
         EXPECT_EQ(ref.ptr(), anotherObject.get());
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
     }
 
     {
         auto checkedObject = makeUnique<DerivedCheckedObject>(10);
         auto anotherObject = makeUnique<DerivedCheckedObject>(20);
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         CheckedRef<DerivedCheckedObject> ref1 = *checkedObject;
         EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), 10);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), 10);
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         const CheckedRef<CheckedObject> ref2 = ref1;
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref2->someFunction(), 10);
         EXPECT_EQ(static_cast<const CheckedObject&>(ref2).someFunction(), 10);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         CheckedRef<CheckedObject> ref3 = ref1;
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
         EXPECT_EQ(static_cast<CheckedObject&>(ref3).someFunction(), 10);
-        EXPECT_EQ(checkedObject->ptrCount(), 3u);
-        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 3u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
 
         ref1 = *anotherObject;
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
         EXPECT_EQ(ref1.ptr(), anotherObject.get());
         EXPECT_EQ(ref1->someFunction(), 20);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), 20);
@@ -206,8 +206,8 @@ TEST(WTF_CheckedRef, DerivedClass)
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
         CheckedRef<CheckedObject> ref4 = WTFMove(ref1);
-        EXPECT_EQ(checkedObject->ptrCount(), 2u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
         EXPECT_EQ(ref4.ptr(), anotherObject.get());
@@ -215,8 +215,8 @@ TEST(WTF_CheckedRef, DerivedClass)
         EXPECT_EQ(ref4->someFunction(), 20);
 
         ref1 = *checkedObject;
-        EXPECT_EQ(checkedObject->ptrCount(), 3u);
-        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 3u);
+        EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
         EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), 10);
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
@@ -228,56 +228,56 @@ TEST(WTF_CheckedRef, HashSet)
 {
     {
         auto checkedObject = makeUnique<CheckedObject>();
-        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
         {
             CheckedRef ref = *checkedObject;
             EXPECT_EQ(ref.ptr(), checkedObject.get());
-            EXPECT_EQ(checkedObject->ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
 
             set.add(ref);
-            EXPECT_EQ(checkedObject->ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
     }
 
     {
         auto object1 = makeUnique<CheckedObject>();
         auto object2 = makeUnique<DerivedCheckedObject>();
-        EXPECT_EQ(object1->ptrCount(), 0u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 0u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
         set.add(*object1);
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
         EXPECT_TRUE(set.contains(*object1));
         EXPECT_FALSE(set.contains(*object2));
 
         set.add(*object1);
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 0u);
         EXPECT_TRUE(set.contains(*object1));
         EXPECT_FALSE(set.contains(*object2));
 
         {
             CheckedRef<DerivedCheckedObject> ref { *object2 };
             set.add(ref);
-            EXPECT_EQ(object1->ptrCount(), 1u);
-            EXPECT_EQ(object2->ptrCount(), 2u);
+            EXPECT_EQ(object1->checkedPtrCount(), 1u);
+            EXPECT_EQ(object2->checkedPtrCount(), 2u);
             EXPECT_TRUE(set.contains(*object1));
             EXPECT_TRUE(set.contains(*object2));
         }
 
-        EXPECT_EQ(object1->ptrCount(), 1u);
-        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_EQ(object1->checkedPtrCount(), 1u);
+        EXPECT_EQ(object2->checkedPtrCount(), 1u);
         EXPECT_TRUE(set.contains(*object1));
         EXPECT_TRUE(set.contains(*object2));
 
         set.remove(*object1);
-        EXPECT_EQ(object1->ptrCount(), 0u);
-        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_EQ(object1->checkedPtrCount(), 0u);
+        EXPECT_EQ(object2->checkedPtrCount(), 1u);
         EXPECT_FALSE(set.contains(*object1));
         EXPECT_TRUE(set.contains(*object2));
     }
@@ -285,7 +285,7 @@ TEST(WTF_CheckedRef, HashSet)
     {
         Vector<std::unique_ptr<CheckedObject>> objects;
         objects.append(makeUnique<CheckedObject>(0));
-        EXPECT_EQ(objects[0]->ptrCount(), 0u);
+        EXPECT_EQ(objects[0]->checkedPtrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
         set.add(*objects[0].get());
@@ -300,7 +300,7 @@ TEST(WTF_CheckedRef, HashSet)
         }
 
         for (auto& object : objects) {
-            EXPECT_EQ(object->ptrCount(), 1u);
+            EXPECT_EQ(object->checkedPtrCount(), 1u);
             EXPECT_TRUE(set.contains(*object));
         }
 
@@ -314,7 +314,7 @@ TEST(WTF_CheckedRef, HashSet)
         auto setVector = WTF::copyToVector(set);
 
         for (auto& object : objects)
-            EXPECT_EQ(object->ptrCount(), 2u);
+            EXPECT_EQ(object->checkedPtrCount(), 2u);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -95,10 +95,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
     Vector<String> m_headers;
     Vector<uint8_t> m_data;


### PR DESCRIPTION
#### 1a981cca81c6b9825b101875b4c59e9ed238425a
<pre>
Rename some of the CanMakeCheckedPtrBase member functions to make their names less generic
<a href="https://bugs.webkit.org/show_bug.cgi?id=282459">https://bugs.webkit.org/show_bug.cgi?id=282459</a>

Reviewed by Ryosuke Niwa.

Rename some of the CanMakeCheckedPtrBase member functions to make their
names less generic. This is important since their existence is checked
by the `HasCheckedPtrMethods` type trait and given that many classes
need to define their own implementation.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::refIfNotNull):
(WTF::CheckedPtr::derefIfNotNull):
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::~CheckedRef):
(WTF::CheckedRef::CheckedRef):
(WTF::CheckedRef::ptr const):
(WTF::CanMakeCheckedPtrBase::checkedPtrCount const):
(WTF::CanMakeCheckedPtrBase::incrementCheckedPtrCount const):
(WTF::CanMakeCheckedPtrBase::decrementCheckedPtrCount const):
(WTF::CanMakeCheckedPtrBase::checkedPtrCountWithoutThreadCheck const):
(WTF::CanMakeCheckedPtrBase::ptrCount const): Deleted.
(WTF::CanMakeCheckedPtrBase::incrementPtrCount const): Deleted.
(WTF::CanMakeCheckedPtrBase::decrementPtrCount const): Deleted.
(WTF::CanMakeCheckedPtrBase::ptrCountWithoutThreadCheck const): Deleted.
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/TypeTraits.h:
* Source/WebCore/Modules/badge/WorkerBadgeProxy.h:
* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
(WebCore::AudioWorkletMessagingProxy::checkedPtrCount const):
(WebCore::AudioWorkletMessagingProxy::checkedPtrCountWithoutThreadCheck const):
(WebCore::AudioWorkletMessagingProxy::incrementCheckedPtrCount const):
(WebCore::AudioWorkletMessagingProxy::decrementCheckedPtrCount const):
(WebCore::AudioWorkletMessagingProxy::ptrCount const): Deleted.
(WebCore::AudioWorkletMessagingProxy::ptrCountWithoutThreadCheck const): Deleted.
(WebCore::AudioWorkletMessagingProxy::incrementPtrCount const): Deleted.
(WebCore::AudioWorkletMessagingProxy::decrementPtrCount const): Deleted.
* Source/WebCore/dom/PendingScriptClient.h:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/platform/PopupMenuClient.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
* Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
(WebCore::PlaybackSessionInterfaceIOS::checkedPtrCount const):
(WebCore::PlaybackSessionInterfaceIOS::checkedPtrCountWithoutThreadCheck const):
(WebCore::PlaybackSessionInterfaceIOS::incrementCheckedPtrCount const):
(WebCore::PlaybackSessionInterfaceIOS::decrementCheckedPtrCount const):
(WebCore::PlaybackSessionInterfaceIOS::ptrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::ptrCountWithoutThreadCheck const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::incrementPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceIOS::decrementPtrCount const): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::checkedPtrCount const):
(WebCore::PlaybackSessionInterfaceMac::checkedPtrCountWithoutThreadCheck const):
(WebCore::PlaybackSessionInterfaceMac::incrementCheckedPtrCount const):
(WebCore::PlaybackSessionInterfaceMac::decrementCheckedPtrCount const):
(WebCore::PlaybackSessionInterfaceMac::ptrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::ptrCountWithoutThreadCheck const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::incrementPtrCount const): Deleted.
(WebCore::PlaybackSessionInterfaceMac::decrementPtrCount const): Deleted.
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h:
* Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h:
* Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h:
* Source/WebCore/platform/network/curl/CurlRequest.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/workers/WorkerDebuggerProxy.h:
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerReportingProxy.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
(TestWebKitAPI::TEST(WTF_CheckedPtr, Basic)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, CheckedRef)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, DerivedClass)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, HashSet)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, ReferenceCountLimit)):
* Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp:

Canonical link: <a href="https://commits.webkit.org/286041@main">https://commits.webkit.org/286041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0de24a7fc72446fda2fb62286ab30d296ae66d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16891 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24124 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67690 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80497 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73811 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1104 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66159 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8239 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/95592 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11515 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4622 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1863 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->