### PR TITLE
Updated bindings expectations after 286022@main

### DIFF
--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
@@ -59,6 +59,7 @@
 #include "JSTestInterface.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -400,3 +401,4 @@ DOMWindow* JSDOMWindow::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -195,3 +196,4 @@ void JSDedicatedWorkerGlobalScope::analyzeHeap(JSCell* cell, HeapAnalyzer& analy
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
@@ -46,6 +46,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -296,3 +297,4 @@ ExposedStar* JSExposedStar::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -324,3 +325,4 @@ ExposedToWorkerAndWindow* JSExposedToWorkerAndWindow::toWrapped(JSC::VM&, JSC::J
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -194,3 +195,4 @@ void JSPaintWorkletGlobalScope::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -194,3 +195,4 @@ void JSServiceWorkerGlobalScope::analyzeHeap(JSCell* cell, HeapAnalyzer& analyze
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
@@ -46,6 +46,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -192,3 +193,4 @@ ShadowRealmGlobalScope* JSShadowRealmGlobalScope::toWrapped(JSC::VM&, JSC::JSVal
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -195,3 +196,4 @@ void JSSharedWorkerGlobalScope::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -342,3 +343,4 @@ TestAsyncIterable* JSTestAsyncIterable::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -343,3 +344,4 @@ TestAsyncKeyValueIterable* JSTestAsyncKeyValueIterable::toWrapped(JSC::VM&, JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
@@ -53,6 +53,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -516,3 +517,4 @@ TestCEReactions* JSTestCEReactions::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
@@ -46,6 +46,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -336,3 +337,4 @@ TestCEReactionsStringifier* JSTestCEReactionsStringifier::toWrapped(JSC::VM&, JS
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -59,6 +59,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -596,3 +597,4 @@ TestCallTracer* JSTestCallTracer::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
@@ -43,6 +43,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -244,3 +245,4 @@ TestClassWithJSBuiltinConstructor* JSTestClassWithJSBuiltinConstructor::toWrappe
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
@@ -64,6 +64,7 @@
 #include <JavaScriptCore/JSArray.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -865,3 +866,4 @@ TestConditionalIncludes* JSTestConditionalIncludes::toWrapped(JSC::VM&, JSC::JSV
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
@@ -50,6 +50,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -537,3 +538,4 @@ TestConditionallyReadWrite* JSTestConditionallyReadWrite::toWrapped(JSC::VM&, JS
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
@@ -57,6 +57,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -1272,3 +1273,4 @@ void JSTestDOMJIT::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
@@ -67,6 +67,7 @@
 #include "JSTestDefaultToJSONEnum.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -904,3 +905,4 @@ TestDefaultToJSON* JSTestDefaultToJSON::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
@@ -49,6 +49,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -340,3 +341,4 @@ TestDefaultToJSONFilteredByExposed* JSTestDefaultToJSONFilteredByExposed::toWrap
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
@@ -41,6 +41,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -177,3 +178,4 @@ void JSTestDefaultToJSONIndirectInheritance::analyzeHeap(JSCell* cell, HeapAnaly
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
@@ -63,6 +63,7 @@
 #include "JSTestDefaultToJSONEnum.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -310,3 +311,4 @@ void JSTestDefaultToJSONInherit::analyzeHeap(JSCell* cell, HeapAnalyzer& analyze
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
@@ -63,6 +63,7 @@
 #include "JSTestDefaultToJSONEnum.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -352,3 +353,4 @@ void JSTestDefaultToJSONInheritFinal::analyzeHeap(JSCell* cell, HeapAnalyzer& an
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -318,3 +319,4 @@ TestDelegateToSharedSyntheticAttribute* JSTestDelegateToSharedSyntheticAttribute
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
@@ -52,6 +52,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -393,3 +394,4 @@ TestDomainSecurity* JSTestDomainSecurity::toWrapped(JSC::VM&, JSC::JSValue value
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
@@ -53,6 +53,7 @@
 #include "JSDOMConvertBase.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -542,3 +543,4 @@ TestEnabledBySetting* JSTestEnabledBySetting::toWrapped(JSC::VM&, JSC::JSValue v
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -262,3 +263,4 @@ TestEnabledForContext* JSTestEnabledForContext::toWrapped(JSC::VM&, JSC::JSValue
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -46,6 +46,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -373,3 +374,4 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -444,3 +445,4 @@ TestEventTarget* JSTestEventTarget::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -255,3 +256,4 @@ TestException* JSTestException::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -267,3 +268,4 @@ TestGenerateAddOpaqueRoot* JSTestGenerateAddOpaqueRoot::toWrapped(JSC::VM&, JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -267,3 +268,4 @@ TestGenerateIsReachable* JSTestGenerateIsReachable::toWrapped(JSC::VM&, JSC::JSV
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
@@ -135,6 +135,7 @@
 #include "TestGlobalObjectBuiltins.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -2308,3 +2309,4 @@ TestGlobalObject* JSTestGlobalObject::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -389,3 +390,4 @@ TestIndexedSetterNoIdentifier* JSTestIndexedSetterNoIdentifier::toWrapped(JSC::V
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -389,3 +390,4 @@ TestIndexedSetterThrowingException* JSTestIndexedSetterThrowingException::toWrap
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -423,3 +424,4 @@ TestIndexedSetterWithIdentifier* JSTestIndexedSetterWithIdentifier::toWrapped(JS
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -78,6 +78,7 @@
 #include <JavaScriptCore/JSArray.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -1280,5 +1281,6 @@ TestInterface* JSTestInterface::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(Condition1) || ENABLE(Condition2)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -255,3 +256,4 @@ TestInterfaceLeadingUnderscore* JSTestInterfaceLeadingUnderscore::toWrapped(JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -347,3 +348,4 @@ TestIterable* JSTestIterable::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
@@ -40,6 +40,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -231,3 +232,4 @@ JSC::GCClient::IsoSubspace* JSTestJSBuiltinConstructor::subspaceForImpl(JSC::VM&
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -309,3 +310,4 @@ TestLegacyFactoryFunction* JSTestLegacyFactoryFunction::toWrapped(JSC::VM&, JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
@@ -50,6 +50,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -410,5 +411,6 @@ TestLegacyNoInterfaceObject* JSTestLegacyNoInterfaceObject::toWrapped(JSC::VM&, 
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(Condition22) || ENABLE(Condition23)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -437,3 +438,4 @@ TestLegacyOverrideBuiltIns* JSTestLegacyOverrideBuiltIns::toWrapped(JSC::VM&, JS
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -440,3 +441,4 @@ TestMapLike* JSTestMapLike::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -454,3 +455,4 @@ TestMapLikeWithOverriddenOperations* JSTestMapLikeWithOverriddenOperations::toWr
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -474,3 +475,4 @@ TestNamedAndIndexedSetterNoIdentifier* JSTestNamedAndIndexedSetterNoIdentifier::
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -474,3 +475,4 @@ TestNamedAndIndexedSetterThrowingException* JSTestNamedAndIndexedSetterThrowingE
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -52,6 +52,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -535,3 +536,4 @@ TestNamedAndIndexedSetterWithIdentifier* JSTestNamedAndIndexedSetterWithIdentifi
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -403,3 +404,4 @@ TestNamedDeleterNoIdentifier* JSTestNamedDeleterNoIdentifier::toWrapped(JSC::VM&
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -403,3 +404,4 @@ TestNamedDeleterThrowingException* JSTestNamedDeleterThrowingException::toWrappe
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
@@ -50,6 +50,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -428,3 +429,4 @@ TestNamedDeleterWithIdentifier* JSTestNamedDeleterWithIdentifier::toWrapped(JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -420,3 +421,4 @@ TestNamedDeleterWithIndexedGetter* JSTestNamedDeleterWithIndexedGetter::toWrappe
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -413,3 +414,4 @@ TestNamedGetterCallWith* JSTestNamedGetterCallWith::toWrapped(JSC::VM&, JSC::JSV
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -413,3 +414,4 @@ TestNamedGetterNoIdentifier* JSTestNamedGetterNoIdentifier::toWrapped(JSC::VM&, 
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -440,3 +441,4 @@ TestNamedGetterWithIdentifier* JSTestNamedGetterWithIdentifier::toWrapped(JSC::V
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -432,3 +433,4 @@ TestNamedSetterNoIdentifier* JSTestNamedSetterNoIdentifier::toWrapped(JSC::VM&, 
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -432,3 +433,4 @@ TestNamedSetterThrowingException* JSTestNamedSetterThrowingException::toWrapped(
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
@@ -50,6 +50,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -465,3 +466,4 @@ TestNamedSetterWithIdentifier* JSTestNamedSetterWithIdentifier::toWrapped(JSC::V
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -52,6 +52,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -508,3 +509,4 @@ TestNamedSetterWithIndexedGetter* JSTestNamedSetterWithIndexedGetter::toWrapped(
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -52,6 +52,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -563,3 +564,4 @@ TestNamedSetterWithIndexedGetterAndSetter* JSTestNamedSetterWithIndexedGetterAnd
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -408,3 +409,4 @@ TestNamedSetterWithLegacyOverrideBuiltIns* JSTestNamedSetterWithLegacyOverrideBu
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -493,3 +494,4 @@ TestNamedSetterWithLegacyUnforgeableProperties* JSTestNamedSetterWithLegacyUnfor
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -469,3 +470,4 @@ TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* JSTestN
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
@@ -39,6 +39,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -101,3 +102,4 @@ JSC::GCClient::IsoSubspace* JSTestNamespaceConst::subspaceForImpl(JSC::VM& vm)
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
@@ -56,6 +56,7 @@
 #include "TestNamespaceObjectImpl.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -284,3 +285,4 @@ JSC::GCClient::IsoSubspace* JSTestNamespaceObject::subspaceForImpl(JSC::VM& vm)
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -58,6 +58,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -539,3 +540,4 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -128,6 +128,7 @@
 #include "TestObjBuiltins.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -10023,3 +10024,4 @@ TestObj* JSTestObj::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
@@ -51,6 +51,7 @@
 #include "JSDOMConvertBase.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -302,5 +303,6 @@ TestOperationConditional* JSTestOperationConditional::toWrapped(JSC::VM&, JSC::J
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(ConditionDerived)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
@@ -49,6 +49,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -378,3 +379,4 @@ TestOverloadedConstructors* JSTestOverloadedConstructors::toWrapped(JSC::VM&, JS
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -313,3 +314,4 @@ TestOverloadedConstructorsWithSequence* JSTestOverloadedConstructorsWithSequence
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
@@ -46,6 +46,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -346,3 +347,4 @@ TestPluginInterface* JSTestPluginInterface::toWrapped(JSC::VM&, JSC::JSValue val
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -50,6 +50,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -355,3 +356,4 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -376,3 +377,4 @@ TestReadOnlyMapLike* JSTestReadOnlyMapLike::toWrapped(JSC::VM&, JSC::JSValue val
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -354,3 +355,4 @@ TestReadOnlySetLike* JSTestReadOnlySetLike::toWrapped(JSC::VM&, JSC::JSValue val
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
@@ -42,6 +42,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -263,3 +264,4 @@ TestReportExtraMemoryCost* JSTestReportExtraMemoryCost::toWrapped(JSC::VM&, JSC:
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
@@ -47,6 +47,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -269,3 +270,4 @@ TestScheduledAction* JSTestScheduledAction::toWrapped(JSC::VM&, JSC::JSValue val
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
@@ -56,6 +56,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -434,5 +435,6 @@ TestSerializedScriptValueInterface* JSTestSerializedScriptValueInterface::toWrap
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(Condition1) || ENABLE(Condition2)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -48,6 +48,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -414,3 +415,4 @@ TestSetLike* JSTestSetLike::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -51,6 +51,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -426,3 +427,4 @@ TestSetLikeWithOverriddenOperations* JSTestSetLikeWithOverriddenOperations::toWr
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -260,3 +261,4 @@ TestStringifier* JSTestStringifier::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -260,3 +261,4 @@ TestStringifierAnonymousOperation* JSTestStringifierAnonymousOperation::toWrappe
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -277,3 +278,4 @@ TestStringifierNamedOperation* JSTestStringifierNamedOperation::toWrapped(JSC::V
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -277,3 +278,4 @@ TestStringifierOperationImplementedAs* JSTestStringifierOperationImplementedAs::
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -260,3 +261,4 @@ TestStringifierOperationNamedToString* JSTestStringifierOperationNamedToString::
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -276,3 +277,4 @@ TestStringifierReadOnlyAttribute* JSTestStringifierReadOnlyAttribute::toWrapped(
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
@@ -45,6 +45,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -297,3 +298,4 @@ TestStringifierReadWriteAttribute* JSTestStringifierReadWriteAttribute::toWrappe
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
@@ -42,6 +42,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -238,3 +239,4 @@ TestTaggedWrapper* JSTestTaggedWrapper::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -66,6 +66,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -882,3 +883,4 @@ TestTypedefs* JSTestTypedefs::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
@@ -49,6 +49,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -282,3 +283,4 @@ WorkerGlobalScope* JSWorkerGlobalScope::toWrapped(JSC::VM&, JSC::JSValue value)
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
@@ -44,6 +44,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 using namespace JSC;
@@ -196,3 +197,4 @@ WorkletGlobalScope* JSWorkletGlobalScope::toWrapped(JSC::VM&, JSC::JSValue value
 }
 
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 0d723d86354d898759715cee796b6f2d818dc9d8
<pre>
Updated bindings expectations after 286022@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=282461">https://bugs.webkit.org/show_bug.cgi?id=282461</a>
<a href="https://rdar.apple.com/139094305">rdar://139094305</a>

Unreviewed, build fix.

Added unsafe-buffer-usage skip markers to expected results.

* Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp:

Canonical link: <a href="https://commits.webkit.org/286024@main">https://commits.webkit.org/286024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4c90097e37e1080f666c40b8a893813c82725b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74563 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/53992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/25801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76680 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/63125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/1777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/78971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/25801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77630 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/63125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/78971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/63125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/63125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/1880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/1777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/80473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/2028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/80473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/27374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11503 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/1845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/1873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/1953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/1880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->