### PR TITLE
soylent.com: dropdown menu dismisses when trying to tap on links

### DIFF
--- a/LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk-expected.txt
+++ b/LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk-expected.txt
@@ -1,0 +1,10 @@
+Verifies that tapping on a link inside of a container that hides itself when receiving pointerleave. This test requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS dispatchedClick became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk.html
+++ b/LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+}
+
+.container {
+    width: 200px;
+    height: 200px;
+    text-align: center;
+    line-height: 200px;
+}
+
+.hover {
+    background: orange;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+dispatchedClick = false;
+
+window.internals?.setTopDocumentURLForQuirks("https://soylent.com");
+
+addEventListener("load", async () => {
+    description("Verifies that tapping on a link inside of a container that hides itself when receiving pointerleave. This test requires WebKitTestRunner");
+    const hover = document.querySelector(".hover");
+    hover.addEventListener("pointerleave", (event) => {
+        hover.style.display = "none";
+    });
+
+    const link = document.querySelector(".hover > a");
+    link.addEventListener("click", (event) => {
+        dispatchedClick = true;
+        event.preventDefault();
+    });
+
+    await UIHelper.activateElement(link);
+    await shouldBecomeEqual("dispatchedClick", "true");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="hover container"><a href="#">Tap here</a></div>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1874,6 +1874,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/StyleAppearance.h
     platform/SuddenTermination.h
     platform/Supplementable.h
+    platform/SyntheticClickResult.h
     platform/SystemSoundDelegate.h
     platform/TextRecognitionOptions.h
     platform/ThemeTypes.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -85,7 +85,6 @@ page/FrameSnapshotting.cpp
 page/NavigatorLoginStatus.h
 page/OpportunisticTaskScheduler.h
 page/PerformanceLogging.h
-page/PointerCaptureController.h
 page/PointerLockController.h
 page/RenderingUpdateScheduler.h
 page/ResourceUsageThread.h

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -55,6 +55,7 @@
 #include "ScrollTypes.h"
 #include "ScrollingCoordinator.h"
 #include "SearchPopupMenu.h"
+#include "SyntheticClickResult.h"
 #include "TextDetectorInterface.h"
 #include "WebCoreKeyboardUIMode.h"
 #include "WebGPU.h"
@@ -702,6 +703,8 @@ public:
     virtual void hasActiveNowPlayingSessionChanged(bool) { }
 
     virtual void getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<ImageBufferResourceLimits>)>&& callback) const { callback(std::nullopt); }
+
+    virtual void callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion) { completion(SyntheticClickResult::Failed); }
 
     WEBCORE_EXPORT virtual ~ChromeClient();
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -25,7 +25,9 @@
 #include "config.h"
 #include "PointerCaptureController.h"
 
-#include "Document.h"
+#include "Chrome.h"
+#include "ChromeClient.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "EventHandler.h"
 #include "EventNames.h"
@@ -33,6 +35,7 @@
 #include "HitTestResult.h"
 #include "Page.h"
 #include "PointerEvent.h"
+#include "Quirks.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -211,37 +214,43 @@ static bool hierarchyHasCapturingEventListeners(Element* target, const AtomStrin
     return false;
 }
 
+void PointerCaptureController::dispatchOverOrOutEvent(const AtomString& type, EventTarget* target, const PlatformTouchEvent& event, unsigned index, bool isPrimary, WindowProxy& view, IntPoint touchDelta)
+{
+    dispatchEvent(PointerEvent::create(type, event, { }, { }, index, isPrimary, view, touchDelta), target);
+}
+
+void PointerCaptureController::dispatchEnterOrLeaveEvent(const AtomString& type, Element& targetElement, const PlatformTouchEvent& event, unsigned index, bool isPrimary, WindowProxy& view, IntPoint touchDelta)
+{
+    bool hasCapturingListenerInHierarchy = false;
+    for (RefPtr<ContainerNode> currentNode = &targetElement; currentNode; currentNode = currentNode->parentInComposedTree()) {
+        if (currentNode->hasCapturingEventListeners(type)) {
+            hasCapturingListenerInHierarchy = true;
+            break;
+        }
+    }
+
+    Vector<Ref<Element>, 32> targetChain;
+    for (RefPtr element = &targetElement; element; element = element->parentElementInComposedTree()) {
+        if (hasCapturingListenerInHierarchy || element->hasEventListeners(type))
+            targetChain.append(*element);
+    }
+
+    if (type == eventNames().pointerenterEvent) {
+        for (auto& element : makeReversedRange(targetChain))
+            dispatchEvent(PointerEvent::create(type, event, { }, { }, index, isPrimary, view, touchDelta), element.ptr());
+    } else {
+        for (auto& element : targetChain)
+            dispatchEvent(PointerEvent::create(type, event, { }, { }, index, isPrimary, view, touchDelta), element.ptr());
+    }
+}
+
 void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target, const PlatformTouchEvent& platformTouchEvent, unsigned index, bool isPrimary, WindowProxy& view, const IntPoint& touchDelta)
 {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RELEASE_ASSERT(is<Element>(target));
-
-    auto dispatchOverOrOutEvent = [&](const AtomString& type, EventTarget* target) {
-        dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, { }, index, isPrimary, view, touchDelta), target);
-    };
-
-    auto dispatchEnterOrLeaveEvent = [&](const AtomString& type, Element& targetElement) {
-        bool hasCapturingListenerInHierarchy = false;
-        for (RefPtr<ContainerNode> currentNode = &targetElement; currentNode; currentNode = currentNode->parentInComposedTree()) {
-            if (currentNode->hasCapturingEventListeners(type)) {
-                hasCapturingListenerInHierarchy = true;
-                break;
-            }
-        }
-
-        Vector<Ref<Element>, 32> targetChain;
-        for (RefPtr element = &targetElement; element; element = element->parentElementInComposedTree()) {
-            if (hasCapturingListenerInHierarchy || element->hasEventListeners(type))
-                targetChain.append(*element);
-        }
-
-        if (type == eventNames().pointerenterEvent) {
-            for (auto& element : makeReversedRange(targetChain))
-                dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, { }, index, isPrimary, view, touchDelta), element.ptr());
-        } else {
-            for (auto& element : targetChain)
-                dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, { }, index, isPrimary, view, touchDelta), element.ptr());
-        }
-    };
 
     auto mapToPointerEvents = [&](const Vector<PlatformTouchEvent>& events) -> Vector<Ref<PointerEvent>> {
         if (index)
@@ -292,7 +301,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
         }
 
         if (previousTarget)
-            dispatchOverOrOutEvent(eventNames().pointeroutEvent, previousTarget.get());
+            dispatchOverOrOutEvent(eventNames().pointeroutEvent, previousTarget.get(), platformTouchEvent, index, isPrimary, view, touchDelta);
 
         for (auto& chain : leftElementsChain) {
             if (hasCapturingPointerLeaveListener || chain->hasEventListeners(eventNames().pointerleaveEvent))
@@ -300,7 +309,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
         }
 
         if (currentTarget)
-            dispatchOverOrOutEvent(eventNames().pointeroverEvent, currentTarget.get());
+            dispatchOverOrOutEvent(eventNames().pointeroverEvent, currentTarget.get(), platformTouchEvent, index, isPrimary, view, touchDelta);
 
         for (auto& chain : makeReversedRange(enteredElementsChain)) {
             if (hasCapturingPointerEnterListener || chain->hasEventListeners(eventNames().pointerenterEvent))
@@ -312,8 +321,8 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
         // https://w3c.github.io/pointerevents/#the-pointerdown-event
         // For input devices that do not support hover, a user agent MUST also fire a pointer event named pointerover followed by a pointer event named
         // pointerenter prior to dispatching the pointerdown event.
-        dispatchOverOrOutEvent(eventNames().pointeroverEvent, currentTarget.get());
-        dispatchEnterOrLeaveEvent(eventNames().pointerenterEvent, *currentTarget);
+        dispatchOverOrOutEvent(eventNames().pointeroverEvent, currentTarget.get(), platformTouchEvent, index, isPrimary, view, touchDelta);
+        dispatchEnterOrLeaveEvent(eventNames().pointerenterEvent, *currentTarget, platformTouchEvent, index, isPrimary, view, touchDelta);
     }
 
 #if PLATFORM(IOS_FAMILY)
@@ -325,17 +334,47 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
     dispatchEvent(pointerEvent, &target);
 
-    if (pointerEvent->type() == eventNames().pointerupEvent) {
+    if (pointerEvent->type() != eventNames().pointerupEvent)
+        return;
+
+    auto dispatchPointerOutAndLeave = [weakPage = m_page, currentTarget, platformTouchEvent, index, isPrimary, view = Ref { view }, touchDelta](SyntheticClickResult result) {
+        RefPtr page = weakPage.get();
+        if (!page)
+            return;
+
+        switch (result) {
+        case SyntheticClickResult::Failed:
+        case SyntheticClickResult::Click:
+            break;
+        case SyntheticClickResult::Hover:
+        case SyntheticClickResult::PageInvalid:
+            return;
+        }
+
         // https://w3c.github.io/pointerevents/#the-pointerup-event
         // For input devices that do not support hover, a user agent MUST also fire a pointer event named pointerout followed by a
         // pointer event named pointerleave after dispatching the pointerup event.
-        dispatchOverOrOutEvent(eventNames().pointeroutEvent, currentTarget.get());
-        dispatchEnterOrLeaveEvent(eventNames().pointerleaveEvent, *currentTarget);
-        capturingData->previousTarget = nullptr;
-        capturingData->state = CapturingData::State::Finished;
-    }
-}
+        page->pointerCaptureController().dispatchOverOrOutEvent(eventNames().pointeroutEvent, currentTarget.get(), platformTouchEvent, index, isPrimary, view.get(), touchDelta);
+        page->pointerCaptureController().dispatchEnterOrLeaveEvent(eventNames().pointerleaveEvent, *currentTarget, platformTouchEvent, index, isPrimary, view.get(), touchDelta);
+    };
+
+    bool shouldWaitForSyntheticClick = [&] {
+#if PLATFORM(IOS_FAMILY)
+        if (platformTouchEvent.isPotentialTap())
+            return currentTarget->protectedDocument()->quirks().shouldDispatchPointerOutAfterHandlingSyntheticClick();
 #endif
+        return false;
+    }();
+
+    if (shouldWaitForSyntheticClick)
+        page->chrome().client().callAfterPendingSyntheticClick(WTFMove(dispatchPointerOutAndLeave));
+    else
+        dispatchPointerOutAndLeave(SyntheticClickResult::Failed);
+
+    capturingData->state = CapturingData::State::Finished;
+    capturingData->previousTarget = nullptr;
+}
+#endif // ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
 
 RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
@@ -508,6 +547,10 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
     if (capturingData->state == CapturingData::State::Cancelled)
         return;
 
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     capturingData->pendingTargetOverride = nullptr;
     capturingData->state = CapturingData::State::Cancelled;
 
@@ -519,7 +562,7 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
         if (capturingData->targetOverride)
             return capturingData->targetOverride;
         constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
         if (!localMainFrame)
             return nullptr;
         return localMainFrame->checkedEventHandler()->hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -115,7 +115,10 @@ private:
     void updateHaveAnyCapturingElement();
     void elementWasRemovedSlow(Element&);
 
-    Page& m_page;
+    void dispatchOverOrOutEvent(const AtomString&, EventTarget*, const PlatformTouchEvent&, unsigned index, bool isPrimary, WindowProxy&, IntPoint);
+    void dispatchEnterOrLeaveEvent(const AtomString&, Element&, const PlatformTouchEvent&, unsigned index, bool isPrimary, WindowProxy&, IntPoint);
+
+    WeakPtr<Page> m_page;
     // While PointerID is defined as int32_t, we use int64_t here so that we may use a value outside of the int32_t range to have safe
     // empty and removed values, allowing any int32_t to be provided through the API for lookup in this hashmap.
     using PointerIdToCapturingDataMap = UncheckedKeyHashMap<int64_t, Ref<CapturingData>, IntHash<int64_t>, WTF::SignedWithZeroKeyHashTraits<int64_t>>;

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -159,7 +159,10 @@ public:
 
 #if ENABLE(TOUCH_EVENTS)
     WEBCORE_EXPORT static bool shouldOmitTouchEventDOMAttributesForDesktopWebsite(const URL&);
+    bool shouldDispatchPointerOutAfterHandlingSyntheticClick() const;
 #endif
+
+    WEBCORE_EXPORT void setTopDocumentURLForTesting(URL&&);
 
     static bool shouldOmitHTMLDocumentSupportedPropertyNames();
 
@@ -226,8 +229,10 @@ public:
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
+    bool domainStartsWith(const String&) const;
     bool isEmbedDomain(const String&) const;
     bool isYoutubeEmbedDomain() const;
+    bool isYahooMail() const;
 
     bool isAmazon() const;
 #if ENABLE(TOUCH_EVENTS)
@@ -235,6 +240,8 @@ private:
 #endif
 
     RefPtr<Document> protectedDocument() const;
+
+    URL topDocumentURL() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
@@ -258,6 +265,7 @@ private:
         Yes,
     };
     mutable ShouldDispatchSimulatedMouseEvents m_shouldDispatchSimulatedMouseEventsQuirk { ShouldDispatchSimulatedMouseEvents::Unknown };
+    mutable std::optional<bool> m_shouldDispatchPointerOutAfterHandlingSyntheticClick;
 #endif
     mutable std::optional<bool> m_needsCanPlayAfterSeekedQuirk;
     mutable std::optional<bool> m_shouldBypassAsyncScriptDeferring;
@@ -303,6 +311,7 @@ private:
     mutable std::optional<bool> m_needsChromeMediaControlsPseudoElementQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
+    URL m_topDocumentURLForTesting;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SyntheticClickResult.h
+++ b/Source/WebCore/platform/SyntheticClickResult.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class SyntheticClickResult : uint8_t {
+    Failed,
+    Click,
+    Hover,
+    PageInvalid,
+};
+
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -179,6 +179,7 @@
 #include "PseudoElement.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionData.h"
+#include "Quirks.h"
 #include "RTCNetworkManager.h"
 #include "RTCRtpSFrameTransform.h"
 #include "Range.h"
@@ -7731,6 +7732,16 @@ void Internals::setResourceCachingDisabledByWebInspector(bool disabled)
         return;
 
     document->page()->setResourceCachingDisabledByWebInspector(disabled);
+}
+
+void Internals::setTopDocumentURLForQuirks(const String& urlString)
+{
+    RefPtr document = contextDocument();
+    if (!document)
+        return;
+
+    document->protectedPage()->settings().setNeedsSiteSpecificQuirks(true);
+    document->quirks().setTopDocumentURLForTesting(URL { urlString });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1390,7 +1390,9 @@ public:
 
     ExceptionOr<unsigned> createSleepDisabler(const String& reason, bool display);
     bool destroySleepDisabler(unsigned identifier);
-        
+
+    void setTopDocumentURLForQuirks(const String&);
+
 #if ENABLE(APP_HIGHLIGHTS)
     Vector<String> appHighlightContextMenuItemTitles() const;
     unsigned numberOfAppHighlights();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1414,4 +1414,6 @@ enum RenderingMode {
 
     RenderingMode? getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
     Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();
+
+    undefined setTopDocumentURLForQuirks(DOMString urlString);
 };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -542,6 +542,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void commitPotentialTapFailed() = 0;
     virtual void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) = 0;
+    virtual bool isPotentialTapInProgress() const = 0;
 
     virtual void couldNotRestorePageState() = 0;
     virtual void restorePageState(std::optional<WebCore::FloatPoint> scrollPosition, const WebCore::FloatPoint& scrollOrigin, const WebCore::FloatBoxExtent& obscuredInsetsOnSave, double scale) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2585,6 +2585,10 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+#if PLATFORM(IOS_FAMILY)
+    void isPotentialTapInProgress(CompletionHandler<void(bool)>&&);
+#endif
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -181,6 +181,7 @@ messages -> WebPageProxy {
     DidHandleTapAsHover()
     DisableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier requestID)
     HandleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier requestID, WebCore::FloatRect renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel)
+    IsPotentialTapInProgress() -> (bool result)
 #endif
 #if ENABLE(DATA_DETECTION)
     SetDataDetectionResult(struct WebKit::DataDetectionResult dataDetectionResult)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -355,6 +355,8 @@ private:
     UIViewController *presentingViewController() const final;
 #endif
 
+    bool isPotentialTapInProgress() const final;
+
     WebCore::FloatPoint webViewToRootView(const WebCore::FloatPoint&) const final;
     WebCore::FloatRect rootViewToWebView(const WebCore::FloatRect&) const final;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1253,6 +1253,11 @@ void PageClientImpl::pluginDidInstallPDFDocument(double initialScale)
 }
 #endif
 
+bool PageClientImpl::isPotentialTapInProgress() const
+{
+    return [m_contentView isPotentialTapInProgress];
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -671,6 +671,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) UIView *unscaledView;
 @property (nonatomic, readonly) BOOL isPresentingEditMenu;
 @property (nonatomic, readonly) CGSize sizeForLegacyFormControlPickerViews;
+@property (nonatomic, readonly, getter=isPotentialTapInProgress) BOOL potentialTapInProgress;
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3725,6 +3725,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _potentialTapInProgress = NO;
 }
 
+- (BOOL)isPotentialTapInProgress
+{
+    return _potentialTapInProgress;
+}
+
 - (void)_singleTapIdentified:(UITapGestureRecognizer *)gestureRecognizer
 {
     auto position = [gestureRecognizer locationInView:self];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1738,6 +1738,15 @@ void WebPageProxy::pluginDidInstallPDFDocument(double initialScale)
 
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+
+void WebPageProxy::isPotentialTapInProgress(CompletionHandler<void(bool)>&& completion)
+{
+    completion(protectedPageClient()->isPotentialTapInProgress());
+}
+
+#endif // PLATFORM(IOS_FAMILY)
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1944,4 +1944,9 @@ bool WebChromeClient::requiresScriptTelemetryForURL(const URL& url, const Securi
     return WebProcess::singleton().requiresScriptTelemetryForURL(url, topOrigin);
 }
 
+void WebChromeClient::callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion)
+{
+    protectedPage()->callAfterPendingSyntheticClick(WTFMove(completion));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -546,6 +546,8 @@ private:
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<WebCore::ImageBufferResourceLimits>)>&&) const final;
 #endif
 
+    void callAfterPendingSyntheticClick(CompletionHandler<void(WebCore::SyntheticClickResult)>&&) final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1898,6 +1898,7 @@ void WebPage::close()
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    invokePendingSyntheticClickCallback(SyntheticClickResult::PageInvalid);
     m_updateFocusedElementInformationTimer.stop();
 #endif
 
@@ -7735,6 +7736,8 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_shouldRevealCurrentSelectionAfterInsertion = true;
     m_lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage = std::nullopt;
 
+    invokePendingSyntheticClickCallback(SyntheticClickResult::PageInvalid);
+
 #if ENABLE(IOS_TOUCH_EVENTS)
     auto queuedEvents = makeUniqueRef<EventDispatcher::TouchEventQueue>();
     WebProcess::singleton().eventDispatcher().takeQueuedTouchEventsForPage(*this, queuedEvents);
@@ -10161,6 +10164,15 @@ bool WebPage::isAlwaysOnLoggingAllowed() const
     RefPtr page { protectedCorePage() };
     return page && page->isAlwaysOnLoggingAllowed();
 }
+
+#if !PLATFORM(IOS_FAMILY)
+
+void WebPage::callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion)
+{
+    completion(SyntheticClickResult::Failed);
+}
+
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -259,6 +259,7 @@ enum class MediaProducerMutedState : uint8_t;
 enum class ScheduleLocationChangeResult : uint8_t;
 enum class SelectionDirection : uint8_t;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
+enum class SyntheticClickResult : uint8_t;
 enum class SyntheticClickType : uint8_t;
 enum class TextAnimationType : uint8_t;
 enum class TextIndicatorPresentationTransition : uint8_t;
@@ -934,6 +935,7 @@ public:
     void potentialTapAtPosition(WebKit::TapIdentifier, const WebCore::FloatPoint&, bool shouldRequestMagnificationInformation);
     void commitPotentialTap(OptionSet<WebKit::WebEventModifier>, TransactionID lastLayerTreeTransactionId, WebCore::PointerID);
     void commitPotentialTapFailed();
+    void didHandleTapAsHover();
     void cancelPotentialTap();
     void cancelPotentialTapInFrame(WebFrame&);
     void tapHighlightAtPosition(WebKit::TapIdentifier, const WebCore::FloatPoint&);
@@ -1852,6 +1854,8 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+    void callAfterPendingSyntheticClick(CompletionHandler<void(WebCore::SyntheticClickResult)>&&);
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -1888,6 +1892,7 @@ private:
     void setFocusedFrameBeforeSelectingTextAtLocation(const WebCore::IntPoint&);
     void setSelectedRangeDispatchingSyntheticMouseEventsIfNeeded(const WebCore::SimpleRange&, WebCore::Affinity);
     void dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch, const WebCore::IntPoint&);
+    void invokePendingSyntheticClickCallback(WebCore::SyntheticClickResult);
 
     void sendPositionInformation(InteractionInformationAtPosition&&);
     RefPtr<WebCore::ShareableBitmap> shareableBitmapSnapshotForNode(WebCore::Element&);
@@ -2708,6 +2713,7 @@ private:
     RefPtr<WebCore::Node> m_potentialTapNode;
     WebCore::FloatPoint m_potentialTapLocation;
     RefPtr<WebCore::SecurityOrigin> m_potentialTapSecurityOrigin;
+    CompletionHandler<void(WebCore::SyntheticClickResult)> m_pendingSyntheticClickCallback;
 
     bool m_hasReceivedVisibleContentRectsAfterDidCommitLoad { false };
     bool m_hasRestoredExposedContentRectAfterDidCommitLoad { false };


### PR DESCRIPTION
#### ea5905fd9777612df86ae3b8471c24c60e9935b7
<pre>
soylent.com: dropdown menu dismisses when trying to tap on links
<a href="https://bugs.webkit.org/show_bug.cgi?id=282476">https://bugs.webkit.org/show_bug.cgi?id=282476</a>
<a href="https://rdar.apple.com/113314067">rdar://113314067</a>

Reviewed by Aditya Keerthi.

On soylent.com, the site navigation dropdown contains a `pointerout` event listener which dismisses
the entire dropdown when dispatched. This, when combined with synthetic mouse events and content
observation, makes it impossible to actually navigate to any links in the header, since we get the
following sequence of events:

a.  User begins a touch over a link inside the dropdown menu, dispatching `pointerdown`
b.  User ends the touch, dispatching `pointerup`
c.  Because the touch has ended, we immediately dispatch `pointerout`, and the page closes the menu
d.  In parallel, a synthetic click is recognized in the UI process, dispatching a synthetic click to
    the page
e.  This synthetic click hits the `body` element (because the dropdown menu has already closed), and
    we don&apos;t click the link

To fix this, we add a quirk to ensure that step (c) now happens after the synthetic click is
dispatched to the page on `soylent.com`; additionally, this quirk *prevents* the `pointerout` event
from being dispatched after ending the touch, in the case where the synthetic click resulted in a
nontrivial content observation (such that the synthetic click state remains in hover state). This
latter adjustment is required in order to prevent the dropdown menu from immediately closing after
opening the menu, as a result of dispatching `pointerout`.

At a high level, this bug boils down to the fact that when using a touch-capable device, `pointer*`
events track the user&apos;s touch state and follow the life cycle of touch events, rather than mapping
to the compatibility mouse events (synthetic clicks) that are dispatched in response to tapping
elements on the page. soylent.com presents an interesting situation where the webpage relies on
*both* compatibility mouse events (so that the menu opens when tapping on the dropdown button), as
well as pointer events (for knowing when to dismiss the menu). The behavior introduced in this quirk
essentially bridges this gap by allowing `pointerout` to honor the synthetic mouse hover and clicks
dispatched when tapping the screen, but is likely too risky to deploy in the general case.

* LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk-expected.txt: Added.
* LayoutTests/pointerevents/ios/dispatch-pointerout-after-synthetic-click-quirk.html: Added.

Add a layout test to exercise this quirk.

* Source/WebCore/Headers.cmake:

Add `SyntheticClickResult.h`.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:

Update Safer C++ expectations, now that `m_page` is a weak pointer.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::callAfterPendingSyntheticClick):

Add a chrome client hook to invoke a callback after waiting for a pending synthetic click completes.
This may be invoked immediately or asynchronously, with the following results:

• `Failed`        The gesture was not recognized as a synthetic click
• `Click`         The synthetic click was dispatched
• `Hover`         The synthetic click stopped at mouse hover state
• `PageInvalid`   The page was invalidated (either because the tab was closed, or we navigated away)

In the case of `Hover` and `PageInvalid`, we avoid dispatching the `pointer(out|leave)` events.

* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchOverOrOutEvent):
(WebCore::PointerCaptureController::dispatchEnterOrLeaveEvent):

Pull these two helpers out as private methods on `PointerCaptureController`, so we can call into
them asynchronously below.

(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):

Use `callAfterPendingSyntheticClick` to defer the `pointerout` and `pointerleave` events until after
the synthetic click has completed (and even withhold them altogether, in the case of synthetic
hover).

(WebCore::PointerCaptureController::cancelPointer):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::isYahooMail const):
(WebCore::Quirks::isDomain const):
(WebCore::Quirks::domainStartsWith const):
(WebCore::Quirks::needsFormControlToBeMouseFocusable const):
(WebCore::Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable const):
(WebCore::Quirks::isNeverRichlyEditableForTouchBar const):
(WebCore::Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas const):
(WebCore::Quirks::shouldDisableWritingSuggestionsByDefault const):
(WebCore::Quirks::isAmazon const):
(WebCore::Quirks::isGoogleMaps const):
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const):
(WebCore::Quirks::shouldPreventDispatchOfTouchEvent const):
(WebCore::Quirks::shouldAvoidResizingWhenInputViewBoundsChange const):
(WebCore::Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::Quirks::shouldBypassAsyncScriptDeferring const):
(WebCore::Quirks::shouldAvoidPastingImagesAsWebContent const):
(WebCore::Quirks::requestStorageAccessAndHandleClick const):
(WebCore::Quirks::requiresUserGestureToPauseInPictureInPicture const):
(WebCore::Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk const):
(WebCore::Quirks::allowLayeredFullscreenVideos const):
(WebCore::Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape const):
(WebCore::Quirks::shouldFlipScreenDimensions const):
(WebCore::Quirks::shouldIgnoreTextAutoSizing const):
(WebCore::Quirks::scriptToEvaluateBeforeRunningScriptFromURL):
(WebCore::Quirks::shouldHideCoarsePointerCharacteristics const):
(WebCore::Quirks::implicitMuteWhenVolumeSetToZero const):
(WebCore::Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick const):
(WebCore::Quirks::needsMozillaFileTypeForDataTransfer const):
(WebCore::Quirks::setTopDocumentURLForTesting):
(WebCore::Quirks::topDocumentURL const):

Add the quirk, and also add plumbing for a testing-only hook to allow tests that have access to
`window.internals` to override the top document URL used for deciding quirks. The new layout test
uses this mechanism.

(WebCore::isYahooMail): Deleted.

Turn this into a method instead, so that we can use `topDocumentURL` which accounts for the new
override URL for testing.

* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/SyntheticClickResult.h: Added.

Add a new enum type; see above for more details.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setTopDocumentURLForQuirks):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Add a new testing hook to simulate top URLs for quirks; see above for more details.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:

Add plumbing for an IPC message that returns whether or not a potential tap is in progress on iOS.
See below for more details.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::isPotentialTapInProgress const):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView isPotentialTapInProgress]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::isPotentialTapInProgress):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::callAfterPendingSyntheticClick):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
(WebKit::WebPage::didCommitLoad):

Invoke the pending synthetic click callback with `PageInvalid`, if needed.

(WebKit::WebPage::callAfterPendingSyntheticClick):

Add an empty stub for non-iOS platforms.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::didHandleTapAsHover):
(WebKit::WebPage::didFinishContentChangeObserving):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::commitPotentialTapFailed):

Add calls to invoke the pending synthetic click callback throughout the various checkpoints during
synthetic mouse event dispatch: `Failed` (for when the potential tap node is rejected), `Hover` (for
when content change observation fires), and `Click` (for when the click is dispatched).

(WebKit::WebPage::invokePendingSyntheticClickCallback):
(WebKit::WebPage::callAfterPendingSyntheticClick):

Implement a new helper method on `WebPage` that invokes the callback after the current synthetic
click event has been dispatched. This avoids racing against gesture state in the UI process, by
round-tripping to `WKContentView` to determine whether or not the single tap gesture recognizer has
fired before stashing the callback in `m_pendingSyntheticClickCallback` on the `WebPage`.

Canonical link: <a href="https://commits.webkit.org/286270@main">https://commits.webkit.org/286270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1030e832154509eebf2e53de76a73300d1339aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75377 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/39 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77493 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/39 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59158 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/39 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39520 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/39 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24968 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/39 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2716 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64746 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8797 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->