### PR TITLE
[WebGPU] computeMininumVertexInstanceCount() does not handle buffer sizes less than lastStride

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282485-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282485-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282485.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282485.html
@@ -1,0 +1,4146 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxTextureDimension2D: 8192,
+    maxUniformBufferBindingSize: 13935318,
+    maxStorageBufferBindingSize: 149921439,
+  },
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 817});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder0 = device0.createCommandEncoder({});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let sampler0 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.92,
+  lodMaxClamp: 99.28,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({label: '\u52a2\uc139\uf3b7\u8855\ua4bd\u{1fffc}\u7fcd'});
+let texture0 = device0.createTexture({
+  label: '\u0a92\u09b8\u08d3\u{1f765}\uf713',
+  size: {width: 64, height: 64, depthOrArrayLayers: 25},
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.label = '\u0693\u1657\u5c88\u055b\u0423\u06ff\u6662\u099c\u{1f717}\u0f91\u{1ff2b}';
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let sampler1 = device0.createSampler({
+  label: '\u4057\u{1fe31}\ud0cd\u8c9b\u0b06\u9a4c\u4d91\ud4c7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.12,
+  maxAnisotropy: 7,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float']});
+let commandEncoder3 = device0.createCommandEncoder();
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 380,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer0 = device0.createBuffer({size: 9115, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView0 = texture0.createView({dimension: '2d', baseArrayLayer: 6});
+let textureView1 = texture0.createView({
+  label: '\u7f24\u03b6\u722f\u9378\u8599\u8bf4\u57dc\u03df\uf14b\u0f64',
+  dimension: 'cube',
+  baseArrayLayer: 5,
+});
+let sampler2 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 16.04,
+  lodMaxClamp: 66.60,
+});
+let texture1 = device0.createTexture({
+  size: {width: 570, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView2 = texture0.createView({
+  label: '\u07af\u9054\u4c23\u2d5e\u{1f74a}\udfef\u{1fbc6}\u0c3b\u{1fe96}',
+  dimension: 'cube-array',
+  format: 'etc2-rgb8a1unorm',
+  baseArrayLayer: 4,
+  arrayLayerCount: 6,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float']});
+try {
+renderBundleEncoder0.setVertexBuffer(5, undefined, 263_013_090, 60_892_064);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 8},
+  aspect: 'all',
+}, new Uint8Array(167).fill(240), /* required buffer size: 167 */
+{offset: 167, bytesPerRow: 38}, {width: 12, height: 28, depthOrArrayLayers: 0});
+} catch {}
+let buffer1 = device0.createBuffer({size: 565, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.72,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer1);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+let imageData0 = new ImageData(36, 68);
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let buffer2 = device0.createBuffer({
+  size: 10298,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder5 = device0.createCommandEncoder({});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 215, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 135,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 482});
+let commandBuffer0 = commandEncoder4.finish();
+let sampler4 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.69,
+  lodMaxClamp: 98.57,
+  compare: 'less',
+  maxAnisotropy: 7,
+});
+let texture2 = device0.createTexture({
+  size: {width: 42, height: 40, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 50.40,
+  lodMaxClamp: 61.93,
+});
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer2, 96);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 108,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let textureView3 = texture1.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let texture3 = device0.createTexture({
+  label: '\u0aaa\u0954\u6eea\u{1fb26}\u8a2d\u0e6d\u16ec\ub2ea\ued61',
+  size: [64],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView4 = texture1.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder3 = commandEncoder3.beginComputePass({});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(2028), 21, 0);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer2, 148, buffer0, 1204, 1568);
+} catch {}
+let buffer3 = device0.createBuffer({size: 5871, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView5 = texture1.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder4 = commandEncoder5.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+let querySet2 = device0.createQuerySet({label: '\u{1f6f6}\u0768\ua20c\ud430\u{1f7ff}\u236c\u1914\ua5ac\u145e', type: 'occlusion', count: 658});
+let texture4 = device0.createTexture({size: [64, 64, 25], format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder5 = commandEncoder6.beginComputePass({});
+let sampler6 = device0.createSampler({
+  label: '\u03d4\ue5a2',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.88,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1440 */
+  offset: 1440,
+  buffer: buffer2,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u82b7');
+} catch {}
+let texture5 = device0.createTexture({
+  size: {width: 10, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder6 = commandEncoder7.beginComputePass({label: '\uf80c\udc81\u00e9\u0772\u5af1'});
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(243).fill(176), /* required buffer size: 243 */
+{offset: 243}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer4 = device0.createBuffer({
+  label: '\u9fd0\ubff5\u0819\u6265\u3002\u0141',
+  size: 273,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+device0.queue.writeBuffer(buffer0, 1516, new Int16Array(3338), 845, 288);
+} catch {}
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(2477), 541, 0);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView6 = texture2.createView({format: 'rgba16float', arrayLayerCount: 1});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1816 */
+  offset: 1816,
+  bytesPerRow: 21760,
+  buffer: buffer2,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 1},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let texture6 = device0.createTexture({
+  size: {width: 10, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder8.beginComputePass();
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1).fill(85), /* required buffer size: 1 */
+{offset: 1}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+try {
+device0.addEventListener('uncapturederror', e => {  });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 20, new BigUint64Array(8859), 687, 0);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\u0967\u95b4\uebfe\u6b0d\uf03f\u52e8',
+  layout: bindGroupLayout0,
+  entries: [{binding: 380, resource: textureView0}],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let commandEncoder10 = device0.createCommandEncoder();
+let textureView7 = texture5.createView({label: '\uf696\u{1f992}\ud961\u0b7f\u4b7b\u73ba\u{1f86a}'});
+let computePassEncoder8 = commandEncoder10.beginComputePass();
+try {
+device0.queue.writeBuffer(buffer0, 764, new DataView(new ArrayBuffer(3634)), 62, 32);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0b6c\u2fc4\udc50\u0381\u{1fbdc}\u5cb0\uc0d1\ub5a3\u8c72',
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+var<workgroup> vw6: vec4i;
+
+@id(1876) override override5 = 0.2349;
+
+var<private> vp0: mat2x4h = mat2x4h();
+
+var<workgroup> vw5: array<atomic<i32>, 46>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw8: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(17814) override override1: bool;
+
+struct T1 {
+  @size(8) f0: array<u32>,
+}
+
+var<workgroup> vw7: i32;
+
+var<workgroup> vw0: f32;
+
+override override3 = 0.01855;
+
+var<workgroup> vw2: bool;
+
+@group(0) @binding(52) var tex0: texture_2d<f32>;
+
+@id(56015) override override0: bool;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(108) var tex1: texture_depth_2d;
+
+var<workgroup> vw4: array<atomic<i32>, 1>;
+
+@id(9490) override override2: u32;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw1: vec2<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn2() -> mat2x3h {
+  var out: mat2x3h;
+  var vf6: u32 = pack2x16snorm(vec2f(unconst_f32(0.1687), unconst_f32(0.04271)));
+  out += mat2x3h(f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))), f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))), f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))), f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))), f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))), f16(distance(vec2f(unconst_f32(0.2402), unconst_f32(0.1240)), vec2f(unconst_f32(0.1145), unconst_f32(0.07185)))));
+  vf6 = firstLeadingBit(vec2u(unconst_u32(55), unconst_u32(208))).y;
+  vp0 -= mat2x4h(vp0[u32(unconst_u32(118))], vp0[u32(unconst_u32(118))]);
+  var vf7: bool = override0;
+  vp0 += mat2x4h(f16(override3), f16(override3), f16(override3), f16(override3), f16(override3), f16(override3), f16(override3), f16(override3));
+  let ptr0: ptr<function, u32> = &vf6;
+  vf7 = bool(cosh(vec3f(unconst_f32(0.07257), unconst_f32(0.1312), unconst_f32(0.05195))).r);
+  out = mat2x3h(f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))), f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))), f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))), f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))), f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))), f16(pack2x16snorm(vec2f(unconst_f32(0.06176), unconst_f32(0.03799)))));
+  out = mat2x3h(f16(override4), f16(override4), f16(override4), f16(override4), f16(override4), f16(override4));
+  out = mat2x3h(f16(override4), f16(override4), f16(override4), f16(override4), f16(override4), f16(override4));
+  return out;
+  _ = override3;
+  _ = override0;
+  _ = override4;
+}
+
+fn fn0() -> array<u32, 19> {
+  var out: array<u32, 19>;
+  var vf0: f16 = asin(f16(unconst_f16(2923.5)));
+  vp0 -= mat2x4h(bitcast<vec4h>(insertBits(vec2u(unconst_u32(55), unconst_u32(207)), vec2u(unconst_u32(27), unconst_u32(205)), u32(unconst_u32(85)), u32(unconst_u32(58)))), bitcast<vec4h>(insertBits(vec2u(unconst_u32(55), unconst_u32(207)), vec2u(unconst_u32(27), unconst_u32(205)), u32(unconst_u32(85)), u32(unconst_u32(58)))));
+  vp0 = mat2x4h(asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))), asin(f16(unconst_f16(6843.1))));
+  let vf1: f32 = textureLoad(tex1, vec2i(unconst_i32(63), unconst_i32(53)), bitcast<vec3i>(countTrailingZeros(vec3u(unconst_u32(202), unconst_u32(232), unconst_u32(315))))[1]);
+  return out;
+}
+
+var<workgroup> vw3: array<vec4u, 7>;
+
+override override4: bool;
+
+fn fn1() -> vec2f {
+  var out: vec2f;
+  let vf2: vec3f = faceForward(vec3f(unconst_f32(0.2005), unconst_f32(0.00469), unconst_f32(0.4853)), vec3f(unconst_f32(0.3888), unconst_f32(0.1594), unconst_f32(0.2041)), vec3f(unconst_f32(0.01906), unconst_f32(0.03587), unconst_f32(0.3305)));
+  var vf3: f32 = override3;
+  let vf4: f32 = atan(f32(unconst_f32(0.9338)));
+  var vf5: u32 = pack4x8unorm(vec4f(f32(vp0[u32(unconst_u32(202))][u32(unconst_u32(6))])));
+  return out;
+  _ = override3;
+}`,
+  hints: {},
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: [10, 10, 1],
+  sampleCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView8 = texture0.createView({baseMipLevel: 0, baseArrayLayer: 0, arrayLayerCount: 9});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup2, new Uint32Array(718), 164, 0);
+} catch {}
+await gc();
+let bindGroup3 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 108, resource: textureView3}, {binding: 52, resource: textureView0}],
+});
+let buffer5 = device0.createBuffer({size: 12349, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder12 = device0.createCommandEncoder({});
+let computePassEncoder9 = commandEncoder12.beginComputePass({label: '\uc281\u0ab0\u498b\u75db\ueb09\uef9a'});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(3165), 199, 0);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(4) @interpolate(flat) f1: vec4i,
+  @location(0) f2: vec4f,
+  @location(3) f3: u32,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(52) var tex2: texture_2d<f32>;
+
+fn fn0() -> mat2x2h {
+  var out: mat2x2h;
+  vp2.fract = mix(f16(unconst_f16(4055.4)), f16(unconst_f16(15904.5)), f16(unconst_f16(11852.8)));
+  let vf8: u32 = firstTrailingBit(u32(unconst_u32(9)));
+  let ptr1: ptr<private, vec3h> = &vp1.fract;
+  let vf9: vec3f = atanh(vec3f(unconst_f32(0.2906), unconst_f32(0.1947), unconst_f32(0.04398)));
+  var vf10: f32 = mix(f32(unconst_f32(0.08643)), f32(unconst_f32(0.2501)), f32(unconst_f32(0.09596)));
+  return out;
+}
+
+fn fn1(a0: ptr<function, vec4f>) -> array<f32, 14> {
+  var out: array<f32, 14>;
+  let ptr2 = &vp1;
+  out[u32(unconst_u32(83))] = f32(abs(f16(unconst_f16(8987.1))));
+  let vf11: f32 = (*a0)[u32(unconst_u32(270))];
+  (*a0) = bitcast<vec4f>(unpack4xU8(u32(unconst_u32(112))));
+  return out;
+}
+
+struct T0 {
+  @size(92) f0: array<u32>,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct S0 {
+  @location(7) f0: i32,
+}
+
+var<workgroup> vw10: VertexOutput0;
+
+var<private> vp1 = modf(vec3h(18831.7, 3752.9, 328.6));
+
+@group(0) @binding(108) var tex3: texture_depth_2d;
+
+var<private> vp2 = modf(f16(1828.0));
+
+var<workgroup> vw9: array<array<array<S0, 1>, 12>, 3>;
+
+struct VertexOutput0 {
+  @location(8) @interpolate(flat, sample) f0: i32,
+  @location(6) @interpolate(flat) f1: vec4f,
+  @builtin(position) f2: vec4f,
+  @location(7) f3: i32,
+  @location(12) @interpolate(flat, centroid) f4: f16,
+  @location(2) f5: u32,
+  @location(11) f6: f16,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@vertex
+fn vertex0(@location(11) @interpolate(flat, sample) a0: vec4u, @location(10) @interpolate(linear, sample) a1: vec2f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  fn0();
+  fn0();
+  out.f2 *= vec4f(bitcast<f32>(pack4xU8(vec4u(unconst_u32(72), unconst_u32(35), unconst_u32(104), unconst_u32(3)))));
+  let ptr3: ptr<private, vec3h> = &vp1.whole;
+  let vf12: u32 = a0[u32(unconst_u32(15))];
+  out.f2 = vec4f(vp1.fract.zxxx);
+  out.f0 = i32(pack4xU8(vec4u(unconst_u32(47), unconst_u32(285), unconst_u32(19), unconst_u32(173))));
+  out.f6 -= f16(a1[u32(unconst_u32(12))]);
+  var vf13: f16 = (*ptr3)[u32(unconst_u32(140))];
+  let vf14: vec2h = log(vec2h(unconst_f16(641.3), unconst_f16(673.9)));
+  let vf15: u32 = vf12;
+  var vf16 = fn0();
+  vf13 = f16(a0[u32(vp1.fract[1])]);
+  out.f4 *= f16(log2(vec3f(round(f32(unconst_f32(0.06778)))))[2]);
+  let ptr4 = &vp2;
+  out.f2 = vec4f(f32((*ptr3)[u32(unconst_u32(308))]));
+  return out;
+}
+
+@fragment
+fn fragment0(@location(6) @interpolate(linear, centroid) a0: vec4f, @location(2) @interpolate(flat, sample) a1: u32, @location(8) a2: i32, a3: S0) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf17: vec3f = refract(vec3f(bitcast<f32>(textureNumLevels(tex3))), vec3f(unconst_f32(0.05166), unconst_f32(0.2956), unconst_f32(-0.1455)), f32(unconst_f32(0.02785)));
+  var vf18: vec2h = cos(vec2h(unconst_f16(1689.3), unconst_f16(-4781.5)));
+  var vf19: i32 = a2;
+  out = FragmentOutput0(bitcast<u32>(cos(vec2h(unconst_f16(6232.3), unconst_f16(13552.3)))), vec4i(cos(vec2h(unconst_f16(6232.3), unconst_f16(13552.3))).ggrg), vec4f(cos(vec2h(unconst_f16(6232.3), unconst_f16(13552.3))).rggr), bitcast<u32>(cos(vec2h(unconst_f16(6232.3), unconst_f16(13552.3)))));
+  var vf20: vec3f = refract(vec3f(vf18.yxx), vec3f(unconst_f32(0.00825), unconst_f32(0.1982), unconst_f32(0.3462)), f32(unconst_f32(0.01079)));
+  out.f1 &= bitcast<vec4i>(clamp(vec2u(unconst_u32(303), unconst_u32(19)), vec2u(unconst_u32(283), unconst_u32(63)), vec2u(unconst_u32(55), unconst_u32(74))).xyxy);
+  var vf21: i32 = a3.f0;
+  out.f1 ^= vec4i(vf21);
+  let vf22: vec4f = unpack4x8snorm(u32(unconst_u32(68)));
+  vp2 = modf(vec2h(acosh(vec2f(unconst_f32(0.2529), unconst_f32(0.02241))))[1]);
+  let ptr5: ptr<function, vec3f> = &vf17;
+  vf17 *= vec3f(f32(vp2.fract));
+  let ptr6: ptr<function, vec2h> = &vf18;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder13 = device0.createCommandEncoder();
+let textureView9 = texture1.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let texture8 = device0.createTexture({
+  size: [64, 64, 25],
+  sampleCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder10 = commandEncoder9.beginComputePass({});
+try {
+buffer1.unmap();
+} catch {}
+let texture9 = device0.createTexture({
+  size: [64, 64, 25],
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 2.286,
+  lodMaxClamp: 77.85,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(1359), 119, 0);
+} catch {}
+try {
+commandEncoder13.insertDebugMarker('\u0c3b');
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 118});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u27ac\u064d\ueb74\u4b38\u0d6a',
+  code: `
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(58147) override override7: bool;
+
+override override6 = false;
+
+var<workgroup> vw12: atomic<i32>;
+
+@id(21988) override override8 = 0.1526;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @align(2) @size(32) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput1 {
+  @builtin(position) f7: vec4f,
+}
+
+@group(0) @binding(52) var tex4: texture_2d<f32>;
+
+@group(0) @binding(108) var tex5: texture_depth_2d;
+
+struct S1 {
+  @location(6) @interpolate(flat, sample) f0: vec2u,
+  @builtin(vertex_index) f1: u32,
+  @location(1) @interpolate(flat) f2: f32,
+  @location(13) @interpolate(flat) f3: u32,
+  @location(0) f4: u32,
+  @location(5) f5: vec2f,
+  @location(12) @interpolate(flat, centroid) f6: i32,
+  @location(14) @interpolate(flat, sample) f7: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw11: atomic<u32>;
+
+var<workgroup> vw13: array<atomic<u32>, 13>;
+
+@vertex @must_use
+fn vertex1(@location(2) a0: vec4h, a1: S1, @location(4) a2: f32, @location(15) @interpolate(flat, centroid) a3: u32, @location(11) @interpolate(flat, sample) a4: vec4i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let vf23: f16 = round(f16(unconst_f16(3370.0)));
+  var vf24: vec2u = a1.f0;
+  return out;
+}
+
+@fragment
+fn fragment1(@location(12) @interpolate(flat, center) a0: f16, @location(2) @interpolate(flat, centroid) a1: u32) -> @location(200) @interpolate(linear) vec4f {
+  var out: vec4f;
+  out -= unpack4x8snorm(textureNumLevels(tex5));
+  var vf25: bool = override7;
+  var vf26: vec4f = exp2(vec4f(unconst_f32(0.2548), unconst_f32(0.1867), unconst_f32(0.1394), unconst_f32(0.1332)));
+  var vf27: bool = override7;
+  vf26 = vec4f(f32(override6));
+  let vf28: vec4f = unpack4x8unorm(u32(unconst_u32(250)));
+  vf27 = any(bool(unconst_bool(true)));
+  let vf29: u32 = textureNumLevels(tex5);
+  let ptr7: ptr<function, vec4f> = &vf26;
+  var vf30: f32 = textureLoad(tex5, vec2i(unconst_i32(24), unconst_i32(103)), i32(unconst_i32(59)));
+  return out;
+  _ = override6;
+  _ = override7;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  let vf31: i32 = atomicExchange(&vw12, i32(unconst_i32(83)));
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  atomicStore(&vw12, i32(unconst_i32(57)));
+  atomicMax(&vw11, u32(unconst_u32(116)));
+  let ptr8: ptr<workgroup, array<atomic<u32>, 13>> = &vw13;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+commandEncoder14.copyBufferToBuffer(buffer2, 344, buffer0, 20, 836);
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 424, shaderLocation: 10},
+          {format: 'uint16x4', offset: 112, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let computePassEncoder12 = commandEncoder13.beginComputePass({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 22.19,
+  lodMaxClamp: 92.67,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<workgroup> vw16: atomic<i32>;
+
+var<workgroup> vw29: bool;
+
+var<workgroup> vw14: FragmentOutput1;
+
+override override11: i32;
+
+var<workgroup> vw17: array<atomic<u32>, 3>;
+
+var<workgroup> vw22: VertexOutput2;
+
+var<private> vp3: FragmentOutput1 = FragmentOutput1(vec4i(13, -30, 499, -20));
+
+@group(0) @binding(108) var tex7: texture_depth_2d;
+
+override override13 = 0.1926;
+
+var<workgroup> vw21: VertexOutput2;
+
+struct VertexOutput2 {
+  @location(11) f8: vec2h,
+  @location(8) f9: f16,
+  @location(3) f10: f32,
+  @location(6) f11: vec4u,
+  @location(14) f12: vec2f,
+  @builtin(position) f13: vec4f,
+}
+
+var<workgroup> vw26: mat4x2f;
+
+override override14: f16;
+
+@id(6991) override override12: f32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct FragmentOutput1 {
+  @location(0) f0: vec4i,
+}
+
+var<workgroup> vw18: vec2i;
+
+var<workgroup> vw25: FragmentOutput1;
+
+var<workgroup> vw27: f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override10: u32;
+
+var<workgroup> vw24: array<atomic<u32>, 5>;
+
+var<workgroup> vw28: atomic<i32>;
+
+var<workgroup> vw19: mat3x4h;
+
+var<workgroup> vw15: atomic<u32>;
+
+@group(0) @binding(52) var tex6: texture_2d<f32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(23895) override override9: u32;
+
+var<workgroup> vw20: VertexOutput2;
+
+var<workgroup> vw23: array<array<array<FragmentOutput1, 3>, 1>, 2>;
+
+@vertex
+fn vertex2(@location(3) @interpolate(perspective) a0: vec2h, @builtin(instance_index) a1: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  let ptr9: ptr<private, FragmentOutput1> = &vp3;
+  let vf32: f16 = cosh(f16(unconst_f16(1484.2)));
+  out.f9 = f16((*ptr9).f0[3]);
+  out.f8 = vec2h(a0[u32(unconst_u32(138))]);
+  out.f10 = override13;
+  out.f11 = vec4u(vp3.f0);
+  let vf33: f16 = override14;
+  let ptr10: ptr<private, FragmentOutput1> = &(*ptr9);
+  vp3.f0 = vec4i(i32(vf32));
+  let ptr11: ptr<private, vec4i> = &(*ptr9).f0;
+  out.f9 = f16((*ptr11).a);
+  let vf34: i32 = override11;
+  let vf35: vec2h = a0;
+  let vf36: f32 = override13;
+  out.f11 = unpack4xU8(u32(vf35[bitcast<u32>(vp3.f0.b)]));
+  return out;
+  _ = override13;
+  _ = override14;
+  _ = override11;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf37: vec4h = mix(vec4h(unconst_f16(3281.0), unconst_f16(16894.0), unconst_f16(1276.6), unconst_f16(247.5)), vec4h(f16(override13)), vec4h(unconst_f16(843.3), unconst_f16(273.0), unconst_f16(6462.0), unconst_f16(11355.7)));
+  let vf38: i32 = vp3.f0[u32(unconst_u32(38))];
+  out = FragmentOutput1(vec4i(i32(textureLoad(tex7, vec2i(unconst_i32(127), unconst_i32(600)), i32(unconst_i32(169))))));
+  let vf39: i32 = override11;
+  let vf40: f16 = inverseSqrt(f16(unconst_f16(4649.6)));
+  vp3 = FragmentOutput1(vec4i(vf39));
+  out.f0 = vec4i(textureDimensions(tex7, i32(unconst_i32(216))).rrrr);
+  out.f0 = vec4i(i32(inverseSqrt(f16(unconst_f16(14812.2)))));
+  var vf41: f32 = override12;
+  var vf42: i32 = override11;
+  var vf43: vec4h = ceil(vec4h(f16(vf42)));
+  return out;
+  _ = override12;
+  _ = override13;
+  _ = override11;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute2() {
+  vw18 = vec2i(vw21.f13.rg);
+  let vf44: f32 = (*&vw20).f13[u32(unconst_u32(182))];
+  let ptr12: ptr<workgroup, vec4i> = &(*&vw23)[u32(unconst_u32(69))][0][2].f0;
+  var vf45: vec2u = textureDimensions(tex6, i32(unconst_i32(25)));
+  let vf46: f32 = vw20.f12[u32(unconst_u32(880))];
+  let ptr13: ptr<workgroup, vec4i> = &(*ptr12);
+  let ptr14: ptr<workgroup, vec2h> = &(*&vw20).f8;
+  atomicStore(&vw17[u32(unconst_u32(158))], u32(unconst_u32(355)));
+  atomicXor(&vw17[bitcast<u32>((*ptr14))], u32(unconst_u32(108)));
+  let ptr15: ptr<workgroup, atomic<u32>> = &(*&vw24)[4];
+  let ptr16: ptr<workgroup, vec4i> = &vw23[1][u32(unconst_u32(60))][2].f0;
+  let ptr17: ptr<workgroup, array<FragmentOutput1, 3>> = &(*&vw23)[u32(unconst_u32(152))][u32(unconst_u32(236))];
+  var vf47: i32 = atomicLoad(&(*&vw16));
+  let ptr18: ptr<workgroup, vec4i> = &(*ptr17)[u32(unconst_u32(79))].f0;
+  let ptr19: ptr<workgroup, mat3x4h> = &(*&vw19);
+  vw19 = mat3x4h(f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])), f16(atomicLoad(&vw24[4])));
+  atomicXor(&vw16, i32(unconst_i32(319)));
+  var vf48: u32 = vf45[u32(unconst_u32(59))];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView10 = texture1.createView({
+  label: '\ue517\u0a84\ue15b\u1029\u8e10\u8f4e\ua21d\u{1f64c}\u{1fcb7}',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder13 = commandEncoder14.beginComputePass({});
+let buffer6 = device0.createBuffer({
+  size: 31965,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let computePassEncoder14 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(812), 58, 0);
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 108, resource: textureView3}, {binding: 52, resource: textureView7}],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer7 = device0.createBuffer({size: 10295, usage: GPUBufferUsage.MAP_WRITE});
+let texture10 = device0.createTexture({
+  label: '\u{1f6a8}\u91be\u{1f61f}\u0f6f\u0920\u01cb\u1b14',
+  size: [84, 80, 384],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.writeBuffer(buffer5, 3376, new BigUint64Array(31553), 13742, 272);
+} catch {}
+let buffer8 = device0.createBuffer({size: 6070, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView11 = texture0.createView({
+  label: '\u{1f9ee}\u{1fdb4}\u{1f9c6}\u{1ff1f}\u92fd\u6834\ub20b\ua98f\u06ca',
+  dimension: 'cube-array',
+  aspect: 'all',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let bindGroup6 = device0.createBindGroup({
+  label: '\u{1fafe}\ubb50\u{1f85f}\udf0c\u2387\u9f60\u5798\u169e\u54d3\ufeb8\u{1ff50}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 380, resource: textureView7}],
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 3274});
+let computePassEncoder15 = commandEncoder16.beginComputePass({});
+let sampler9 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.76,
+  lodMaxClamp: 98.64,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 452, new DataView(new ArrayBuffer(16791)), 58, 240);
+} catch {}
+let bindGroup7 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView3}]});
+let textureView12 = texture9.createView({dimension: 'cube', baseMipLevel: 0});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let imageData1 = new ImageData(76, 24);
+let buffer9 = device0.createBuffer({
+  size: 27722,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture11 = device0.createTexture({
+  size: [20, 1, 43],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup7);
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0a34\u2615\u{1fc39}\ufdbb\u0dee\u3585',
+  colorFormats: ['rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup6, new Uint32Array(86), 38, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer9, 'uint16', 554, 7_721);
+} catch {}
+try {
+  await shaderModule3.getCompilationInfo();
+} catch {}
+let computePassEncoder16 = commandEncoder17.beginComputePass({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.08,
+  lodMaxClamp: 94.99,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer6, 'uint32', 6_884, 1_787);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView13 = texture6.createView({dimension: '2d-array', format: 'rgba32sint'});
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer9, 'uint16', 5_426, 894);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer4, 68);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(386).fill(168), /* required buffer size: 386 */
+{offset: 386}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder19.beginComputePass({});
+let renderBundle2 = renderBundleEncoder2.finish({});
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  size: [40, 1, 54],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView14 = texture1.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+let sampler11 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 74.91,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(2, bindGroup2, new Uint32Array(5478), 449, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => {  });
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u{1fd6e}');
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u{1f8fa}\uce27\u087d\ue1bd\ue81b',
+  layout: bindGroupLayout2,
+  entries: [{binding: 108, resource: textureView3}, {binding: 52, resource: textureView0}],
+});
+let texture13 = device0.createTexture({
+  size: [10, 1, 128],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler12 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.12,
+  lodMaxClamp: 99.46,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u0e14');
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let texture14 = device0.createTexture({
+  size: {width: 285, height: 1, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView15 = texture1.createView({dimension: '2d', aspect: 'stencil-only', format: 'stencil8', mipLevelCount: 1});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup6, []);
+} catch {}
+let textureView16 = texture14.createView({});
+let sampler13 = device0.createSampler({
+  label: '\u06f1\u{1f7e3}\u5b0d\ud095\u{1fef6}\u0101\u0709',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 47.80,
+  lodMaxClamp: 53.20,
+});
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 7648 */
+  offset: 7648,
+  bytesPerRow: 17664,
+  buffer: buffer9,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let sampler14 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 90.10,
+  lodMaxClamp: 99.98,
+});
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(191).fill(74), /* required buffer size: 191 */
+{offset: 191}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1f688}\uedda\u4aa9\u{1f714}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 380, resource: textureView7}],
+});
+let buffer10 = device0.createBuffer({size: 276, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 129});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup0, new Uint32Array(5740), 106, 0);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u04f7\u0c2a\u0e30\u9aab\u50e4'});
+let texture15 = device0.createTexture({
+  label: '\u2425\u3d13\u{1fa8e}\u{1feee}\u4cd3',
+  size: {width: 40, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView17 = texture4.createView({dimension: 'cube-array', aspect: 'all', arrayLayerCount: 6});
+let computePassEncoder19 = commandEncoder21.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.43,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(1, bindGroup5, new Uint32Array(3036), 39, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture16 = device0.createTexture({
+  size: [84, 80, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder20 = commandEncoder20.beginComputePass({});
+try {
+buffer10.unmap();
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 156,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 445,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 50, visibility: 0, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 129,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder21 = commandEncoder23.beginComputePass({label: '\ub6db\u05d3\u0285'});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup6, new Uint32Array(2205), 497, 0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4, new DataView(new ArrayBuffer(18677)), 1124, 88);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let texture18 = device0.createTexture({
+  size: {width: 1140},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler16 = device0.createSampler({
+  label: '\uc2b6\u08f8\u{1fcd3}\u0464\u3052\u0e84\u0da4\u0955\u89e6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.94,
+  lodMaxClamp: 98.26,
+  compare: 'less',
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup0, new Uint32Array(2099), 137, 0);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let textureView18 = texture17.createView({label: '\u53c2\u{1f8cc}\u29b6\u66e7\u0fc2\u{1f73f}\u094a\u0f57\u{1fbfe}', mipLevelCount: 1});
+let textureView19 = texture15.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder22 = commandEncoder22.beginComputePass({});
+let renderPassEncoder0 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 15,
+  clearValue: { r: 911.1, g: 700.4, b: 866.4, a: 694.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 6_220, 900);
+} catch {}
+let buffer11 = device0.createBuffer({
+  size: 5968,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  label: '\ua47b\uad50\u5003\u1f2a\u0b0d\uefc3\uf805\uecae',
+  size: [570, 1, 13],
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView20 = texture2.createView({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uf2dc');
+} catch {}
+let texture20 = device0.createTexture({
+  size: {width: 84},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture21 = device0.createTexture({
+  label: '\u4462\udf47\ue4c2\u{1febf}\u8dba\u{1fd96}\u{1f626}\ub94a',
+  size: [64],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView21 = texture21.createView({format: 'rgba32sint'});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(142), 6, 0);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 176 */
+  offset: 176,
+  bytesPerRow: 17408,
+  buffer: buffer3,
+}, {
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 4, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let imageBitmap0 = await createImageBitmap(imageData0);
+let textureView22 = texture18.createView({});
+let renderPassEncoder1 = commandEncoder25.beginRenderPass({
+  label: '\u{1f966}\u9845\u3a1e\u24ce',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 1,
+  clearValue: { r: -378.4, g: -503.5, b: -689.9, a: 222.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 82.45,
+  lodMaxClamp: 93.99,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 827.5, g: 100.6, b: 461.6, a: 431.8, });
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'iec61966-2-1'} });
+let buffer12 = device0.createBuffer({
+  size: 14826,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView23 = texture6.createView({dimension: '2d'});
+let textureView24 = texture16.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 488 */
+  offset: 488,
+  bytesPerRow: 36096,
+  buffer: buffer11,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 215, resource: sampler4},
+    {binding: 135, resource: {buffer: buffer5, offset: 1280, size: 1492}},
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture22 = device0.createTexture({
+  label: '\u05f3\uc7a1\u0faf\u05c0\u0bad\ufda6',
+  size: [2280, 1, 1],
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture23 = device0.createTexture({
+  size: {width: 570, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder23 = commandEncoder2.beginComputePass({});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.setViewport(119.8284807023631, 0.8656419609178887, 125.5826892134362, 0.04375277874560422, 0.814014566224891, 0.870758983302877);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint16', 1_472, 2_532);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer1, 120, 92);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(querySet5, 51, 10, buffer2, 1536);
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  label: '\uc215\u716c\ub6a2\u{1fe67}\u007e',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x74a095c8},
+  fragment: {
+  module: shaderModule3,
+  constants: {override11: 0, 6_991: 0},
+  targets: [{
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {
+        arrayStride: 108,
+        attributes: [
+          {format: 'float32x4', offset: 16, shaderLocation: 2},
+          {format: 'float32', offset: 4, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 1},
+          {format: 'uint32x4', offset: 8, shaderLocation: 0},
+          {format: 'uint8x2', offset: 8, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 692,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 452, shaderLocation: 12},
+          {format: 'sint32', offset: 0, shaderLocation: 11},
+          {format: 'uint32x4', offset: 36, shaderLocation: 6},
+          {format: 'uint16x4', offset: 168, shaderLocation: 13},
+          {format: 'uint16x4', offset: 108, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 40,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x4', offset: 16, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+let imageData2 = new ImageData(8, 32);
+let bindGroup11 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 52, resource: textureView0}, {binding: 108, resource: textureView3}],
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView25 = texture22.createView({label: '\u042d\u018b\u074d\u2f01\u3b14\ub168\ue074\u1656', dimension: '2d-array'});
+let textureView26 = texture16.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder24 = commandEncoder27.beginComputePass({});
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+let imageData3 = new ImageData(68, 28);
+let commandEncoder29 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 1067});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 1088, buffer5, 4316, 1892);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet2, 254, 36, buffer6, 1536);
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 45});
+let sampler18 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.40,
+  lodMaxClamp: 82.64,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup7, new Uint32Array(1973), 79, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer1);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 487, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 256 */
+  offset: 256,
+  buffer: buffer12,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.insertDebugMarker('\u124c');
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 387, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup12 = device0.createBindGroup({
+  label: '\u{1fae8}\u7db5\u7f76\u0e5b\u0ed7',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 135, resource: {buffer: buffer2, offset: 0, size: 3360}},
+    {binding: 215, resource: sampler16},
+  ],
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder30 = device0.createCommandEncoder({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(1096), 18, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup12, new Uint32Array(748), 604, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 1120 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1536 */
+  offset: 1536,
+  bytesPerRow: 14336,
+  rowsPerImage: 516,
+  buffer: buffer6,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(36, 16);
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u{1fff6}\u6a06\u002c\u4e6d\ue95b\u0c08\uc7d4\ue9b5\ue76e',
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 52, resource: textureView0}, {binding: 108, resource: textureView3}],
+});
+let textureView27 = texture4.createView({dimension: '2d', baseArrayLayer: 4});
+let computePassEncoder25 = commandEncoder30.beginComputePass({});
+let renderPassEncoder2 = commandEncoder29.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 7,
+  clearValue: { r: -431.1, g: 576.6, b: 899.9, a: -744.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 126005199,
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+// renderPassEncoder2.executeBundles([renderBundle1, renderBundle0, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 28, z: 3},
+  aspect: 'all',
+}, new Uint8Array(7_374).fill(108), /* required buffer size: 7_374 */
+{offset: 29, bytesPerRow: 65, rowsPerImage: 113}, {width: 20, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 70, resource: sampler13}]});
+let buffer13 = device0.createBuffer({size: 3580, usage: GPUBufferUsage.MAP_READ});
+let commandBuffer1 = commandEncoder25.finish();
+let texture24 = device0.createTexture({
+  size: [84, 80, 1],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler19 = device0.createSampler({
+  label: '\u15ff\ue9bd\u6583\u98f0',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 47.63,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+}, new Uint8Array(41).fill(152), /* required buffer size: 41 */
+{offset: 41, rowsPerImage: 24}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'iec61966-2-1'} });
+try {
+adapter0.label = '\u3b5a\u{1fc99}\u0a5c';
+} catch {}
+let buffer14 = device0.createBuffer({size: 345, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture25 = device0.createTexture({
+  size: {width: 570},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 62.35,
+  lodMaxClamp: 63.41,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 0, 24);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer9, 1800, buffer12, 72, 1568);
+} catch {}
+let computePassEncoder26 = commandEncoder26.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({label: '\u0c21\uc287', colorFormats: ['rgba16float'], depthReadOnly: true});
+let renderBundle3 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let renderPassEncoder3 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 13,
+  clearValue: { r: 630.8, g: -563.0, b: -280.5, a: -458.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 379348931,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.80,
+  compare: 'not-equal',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer12, 'uint16', 2_934, 696);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let bindGroup15 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let buffer15 = device0.createBuffer({size: 17785, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0c9f\u478c\u1a6d\u{1f88e}\u{1f6a7}\u1e99'});
+let computePassEncoder27 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder18.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 960, new Int16Array(8700), 532, 1340);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer16 = device0.createBuffer({
+  size: 11652,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView28 = texture22.createView({label: '\u02fb\u{1ffe1}\u5bc4\u3e6c\u{1feae}\u157d\u5c4a\u273b\ufa3c\u08a6\ud75f'});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup9, new Uint32Array(3591), 80, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint16', 10, 11);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer2, 0, 8);
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 446});
+try {
+device0.queue.label = '\u3523\u51d2\uc862\ua163\u0edd\u0d51';
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u07cc\u{1f89f}\uf6b1\u{1fa6b}\u055a\u8516\u{1febc}\ub355\u{1fdd8}\u120e\ud901',
+  layout: bindGroupLayout0,
+  entries: [{binding: 380, resource: textureView7}],
+});
+let buffer17 = device0.createBuffer({size: 3004, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup2, new Uint32Array(355), 193, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 4440, new BigUint64Array(1196), 99, 8);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u63de\u{1feac}\uda67\ud41a\ufe74\u22f6\u09d9\u66e6\u{1f6b5}',
+  entries: [
+    {
+      binding: 383,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 18, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: [5, 1, 7],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+});
+let computePassEncoder28 = commandEncoder32.beginComputePass({label: '\u5a4a\u773f'});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(191), 12, 0);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 410,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 267, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 163,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 149,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 108,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture27 = device0.createTexture({
+  size: [1140],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler22 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.51,
+  lodMaxClamp: 87.88,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, new Uint32Array(544), 47, 0);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  size: [42],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView29 = texture17.createView({});
+let sampler23 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 27.85,
+  lodMaxClamp: 88.92,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup13, new Uint32Array(4226), 518, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(457).fill(114), /* required buffer size: 457 */
+{offset: 457}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let textureView30 = texture28.createView({label: '\u68d4\u0961\ufd22\u3012\ub84e\u7de1\u913f\u0af3'});
+let computePassEncoder29 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder11.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(0, bindGroup0, new Uint32Array(1746), 81, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+  /* bytesInLastRow: 672 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 640 */
+  offset: 640,
+  rowsPerImage: 163,
+  buffer: buffer6,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder33.insertDebugMarker('\u56ba');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 7, z: 6},
+  aspect: 'all',
+}, new Uint8Array(108).fill(45), /* required buffer size: 108 */
+{offset: 108, bytesPerRow: 334, rowsPerImage: 32}, {width: 19, height: 22, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let buffer18 = device0.createBuffer({
+  size: 5981,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView31 = texture27.createView({});
+let texture29 = device0.createTexture({
+  size: {width: 84, height: 80, depthOrArrayLayers: 384},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(2441), 839, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder35.insertDebugMarker('\ude78');
+} catch {}
+let textureView32 = texture15.createView({mipLevelCount: 1});
+let texture30 = device0.createTexture({
+  size: [64, 64, 25],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder30 = commandEncoder33.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(1753), 169, 0);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  label: '\u7d5d\u05b5\u4aa6',
+  layout: bindGroupLayout2,
+  entries: [{binding: 52, resource: textureView0}, {binding: 108, resource: textureView3}],
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+let computePassEncoder31 = commandEncoder35.beginComputePass({label: '\u{1f9a0}\u0175\u{1f90f}\u8c3b\uc2e4\u89e5'});
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer15, 8_800, 281);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 704 */
+  offset: 704,
+  bytesPerRow: 22272,
+  buffer: buffer9,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7120 widthInBlocks: 445 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 400 */
+  offset: 400,
+  bytesPerRow: 32256,
+  rowsPerImage: 23,
+  buffer: buffer5,
+}, {width: 445, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img0 = await imageWithData(16, 161, '#10101010', '#20202020');
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 70, resource: sampler13}]});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(99);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3, renderBundle1, renderBundle0, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(41, 0, 70, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint32', 24, 80);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2336 */
+  offset: 2336,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let buffer19 = device0.createBuffer({
+  size: 24291,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder32 = commandEncoder36.beginComputePass();
+try {
+computePassEncoder32.setBindGroup(3, bindGroup0, new Uint32Array(107), 7, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, undefined, 0);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u06c1');
+} catch {}
+try {
+textureView11.label = '\u078d\u890c\u4e55';
+} catch {}
+let buffer20 = device0.createBuffer({
+  size: 2794,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 1884});
+let texture31 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 25},
+  mipLevelCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler24 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 90.86,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+let textureView33 = texture0.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 58.95,
+  lodMaxClamp: 82.06,
+});
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 124, new DataView(new ArrayBuffer(5835)), 70, 1992);
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 481});
+let computePassEncoder33 = commandEncoder37.beginComputePass({label: '\u07ca\u2ef3\u4120\ueb20\u0a29\u0617\u2ff8\u1862\u0bb0\u0be3\u05d2'});
+let sampler26 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 42.68,
+  lodMaxClamp: 77.29,
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint16', 18, 59);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer20, 296, 472);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 2204, new BigUint64Array(4559), 1337, 320);
+} catch {}
+document.body.append(img0);
+try {
+textureView20.label = '\u6acc\u0223\u{1ffbb}\u25c4\u{1ff59}\u0822';
+} catch {}
+let bindGroup20 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let commandEncoder38 = device0.createCommandEncoder({});
+let textureView34 = texture5.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder34 = commandEncoder38.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup19, new Uint32Array(3100), 391, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(225.0749769715294, 0.17043736218568328, 38.69319064550599, 0.0743709128616635, 0.2690621581748186, 0.4363115134271789);
+} catch {}
+try {
+externalTexture0.label = '\ub06f\uc15c\u{1fcde}\u8d4e';
+} catch {}
+let texture32 = device0.createTexture({
+  size: {width: 570, height: 1, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup2, new Uint32Array(599), 142, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(116.66295895012105, 0.3657568115885169, 0.49441739375385896, 0.04357934458254957, 0.8820047271485418, 0.9630907524897722);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1, new Uint32Array(27), 11, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup18, new Uint32Array(609), 101, 0);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u{1f701}');
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder();
+let texture33 = device0.createTexture({size: [10], mipLevelCount: 1, dimension: '1d', format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+let textureView35 = texture32.createView({
+  label: '\u{1f6e4}\u{1febe}\u4dc2\u6db5\u{1f654}\uc7a0\u07c7\u6c98\ua0be',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(1510), 6, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer2, 'uint16', 60, 111);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 2304 widthInBlocks: 144 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1696 */
+  offset: 1696,
+  bytesPerRow: 25856,
+  rowsPerImage: 0,
+  buffer: buffer6,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 257, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 144, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 804, new Int16Array(17839), 1134, 544);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder40 = device0.createCommandEncoder({});
+let computePassEncoder35 = commandEncoder40.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup11, new Uint32Array(1297), 152, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint32', 2_072, 822);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 4096,
+  buffer: buffer3,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1584 */
+  offset: 1584,
+  bytesPerRow: 3840,
+  rowsPerImage: 289,
+  buffer: buffer12,
+}, {width: 2, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder35.pushDebugGroup('\u01ef');
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 39, resource: textureView22},
+    {binding: 19, resource: textureView25},
+    {binding: 154, resource: textureView23},
+    {binding: 50, resource: {buffer: buffer2, offset: 256, size: 1896}},
+    {binding: 156, resource: textureView18},
+    {binding: 129, resource: {buffer: buffer19, offset: 12800, size: 995}},
+    {binding: 445, resource: textureView3},
+  ],
+});
+let buffer21 = device0.createBuffer({size: 12804, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler27 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.25,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup12, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 120, 3_296);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer11, 1384, buffer21, 1848, 500);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 404, new Float32Array(10103), 2204, 260);
+} catch {}
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer2 = commandEncoder23.finish({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], sampleCount: 4});
+let sampler28 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.03,
+  lodMaxClamp: 80.18,
+  maxAnisotropy: 5,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup13, new Uint32Array(4916), 52, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer20, 228, 737);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 42, height: 40, depthOrArrayLayers: 192}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 4, y: 8, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder41 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup3, new Uint32Array(1568), 61, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer4, 0, 32);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer9, 3888, buffer4, 12, 48);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 488 */
+  offset: 488,
+  buffer: buffer18,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 17},
+  aspect: 'all',
+},
+{width: 1, height: 9, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 39, resource: textureView22},
+    {binding: 50, resource: {buffer: buffer14, offset: 0, size: 8}},
+    {binding: 19, resource: textureView25},
+    {binding: 154, resource: textureView23},
+    {binding: 445, resource: textureView3},
+    {binding: 129, resource: {buffer: buffer9, offset: 2560, size: 5326}},
+    {binding: 156, resource: textureView29},
+  ],
+});
+let computePassEncoder36 = commandEncoder39.beginComputePass({});
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer20, 32, 356);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(7, buffer20, 0, 1_060);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 2, y: 16, z: 0},
+  aspect: 'all',
+}, new Uint8Array(641).fill(99), /* required buffer size: 641 */
+{offset: 641, bytesPerRow: 63, rowsPerImage: 14}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView36 = texture13.createView({label: '\u0122\u9282\u0733\u{1fab0}'});
+let computePassEncoder37 = commandEncoder41.beginComputePass();
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer20, 0);
+} catch {}
+let texture34 = device0.createTexture({
+  size: {width: 1140, height: 1, depthOrArrayLayers: 54},
+  mipLevelCount: 6,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 235.5, g: -410.0, b: 210.0, a: -289.1, });
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer11, 0, 827);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 1908, new BigUint64Array(22688), 3283, 132);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 383, resource: textureView23}, {binding: 18, resource: sampler13}],
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  size: {width: 2280, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder38 = commandEncoder42.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer9, 668);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, undefined, 847_886_263, 1_054_047_496);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 22, resource: textureView15},
+    {binding: 267, resource: {buffer: buffer19, offset: 1024, size: 3754}},
+    {binding: 16, resource: textureView3},
+    {binding: 207, resource: textureView0},
+    {binding: 362, resource: {buffer: buffer5, offset: 0, size: 196}},
+    {binding: 163, resource: {buffer: buffer9, offset: 6144, size: 3653}},
+    {binding: 410, resource: textureView32},
+    {binding: 86, resource: textureView1},
+    {binding: 26, resource: {buffer: buffer1, offset: 0, size: 20}},
+    {binding: 149, resource: {buffer: buffer14, offset: 0, size: 212}},
+    {binding: 36, resource: {buffer: buffer18, offset: 256, size: 1196}},
+    {binding: 40, resource: textureView30},
+    {binding: 59, resource: textureView31},
+    {binding: 61, resource: textureView23},
+    {binding: 108, resource: {buffer: buffer19, offset: 15360, size: 1532}},
+  ],
+});
+let commandEncoder43 = device0.createCommandEncoder();
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.77,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup2, new Uint32Array(1184), 387, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint32', 4_376, 131);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 383, resource: textureView23}, {binding: 18, resource: sampler20}],
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 533});
+let computePassEncoder39 = commandEncoder43.beginComputePass({label: '\u5a7f\u7bd9\u7658'});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.50,
+  lodMaxClamp: 87.03,
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup10, new Uint32Array(1989), 21, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(15, 288, 37, -2_128_699_181, 331_310_054);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer11, 1_056);
+} catch {}
+try {
+computePassEncoder35.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 141,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup11, new Uint32Array(6062), 222, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 570, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(214, 47, '#10101010', '#20202020');
+let commandEncoder44 = device0.createCommandEncoder({label: '\ucff9\u01a3\u0f20\uc4d2\u0839\u0b29\u0001\u{1fe27}\u0f22\u{1fbf6}'});
+let computePassEncoder40 = commandEncoder24.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer2, 0, 30);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u871e');
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+let textureView37 = texture6.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let texture36 = device0.createTexture({
+  size: {width: 1140},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup1, new Uint32Array(604), 3, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(117.95588159117351, 0.5957597549351241, 95.32722713634112, 0.36155901213809893, 0.3266779003089968, 0.6067342456817081);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer10, 16, buffer4, 12, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 4, y: 59, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40_296).fill(75), /* required buffer size: 40_296 */
+{offset: 102, bytesPerRow: 33, rowsPerImage: 203}, {width: 1, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpteSt4281', transfer: 'hlg'} });
+let videoFrame3 = new VideoFrame(videoFrame1, {timestamp: 0});
+let buffer22 = device0.createBuffer({
+  size: 1940,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup10, new Uint32Array(1599), 75, 0);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 1098, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  label: '\u8b78\u7b6a\u{1f999}\ub32b\udc66\u{1fe97}\u172e\u{1fe41}\u0238\u{1fc23}',
+  layout: bindGroupLayout8,
+  entries: [{binding: 141, resource: textureView23}],
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  label: '\u6c86\u{1ff2f}\uf23b\u1804\u0463\u0011\u074b\u89be\uc069',
+  size: {width: 570, height: 1, depthOrArrayLayers: 810},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler31 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.32,
+  lodMaxClamp: 99.41,
+  compare: 'greater',
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(2, bindGroup11, new Uint32Array(350), 3, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer6, 'uint32', 3_592, 7_347);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 61, resource: textureView23},
+    {binding: 86, resource: textureView1},
+    {binding: 207, resource: textureView7},
+    {binding: 36, resource: {buffer: buffer14, offset: 0, size: 96}},
+    {binding: 362, resource: {buffer: buffer1, offset: 0, size: 96}},
+    {binding: 16, resource: textureView3},
+    {binding: 108, resource: {buffer: buffer20, offset: 768, size: 1828}},
+    {binding: 26, resource: {buffer: buffer5, offset: 512, size: 1668}},
+    {binding: 149, resource: {buffer: buffer1, offset: 0, size: 148}},
+    {binding: 267, resource: {buffer: buffer8, offset: 512, size: 911}},
+    {binding: 22, resource: textureView15},
+    {binding: 40, resource: textureView30},
+    {binding: 410, resource: textureView35},
+    {binding: 163, resource: {buffer: buffer19, offset: 11520, size: 149}},
+    {binding: 59, resource: textureView31},
+  ],
+});
+let sampler32 = device0.createSampler({
+  label: '\ud920\u46d3\ub50c\u0d72\u4db9\u9e1f\u4a36\ud2b4\u93c1\u{1f75d}\u{1f77b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.02,
+  lodMaxClamp: 66.42,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup19, new Uint32Array(2262), 760, 0);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 26, y: 5, z: 65},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(35).fill(255), /* required buffer size: 35 */
+{offset: 35}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 197});
+let computePassEncoder41 = commandEncoder45.beginComputePass({label: '\u0556\u7f66\u079f\u{1f960}\u{1fe27}\u{1f788}\u5ae6\u5e1f\u6cf3\u05e0'});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer20, 0, 384);
+} catch {}
+try {
+commandEncoder47.insertDebugMarker('\u{1ff9c}');
+} catch {}
+document.body.prepend(img0);
+let computePassEncoder42 = commandEncoder46.beginComputePass({});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.76,
+  lodMaxClamp: 99.01,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup20, new Uint32Array(2119), 810, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -639.7, g: -938.0, b: 929.2, a: 255.3, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint32', 2_376, 224);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+await gc();
+let commandEncoder48 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  label: '\uba30\u484a',
+  size: {width: 10, height: 10, depthOrArrayLayers: 5},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup14, new Uint32Array(816), 446, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(247.94456351873495, 0.8961923900091714, 15.637475928849806, 0.018062578489310657, 0.8274091541622465, 0.8845333596688996);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3216 */
+  offset: 3216,
+  bytesPerRow: 37632,
+  buffer: buffer18,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 17749,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({label: '\u0ea9\u1142\u131f\u435b', type: 'occlusion', count: 774});
+let computePassEncoder43 = commandEncoder47.beginComputePass();
+try {
+computePassEncoder38.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 864 widthInBlocks: 108 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 14592,
+  buffer: buffer19,
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 198, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 108, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u05e8');
+} catch {}
+document.body.prepend(img0);
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer20);
+} catch {}
+try {
+externalTexture1.label = '\u2964\u02e1';
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 141, resource: textureView23}]});
+let commandEncoder50 = device0.createCommandEncoder({label: '\udcd6\uc8c2\u07ba\u{1f997}\u{1fdfd}\u13c5\ue394\u089a\u3a63'});
+let computePassEncoder44 = commandEncoder44.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer20, 680, 79);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1392 */
+  offset: 1392,
+  bytesPerRow: 2816,
+  buffer: buffer6,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 24},
+  aspect: 'all',
+}, new Uint8Array(35_217).fill(172), /* required buffer size: 35_217 */
+{offset: 67, bytesPerRow: 25, rowsPerImage: 37}, {width: 1, height: 0, depthOrArrayLayers: 39});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+let commandEncoder51 = device0.createCommandEncoder({});
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 752 */
+  offset: 752,
+  bytesPerRow: 5888,
+  buffer: buffer18,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 6, y: 6, z: 1},
+  aspect: 'all',
+}, {width: 2, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 13, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 34, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let img2 = await imageWithData(126, 40, '#10101010', '#20202020');
+try {
+globalThis.someLabel = computePassEncoder40.label;
+} catch {}
+let buffer24 = device0.createBuffer({
+  label: '\u164d\u{1fc88}\u{1fc5d}\u{1f69f}\u0c7f\u{1f6a2}\u{1fab4}\u{1fd83}\u0564',
+  size: 8658,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView38 = texture9.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 1});
+let computePassEncoder45 = commandEncoder51.beginComputePass({});
+let renderPassEncoder4 = commandEncoder49.beginRenderPass({colorAttachments: [{view: textureView16, depthSlice: 9, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup13, new Uint32Array(1756), 531, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(14.03231650586914, 0.25425897811426734, 101.44109204664016, 0.12644337271427933, 0.43892128579058043, 0.8138356973207528);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer20, 0, 2_158);
+} catch {}
+try {
+commandEncoder48.insertDebugMarker('\u725e');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 2688, new BigUint64Array(4753), 1008, 504);
+} catch {}
+let texture39 = device0.createTexture({
+  size: [570],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView39 = texture25.createView({});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer25 = device0.createBuffer({size: 18906, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder52 = device0.createCommandEncoder();
+let textureView40 = texture37.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint16', 910, 4_667);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer22, 100, buffer9, 27720, 0);
+} catch {}
+document.body.append(img0);
+let bindGroup30 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView0}]});
+let commandEncoder53 = device0.createCommandEncoder();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(276);
+} catch {}
+try {
+renderPassEncoder3.setViewport(71.89837150806905, 0.7034179030998406, 129.1386636759498, 0.28173910133554797, 0.7827188595536252, 0.9431159525527751);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 56},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView41 = texture9.createView({dimension: '2d', aspect: 'all'});
+let computePassEncoder46 = commandEncoder50.beginComputePass({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer16, 'uint32', 2_548, 1_193);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup16, new Uint32Array(629), 159, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer9, 'uint16', 2_106, 135);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw30: array<vec2u, 2>;
+
+override override16: f32;
+
+struct T1 {
+  @align(2) @size(40) f0: array<u32>,
+}
+
+struct FragmentOutput2 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(flat) f1: vec4f,
+}
+
+@group(0) @binding(52) var tex8: texture_2d<f32>;
+
+fn fn1() {
+  var vf59: f32 = override16;
+  fn0();
+  vf59 -= vec4f(cos(vec4h(unconst_f16(-1216.2), unconst_f16(1249.5), unconst_f16(-23665.5), unconst_f16(841.7))))[1];
+  vf59 = f32(firstTrailingBit(vec3u(u32(mix(f16(unconst_f16(5569.7)), f16(unconst_f16(12388.1)), f16(unconst_f16(2465.6))))))[2]);
+  vf59 = f32(unpack4xI8(u32(unconst_u32(57)))[1]);
+  fn0();
+  vf59 = unpack4x8unorm(u32(unconst_u32(61)))[1];
+  vf59 = sin(vec4f(unconst_f32(0.4456), unconst_f32(0.1076), unconst_f32(0.1995), unconst_f32(0.2433))).z;
+  var vf60: vec3f = asin(vec3f(unconst_f32(0.2702), unconst_f32(0.1716), unconst_f32(0.1189)));
+  vf59 = f32(floor(vec3h(unconst_f16(-18562.3), unconst_f16(3980.2), unconst_f16(14610.4))).b);
+  vf59 = vf59;
+  var vf61 = fn0();
+  vf60 = vec3f(vf59);
+  vf60 *= vec3f(floor(vec3h(unconst_f16(16040.8), unconst_f16(7961.4), unconst_f16(-4780.0))));
+  fn0();
+  let ptr23: ptr<function, u32> = &vf61.f0;
+  let vf62: vec4i = unpack4xI8(u32(unconst_u32(157)));
+  vf60 *= vec3f(floor(vec3h(unconst_f16(16357.4), unconst_f16(23167.2), unconst_f16(22081.8))));
+  let vf63: vec3f = step(vec3f(unconst_f32(0.4049), unconst_f32(0.01115), unconst_f32(0.06028)), vec3f(unconst_f32(0.5287), unconst_f32(-0.1492), unconst_f32(0.2380)));
+  fn0();
+  _ = override16;
+}
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw31: FragmentOutput2;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(57026) override override15: i32 = 119;
+
+@group(0) @binding(108) var tex9: texture_depth_2d;
+
+struct FragmentOutput3 {
+  @location(0) @interpolate(flat) f0: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf49: u32 = dot4U8Packed(u32(unconst_u32(6)), u32(unconst_u32(113)));
+  let vf50: vec2h = radians(vec2h(unconst_f16(1318.3), unconst_f16(8217.5)));
+  out = FragmentOutput2(pack4xU8(reverseBits(vec4u(unconst_u32(14), unconst_u32(117), unconst_u32(100), unconst_u32(12)))), vec4f(reverseBits(vec4u(unconst_u32(14), unconst_u32(117), unconst_u32(100), unconst_u32(12)))));
+  let vf51: vec2h = cosh(vec2h(unconst_f16(-3911.9), unconst_f16(23326.8)));
+  let vf52: vec2h = vf50;
+  out.f0 |= vf49;
+  var vf53: vec3h = min(vec3h(unconst_f16(14484.6), unconst_f16(4178.3), unconst_f16(26101.2)), vec3h(unconst_f16(20018.4), unconst_f16(-12077.3), unconst_f16(13462.9)));
+  var vf54: vec2h = cosh(vec2h(unconst_f16(7186.2), unconst_f16(1588.5)));
+  var vf55: vec2h = vf50;
+  vf49 = u32(min(vec3h(unconst_f16(11760.2), unconst_f16(10129.7), unconst_f16(5624.6)), vec3h(unconst_f16(3659.0), unconst_f16(-3755.8), unconst_f16(13148.6))).y);
+  out.f0 -= pack4xU8(vec4u(step(vec4f(unconst_f32(0.1001), unconst_f32(0.2344), unconst_f32(0.03772), unconst_f32(0.2023)), vec4f(unconst_f32(0.2034), unconst_f32(0.3192), unconst_f32(0.07534), unconst_f32(0.1456)))));
+  out = FragmentOutput2(bitcast<u32>(radians(vec2h(asinh(f16(unconst_f16(736.4)))))), vec4f(radians(vec2h(asinh(f16(unconst_f16(736.4))))).grgr));
+  var vf56: f16 = vf55[u32(unconst_u32(94))];
+  let ptr20: ptr<function, u32> = &vf49;
+  vf56 = min(vec3h(unconst_f16(4575.9), unconst_f16(19122.5), unconst_f16(7466.8)), vec3h(unconst_f16(20834.3), unconst_f16(6033.5), unconst_f16(25550.7))).x;
+  vf54 += vec2h(unpack4x8unorm(u32(unconst_u32(163))).ra);
+  let vf57: f16 = vf52[u32(unconst_u32(10))];
+  let vf58: f16 = vf57;
+  out.f1 = vec4f(vf54.ggrr);
+  let ptr21: ptr<function, f16> = &vf56;
+  let ptr22: ptr<function, u32> = &(*ptr20);
+  vf54 = vec2h(vf54[u32(unconst_u32(99))]);
+  vf54 += vec2h(vf51[u32(unconst_u32(129))]);
+  return out;
+}
+
+@vertex @must_use
+fn vertex3(@location(9) @interpolate(linear) a0: f16, @location(12) a1: vec4h, @location(14) @interpolate(linear) a2: vec4h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(a1);
+  let vf64: mat2x2h = transpose(mat2x2h());
+  var vf65 = fn0();
+  var vf66: vec3h = trunc(vec3h(unconst_f16(4503.0), unconst_f16(5336.1), unconst_f16(7400.6)));
+  fn1();
+  vf65 = FragmentOutput2(bitcast<u32>(override15), vec4f(bitcast<f32>(override15)));
+  out = vec4f(f32(vf65.f0));
+  fn1();
+  out = vec4f(acosh(vec2h(unconst_f16(29838.5), unconst_f16(21218.6))).grgg);
+  vf65 = FragmentOutput2(dot4U8Packed(u32(unconst_u32(271)), u32(unconst_u32(63))), unpack4x8snorm(dot4U8Packed(u32(unconst_u32(271)), u32(unconst_u32(63)))));
+  let vf67: vec3f = max(vec3f(unconst_f32(0.1101), unconst_f32(0.1985), unconst_f32(0.2280)), vec3f(unconst_f32(0.09097), unconst_f32(-0.07132), unconst_f32(0.1548)));
+  fn0();
+  var vf68 = fn0();
+  let vf69: f16 = vf64[u32(unconst_u32(18))][u32(unconst_u32(679))];
+  return out;
+  _ = override15;
+  _ = override16;
+}
+
+@fragment
+fn fragment3(@builtin(position) a0: vec4f) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 = pack4xU8(countLeadingZeros(vec4u(unconst_u32(5), unconst_u32(76), unconst_u32(108), unconst_u32(1000))));
+  var vf70: vec2f = cos(vec2f(unconst_f32(0.00967), unconst_f32(0.1596)));
+  let vf71: u32 = textureNumLevels(tex9);
+  let vf72: vec4f = a0;
+  let vf73: i32 = dot4I8Packed(u32(unconst_u32(17)), u32(unconst_u32(98)));
+  let vf74: vec3h = acosh(vec3h(unconst_f16(12057.3), unconst_f16(13509.6), unconst_f16(5016.0)));
+  var vf75 = fn0();
+  vf70 *= vec2f(f32(vf73));
+  fn0();
+  out.f0 <<= bitcast<vec3u>(countTrailingZeros(vec3i(unconst_i32(277), unconst_i32(622), unconst_i32(28))))[2];
+  var vf76 = fn0();
+  var vf77: i32 = vf73;
+  vf70 -= vec2f(vf75.f1[u32(unconst_u32(82))]);
+  var vf78: u32 = pack2x16unorm(vec2f(unconst_f32(0.01903), unconst_f32(0.1035)));
+  var vf79 = fn0();
+  discard;
+  vf75.f0 -= countLeadingZeros(vec4u(unconst_u32(307), unconst_u32(350), unconst_u32(445), unconst_u32(44)))[3];
+  out.f0 |= bitcast<u32>(vf76.f1.r);
+  vf78 &= u32(vf75.f1.w);
+  var vf80: u32 = pack4xI8(vec4i(unconst_i32(239), unconst_i32(192), unconst_i32(-58), unconst_i32(67)));
+  out.f0 -= textureDimensions(tex9, i32(unconst_i32(72)))[1];
+  let ptr24: ptr<function, u32> = &vf76.f0;
+  let vf81: vec4f = a0;
+  var vf82 = fn0();
+  return out;
+}
+
+@fragment
+fn fragment4(@location(11) a0: f16, @location(8) @interpolate(flat, center) a1: i32) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let vf83: i32 = a1;
+  var vf84 = fn0();
+  out = FragmentOutput3(unpack4x8snorm(countTrailingZeros(u32(unconst_u32(193)))));
+  out.f0 = vec4f(textureLoad(tex9, vec2i(unconst_i32(100), unconst_i32(80)), i32(fma(vec4h(unconst_f16(18591.6), unconst_f16(3408.2), unconst_f16(9059.9), unconst_f16(1424.6)), vec4h(unconst_f16(1227.9), unconst_f16(3612.0), unconst_f16(20897.0), unconst_f16(16153.0)), vec4h(unconst_f16(5238.0), unconst_f16(1979.2), unconst_f16(10461.6), unconst_f16(861.0)))[3])));
+  out.f0 = vec4f(distance(vec4f(unconst_f32(0.3955), unconst_f32(0.01934), unconst_f32(0.1781), unconst_f32(0.02628)), vec4f(unconst_f32(0.1602), unconst_f32(0.00093), unconst_f32(0.2691), unconst_f32(-0.04254))));
+  var vf85 = fn0();
+  let ptr25: ptr<function, FragmentOutput2> = &vf85;
+  var vf86 = fn0();
+  fn0();
+  var vf87 = fn0();
+  var vf88 = fn0();
+  vf87.f1 *= vec4f(fma(vec4h(unconst_f16(-3346.2), unconst_f16(-3322.6), unconst_f16(-7295.5), unconst_f16(14388.8)), vec4h(unconst_f16(12088.6), unconst_f16(16510.1), unconst_f16(3821.3), unconst_f16(-5596.2)), vec4h(unconst_f16(12365.6), unconst_f16(22973.2), unconst_f16(-1719.9), unconst_f16(8172.5))));
+  fn0();
+  var vf89 = fn0();
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 2)
+fn compute3() {
+  var vf90: u32 = vw30[u32(unconst_u32(224))][u32(unconst_u32(134))];
+  vf90 -= textureDimensions(tex9).x;
+  var vf91 = fn0();
+  var vf92 = fn0();
+  let ptr26: ptr<workgroup, u32> = &(*&vw31).f0;
+  fn0();
+  var vf93 = fn0();
+  let vf94: u32 = vw30[u32(unconst_u32(40))][u32(unconst_u32(139))];
+  vf91 = FragmentOutput2(pack4x8unorm(textureLoad(tex8, vec2i(unconst_i32(150), unconst_i32(194)), i32(unconst_i32(165)))), textureLoad(tex8, vec2i(unconst_i32(150), unconst_i32(194)), i32(unconst_i32(165))));
+  var vf95 = fn0();
+  let ptr27: ptr<function, vec4f> = &vf91.f1;
+  let ptr28: ptr<function, vec4f> = &vf93.f1;
+  vf91 = FragmentOutput2((*&vw30)[1].x, bitcast<vec4f>((*&vw30)[1].rrgg));
+  vf91.f0 <<= pack4x8unorm((*ptr28));
+  vf92.f0 ^= bitcast<u32>(override16);
+  let ptr29: ptr<function, vec4f> = &vf91.f1;
+  let vf96: vec2u = textureDimensions(tex9);
+  vf91.f0 = u32(override15);
+  let ptr30: ptr<function, u32> = &vf95.f0;
+  let ptr31: ptr<workgroup, u32> = &vw31.f0;
+  fn0();
+  vw31 = FragmentOutput2(textureNumLevels(tex8), vec4f(bitcast<f32>(textureNumLevels(tex8))));
+  vf95 = FragmentOutput2(pack4xU8Clamp(vec4u((*ptr29))), (*ptr29));
+  vf91.f0 ^= dot4U8Packed((*&vw31).f0, u32(unconst_u32(291)));
+  vf90 = (*&vw30)[1][1];
+  _ = override16;
+  _ = override15;
+}`,
+  sourceMap: {},
+});
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 215, resource: sampler33},
+    {binding: 135, resource: {buffer: buffer16, offset: 768, size: 844}},
+  ],
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView42 = texture3.createView({label: '\u0422\u03e3\u{1f6e0}\uc1ac\u93cb\u{1f9a8}\u0c05\udb38', aspect: 'all', format: 'rgba16float'});
+let computePassEncoder47 = commandEncoder48.beginComputePass({label: '\u0d0c\u{1ffda}\u6a85\u9e25\ua578\u273e\u1683\u{1f831}\ud18a'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], sampleCount: 4});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.81,
+  lodMaxClamp: 94.86,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup27, new Uint32Array(1572), 64, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer4, 28, 92);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer16, 'uint16', 472, 399);
+} catch {}
+let texture40 = device0.createTexture({
+  size: [42, 40, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder48 = commandEncoder54.beginComputePass({});
+let renderBundle5 = renderBundleEncoder6.finish({});
+try {
+// renderPassEncoder2.drawIndirect(buffer15, 7_052);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer11, 'uint16', 1_472, 269);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(3, buffer6, 0, 4_270);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 156 */
+  offset: 156,
+  buffer: buffer23,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer0, 1780, 3712);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 460, new BigUint64Array(137), 47, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(50).fill(134), /* required buffer size: 50 */
+{offset: 50}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 24061,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView43 = texture11.createView({dimension: '2d', baseArrayLayer: 5});
+let textureView44 = texture17.createView({label: '\udfc3\u97c9\u{1ff95}\u52a8\u0dbc\u3b88\u{1fb69}\u12da\u{1fd92}\u897f\u0ca2', aspect: 'all'});
+let computePassEncoder49 = commandEncoder52.beginComputePass({});
+let sampler35 = device0.createSampler({
+  label: '\u0336\u04cb\u8682\u8a81\u6535\u{1fa6d}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.20,
+  lodMaxClamp: 97.94,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup3, new Uint32Array(833), 27, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle0, renderBundle0]);
+} catch {}
+try {
+// renderPassEncoder2.draw(0, 257, 0, 1_711_497_446);
+} catch {}
+try {
+// renderPassEncoder2.drawIndexed(650, 86, 934, 325_632_845, 61_284_096);
+} catch {}
+try {
+// renderPassEncoder2.drawIndexedIndirect(buffer23, 3_408);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer26, 'uint16', 3_088, 1_737);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(3, buffer25, 532, 9_598);
+} catch {}
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 6, y: 7, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 200 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 456 */
+  offset: 456,
+  bytesPerRow: 17920,
+  buffer: buffer26,
+}, {width: 25, height: 23, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup32 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 141, resource: textureView23}]});
+let texture41 = device0.createTexture({
+  size: {width: 42, height: 40, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder50 = commandEncoder53.beginComputePass({label: '\u7e32\ubf80\u{1fa38}\u3717\u{1fb81}\u0e59\u511b\udd26\u{1f86e}\u39fb\u2a16'});
+let renderBundle6 = renderBundleEncoder5.finish({});
+try {
+// renderPassEncoder2.drawIndexed(140, 310, 16, 251_242_959, 87_316_865);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer12, 'uint32', 4_404, 2_455);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+adapter0.label = '\uc67d\u023c\u0af2\u{1fe0c}\u5b2d\ua559\u0640\u7c3d';
+} catch {}
+try {
+// renderPassEncoder2.draw(0, 252, 0, 212_498_553);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(231, 197, 40, 14_186_239, 406_838_528);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer26, 2_480);
+} catch {}
+try {
+  await shaderModule4.getCompilationInfo();
+} catch {}
+let buffer27 = device0.createBuffer({
+  size: 15434,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 811});
+let texture42 = device0.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 72},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup28, new Uint32Array(165), 3, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.draw(0, 221, 0, 525_096_300);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer26, 'uint16', 7_040, 3_251);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer4, 20, 27);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(532).fill(54), /* required buffer size: 532 */
+{offset: 532}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let buffer28 = device0.createBuffer({size: 64946, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder55 = device0.createCommandEncoder({});
+let sampler36 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.65,
+  lodMaxClamp: 59.24,
+  compare: 'never',
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(111), 34, 0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(24, 0, 6, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(63.12770620619123, 0.4953696575272306, 133.53762941175054, 0.18867128843179998, 0.8430068591884545, 0.8537871258225457);
+} catch {}
+try {
+renderPassEncoder2.draw(0, 7, 0, 529_874_960);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer27, 636);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer23, 'uint16', 404, 3_529);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData0);
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'unspecified', transfer: 'iec6196624'} });
+let buffer29 = device0.createBuffer({
+  size: 18310,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  size: [2280, 1, 13],
+  mipLevelCount: 6,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint'],
+});
+let textureView45 = texture40.createView({arrayLayerCount: 1});
+let computePassEncoder51 = commandEncoder56.beginComputePass();
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7, new Uint32Array(437), 61, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 2_232);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 71, height: 1, depthOrArrayLayers: 101}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'unspecified', transfer: 'pq'} });
+let bindGroup33 = device0.createBindGroup({
+  label: '\u0072\u72ac\ub222\u6042\u6ce4',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 86, resource: textureView1},
+    {binding: 410, resource: textureView32},
+    {binding: 16, resource: textureView3},
+    {binding: 59, resource: textureView31},
+    {binding: 267, resource: {buffer: buffer16, offset: 0, size: 3740}},
+    {binding: 40, resource: textureView30},
+    {binding: 362, resource: {buffer: buffer16, offset: 0}},
+    {binding: 22, resource: textureView3},
+    {binding: 163, resource: {buffer: buffer20, offset: 0, size: 412}},
+    {binding: 207, resource: textureView45},
+    {binding: 26, resource: {buffer: buffer1, offset: 0, size: 8}},
+    {binding: 61, resource: textureView23},
+    {binding: 36, resource: {buffer: buffer16, offset: 256}},
+    {binding: 149, resource: {buffer: buffer5, offset: 256, size: 2404}},
+    {binding: 108, resource: {buffer: buffer26, offset: 6400, size: 24}},
+  ],
+});
+let pipelineLayout5 = device0.createPipelineLayout({label: '\ubb02\u1944\u1dfa\u65f1\u73df\u37b6\ub0ac\ue2b2', bindGroupLayouts: []});
+let texture44 = device0.createTexture({
+  size: [10, 10, 77],
+  sampleCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder2.draw(0, 65, 0, 468_072_988);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer23, 68);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer11, 28, buffer21, 904, 536);
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder();
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 32.91,
+  lodMaxClamp: 62.81,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.draw(0, 120, 0, 1_062_025_906);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer2, 3_924);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer9, 'uint16', 1_368, 2_573);
+} catch {}
+try {
+computePassEncoder36.pushDebugGroup('\ub8e1');
+} catch {}
+try {
+computePassEncoder36.popDebugGroup();
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame5, {timestamp: 0});
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 215, resource: sampler33},
+    {binding: 135, resource: {buffer: buffer5, offset: 512, size: 2316}},
+  ],
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer26, 'uint16', 914, 447);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let bindGroup35 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 380, resource: textureView45}]});
+let buffer30 = device0.createBuffer({size: 24989, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView46 = texture36.createView({label: '\u44b4\u0012\u{1f993}\u0a29\u0564\u0b81\u3e35\ud643\u0b73\u8ce1', format: 'rgba32sint'});
+let computePassEncoder52 = commandEncoder57.beginComputePass({});
+let sampler38 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 9.562, lodMaxClamp: 64.45});
+try {
+buffer21.unmap();
+} catch {}
+document.body.prepend(img0);
+let computePassEncoder53 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup9, new Uint32Array(369), 30, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(42, 0, 39, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer20, 0);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1352 */
+  offset: 1352,
+  bytesPerRow: 512,
+  buffer: buffer2,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\u9178\u06e4\u065a'});
+let commandBuffer3 = commandEncoder29.finish({});
+
+
+
+
+
+
+
+try {
+computePassEncoder16.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer29, 'uint32', 2_588, 9_171);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer28, 0, 18_601);
+} catch {}
+let buffer31 = device0.createBuffer({size: 7856, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 409});
+let textureView47 = texture19.createView({label: '\uf4c6\u{1fe12}\u0513\ud628', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 3});
+let computePassEncoder54 = commandEncoder58.beginComputePass({});
+let sampler39 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 67.62,
+  lodMaxClamp: 81.60,
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup22, new Uint32Array(4586), 1_552, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup26, new Uint32Array(199), 14, 0);
+} catch {}
+document.body.append(img0);
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: {width: 84},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView48 = texture13.createView({});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup14, new Uint32Array(472), 7, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer20, 0, 410);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame10.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame47.close();
+videoFrame48.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -636,25 +636,9 @@ bool RenderBundleEncoder::runVertexBufferValidation(uint32_t vertexCount, uint32
 
 std::pair<uint32_t, uint32_t> RenderBundleEncoder::computeMininumVertexInstanceCount() const
 {
-    if (!m_pipeline)
-        return std::make_pair(0u, 0u);
-
-    uint32_t minVertexCount = invalidVertexInstanceCount;
-    uint32_t minInstanceCount = invalidVertexInstanceCount;
-    auto& requiredBufferIndices = m_pipeline->requiredBufferIndices();
-    for (auto& [bufferIndex, bufferData] : requiredBufferIndices) {
-        auto bufferSize = bufferIndex < m_vertexBuffers.size() ? m_vertexBuffers[bufferIndex].size : 0;
-        auto stride = bufferData.stride;
-        auto lastStride = bufferData.lastStride;
-        if (!stride)
-            continue;
-        auto elementCount = bufferSize < lastStride ? 0 : ((bufferSize - lastStride) / stride + 1);
-        if (bufferData.stepMode == WGPUVertexStepMode_Vertex)
-            minVertexCount = std::min<uint32_t>(minVertexCount, elementCount);
-        else
-            minInstanceCount = std::min<uint32_t>(minInstanceCount, elementCount);
-    }
-    return std::make_pair(minVertexCount, minInstanceCount);
+    return RenderPassEncoder::computeMininumVertexInstanceCount(m_pipeline.get(), ^(uint32_t bufferIndex) {
+        return bufferIndex < m_vertexBuffers.size() ? m_vertexBuffers[bufferIndex].size : 0;
+    });
 }
 
 void RenderBundleEncoder::storeVertexBufferCountsForValidation(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance, MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -110,6 +110,7 @@ public:
     enum class IndexCall { Draw, IndirectDraw, Skip, CachedIndirectDraw };
     static IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, id<MTLRenderCommandEncoder>, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
     void splitRenderPass();
+    static std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(const RenderPipeline*, uint64_t (^)(uint32_t));
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&, MTLRenderPassDescriptor*);


### PR DESCRIPTION
#### bf7503217164cad8cc2c4ba547aee7c298e5ccbc
<pre>
[WebGPU] computeMininumVertexInstanceCount() does not handle buffer sizes less than lastStride
<a href="https://bugs.webkit.org/show_bug.cgi?id=282485">https://bugs.webkit.org/show_bug.cgi?id=282485</a>
<a href="https://rdar.apple.com/138783147">rdar://138783147</a>

Reviewed by Tadeu Zagallo.

When stride == 0 but lastStride &gt; bufferSize, we incorrectly did not report
the max allowed vertex count was zero.

* LayoutTests/fast/webgpu/nocrash/fuzz-282485-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-282485.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::computeMininumVertexInstanceCount const):
Refactor common logic.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::runIndexBufferValidation):
(WebGPU::RenderPassEncoder::computeMininumVertexInstanceCount):
(WebGPU::RenderPassEncoder::computeMininumVertexInstanceCount const):

Canonical link: <a href="https://commits.webkit.org/286109@main">https://commits.webkit.org/286109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10abfb08573c6920586f9fec5d5a41b90d6bea8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58673 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16957 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24267 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66224 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8320 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1979 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->