### PR TITLE
[de-duper] Too many links

### DIFF
--- a/Tools/CISupport/Shared/de-duper
+++ b/Tools/CISupport/Shared/de-duper
@@ -22,6 +22,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import errno
 import hashlib
 import os
 import sys
@@ -86,7 +87,7 @@ def main(args):
     de_duped = 0
     processed = 0
 
-    existing_links = set()
+    link_count = 0
     with os.scandir(args.storage) as existing_files:
         for existing_file in existing_files:
             if not existing_file.name.startswith('.') and existing_file.is_file():
@@ -96,16 +97,20 @@ def main(args):
             sha_value, extension = existing_file.name.split('.', 1)
             if extension != 'png':
                 continue
-            if not existing_file.inode() <= 1:
+            connected_to = existing_file.inode()
+            if connected_to <= 1:
                 if args.dry_run:
                     print(f'[dry-run] Removing {existing_file.path}')
                 else:
                     os.remove(existing_file.path)
                 cleaned_up += 1
             else:
-                existing_links.add(sha_value)
+                link_count += 1
 
     for root, _, files in os.walk(args.root, topdown=False):
+        if os.path.samefile(root, args.storage):
+            continue
+
         for file in files:
             if not file.endswith('.png'):
                 continue
@@ -114,12 +119,28 @@ def main(args):
             if os.stat(full_path).st_nlink > 1:
                 continue
             sha_value = sha1(full_path)
-            if sha_value in existing_links:
+            sha_path = os.path.join(args.storage, f'{sha_value}.png')
+            assert sha_path != full_path
+            if os.path.isfile(sha_path):
                 if args.dry_run:
                     print(f'[dry-run] Linking {full_path} to {sha_value}.png')
                 else:
-                    os.remove(full_path)
-                    os.link(os.path.join(args.storage, f'{sha_value}.png'), full_path)
+                    try:
+                        tempfile = os.path.join(root, f'{sha_value}.png')
+                        os.link(sha_path, tempfile)
+                        os.replace(tempfile, full_path)
+                    except OSError as e:
+                        if e.errno == errno.EMLINK:
+                            # sha_path already has LINK_MAX links, so create a copy of that file at
+                            # full_path, and create a new hard link within storage pointing at another
+                            # identical file. In practice, the previous network of hard-linked files will
+                            # slowly be deleted as old results are pruned.
+
+                            # We don't use os.replace here because we don't care if the reference file is deleted.
+                            os.remove(sha_path)
+                            os.link(full_path, sha_path)
+                        else:
+                            raise
                 de_duped += 1
             elif not sha_value:
                 print(f"Failed to compute SHA for '{full_path}'\n", file=sys.stderr)
@@ -127,10 +148,10 @@ def main(args):
                 if args.dry_run:
                     print(f'[dry-run] Storing and linking {full_path} to {sha_value}.png')
                 else:
-                    os.link(full_path, os.path.join(args.storage, f'{sha_value}.png'))
-                existing_links.add(sha_value)
+                    os.link(full_path, sha_path)
+                link_count += 1
 
-    print(f'{len(existing_links)} unique png files in storage of {processed} processed')
+    print(f'{link_count} unique png files in storage of {processed} processed')
     print(f'{cleaned_up} files removed, {de_duped} de-duped')
 
     return 0


### PR DESCRIPTION
#### dbef21b6b3541049e000ee180ae34ec600896d89
<pre>
[de-duper] Too many links
<a href="https://bugs.webkit.org/show_bug.cgi?id=282471">https://bugs.webkit.org/show_bug.cgi?id=282471</a>
<a href="https://rdar.apple.com/139101004">rdar://139101004</a>

Reviewed by Sam Sneddon.

* Tools/CISupport/Shared/de-duper:
(main): Don&apos;t try to link the storage directory to itself, and gracefully handle the maximum
number of file links.

Canonical link: <a href="https://commits.webkit.org/286617@main">https://commits.webkit.org/286617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c8b51c2b338599ebf345931f29fdce92cf58c61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76537 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/55572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78654 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/64714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/3865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/81064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79604 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/64714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/64714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/26137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/64714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/82513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/3913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/3865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/82513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/76214 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/4066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/82513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/29443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11841 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/3860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3883 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->