### PR TITLE
Implement scoped custom element registry

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-constructor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-constructor.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Create non-global CustomElementRegistry and add definitions Illegal constructor
+PASS Create non-global CustomElementRegistry and add definitions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-multi-register.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-multi-register.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Same constructor can be registered to different registries Illegal constructor
-FAIL Non-global registries still reject duplicate registrations of the same constructor Illegal constructor
+PASS Same constructor can be registered to different registries
+PASS Non-global registries still reject duplicate registrations of the same constructor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ShadowRoot.createElement() for autonomous custom element Illegal constructor
-FAIL ShadowRoot.createElementNS() for autonomous custom element Illegal constructor
-FAIL ShadowRoot.createElement() for customized built-in element Illegal constructor
-FAIL ShadowRoot.createElementNS() for customized built-in element Illegal constructor
+PASS ShadowRoot.createElement() for autonomous custom element
+PASS ShadowRoot.createElementNS() for autonomous custom element
+FAIL ShadowRoot.createElement() for customized built-in element assert_true: expected true got false
+FAIL ShadowRoot.createElementNS() for customized built-in element assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL ShadowRoot.registry is null if not explicitly specified assert_equals: expected (object) null but got (undefined) undefined
-FAIL Attach the global registry to a shadow root assert_equals: expected (object) object "[object CustomElementRegistry]" but got (undefined) undefined
-FAIL Attach a non-global registry to a shadow root Illegal constructor
-FAIL Attach the same registry to multiple shadow roots Illegal constructor
-FAIL Attaching registry to shadow root can only be done during initialization Illegal constructor
+PASS ShadowRoot.registry is null if not explicitly specified
+PASS Attach the global registry to a shadow root
+PASS Attach a non-global registry to a shadow root
+PASS Attach the same registry to multiple shadow roots
+PASS Attaching registry to shadow root can only be done during initialization
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt
@@ -1,7 +1,10 @@
+CONSOLE MESSAGE: TypeError: new.target does not define a custom element
 
-FAIL Upgrade into autonomous custom element when inserted via innerHTML Illegal constructor
-FAIL Upgrade into autonomous custom element when definition is added Illegal constructor
-FAIL Upgrade into customized built-in element when inserted via innerHTML Illegal constructor
-FAIL Upgrade into customized built-in element when definition is added Illegal constructor
-FAIL Upgrade into autonomous custom element should not inherit from global registry for missing values Illegal constructor
+Harness Error (FAIL), message = TypeError: new.target does not define a custom element
+
+PASS Upgrade into autonomous custom element when inserted via innerHTML
+PASS Upgrade into autonomous custom element when definition is added
+FAIL Upgrade into customized built-in element when inserted via innerHTML assert_true: target tree scope expected true got false
+FAIL Upgrade into customized built-in element when definition is added assert_true: target tree scope expected true got false
+PASS Upgrade into autonomous custom element should not inherit from global registry for missing values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-call.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-call.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Calling custom element constructor directly without global registration should fail Illegal constructor
-FAIL Calling custom element constructor directly uses global registration only Illegal constructor
+PASS Calling custom element constructor directly without global registration should fail
+PASS Calling custom element constructor directly uses global registration only
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt
@@ -1,6 +1,8 @@
+CONSOLE MESSAGE: TypeError: Cannot instantiate a custom element inside its own constructor during upgrades
+CONSOLE MESSAGE: TypeError: Cannot instantiate a custom element inside its own constructor during upgrades
 
-FAIL Re-entry via upgrade before calling super() Illegal constructor
-FAIL Re-entry via upgrade after calling super() Illegal constructor
-FAIL Re-entry via direct constructor call before calling super() Illegal constructor
-FAIL Re-entry via direct constructor call after calling super() Illegal constructor
+PASS Re-entry via upgrade before calling super()
+PASS Re-entry via upgrade after calling super()
+PASS Re-entry via direct constructor call before calling super()
+PASS Re-entry via direct constructor call after calling super()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Adding definition to global registry should not affect shadow roots using scoped registry Illegal constructor
+PASS Adding definition to global registry should not affect shadow roots using scoped registry
 PASS Adding definition to global registry should affect shadow roots also using global registry
-FAIL Adding definition to scoped registry should affect all associated shadow roots Illegal constructor
-FAIL Adding definition to scoped registry should not affect document tree scope Illegal constructor
-FAIL Adding definition to scoped registry should not affect shadow roots using other registries Illegal constructor
-FAIL Adding definition to global registry should not upgrade nodes no longer using the registry Illegal constructor
-FAIL Adding definition to scoped registry should not upgrade nodes no longer using the registry Illegal constructor
-FAIL Adding definition to scoped registry affects associated shadow roots in all iframes Illegal constructor
-FAIL Adding definition to scoped registry affects associated shadow roots in other frame trees assert_true: expected true got false
-FAIL Adding definition to scoped registry should not upgrade disconnected elements Illegal constructor
-FAIL Adding definition to scoped registry should not upgrade nodes in constructed documents Illegal constructor
-FAIL Adding definition to scoped registry should not upgrade nodes in detached frames Illegal constructor
+PASS Adding definition to scoped registry should affect all associated shadow roots
+PASS Adding definition to scoped registry should not affect document tree scope
+PASS Adding definition to scoped registry should not affect shadow roots using other registries
+PASS Adding definition to global registry should not upgrade nodes no longer using the registry
+PASS Adding definition to scoped registry should not upgrade nodes no longer using the registry
+PASS Adding definition to scoped registry affects associated shadow roots in all iframes
+PASS Adding definition to scoped registry affects associated shadow roots in other frame trees
+PASS Adding definition to scoped registry should not upgrade disconnected elements
+PASS Adding definition to scoped registry should not upgrade nodes in constructed documents
+PASS Adding definition to scoped registry should not upgrade nodes in detached frames
 PASS Adding definition to scoped registry should not upgrade nodes in closed windows
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Upgrade in tree order in the same tree scope Illegal constructor
-FAIL Upgrade in shadow-including tree order across tree scopes Illegal constructor
-FAIL Upgrade order does not depend on shadow root attach order Illegal constructor
-FAIL Upgrade in association order across documents, then tree order in each document Illegal constructor
-FAIL Upgrade order is not affected by DOM order between child frames Illegal constructor
-FAIL Upgrade order is affected by shadow tree adoption across documents Illegal constructor
-FAIL Elements in the "owner" window of a scoped registry are not always upgraded first Illegal constructor
+PASS Upgrade in tree order in the same tree scope
+PASS Upgrade in shadow-including tree order across tree scopes
+PASS Upgrade order does not depend on shadow root attach order
+PASS Upgrade in association order across documents, then tree order in each document
+PASS Upgrade order is not affected by DOM order between child frames
+PASS Upgrade order is affected by shadow tree adoption across documents
+PASS Elements in the "owner" window of a scoped registry are not always upgraded first
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-registry-define-get-etc.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-registry-define-get-etc.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Custom element registries with a registered custom element return the class in their get method, and the name in their getName method Illegal constructor
-FAIL Scoped Custom element registries do not inherit names or classes from the global registry Illegal constructor
-FAIL Scoped Custom element registries return the same constructor when it is defined in both Illegal constructor
-FAIL Scoped Custom element registries allow registering name that exists in global registry Illegal constructor
-FAIL Custom element registries with a registered custom element resolve the class in their whenDefined method promise_test: Unhandled rejection with value: object "TypeError: Illegal constructor"
-FAIL Scoped Custom element registries resolve the same constructor from whenDefined when it is defined in both promise_test: Unhandled rejection with value: object "TypeError: Illegal constructor"
-FAIL Scoped Custom element registry getters do not resolve globally registered classes from whenDefined promise_test: Unhandled rejection with value: object "TypeError: Illegal constructor"
+PASS Custom element registries with a registered custom element return the class in their get method, and the name in their getName method
+PASS Scoped Custom element registries do not inherit names or classes from the global registry
+PASS Scoped Custom element registries return the same constructor when it is defined in both
+PASS Scoped Custom element registries allow registering name that exists in global registry
+PASS Custom element registries with a registered custom element resolve the class in their whenDefined method
+PASS Scoped Custom element registries resolve the same constructor from whenDefined when it is defined in both
+PASS Scoped Custom element registry getters do not resolve globally registered classes from whenDefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -829,7 +829,9 @@ PASS OffscreenCanvasRenderingContext2D interface: operation rect(unrestricted do
 PASS OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, sequence<(unrestricted double or DOMPointInit)>)
 PASS OffscreenCanvasRenderingContext2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS OffscreenCanvasRenderingContext2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
-PASS CustomElementRegistry interface: existence and properties of interface object
+FAIL CustomElementRegistry interface: existence and properties of interface object assert_throws_js: interface object didn't throw TypeError when called as a constructor function "function() {
+                new interface_object();
+            }" did not throw
 PASS CustomElementRegistry interface object length
 PASS CustomElementRegistry interface object name
 PASS CustomElementRegistry interface: existence and properties of interface prototype object

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -829,7 +829,9 @@ PASS OffscreenCanvasRenderingContext2D interface: operation rect(unrestricted do
 PASS OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, sequence<(unrestricted double or DOMPointInit)>)
 PASS OffscreenCanvasRenderingContext2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS OffscreenCanvasRenderingContext2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
-PASS CustomElementRegistry interface: existence and properties of interface object
+FAIL CustomElementRegistry interface: existence and properties of interface object assert_throws_js: interface object didn't throw TypeError when called as a constructor function "function() {
+                new interface_object();
+            }" did not throw
 PASS CustomElementRegistry interface object length
 PASS CustomElementRegistry interface object name
 PASS CustomElementRegistry interface: existence and properties of interface prototype object

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6192,6 +6192,20 @@ SansSerifFontFamily:
     WebCore:
       default: '""_str'
 
+ScopedCustomElementRegistryEnabled:
+  type: bool
+  status: preview
+  category: dom
+  humanReadableName: "Scoped custom element registry"
+  humanReadableDescription: "Enable scoped custom element registry"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 # FIXME: This should have it's own ENABLE.
 ScreenCaptureEnabled:

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -45,6 +45,7 @@ class PrivateName;
 
 namespace WebCore {
 
+class CustomElementRegistry;
 class DOMWrapperWorld;
 class Document;
 class Element;
@@ -60,8 +61,8 @@ public:
         return adoptRef(*new JSCustomElementInterface(name, callback, globalObject));
     }
 
-    Ref<Element> constructElementWithFallback(Document&, const AtomString&, ParserConstructElementWithEmptyStack = ParserConstructElementWithEmptyStack::No);
-    Ref<Element> constructElementWithFallback(Document&, const QualifiedName&);
+    Ref<Element> constructElementWithFallback(Document&, CustomElementRegistry&, const AtomString&, ParserConstructElementWithEmptyStack = ParserConstructElementWithEmptyStack::No);
+    Ref<Element> constructElementWithFallback(Document&, CustomElementRegistry&, const QualifiedName&);
     Ref<HTMLElement> createElement(Document&);
 
     void upgradeElement(Element&);
@@ -122,7 +123,7 @@ public:
 private:
     JSCustomElementInterface(const QualifiedName&, JSC::JSObject* callback, JSDOMGlobalObject*);
 
-    RefPtr<Element> tryToConstructCustomElement(Document&, const AtomString&, ParserConstructElementWithEmptyStack);
+    RefPtr<Element> tryToConstructCustomElement(Document&, CustomElementRegistry&, const AtomString&, ParserConstructElementWithEmptyStack);
 
     template<typename Function>
     void invokeCallback(Element&, JSC::JSObject* callback, const Function& addArguments);

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -67,13 +67,16 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
 
     Ref document = downcast<Document>(*context);
 
-    RefPtr window = document->domWindow();
-    if (!window)
-        return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
+    RefPtr registry = document->activeCustomElementRegistry();
+    if (!registry) {
+        RefPtr window = document->domWindow();
+        if (!window)
+            return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
 
-    RefPtr registry = window->customElementRegistry();
-    if (!registry)
-        return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
+        registry = window->customElementRegistry();
+        if (!registry)
+            return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
+    }
 
     RefPtr elementInterface = registry->findInterface(newTarget);
     if (!elementInterface)

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -147,11 +147,7 @@ void CustomElementReactionQueue::tryToUpgradeElement(Element& element)
 {
     ASSERT(CustomElementReactionDisallowedScope::isReactionAllowed());
     ASSERT(element.isCustomElementUpgradeCandidate());
-    RefPtr window = element.document().domWindow();
-    if (!window)
-        return;
-
-    RefPtr registry = window->customElementRegistry();
+    RefPtr registry = element.treeScope().customElementRegistry();
     if (!registry)
         return;
 

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -31,6 +31,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
@@ -56,10 +57,13 @@ class QualifiedName;
 
 class CustomElementRegistry : public RefCounted<CustomElementRegistry>, public ContextDestructionObserver {
 public:
-    static Ref<CustomElementRegistry> create(LocalDOMWindow&, ScriptExecutionContext*);
+    static Ref<CustomElementRegistry> create(ScriptExecutionContext&, LocalDOMWindow&);
+    static Ref<CustomElementRegistry> create(ScriptExecutionContext&);
     ~CustomElementRegistry();
 
     Document* document() const;
+
+    void didAssociateWithDocument(Document&);
 
     RefPtr<DeferredPromise> addElementDefinition(Ref<JSCustomElementInterface>&&);
 
@@ -79,14 +83,17 @@ public:
     bool isShadowDisabled(const AtomString& name) const { return m_disabledShadowSet.contains(name); }
 
     template<typename Visitor> void visitJSCustomElementInterfaces(Visitor&) const;
+
 private:
-    CustomElementRegistry(LocalDOMWindow&, ScriptExecutionContext*);
+    CustomElementRegistry(ScriptExecutionContext&, LocalDOMWindow&);
+    CustomElementRegistry(ScriptExecutionContext&);
 
     WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_window;
     UncheckedKeyHashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
     UncheckedKeyHashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>> m_promiseMap;
     MemoryCompactRobinHoodHashSet<AtomString> m_disabledShadowSet;
+    WeakListHashSet<Document, WeakPtrImplWithEventTargetData> m_associatedDocuments;
 
     bool m_elementDefinitionIsRunning { false };
     mutable Lock m_constructorMapLock;

--- a/Source/WebCore/dom/CustomElementRegistry.idl
+++ b/Source/WebCore/dom/CustomElementRegistry.idl
@@ -29,6 +29,8 @@
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface CustomElementRegistry {
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, CallWith=CurrentScriptExecutionContext] constructor();
+
     [CEReactions=Needed, Custom] undefined define(DOMString name, Function constructor);
     any get([AtomString] DOMString name);
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -111,6 +111,7 @@ class CharacterData;
 class Comment;
 class ConstantPropertyMap;
 class ContentVisibilityDocumentState;
+class CustomElementRegistry;
 class DOMImplementation;
 class DOMSelection;
 class LocalDOMWindow;
@@ -511,7 +512,6 @@ public:
     WEBCORE_EXPORT bool hasFocus() const;
     void whenVisible(Function<void()>&&);
 
-    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
     WEBCORE_EXPORT Ref<DocumentFragment> createDocumentFragment();
     WEBCORE_EXPORT Ref<Text> createTextNode(String&& data);
     WEBCORE_EXPORT Ref<Comment> createComment(String&& data);
@@ -520,10 +520,10 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttribute(const AtomString& name);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, bool deep);
-    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
-    WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser);
 
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
+    void setActiveCustomElementRegistry(CustomElementRegistry&);
+    CustomElementRegistry* activeCustomElementRegistry() { return m_activeCustomElementRegistry.get(); }
 
     WEBCORE_EXPORT RefPtr<Range> caretRangeFromPoint(int x, int y, HitTestSource = HitTestSource::Script);
     std::optional<BoundaryPoint> caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource);
@@ -647,6 +647,7 @@ public:
 
     bool isSrcdocDocument() const { return m_isSrcdocDocument; }
 
+    void setSawElementsInKnownNamespaces() { m_sawElementsInKnownNamespaces = true; }
     bool sawElementsInKnownNamespaces() const { return m_sawElementsInKnownNamespaces; }
     bool wasRemovedLastRefCalled() const { return m_wasRemovedLastRefCalled; }
 
@@ -2391,6 +2392,8 @@ private:
     WeakPtr<SpeechRecognition> m_activeSpeechRecognition;
 
     WeakListHashSet<ShadowRoot, WeakPtrImplWithEventTargetData> m_inDocumentShadowRoots;
+
+    RefPtr<CustomElementRegistry> m_activeCustomElementRegistry;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     using TargetIdToClientMap = UncheckedKeyHashMap<PlaybackTargetClientContextIdentifier, WebCore::MediaPlaybackTargetClient*>;

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -56,12 +56,12 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     readonly attribute DocumentType? doctype;
     [DOMJIT=Getter] readonly attribute Element? documentElement;
 
+    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName);
+    [NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
     HTMLCollection getElementsByTagName([AtomString] DOMString qualifiedName);
     HTMLCollection getElementsByTagNameNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
     HTMLCollection getElementsByClassName([AtomString] DOMString classNames);
 
-    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName);
-    [NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
     [NewObject] DocumentFragment createDocumentFragment();
     [NewObject] Text createTextNode(DOMString data);
     [NewObject] CDATASection createCDATASection(DOMString data);

--- a/Source/WebCore/dom/DocumentOrShadowRoot.idl
+++ b/Source/WebCore/dom/DocumentOrShadowRoot.idl
@@ -29,13 +29,6 @@ interface mixin DocumentOrShadowRoot {
     // Extensions from HTML (https://html.spec.whatwg.org/multipage/dom.html#documentorshadowroot)
     readonly attribute Element? activeElement;
 
-    // FIXME: getSelection is currently defined only to be on Document in the Selection API spec
-    // https://w3c.github.io/selection-api/#extensions-to-document-interface, but
-    // previously had been defined to be on DocumentOrShadowRoot in the deprecated Shadow DOM spec
-    // https://w3c.github.io/webcomponents/spec/shadow/#extensions-to-the-documentorshadowroot-mixin.
-    // We should get this resolved in the Selection API spec and move this to the correct IDL files.
-    // DOMSelection? getSelection();
-
     // FIXME: These are currently defined only to be on Document in the CSSOM spec
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface, but
     // previously had been defined to be on DocumentOrShadowRoot in the deprecated Shadow DOM spec

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -30,6 +30,7 @@
 
 #include "CSSStyleSheet.h"
 #include "ChildListMutationScope.h"
+#include "CustomElementRegistry.h"
 #include "ElementInlines.h"
 #include "ElementTraversal.h"
 #include "GetHTMLOptions.h"
@@ -65,13 +66,15 @@ static_assert(sizeof(ShadowRoot) == sizeof(SameSizeAsShadowRoot), "shadowroot sh
 static_assert(sizeof(WeakPtr<Element, WeakPtrImplWithEventTargetData>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
-ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, Clonable clonable, Serializable serializable, AvailableToElementInternals availableToElementInternals)
+ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus,
+    Clonable clonable, Serializable serializable, AvailableToElementInternals availableToElementInternals, RefPtr<CustomElementRegistry>&& registry, ScopedCustomElementRegistry scopedRegistry)
     : DocumentFragment(document, TypeFlag::IsShadowRoot)
-    , TreeScope(*this, document)
+    , TreeScope(*this, document, WTFMove(registry))
     , m_delegatesFocus(delegatesFocus == DelegatesFocus::Yes)
     , m_isClonable(clonable == Clonable::Yes)
     , m_serializable(serializable == Serializable::Yes)
     , m_availableToElementInternals(availableToElementInternals == AvailableToElementInternals::Yes)
+    , m_hasScopedCustomElementRegistry(scopedRegistry == ScopedCustomElementRegistry::Yes)
     , m_mode(mode)
     , m_slotAssignmentMode(assignmentMode)
     , m_styleScope(makeUnique<Style::Scope>(*this))
@@ -84,7 +87,7 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMo
 
 ShadowRoot::ShadowRoot(Document& document, std::unique_ptr<SlotAssignment>&& slotAssignment)
     : DocumentFragment(document, TypeFlag::IsShadowRoot)
-    , TreeScope(*this, document)
+    , TreeScope(*this, document, nullptr)
     , m_mode(ShadowRootMode::UserAgent)
     , m_styleScope(makeUnique<Style::Scope>(*this))
     , m_slotAssignment(WTFMove(slotAssignment))
@@ -121,8 +124,11 @@ ShadowRoot::~ShadowRoot()
 Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     DocumentFragment::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    if (insertionType.connectedToDocument)
+    if (insertionType.connectedToDocument) {
         protectedDocument()->didInsertInDocumentShadowRoot(*this);
+        if (m_hasScopedCustomElementRegistry)
+            RefPtr { customElementRegistry() }->didAssociateWithDocument(protectedDocument());
+    }
     if (!adoptedStyleSheets().empty() && document().frame())
         checkedStyleScope()->didChangeActiveStyleSheetCandidates();
     return InsertedIntoAncestorResult::Done;

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -37,6 +37,12 @@
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] readonly attribute boolean serializable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
+
+    // FIXME: Move to DocumentOrShadowRoot.idl once it's always enabled
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName);
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
+
+    [ImplementedAs=registryForBindings, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? registry;
 };
 
 ShadowRoot includes DocumentOrShadowRoot;

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CustomElementRegistry.h"
 #include "ShadowRootMode.h"
 #include "SlotAssignmentMode.h"
 
@@ -36,6 +37,7 @@ struct ShadowRootInit {
     bool clonable { false };
     bool serializable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
+    RefPtr<CustomElementRegistry> registry;
 };
 
 }

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -31,4 +31,5 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
+    CustomElementRegistry registry = null;
 };

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -43,6 +43,7 @@ namespace WebCore {
 class CSSStyleSheet;
 class CSSStyleSheetObservableArray;
 class ContainerNode;
+class CustomElementRegistry;
 class Document;
 class Element;
 class FloatPoint;
@@ -54,6 +55,7 @@ class LayoutPoint;
 class LegacyRenderSVGResourceContainer;
 class IdTargetObserverRegistry;
 class Node;
+class QualifiedName;
 class RadioButtonGroups;
 class SVGElement;
 class ShadowRoot;
@@ -73,6 +75,12 @@ public:
 
     Element* focusedElementInScope();
     Element* pointerLockElement() const;
+
+    void setCustomElementRegistry(Ref<CustomElementRegistry>&&);
+    CustomElementRegistry* customElementRegistry() const { return m_customElementRegistry.get(); }
+    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
+    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
+    WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser);
 
     WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;
     WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;
@@ -149,7 +157,7 @@ public:
     RefPtr<SVGElement> takeElementFromPendingSVGResourcesForRemovalMap(const AtomString&);
 
 protected:
-    TreeScope(ShadowRoot&, Document&);
+    TreeScope(ShadowRoot&, Document&, RefPtr<CustomElementRegistry>&&);
     explicit TreeScope(Document&);
     ~TreeScope();
 
@@ -171,6 +179,8 @@ private:
     CheckedRef<ContainerNode> m_rootNode;
     std::reference_wrapper<Document> m_documentScope;
     TreeScope* m_parentTreeScope;
+
+    RefPtr<CustomElementRegistry> m_customElementRegistry;
 
     std::unique_ptr<TreeScopeOrderedMap> m_elementsById;
     std::unique_ptr<TreeScopeOrderedMap> m_elementsByName;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -168,6 +168,7 @@ public:
     ElementName currentElementName() const { return m_openElements.topElementName(); }
     HTMLStackItem& currentStackItem() const { return m_openElements.topStackItem(); }
     HTMLStackItem* oneBelowTop() const { return m_openElements.oneBelowTop(); }
+    TreeScope& treeScopeForCurrentNode();
     Document& ownerDocumentForCurrentNode();
     Ref<Document> protectedOwnerDocumentForCurrentNode() { return ownerDocumentForCurrentNode(); }
     HTMLElementStack& openElements() const { return m_openElements; }
@@ -214,7 +215,7 @@ private:
 
     void findFosterSite(HTMLConstructionSiteTask&);
 
-    RefPtr<HTMLElement> createHTMLElementOrFindCustomElementInterface(AtomHTMLToken&, JSCustomElementInterface**);
+    std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomElementRegistry>> createHTMLElementOrFindCustomElementInterface(AtomHTMLToken&);
     Ref<HTMLElement> createHTMLElement(AtomHTMLToken&);
     Ref<Element> createElement(AtomHTMLToken&, const AtomString& namespaceURI);
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -238,7 +238,7 @@ void HTMLDocumentParser::runScriptsForPausedTreeBuilder()
 
             CustomElementReactionStack reactionStack(document()->globalObject());
             auto& elementInterface = constructionData->elementInterface.get();
-            auto newElement = elementInterface.constructElementWithFallback(*document(), constructionData->name,
+            auto newElement = elementInterface.constructElementWithFallback(*document(), constructionData->registry, constructionData->name,
                 m_scriptRunner && !m_scriptRunner->isExecutingScript() ? ParserConstructElementWithEmptyStack::Yes : ParserConstructElementWithEmptyStack::No);
             m_treeBuilder->didCreateCustomOrFallbackElement(WTFMove(newElement), *constructionData);
         }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSTokenizerInputStream.h"
 #include "CommonAtomStrings.h"
+#include "CustomElementRegistry.h"
 #include "DocumentFragment.h"
 #include "HTMLDocument.h"
 #include "HTMLDocumentParser.h"
@@ -67,8 +68,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTreeBuilder);
 using namespace ElementNames;
 using namespace HTMLNames;
 
-CustomElementConstructionData::CustomElementConstructionData(Ref<JSCustomElementInterface>&& customElementInterface, const AtomString& name, Vector<Attribute>&& attributes)
+CustomElementConstructionData::CustomElementConstructionData(Ref<JSCustomElementInterface>&& customElementInterface, Ref<CustomElementRegistry>&& registry, const AtomString& name, Vector<Attribute>&& attributes)
     : elementInterface(WTFMove(customElementInterface))
+    , registry(WTFMove(registry))
     , name(name)
     , attributes(WTFMove(attributes))
 {

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -43,10 +43,11 @@ enum class TagName : uint16_t;
 struct CustomElementConstructionData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    CustomElementConstructionData(Ref<JSCustomElementInterface>&&, const AtomString& name, Vector<Attribute>&&);
+    CustomElementConstructionData(Ref<JSCustomElementInterface>&&, Ref<CustomElementRegistry>&&, const AtomString& name, Vector<Attribute>&&);
     ~CustomElementConstructionData();
 
     Ref<JSCustomElementInterface> elementInterface;
+    Ref<CustomElementRegistry> registry;
     AtomString name;
     Vector<Attribute> attributes;
 };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -609,8 +609,15 @@ bool LocalDOMWindow::isCurrentlyDisplayedInFrame() const
 
 CustomElementRegistry& LocalDOMWindow::ensureCustomElementRegistry()
 {
-    if (!m_customElementRegistry)
-        m_customElementRegistry = CustomElementRegistry::create(*this, scriptExecutionContext());
+    if (!m_customElementRegistry) {
+        m_customElementRegistry = CustomElementRegistry::create(*scriptExecutionContext(), *this);
+        for (Ref shadowRoot : document()->inDocumentShadowRoots()) {
+            if (shadowRoot->mode() == ShadowRootMode::UserAgent)
+                continue;
+            const_cast<ShadowRoot&>(shadowRoot.get()).setCustomElementRegistry(*m_customElementRegistry);
+        }
+        document()->setCustomElementRegistry(*m_customElementRegistry);
+    }
     ASSERT(m_customElementRegistry->scriptExecutionContext() == document());
     return *m_customElementRegistry;
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -820,7 +820,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
         customElementReactionStack.emplace(m_currentNode->document().globalObject());
     }
 
-    auto newElement = m_currentNode->document().createElement(qName, true);
+    auto newElement = m_currentNode->treeScope().createElement(qName, true);
 
     Vector<Attribute> prefixedAttributes;
     if (!handleNamespaceAttributes(prefixedAttributes, libxmlNamespaces, numNamespaces)) {


### PR DESCRIPTION
#### 25c59b18b250c18f1a0d30f9833813e826ed42cb
<pre>
Implement scoped custom element registry
<a href="https://bugs.webkit.org/show_bug.cgi?id=267454">https://bugs.webkit.org/show_bug.cgi?id=267454</a>

Reviewed by Chris Dumez.

Implement scoped custom element registry as an experimental feature.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-constructor.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/CustomElementRegistry-multi-register.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-call.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-registry-define-get-etc.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::constructElementWithFallback):
(WebCore::JSCustomElementInterface::tryToConstructCustomElement):
(WebCore::JSCustomElementInterface::upgradeElement):
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/bindings/js/JSHTMLElementCustom.cpp:
(WebCore::constructJSHTMLElement):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::tryToUpgradeElement):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::create):
(WebCore::CustomElementRegistry::CustomElementRegistry):
(WebCore::CustomElementRegistry::didAssociateWithDocument):
(WebCore::enqueueUpgradeInShadowIncludingTreeOrder):
(WebCore::CustomElementRegistry::addElementDefinition):
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/CustomElementRegistry.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::createHTMLElementWithNameValidation):
(WebCore::TreeScope::createElementForBindings):
(WebCore::TreeScope::createElement):
(WebCore::Document::setActiveCustomElementRegistry):
(WebCore::TreeScope::createElementNS):
(WebCore::Document::createElementForBindings): Deleted.
(WebCore::Document::createElement): Deleted.
(WebCore::Document::createElementNS): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::activeCustomElementRegistry):
(WebCore::Document::setSawElementsInKnownNamespaces):
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/DocumentOrShadowRoot.idl:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
(WebCore::ShadowRoot::insertedIntoAncestor):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/ShadowRootInit.h:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::TreeScope):
(WebCore::TreeScope::setCustomElementRegistry):
* Source/WebCore/dom/TreeScope.h:
(WebCore::TreeScope::customElementRegistry const):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLElementOrFindCustomElementInterface):
(WebCore::HTMLConstructionSite::createElement):
(WebCore::HTMLConstructionSite::treeScopeForCurrentNode):
(WebCore::HTMLConstructionSite::ownerDocumentForCurrentNode):
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
(WebCore::HTMLConstructionSite::createHTMLElement):
(WebCore::findCustomElementInterface): Deleted.
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::runScriptsForPausedTreeBuilder):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::CustomElementConstructionData::CustomElementConstructionData):
* Source/WebCore/html/parser/HTMLTreeBuilder.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::ensureCustomElementRegistry):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Canonical link: <a href="https://commits.webkit.org/286770@main">https://commits.webkit.org/286770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ce786c90f6efa7a448163d0b9bb8564c6e783f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77018 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23611 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26623 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70203 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83002 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76296 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67883 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9952 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98549 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11918 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4344 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7160 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->