### PR TITLE
REGRESSION(284872@main): GIF preview does not show up on x.com

### DIFF
--- a/LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller-expected.html
+++ b/LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        .scroller {
+            position: relative;
+            z-index: 0;
+            overflow: auto;
+            width: 300px;
+            height: 250px;
+            border: 1px solid black;
+        }
+        
+        .spacer {
+            height: 200%;
+        }
+        
+        .transformed {
+            position: absolute;
+            width: 200px;
+            height: 200px;
+            transform: translateY(0px);
+        }
+
+        .relative {
+            position: relative;
+            z-index: 0;
+            width: 100%;
+            height: 100%;
+            background-color: green;
+        }
+    </style>
+  </head>
+  <body>
+      <p>You should see a green box inside the scroller, and no red</p>
+      <div class="scroller">
+          <div class="transformed">
+              <div class="relative"></div>
+            </div>
+            <div class="spacer"></div>
+      </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller.html
+++ b/LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        .scroller {
+            position: relative;
+            z-index: 0;
+            overflow: auto;
+            width: 300px;
+            height: 250px;
+            border: 1px solid black;
+        }
+        
+        .spacer {
+            height: 200%;
+        }
+        
+        .transformed {
+            position: absolute;
+            width: 200px;
+            height: 200px;
+            transform: translateY(0px);
+        }
+
+        .relative {
+            position: relative;
+            z-index: 0;
+            width: 100%;
+            height: 100%;
+            background-color: red;
+        }
+
+        .inner {
+            position: relative;
+            height: 100%;
+            height: 100%;
+            z-index: -1;
+            background-color: green;
+        }
+    </style>
+  </head>
+  <body>
+      <p>You should see a green box inside the scroller, and no red</p>
+      <div class="scroller">
+          <div class="transformed">
+              <div class="relative">
+                <div class="inner"></div>
+              </div>
+            </div>
+            <div class="spacer"></div>
+      </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/overflow/no-double-painted-outline-expected.html
+++ b/LayoutTests/compositing/overflow/no-double-painted-outline-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            position: relative;
+            margin: 50px;
+            width: 300px;
+            height: 250px;
+            overflow-y: scroll;
+        }
+        
+        .contents {
+            height: 400%;
+        }
+        
+        .fake-outline {
+            position: relative;
+            left: 20px;
+            top: 20px;
+            width: 260px;
+            height: 210px;
+            box-sizing: border-box;
+            border: 20px solid rgba(0, 128, 0, 0.5);
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents">
+            <div class="fake-outline"></div>
+            &nbsp;
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/overflow/no-double-painted-outline.html
+++ b/LayoutTests/compositing/overflow/no-double-painted-outline.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            margin: 50px;
+            width: 300px;
+            height: 250px;
+            overflow-y: scroll;
+            outline: 20px solid rgba(0, 128, 0, 0.5);
+            outline-offset: -40px;
+        }
+        
+        .contents {
+            height: 400%;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents">&nbsp;</div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -637,7 +637,7 @@ public:
         PaintingCompositingForegroundPhase    = 1 << 6,
         PaintingCompositingMaskPhase          = 1 << 7,
         PaintingCompositingClipPathPhase      = 1 << 8,
-        PaintingCompositingScrollingPhase     = 1 << 9,
+        PaintingOverflowContainer             = 1 << 9,
         PaintingOverflowContents              = 1 << 10,
         PaintingRootBackgroundOnly            = 1 << 11,
         PaintingSkipRootBackground            = 1 << 12,
@@ -1478,6 +1478,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayer&);
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayer::ClipRectsContext&);
 WTF::TextStream& operator<<(WTF::TextStream&, IndirectCompositingReason);
 WTF::TextStream& operator<<(WTF::TextStream&, PaintBehavior);
+WTF::TextStream& operator<<(WTF::TextStream&, RenderLayer::PaintLayerFlag);
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3570,10 +3570,12 @@ void RenderLayerBacking::paintIntoLayer(const GraphicsLayer* graphicsLayer, Grap
     if (graphicsLayer == destinationForSharingLayers) {
         OptionSet<RenderLayer::PaintLayerFlag> sharingLayerPaintFlags = {
             RenderLayer::PaintLayerFlag::PaintingCompositingBackgroundPhase,
-            RenderLayer::PaintLayerFlag::PaintingCompositingForegroundPhase };
+            RenderLayer::PaintLayerFlag::PaintingCompositingForegroundPhase
+        };
 
         if (graphicsLayer->paintingPhase().contains(GraphicsLayerPaintingPhase::OverflowContents))
             sharingLayerPaintFlags.add(RenderLayer::PaintLayerFlag::PaintingOverflowContents);
+
         if (is<EventRegionContext>(regionContext))
             sharingLayerPaintFlags.add(RenderLayer::PaintLayerFlag::CollectingEventRegion);
 
@@ -3602,8 +3604,11 @@ OptionSet<RenderLayer::PaintLayerFlag> RenderLayerBacking::paintFlagsForLayer(co
         paintFlags.add(RenderLayer::PaintLayerFlag::PaintingChildClippingMaskPhase);
     if (paintingPhase.contains(GraphicsLayerPaintingPhase::OverflowContents))
         paintFlags.add(RenderLayer::PaintLayerFlag::PaintingOverflowContents);
-    if (paintingPhase.contains(GraphicsLayerPaintingPhase::CompositedScroll))
-        paintFlags.add(RenderLayer::PaintLayerFlag::PaintingCompositingScrollingPhase);
+
+    if (paintingPhase.contains(GraphicsLayerPaintingPhase::CompositedScroll)) {
+        if (&graphicsLayer == m_graphicsLayer.get())
+            paintFlags.add(RenderLayer::PaintLayerFlag::PaintingOverflowContainer);
+    }
 
     if (&graphicsLayer == m_backgroundLayer.get() && m_backgroundLayerPaintsFixedRootBackground)
         paintFlags.add({ RenderLayer::PaintLayerFlag::PaintingRootBackgroundOnly, RenderLayer::PaintLayerFlag::PaintingCompositingForegroundPhase }); // Need PaintLayerFlag::PaintingCompositingForegroundPhase to walk child layers.


### PR DESCRIPTION
#### afc81a98ea5535c7e4664158d82c4777c8493f20
<pre>
REGRESSION(284872@main): GIF preview does not show up on x.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=282478">https://bugs.webkit.org/show_bug.cgi?id=282478</a>
<a href="https://rdar.apple.com/138800157">rdar://138800157</a>

Reviewed by Alan Baradlay.

In 284872@main I removed the `PaintingOverflowContents` flag when painting a transformed layer.
This broke painting negative z-index layers with a transformed container inside composited
overflow scrollers. This happened because the logic added in 130068@main consulted
`isPaintingOverflowContents` when painting negative z-index layers.

Fix by clarifying use of the flags. Previously, `isPaintingScrollingContent` was true for both
the scroller&apos;s primary (non-scrolling) layer, and its scrolled contents layer, and then `PaintingOverflowContainer`
was used to differentiate them.

Instead, change `PaintingCompositingScrollingPhase` to `PaintingOverflowContainer` and only apply it to
primary layer. Then rewrite the `shouldPaintOutline` and `shouldPaintNegativeZIndexChildren` logic
in terms of the new flag.

* LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller-expected.html: Added.
* LayoutTests/compositing/overflow/negagtive-z-index-in-transformed-in-scroller.html: Added.
* LayoutTests/compositing/overflow/no-double-painted-outline-expected.html: Added.
* LayoutTests/compositing/overflow/no-double-painted-outline.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintIntoLayer):
(WebCore::RenderLayerBacking::paintFlagsForLayer const):

Canonical link: <a href="https://commits.webkit.org/286055@main">https://commits.webkit.org/286055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/353bdfc49503d99507b0998ba133f9ec19512f3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1894 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58662 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/content-visibility/locked-frame-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16945 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45939 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80591 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10155 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8306 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4749 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1990 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->