### PR TITLE
Migrate NSURLCredential from WKKeyedCoder

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -237,6 +237,14 @@ typedef enum {
 @property (nonatomic, readwrite) BOOL _overrideSessionCookieAcceptPolicy;
 @end
 
+typedef CF_ENUM(int, CFURLCredentialPersistence)
+{
+    kCFURLCredentialPersistenceNone = 1,
+    kCFURLCredentialPersistenceForSession = 2,
+    kCFURLCredentialPersistencePermanent = 3,
+    kCFURLCredentialPersistenceSynchronizable = 4
+};
+
 @interface NSURLCredentialStorage ()
 - (id)_initWithIdentifier:(NSString *)identifier private:(bool)isPrivate;
 @end
@@ -444,6 +452,17 @@ enum : NSUInteger {
 #endif // defined(__OBJC__)
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+enum URLCredentialType {
+    kURLCredentialInternetPassword = 0,
+    kURLCredentialServerTrust,
+    kURLCredentialKerberosTicket,
+    kURLCredentialClientCertificate,
+    kURLCredentialXMobileMeAuthToken,
+    kURLCredentialUnknown,
+    kURLCredentialOAuth2,
+    kURLCredentialOAuth1
+};
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
@@ -29,6 +29,7 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
@@ -26,9 +26,252 @@
 #import "config.h"
 #import "CoreIPCNSURLCredential.h"
 
+#import <pal/spi/cf/CFNetworkSPI.h>
+
+@interface NSURLCredential(WKSecureCoding)
+- (NSDictionary *)_webKitPropertyListData;
+- (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
+#define SET_MDATA(NAME, CLASS, WRAPPER)     \
+    id NAME = dict[@#NAME];                 \
+    if ([NAME isKindOfClass:CLASS.class]) { \
+        auto var = WRAPPER(NAME);           \
+        m_data.NAME = WTFMove(var);         \
+    }
+
 namespace WebKit {
 
-#if !HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
+#if HAVE(WK_SECURE_CODING_NSURLCREDENTIAL)
+CoreIPCNSURLCredential::CoreIPCNSURLCredential(NSURLCredential *credential)
+{
+    auto dict = [credential _webKitPropertyListData];
+
+    NSNumber *persistence = dict[@"persistence"];
+    if ([persistence isKindOfClass:NSNumber.class]) {
+        switch ([persistence unsignedCharValue]) {
+        case kCFURLCredentialPersistenceNone:
+            m_data.persistence = CoreIPCNSURLCredentialPersistence::None;
+            break;
+        case kCFURLCredentialPersistenceForSession:
+            m_data.persistence = CoreIPCNSURLCredentialPersistence::Session;
+            break;
+        case kCFURLCredentialPersistencePermanent:
+            m_data.persistence = CoreIPCNSURLCredentialPersistence::Permanent;
+            break;
+        case kCFURLCredentialPersistenceSynchronizable:
+            m_data.persistence = CoreIPCNSURLCredentialPersistence::Synchronizable;
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            m_data.persistence = CoreIPCNSURLCredentialPersistence::None;
+            break;
+        }
+    }
+    SET_MDATA(user, NSString, CoreIPCString);
+    SET_MDATA(password, NSString, CoreIPCString);
+
+    NSDictionary *attributes = dict[@"attributes"];
+    if ([attributes isKindOfClass:NSDictionary.class]) {
+        Vector<CoreIPCNSURLCredentialData::Attributes> vector;
+        vector.reserveCapacity(attributes.count);
+        for (id key in attributes) {
+            if (![key isKindOfClass:NSString.class]) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+            id value = [attributes objectForKey:key];
+            if (![value isKindOfClass:NSString.class] || ![value isKindOfClass:NSNumber.class] || ![value isKindOfClass:NSDate.class]) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+            std::optional<std::variant<CoreIPCNumber, CoreIPCString, CoreIPCDate>> option;
+            if ([value isKindOfClass:NSString.class])
+                option = CoreIPCString(value);
+            if ([value isKindOfClass:NSNumber.class])
+                option = CoreIPCNumber(value);
+            if ([value isKindOfClass:NSDate.class])
+                option = CoreIPCDate(value);
+            if (option) {
+                auto k = CoreIPCString(key);
+                vector.append(std::make_pair(WTFMove(k), WTFMove(*option)));
+            }
+        }
+        m_data.attributes = WTFMove(vector);
+    }
+
+    SET_MDATA(identifier, NSString, CoreIPCString);
+
+    NSNumber *useKeychain = dict[@"useKeychain"];
+    if ([useKeychain isKindOfClass:NSNumber.class])
+        m_data.useKeychain = [useKeychain boolValue];
+
+    SecTrustRef secTrust = static_cast<SecTrustRef>(dict[@"trust"]);
+    if (secTrust && CFGetTypeID(secTrust) == SecTrustGetTypeID())
+        m_data.trust = CoreIPCSecTrust(secTrust);
+
+    SET_MDATA(service, NSString, CoreIPCString);
+
+    NSDictionary *flags = dict[@"flags"];
+    if ([flags isKindOfClass:NSDictionary.class]) {
+        Vector<WebKit::CoreIPCNSURLCredentialData::Flags> vector;
+        vector.reserveCapacity(flags.count);
+        for (NSString *key in attributes) {
+            if (![key isKindOfClass:NSString.class]) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+            NSString *value = [flags objectForKey:key];
+            if (![value isKindOfClass:NSString.class]) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+            auto k = CoreIPCString(key);
+            auto v = CoreIPCString(value);
+            vector.append(std::make_pair(WTFMove(k), WTFMove(v)));
+        }
+        m_data.flags = WTFMove(vector);
+    }
+
+    SET_MDATA(uuid, NSString, CoreIPCString);
+    SET_MDATA(appleID, NSString, CoreIPCString);
+    SET_MDATA(realm, NSString, CoreIPCString);
+    SET_MDATA(token, NSString, CoreIPCString);
+
+    NSNumber *type = dict[@"type"];
+    if ([type isKindOfClass:NSNumber.class]) {
+        switch ([type intValue]) {
+        case kURLCredentialInternetPassword:
+            m_data.type = CoreIPCNSURLCredentialType::Password;
+            break;
+        case kURLCredentialServerTrust:
+            m_data.type = CoreIPCNSURLCredentialType::ServerTrust;
+            break;
+        case kURLCredentialKerberosTicket:
+            m_data.type = CoreIPCNSURLCredentialType::KerberosTicket;
+            break;
+        case kURLCredentialXMobileMeAuthToken:
+            m_data.type = CoreIPCNSURLCredentialType::XMobileMeAuthToken;
+            break;
+        case kURLCredentialOAuth2:
+            m_data.type = CoreIPCNSURLCredentialType::OAuth2;
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            m_data.type = CoreIPCNSURLCredentialType::Password;
+            break;
+        }
+    }
+}
+
+CoreIPCNSURLCredential::CoreIPCNSURLCredential(CoreIPCNSURLCredentialData&& data)
+    : m_data(WTFMove(data)) { }
+
+RetainPtr<id> CoreIPCNSURLCredential::toID() const
+{
+    auto dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:7]);
+
+    RetainPtr<NSNumber> persistence;
+    switch (m_data.persistence) {
+    case CoreIPCNSURLCredentialPersistence::None:
+        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceNone]);
+        break;
+    case CoreIPCNSURLCredentialPersistence::Session:
+        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceForSession]);
+        break;
+    case CoreIPCNSURLCredentialPersistence::Permanent:
+        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistencePermanent]);
+        break;
+    case CoreIPCNSURLCredentialPersistence::Synchronizable:
+        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceSynchronizable]);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceNone]);
+        break;
+    }
+    [dict setObject:persistence.get() forKey:@"persistence"];
+
+    switch (m_data.type) {
+    case CoreIPCNSURLCredentialType::Password:
+        [dict setObject:@(kURLCredentialInternetPassword) forKey:@"type"];
+        if (m_data.user)
+            [dict setObject:(*m_data.user).toID().get() forKey:@"user"];
+        if (m_data.password)
+            [dict setObject:(*m_data.password).toID().get() forKey:@"password"];
+        if (m_data.attributes) {
+            RetainPtr attributes = adoptNS([[NSMutableDictionary alloc] initWithCapacity:(*m_data.attributes).size()]);
+            for (auto& attributePair : *m_data.attributes) {
+                RetainPtr<id> value;
+                WTF::switchOn(attributePair.second,
+                    [&] (const CoreIPCNumber& n) {
+                        value = n.toID();
+                    },
+                    [&] (const CoreIPCString& s) {
+                        value = s.toID();
+                    },
+                    [&] (const CoreIPCDate& d) {
+                        value = d.toID();
+                    }
+                );
+                [attributes setObject:attributes.get() forKey:attributePair.first.toID().get()];
+            }
+            [dict setObject:attributes.get() forKey:@"attributes"];
+        }
+        if (m_data.identifier)
+            [dict setObject:(*m_data.identifier).toID().get() forKey:@"identifier"];
+        if (m_data.useKeychain)
+            [dict setObject:[NSNumber numberWithBool:(*m_data.useKeychain)] forKey:@"useKeychain"];
+        break;
+    case CoreIPCNSURLCredentialType::ServerTrust: {
+        RetainPtr<SecTrustRef> trust = m_data.trust.createSecTrust();
+        if (trust) {
+            [dict setObject:@(kURLCredentialServerTrust) forKey:@"type"];
+            [dict setObject:(id)trust.get() forKey:@"trust"];
+        }
+        break;
+    }
+    case CoreIPCNSURLCredentialType::KerberosTicket:
+        [dict setObject:@(kURLCredentialKerberosTicket) forKey:@"type"];
+        if (m_data.user)
+            [dict setObject:(*m_data.user).toID().get() forKey:@"user"];
+        if (m_data.service)
+            [dict setObject:(*m_data.service).toID().get() forKey:@"service"];
+        if (m_data.uuid)
+            [dict setObject:(*m_data.uuid).toID().get() forKey:@"uuid"];
+        if (m_data.flags) {
+            auto flags = adoptNS([[NSMutableDictionary alloc] initWithCapacity:(*m_data.flags).size()]);
+            for (auto& flagPair : *m_data.flags)
+                [flags setObject: flagPair.second.toID().get() forKey:flagPair.first.toID().get()];
+            [dict setObject:flags.get() forKey:@"flags"];
+        }
+        break;
+    case CoreIPCNSURLCredentialType::XMobileMeAuthToken:
+        [dict setObject:@(kURLCredentialXMobileMeAuthToken) forKey:@"type"];
+        if (m_data.appleID)
+            [dict setObject:(*m_data.appleID).toID().get() forKey:@"appleid"];
+        if (m_data.password)
+            [dict setObject:(*m_data.password).toID().get() forKey:@"password"];
+        if (m_data.realm)
+            [dict setObject:(*m_data.realm).toID().get() forKey:@"realm"];
+        break;
+    case CoreIPCNSURLCredentialType::OAuth2:
+        [dict setObject:@(kURLCredentialOAuth2) forKey:@"type"];
+        if (m_data.token)
+            [dict setObject:(*m_data.token).toID().get() forKey:@"token"];
+        if (m_data.realm)
+            [dict setObject:(*m_data.realm).toID().get() forKey:@"realm"];
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return adoptNS([[NSURLCredential alloc] _initWithWebKitPropertyListData:dict.get()]);
+}
+#endif
+
+#if !HAVE(WK_SECURE_CODING_NSURLCREDENTIAL) && !HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
 
 CoreIPCNSURLCredential::CoreIPCNSURLCredential(NSURLCredential *credential)
     : m_serializedBytes([NSKeyedArchiver archivedDataWithRootObject:credential requiringSecureCoding:YES error:nil]) { }
@@ -41,3 +284,5 @@ RetainPtr<id> CoreIPCNSURLCredential::toID() const
 #endif
 
 } // namespace WebKit
+
+#undef SET_MDATA

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in
@@ -20,13 +20,58 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
+#if HAVE(WK_SECURE_CODING_NSURLCREDENTIAL)
+webkit_platform_headers: "CoreIPCNSURLCredential.h"
+
+header: "CoreIPCNSURLCredential.h"
+[CustomHeader, WebKitPlatform] enum class WebKit::CoreIPCNSURLCredentialPersistence : uint8_t {
+    None,
+    Session,
+    Permanent,
+    Synchronizable
+};
+
+header: "CoreIPCNSURLCredential.h"
+[CustomHeader, WebKitPlatform] enum class WebKit::CoreIPCNSURLCredentialType : uint8_t {
+    Password,
+    ServerTrust,
+    KerberosTicket,
+    XMobileMeAuthToken,
+    OAuth2
+};
+
+using WebKit::CoreIPCNSURLCredentialData::Flags = std::pair<WebKit::CoreIPCString, WebKit::CoreIPCString>;
+using WebKit::CoreIPCNSURLCredentialData::Attributes = std::pair<WebKit::CoreIPCString, std::variant<WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCDate>>;
+
+header: "CoreIPCNSURLCredential.h"
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCNSURLCredentialData {
+    WebKit::CoreIPCNSURLCredentialPersistence persistence;
+    WebKit::CoreIPCNSURLCredentialType type;
+    std::optional<WebKit::CoreIPCString> user;
+    std::optional<WebKit::CoreIPCString> password;
+    std::optional<Vector<WebKit::CoreIPCNSURLCredentialData::Attributes>> attributes;
+    std::optional<WebKit::CoreIPCString> identifier;
+    std::optional<bool> useKeychain;
+    WebKit::CoreIPCSecTrust trust;
+    std::optional<WebKit::CoreIPCString> service;
+    std::optional<Vector<WebKit::CoreIPCNSURLCredentialData::Flags>> flags;
+    std::optional<WebKit::CoreIPCString> uuid;
+    std::optional<WebKit::CoreIPCString> appleID;
+    std::optional<WebKit::CoreIPCString> realm;
+    std::optional<WebKit::CoreIPCString> token;
+};
+[WebKitPlatform] class WebKit::CoreIPCNSURLCredential {
+    WebKit::CoreIPCNSURLCredentialData m_data
+}
+#endif
+
+#if !HAVE(WK_SECURE_CODING_NSURLCREDENTIAL) && HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
 [SupportWKKeyedCoder] webkit_secure_coding NSURLCredential {
     __nsurlcredential_proto_plist: Dictionary
 }
 #endif
 
-#if !HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
+#if !HAVE(WK_SECURE_CODING_NSURLCREDENTIAL) && !HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
 webkit_platform_headers: "CoreIPCNSURLCredential.h"
 [WebKitPlatform] class WebKit::CoreIPCNSURLCredential {
     RetainPtr<NSData> m_serializedBytes;

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.h
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.h
@@ -120,6 +120,7 @@ public:
     }
 
     CoreIPCNumber(const CoreIPCNumber& other) = default;
+    CoreIPCNumber& operator=(const CoreIPCNumber& other) = default;
 
     RetainPtr<CFNumberRef> createCFNumber() const
     {

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.h
@@ -38,6 +38,9 @@ namespace WebKit {
 
 class CoreIPCSecTrust {
 public:
+    CoreIPCSecTrust()
+        : m_trustData() { };
+
     CoreIPCSecTrust(SecTrustRef trust)
         : m_trustData(adoptCF(SecTrustSerialize(trust, NULL)))
     {

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1320,7 +1320,7 @@ TEST(IPCSerialization, Basic)
     runTestNS({ protectionSpace3.get() });
 
     runTestNS({ [NSURLCredential credentialForTrust:trust.get()] });
-#if HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)
+#if HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL) && !HAVE(WK_SECURE_CODING_NSURLCREDENTIAL)
     runTestNS({ [NSURLCredential credentialWithIdentity:identity.get() certificates:@[(id)cert.get()] persistence:NSURLCredentialPersistencePermanent] });
     runTestNS({ [NSURLCredential credentialWithIdentity:identity.get() certificates:nil persistence:NSURLCredentialPersistenceForSession] });
 #endif


### PR DESCRIPTION
#### 49bf33d6d4354a95f5abccfe7c2361f5aebc124d
<pre>
Migrate NSURLCredential from WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=282456">https://bugs.webkit.org/show_bug.cgi?id=282456</a>
<a href="https://rdar.apple.com/135824840">rdar://135824840</a>

Reviewed by Sihui Liu.

This change extracts NSURLCredential information for
Password, ServerTrust, Kerberos, MobileMe and OAuth2.
Client certificates are handled via AuthenticationManagerCocoa.mm

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDate.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm:
(WebKit::CoreIPCNSURLCredential::CoreIPCNSURLCredential):
(WebKit::CoreIPCNSURLCredential::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCNumber.h:
* Source/WebKit/Shared/cf/CoreIPCSecTrust.h:
(WebKit::CoreIPCSecTrust::CoreIPCSecTrust):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, Basic)):

Canonical link: <a href="https://commits.webkit.org/286450@main">https://commits.webkit.org/286450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de4ec28d847241cfa3de0a24ef4320062124c99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59453 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9060 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5951 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->