### PR TITLE
Provide wrappers for some ObjC Runtime functions that return a MallocSpan

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		465005D82CD2840A00950C5F /* MallocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 465005D72CD2840A00950C5F /* MallocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
+		465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */; };
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
@@ -1226,6 +1227,7 @@
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		465005D72CD2840A00950C5F /* MallocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocSpan.h; sourceTree = "<group>"; };
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
+		465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCRuntimeExtras.mm; sourceTree = "<group>"; };
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
@@ -2358,6 +2360,7 @@
 				A8A472D5151A825B004123FF /* NumberOfCores.cpp */,
 				A8A472D6151A825B004123FF /* NumberOfCores.h */,
 				7E29C33D15FFD79B00516D61 /* ObjCRuntimeExtras.h */,
+				465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */,
 				8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */,
 				83A8AC3D1FABBE94002064AC /* ObjectIdentifier.h */,
 				CD48A87024C8A21600F5800C /* Observer.h */,
@@ -4155,6 +4158,7 @@
 				51B07F542AB8797300E14EE9 /* NativePromise.cpp in Sources */,
 				5CC0EE8A2162BC2200A1A842 /* NSURLExtras.mm in Sources */,
 				A8A473F4151A825B004123FF /* NumberOfCores.cpp in Sources */,
+				465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */,
 				8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */,
 				A3EE5C3A21FFAC5F00FABD61 /* OSAllocatorPOSIX.cpp in Sources */,
 				53FC70D023FB950C005B1990 /* OSLogPrintStream.mm in Sources */,

--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -24,20 +24,38 @@
 
 #pragma once
 
-#include <objc/message.h>
+#import <objc/message.h>
+#import <wtf/MallocSpan.h>
+#import <wtf/SystemMalloc.h>
 
 #ifdef __cplusplus
 
 template<typename ReturnType, typename... ArgumentTypes>
-inline ReturnType wtfObjCMsgSend(id target, SEL selector, ArgumentTypes... arguments)
+ReturnType wtfObjCMsgSend(id target, SEL selector, ArgumentTypes... arguments)
 {
     return reinterpret_cast<ReturnType (*)(id, SEL, ArgumentTypes...)>(objc_msgSend)(target, selector, arguments...);
 }
 
 template<typename ReturnType, typename... ArgumentTypes>
-inline ReturnType wtfCallIMP(IMP implementation, id target, SEL selector, ArgumentTypes... arguments)
+ReturnType wtfCallIMP(IMP implementation, id target, SEL selector, ArgumentTypes... arguments)
 {
     return reinterpret_cast<ReturnType (*)(id, SEL, ArgumentTypes...)>(implementation)(target, selector, arguments...);
 }
+
+namespace WTF {
+
+WTF_EXPORT_PRIVATE MallocSpan<Method, SystemMalloc> class_copyMethodListSpan(Class);
+WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListSpan(Class);
+WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *, BOOL isRequiredMethod, BOOL isInstanceMethod);
+WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *);
+WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *);
+
+} // namespace WTF
+
+using WTF::class_copyMethodListSpan;
+using WTF::class_copyProtocolListSpan;
+using WTF::protocol_copyMethodDescriptionListSpan;
+using WTF::protocol_copyPropertyListSpan;
+using WTF::protocol_copyProtocolListSpan;
 
 #endif // __cplusplus

--- a/Source/WTF/wtf/ObjCRuntimeExtras.mm
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.mm
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ObjCRuntimeExtras.h"
+
+#import <objc/runtime.h>
+#import <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+MallocSpan<Method, SystemMalloc> class_copyMethodListSpan(Class cls)
+{
+    unsigned methodCount = 0;
+    auto* methods = class_copyMethodList(cls, &methodCount);
+    return adoptMallocSpan<Method, SystemMalloc>(unsafeMakeSpan(methods, methodCount));
+}
+
+MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListSpan(Class cls)
+{
+    unsigned protocolCount = 0;
+    auto* protocols = class_copyProtocolList(cls, &protocolCount);
+    return adoptMallocSpan<__unsafe_unretained Protocol *, SystemMalloc>(unsafeMakeSpan(protocols, protocolCount));
+}
+
+MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *protocol, BOOL isRequiredMethod, BOOL isInstanceMethod)
+{
+    unsigned methodCount = 0;
+    auto* methods = protocol_copyMethodDescriptionList(protocol, isRequiredMethod, isInstanceMethod, &methodCount);
+    return adoptMallocSpan<objc_method_description, SystemMalloc>(unsafeMakeSpan(methods, methodCount));
+}
+
+MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *protocol)
+{
+    unsigned propertyCount = 0;
+    auto* properties = protocol_copyPropertyList(protocol, &propertyCount);
+    return adoptMallocSpan<objc_property_t, SystemMalloc>(unsafeMakeSpan(properties, propertyCount));
+}
+
+MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *protocol)
+{
+    unsigned protocolCount = 0;
+    auto* protocols = protocol_copyProtocolList(protocol, &protocolCount);
+    return adoptMallocSpan<__unsafe_unretained Protocol *, SystemMalloc>(unsafeMakeSpan(protocols, protocolCount));
+}
+
+} // namespace WTF

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -35,6 +35,7 @@
 #import "TimeRanges.h"
 #import <AVFoundation/AVTime.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
+#import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/WTFString.h>
 
@@ -159,22 +160,19 @@ static Class createWebAVPlayerControllerForwarderClass()
     objc_registerClassPair(newClass);
 
     // Remove all of AVPlayerController's methods.
-    unsigned methodCount = 0;
-    Method *methods = class_copyMethodList(superClass, &methodCount);
+    auto methods = class_copyMethodListSpan(superClass);
     IMP unknownMethodImp = class_getMethodImplementation(superClass, NSSelectorFromString(@"_web_unknownMethod"));
-    for (unsigned i = 0; i < methodCount; i++)
-        class_addMethod(newClass, method_getName(methods[i]), unknownMethodImp, method_getTypeEncoding(methods[i]));
-    free(methods);
+    for (auto& method : methods.span())
+        class_addMethod(newClass, method_getName(method), unknownMethodImp, method_getTypeEncoding(method));
 
     // Copy methods from WebAVPlayerControllerForwarder.
-    methods = class_copyMethodList(implClass, &methodCount);
-    for (unsigned i = 0; i < methodCount; i++) {
-        SEL selector = method_getName(methods[i]);
+    methods = class_copyMethodListSpan(implClass);
+    for (auto& method : methods.span()) {
+        SEL selector = method_getName(method);
         if ([NSStringFromSelector(selector) hasPrefix:@"."])
             continue;
-        class_replaceMethod(newClass, selector, method_getImplementation(methods[i]), method_getTypeEncoding(methods[i]));
+        class_replaceMethod(newClass, selector, method_getImplementation(method), method_getTypeEncoding(method));
     }
-    free(methods);
 
     class_addIvar(newClass, "_playerController", sizeof(RetainPtr<WebAVPlayerController>), log2(sizeof(RetainPtr<WebAVPlayerController>)), @encode(RetainPtr<WebAVPlayerController>));
 


### PR DESCRIPTION
#### a2691968c2351473b254a2cda09371433ddd4928
<pre>
Provide wrappers for some ObjC Runtime functions that return a MallocSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=282480">https://bugs.webkit.org/show_bug.cgi?id=282480</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/ObjcRuntimeExtras.h:
(protocolImplementsProtocol):
(forEachProtocolImplementingProtocol):
(forEachMethodInClass):
(forEachMethodInProtocol):
(forEachPropertyInProtocol):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/ObjCRuntimeExtras.h:
(WTF::class_copyMethodListSpan):
(WTF::class_copyProtocolListSpan):
(WTF::protocol_copyMethodDescriptionListSpan):
(WTF::protocol_copyPropertyListSpan):
(WTF::protocol_copyProtocolListSpan):
* Source/WebCore/bridge/objc/objc_class.mm:
(JSC::Bindings::ObjcClass::methodNamed const):
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(createWebAVPlayerControllerForwarderClass):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
(initializeMethods):

Canonical link: <a href="https://commits.webkit.org/286064@main">https://commits.webkit.org/286064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de969a910f4317e922b468037243979b821383d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1941 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46065 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24297 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67863 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80639 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73984 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1210 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66248 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8344 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96255 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11530 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4796 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21039 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->