### PR TITLE
[Cocoa] REGRESSION(284617@main): wantsEDR should not be set for RGB10 pixel format

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h
@@ -69,38 +69,6 @@ constexpr NSString *contentsFormatString(ContentsFormat contentsFormat)
     }
 }
 
-constexpr bool contentsFormatWantsExtendedDynamicRangeContent(ContentsFormat contentsFormat)
-{
-    switch (contentsFormat) {
-    case ContentsFormat::RGBA8:
-        return false;
-#if HAVE(IOSURFACE_RGB10)
-    case ContentsFormat::RGBA10:
-        return true;
-#endif
-#if HAVE(HDR_SUPPORT)
-    case ContentsFormat::RGBA16F:
-        return true;
-#endif
-    }
-}
-
-constexpr bool contentsFormatWantsToneMapMode(ContentsFormat contentsFormat)
-{
-    switch (contentsFormat) {
-    case ContentsFormat::RGBA8:
-        return false;
-#if HAVE(IOSURFACE_RGB10)
-    case ContentsFormat::RGBA10:
-        return false;
-#endif
-#if HAVE(HDR_SUPPORT)
-    case ContentsFormat::RGBA16F:
-        return true;
-#endif
-    }
-}
-
 } // namespace WebCore
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1138,10 +1138,13 @@ void PlatformCALayerCocoa::updateContentsFormat()
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         auto contentsFormat = this->contentsFormat();
 
-        [m_layer setContentsFormat:contentsFormatString(contentsFormat)];
+        if (NSString *formatString = contentsFormatString(contentsFormat))
+            [m_layer setContentsFormat:formatString];
 #if HAVE(HDR_SUPPORT)
-        [m_layer setWantsExtendedDynamicRangeContent:contentsFormatWantsExtendedDynamicRangeContent(contentsFormat)];
-        [m_layer setToneMapMode:contentsFormatWantsToneMapMode(contentsFormat) ? CAToneMapModeIfSupported : CAToneMapModeAutomatic];
+        if (contentsFormat == ContentsFormat::RGBA16F) {
+            [m_layer setWantsExtendedDynamicRangeContent:true];
+            [m_layer setToneMapMode:CAToneMapModeIfSupported];
+        }
 #endif
         END_BLOCK_OBJC_EXCEPTIONS
     }

--- a/Source/WebCore/platform/ios/LegacyTileGridTile.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGridTile.mm
@@ -63,7 +63,9 @@ LegacyTileGridTile::LegacyTileGridTile(LegacyTileGrid* tileGrid, const IntRect& 
         m_tileLayer = adoptNS([[LegacyTileLayer alloc] init]);
     }
     LegacyTileLayer* layer = m_tileLayer.get();
-    layer.contentsFormat = contentsFormatString(screenContentsFormat());
+
+    if (NSString *formatString = contentsFormatString(screenContentsFormat()))
+        layer.contentsFormat = formatString;
 
     [layer setTileGrid:tileGrid];
     [layer setOpaque:m_tileGrid->tileCache().tilesOpaque()];

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -321,10 +321,13 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 
     if (properties.changedProperties & LayerChange::ContentsFormatChanged) {
         auto contentsFormat = properties.contentsFormat;
-        [layer setContentsFormat:contentsFormatString(contentsFormat)];
+        if (NSString *formatString = contentsFormatString(contentsFormat))
+            [layer setContentsFormat:formatString];
 #if HAVE(HDR_SUPPORT)
-        [layer setWantsExtendedDynamicRangeContent:contentsFormatWantsExtendedDynamicRangeContent(contentsFormat)];
-        [layer setToneMapMode:contentsFormatWantsToneMapMode(contentsFormat) ? CAToneMapModeIfSupported : CAToneMapModeAutomatic];
+        if (contentsFormat == ContentsFormat::RGBA16F) {
+            [layer setWantsExtendedDynamicRangeContent:true];
+            [layer setToneMapMode:CAToneMapModeIfSupported];
+        }
 #endif
     }
 }


### PR DESCRIPTION
#### b3a7326fa62ff3c2d3b4fec872476179e390ef50
<pre>
[Cocoa] REGRESSION(284617@main): wantsEDR should not be set for RGB10 pixel format
<a href="https://bugs.webkit.org/show_bug.cgi?id=282470">https://bugs.webkit.org/show_bug.cgi?id=282470</a>
<a href="https://rdar.apple.com/138368953">rdar://138368953</a>

Reviewed by Simon Fraser.

284617@main added the call to setWantsExtendedDynamicRangeContent for the RGBA10
and RGBA16F pixel formats. It turned out this not needed for RGBA10 but it is
also very expensive. wantsEDR should be set only for RGBA16F.

* Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h:
(WebCore::contentsFormatWantsExtendedDynamicRangeContent): Deleted.
(WebCore::contentsFormatWantsToneMapMode): Deleted.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::updateContentsFormat):
* Source/WebCore/platform/ios/LegacyTileGridTile.mm:
(WebCore::LegacyTileGridTile::LegacyTileGridTile):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):

Canonical link: <a href="https://commits.webkit.org/286047@main">https://commits.webkit.org/286047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a25dab9ad59c724a78561b6c05266ec4e486f27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16900 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24166 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66872 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66160 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8257 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1877 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4664 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1905 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->