### PR TITLE
[bmalloc] Allow page-zeroing to be profiled

### DIFF
--- a/Source/bmalloc/bmalloc/AllocationCounts.h
+++ b/Source/bmalloc/bmalloc/AllocationCounts.h
@@ -110,3 +110,10 @@
 #define BENABLE_PROFILE_COMPACTIBLE_TRY_ALLOCATION 0
 #define BPROFILE_TRY_ALLOCATION_COMPACTIBLE(ptr, size) do { } while (false)
 #endif
+
+#ifdef BPROFILE_ZERO_FILL_PAGE
+#define BENABLE_PROFILE_ZERO_FILL_PAGE 1
+#else
+#define BENABLE_PROFILE_ZERO_FILL_PAGE 0
+#define BPROFILE_ZERO_FILL_PAGE(ptr, size, flags, tag) do { } while (false)
+#endif

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AllocationCounts.h"
 #include "BAssert.h"
 #include "BCompiler.h"
 #include "BSyscall.h"
@@ -154,9 +155,12 @@ inline void vmRevokePermissions(void* p, size_t vmSize)
 inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage = VMTag::Malloc)
 {
     vmValidate(p, vmSize);
+    int flags = MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE;
+    int tag = static_cast<int>(usage);
+    BPROFILE_ZERO_FILL_PAGE(p, vmSize, flags, tag);
     // MAP_ANON guarantees the memory is zeroed. This will also cause
     // page faults on accesses to this range following this call.
-    void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
+    void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, flags, tag, 0);
     RELEASE_BASSERT(result == p);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -185,12 +185,10 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
     PAS_ASSERT(pas_is_aligned((uintptr_t)base, page_size));
     PAS_ASSERT(pas_is_aligned(size, page_size));
 
-    result_ptr = mmap(base,
-                      size,
-                      PROT_READ | PROT_WRITE,
-                      MAP_PRIVATE | MAP_ANON | MAP_FIXED | PAS_NORESERVE,
-                      PAS_VM_TAG,
-                      0);
+    int flags = MAP_PRIVATE | MAP_ANON | MAP_FIXED | PAS_NORESERVE;
+    int tag = PAS_VM_TAG;
+    PAS_PROFILE(ZERO_FILL_PAGE, base, size, flags, tag);
+    result_ptr = mmap(base, size, PROT_READ | PROT_WRITE, flags, tag, 0);
     PAS_ASSERT(result_ptr == base);
 }
 


### PR DESCRIPTION
#### faa94828cacb7a576a19844940067423e90e096c
<pre>
[bmalloc] Allow page-zeroing to be profiled
<a href="https://bugs.webkit.org/show_bug.cgi?id=282466">https://bugs.webkit.org/show_bug.cgi?id=282466</a>
<a href="https://rdar.apple.com/139096094">rdar://139096094</a>

Reviewed by David Degazio.

Page zeroing can be an important contributor to performance degredation but
currently we have no way to track it. This patch fixes that by allowing
us to hook into the two places it happens.

* Source/bmalloc/bmalloc/VMAllocate.h:
(bmalloc::vmZeroAndPurge):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_zero_fill):

Canonical link: <a href="https://commits.webkit.org/286252@main">https://commits.webkit.org/286252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0af0634f5c5ddd452ad928fe36f8f35c0513c6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26366 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24690 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68257 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81043 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74373 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1506 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67234 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html webanimations/marker-opacity-animation-no-effect.html webanimations/relative-ordering-of-translate-and-rotate-properties-accelerated.html webanimations/relative-ordering-of-translate-and-scale-properties-accelerated.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8616 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96641 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11632 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2401 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21117 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->