### PR TITLE
[Intelligence Effects] S

### DIFF
--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
@@ -135,5 +135,15 @@ void decorateWritingToolsTextReplacements(Document& document, const SimpleRange&
 }
 #endif
 
+void setSelection(Document& document, const SimpleRange& scope, const CharacterRange& range)
+{
+    auto resolvedRange = resolveCharacterRange(scope, range);
+    auto visibleSelection = VisibleSelection { resolvedRange };
+    if (visibleSelection.isNoneOrOrphaned())
+        return;
+
+    document.selection().setSelection(visibleSelection);
+}
+
 } // namespace IntelligenceTextEffectsSupport
 } // namespace WebCore

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.h
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+namespace WTF {
+class UUID;
+}
+
 namespace WebCore {
 
 class Document;
@@ -40,9 +44,13 @@ namespace IntelligenceTextEffectsSupport {
 WEBCORE_EXPORT Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordinates(Document&, const SimpleRange& scope, const CharacterRange&);
 #endif
 
-WEBCORE_EXPORT void updateTextVisibility(Document&, const SimpleRange& scope, const CharacterRange&, bool visible);
+WEBCORE_EXPORT void updateTextVisibility(Document&, const SimpleRange& scope, const CharacterRange&, bool visible, const WTF::UUID&);
 
 WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange&);
+
+#if ENABLE(WRITING_TOOLS)
+WEBCORE_EXPORT void decorateWritingToolsTextReplacements(Document&, const SimpleRange& scope, const CharacterRange&);
+#endif
 
 } // namespace IntelligenceTextEffectsSupport
 

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.h
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.h
@@ -52,6 +52,8 @@ WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForRange(Document
 WEBCORE_EXPORT void decorateWritingToolsTextReplacements(Document&, const SimpleRange& scope, const CharacterRange&);
 #endif
 
+WEBCORE_EXPORT void setSelection(Document&, const SimpleRange& scope, const CharacterRange&);
+
 } // namespace IntelligenceTextEffectsSupport
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5030,6 +5030,11 @@ void Page::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Se
     m_writingToolsController->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
 }
 
+void Page::willEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
+{
+    m_writingToolsController->willEndWritingToolsSession(session, accepted);
+}
+
 void Page::didEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
 {
     m_writingToolsController->didEndWritingToolsSession(session, accepted);
@@ -5130,6 +5135,24 @@ void Page::decorateTextReplacementsForActiveWritingToolsSession(const CharacterR
     }
 
     IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements(*document, *scope, rangeRelativeToSessionRange);
+}
+
+void Page::setSelectionForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
+{
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto scope = m_writingToolsController->activeSessionRange();
+    if (!scope) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    IntelligenceTextEffectsSupport::setSelection(*document, *scope, rangeRelativeToSessionRange);
 }
 
 std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() const

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5020,14 +5020,9 @@ void Page::didBeginWritingToolsSession(const WritingTools::Session& session, con
     m_writingToolsController->didBeginWritingToolsSession(session, contexts);
 }
 
-void Page::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
+void Page::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const CharacterRange& processedRange, const WritingTools::Context& context, bool finished)
 {
-    m_writingToolsController->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
-}
-
-void Page::proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
-{
-    m_writingToolsController->proofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished);
+    m_writingToolsController->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
 }
 
 void Page::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session& session, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion& suggestion, const WritingTools::Context& context)
@@ -5083,7 +5078,7 @@ Vector<FloatRect> Page::proofreadingSessionSuggestionTextRectsInRootViewCoordina
     return IntelligenceTextEffectsSupport::writingToolsTextSuggestionRectsInRootViewCoordinates(*document, *scope, enclosingRangeRelativeToSessionRange);
 }
 
-void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange, bool visible)
+void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier)
 {
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
     RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
@@ -5098,7 +5093,7 @@ void Page::updateTextVisibilityForActiveWritingToolsSession(const CharacterRange
         return;
     }
 
-    IntelligenceTextEffectsSupport::updateTextVisibility(*document, *scope, rangeRelativeToSessionRange, visible);
+    IntelligenceTextEffectsSupport::updateTextVisibility(*document, *scope, rangeRelativeToSessionRange, visible, identifier);
 }
 
 std::optional<TextIndicatorData> Page::textPreviewDataForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
@@ -5117,6 +5112,24 @@ std::optional<TextIndicatorData> Page::textPreviewDataForActiveWritingToolsSessi
     }
 
     return IntelligenceTextEffectsSupport::textPreviewDataForRange(*document, *scope, rangeRelativeToSessionRange);
+}
+
+void Page::decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)
+{
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr document = localMainFrame ? localMainFrame->document() : nullptr;
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto scope = m_writingToolsController->activeSessionRange();
+    if (!scope) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements(*document, *scope, rangeRelativeToSessionRange);
 }
 
 std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1185,9 +1185,7 @@ public:
 
     WEBCORE_EXPORT void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    WEBCORE_EXPORT void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
-
-    WEBCORE_EXPORT void proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    WEBCORE_EXPORT void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
     WEBCORE_EXPORT void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 
@@ -1203,8 +1201,9 @@ public:
     void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
     WEBCORE_EXPORT Vector<FloatRect> proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const CharacterRange&) const;
-    WEBCORE_EXPORT void updateTextVisibilityForActiveWritingToolsSession(const CharacterRange&, bool);
+    WEBCORE_EXPORT void updateTextVisibilityForActiveWritingToolsSession(const CharacterRange&, bool, const WTF::UUID&);
     WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForActiveWritingToolsSession(const CharacterRange&);
+    WEBCORE_EXPORT void decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange&);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
     WEBCORE_EXPORT void intelligenceTextAnimationsDidComplete();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1189,6 +1189,8 @@ public:
 
     WEBCORE_EXPORT void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 
+    WEBCORE_EXPORT void willEndWritingToolsSession(const WritingTools::Session&, bool accepted);
+
     WEBCORE_EXPORT void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
     WEBCORE_EXPORT void compositionSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
@@ -1204,6 +1206,7 @@ public:
     WEBCORE_EXPORT void updateTextVisibilityForActiveWritingToolsSession(const CharacterRange&, bool, const WTF::UUID&);
     WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForActiveWritingToolsSession(const CharacterRange&);
     WEBCORE_EXPORT void decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange&);
+    WEBCORE_EXPORT void setSelectionForActiveWritingToolsSession(const CharacterRange&);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
     WEBCORE_EXPORT void intelligenceTextAnimationsDidComplete();

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -64,6 +64,8 @@ public:
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 
+    void willEndWritingToolsSession(const WritingTools::Session&, bool accepted);
+
     void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
     void compositionSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
@@ -180,6 +182,9 @@ private:
 
     template<WritingTools::Session::Type Type>
     void writingToolsSessionDidReceiveAction(WritingTools::Action);
+
+    template<WritingTools::Session::Type Type>
+    void willEndWritingToolsSession(bool accepted);
 
     template<WritingTools::Session::Type Type>
     void didEndWritingToolsSession(bool accepted);

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -60,9 +60,7 @@ public:
 
     void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -38,6 +38,7 @@
 #import "FrameSelection.h"
 #import "GeometryUtilities.h"
 #import "HTMLConverter.h"
+#import "IntelligenceTextEffectsSupport.h"
 #import "Logging.h"
 #import "NodeRenderStyle.h"
 #import "RenderedDocumentMarker.h"
@@ -256,12 +257,25 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
     completionHandler({ { WTF::UUID { 0 }, attributedStringFromRange, selectedTextCharacterRange } });
 }
 
-void WritingToolsController::didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>& contexts)
+void WritingToolsController::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::didBeginWritingToolsSession [received contexts: %zu]", contexts.size());
+
+    if (session.type != WritingTools::Session::Type::Proofreading) {
+        // FIXME: Refactor this function into specialized functions per session type.
+        return;
+    }
+
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    document->selection().clear();
 }
 
-void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
+void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const CharacterRange& processedRange, const WritingTools::Context& context, bool finished)
 {
     RELEASE_LOG(WritingTools, "WritingToolsController::proofreadingSessionDidReceiveSuggestion [received suggestions: %zu, finished: %d]", suggestions.size(), finished);
 
@@ -277,11 +291,35 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
         return;
     }
 
-    m_page->chrome().client().removeInitialTextAnimationForActiveWritingToolsSession();
-
-    document->selection().clear();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
 
     auto sessionRange = makeSimpleRange(state->contextRange);
+
+    // Determine if the range for this batch of suggestions, relative to the current text, is covered by transparent content markers or not.
+    // If so, the markers should be removed, and then re-added to the range after the replacement, accounting for any offset that the
+    // replacement operation results in.
+    //
+    // Because this happens in the same run-loop cycle, this change will not be seen by the user.
+
+    auto replacementLocationOffsetBeforeBatch = static_cast<int>(state->replacementLocationOffset);
+    auto adjustedProcessedRangeLocation = processedRange.location + replacementLocationOffsetBeforeBatch;
+
+    auto adjustedProcessedRangeBeforeReplacement = resolveCharacterRange(sessionRange, { adjustedProcessedRangeLocation, processedRange.length });
+
+    HashSet<WTF::UUID> transparentContentMarkerIdentifiers;
+
+    document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarker::Type::TransparentContent }, [&](auto&, auto marker) {
+        auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());
+        transparentContentMarkerIdentifiers.add(data.uuid);
+
+        return false;
+    });
+
+    for (auto& transparentContentMarkerIdentifier : transparentContentMarkerIdentifiers)
+        IntelligenceTextEffectsSupport::updateTextVisibility(*document, sessionRange, { adjustedProcessedRangeLocation, processedRange.length }, true, transparentContentMarkerIdentifier);
+
+    auto attributedTextString = context.attributedText.string;
 
     // The tracking of the additional replacement location offset needs to be scoped to a particular instance
     // of this class, instead of just this function, because the function may need to be called multiple times.
@@ -306,68 +344,29 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
         auto newRangeWithOffset = CharacterRange { locationWithOffset, suggestion.replacement.length() };
         auto newResolvedRange = resolveCharacterRange(sessionRange, newRangeWithOffset);
 
-        auto originalString = [context.attributedText.nsAttributedString() attributedSubstringFromRange:suggestion.originalRange];
+        auto originalString = attributedTextString.substring(suggestion.originalRange.location, suggestion.originalRange.length);
 
-        auto markerData = DocumentMarker::WritingToolsTextSuggestionData { originalString.string, suggestion.identifier, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted, DocumentMarker::WritingToolsTextSuggestionData::Decoration::None };
+        auto markerData = DocumentMarker::WritingToolsTextSuggestionData { originalString, suggestion.identifier, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted, DocumentMarker::WritingToolsTextSuggestionData::Decoration::None };
         addMarker(newResolvedRange, DocumentMarker::Type::WritingToolsTextSuggestion, markerData);
 
         state->replacementLocationOffset += static_cast<int>(suggestion.replacement.length()) - static_cast<int>(suggestion.originalRange.length);
     }
 
-    if (finished) {
+    for (auto& transparentContentMarkerIdentifier : transparentContentMarkerIdentifiers) {
+        // Re-add the transparent content document markers if applicable, adjusted for the character difference after replacement,
+        // and still relative to the current text.
+
+        auto replacementLocationOffsetAfterBatch = (state->replacementLocationOffset);
+        auto characterDelta = replacementLocationOffsetAfterBatch - replacementLocationOffsetBeforeBatch;
+        auto adjustedProcessedRangeAfterReplacement = CharacterRange { adjustedProcessedRangeLocation, processedRange.length + characterDelta };
+
+        IntelligenceTextEffectsSupport::updateTextVisibility(*document, sessionRange, adjustedProcessedRangeAfterReplacement, false, transparentContentMarkerIdentifier);
+    }
+
+    document->selection().clear();
+
+    if (finished)
         document->editor().setSuppressEditingForWritingTools(false);
-        document->selection().setSelection({ sessionRange });
-    }
-}
-
-void WritingToolsController::proofreadingSessionDidCompletePartialReplacement(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context&, bool)
-{
-    CheckedPtr state = currentState<WritingTools::Session::Type::Proofreading>();
-    if (!state) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    RefPtr document = this->document();
-    if (!document) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    auto sessionRange = makeSimpleRange(state->contextRange);
-
-    auto& markers = document->markers();
-
-    markers.forEach(sessionRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
-        auto oldData = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
-        if (oldData.decoration != DocumentMarker::WritingToolsTextSuggestionData::Decoration::None)
-            return false;
-
-#if ASSERT_ENABLED
-        // All previously received suggestions in the session range should already have been decorated,
-        // so this condition should never be `false` given the above check.
-
-        auto isInMostRecentSuggestionBatch = std::ranges::any_of(suggestions, [oldData](auto& suggestion) {
-            return suggestion.identifier == oldData.suggestionID;
-        });
-
-        ASSERT(isInMostRecentSuggestionBatch);
-
-        // An early return is intentionally omitted here because if there are suggestions in prior batches
-        // that were never made visible for some reason by this point, they certainly should be.
-#else
-        UNUSED_PARAM(suggestions);
-#endif
-
-        auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
-
-        markers.removeMarkers(node, offsetRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
-
-        auto newData = DocumentMarker::WritingToolsTextSuggestionData { oldData.originalText, oldData.suggestionID, oldData.state, DocumentMarker::WritingToolsTextSuggestionData::Decoration::Underline };
-        markers.addMarker(node, DocumentMarker { DocumentMarker::Type::WritingToolsTextSuggestion, offsetRange, WTFMove(newData) });
-
-        return false;
-    });
 }
 
 void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State newTextSuggestionState, const WritingTools::TextSuggestion& textSuggestion, const WritingTools::Context&)

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -772,7 +772,7 @@ void WritingToolsController::writingToolsSessionDidReceiveAction(const WritingTo
 }
 
 template<>
-void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool accepted)
+void WritingToolsController::willEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool accepted)
 {
     RefPtr document = this->document();
 
@@ -802,8 +802,28 @@ void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Ty
 
         return false;
     });
+}
 
-    state = nullptr;
+template<>
+void WritingToolsController::willEndWritingToolsSession<WritingTools::Session::Type::Composition>(bool)
+{
+}
+
+void WritingToolsController::willEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
+{
+    switch (session.type) {
+    case WritingTools::Session::Type::Proofreading:
+        willEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(accepted);
+        break;
+    case WritingTools::Session::Type::Composition:
+        willEndWritingToolsSession<WritingTools::Session::Type::Composition>(accepted);
+        break;
+    }
+}
+
+template<>
+void WritingToolsController::didEndWritingToolsSession<WritingTools::Session::Type::Proofreading>(bool)
+{
     m_state = { };
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -252,6 +252,8 @@ struct PerWebProcessState {
     RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
     RetainPtr<WTSession> _activeWritingToolsSession;
 
+    RetainPtr<WKIntelligenceTextEffectCoordinator> _intelligenceTextEffectCoordinator;
+
     NSUInteger _partialIntelligenceTextAnimationCount;
     BOOL _writingToolsTextReplacementsFinished;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1263,14 +1263,9 @@ void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Sess
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::DidBeginWritingToolsSession(session, contexts), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
+void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::CharacterRange& processedRange, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
-}
-
-void WebPageProxy::proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
-{
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
@@ -1298,14 +1293,19 @@ void WebPageProxy::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(c
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ProofreadingSessionSuggestionTextRectsInRootViewCoordinates(enclosingRangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, CompletionHandler<void()>&& completionHandler)
+void WebPageProxy::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier, CompletionHandler<void()>&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::UpdateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::UpdateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
 {
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::TextPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::DecorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& elementID)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1273,6 +1273,11 @@ void WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion(const WebCore:
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::ProofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::willEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::WillEndWritingToolsSession(session, accepted), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::DidEndWritingToolsSession(session, accepted), webPageIDInMainFrameProcess());
@@ -1306,6 +1311,11 @@ void WebPageProxy::textPreviewDataForActiveWritingToolsSession(const WebCore::Ch
 void WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void()>&& completionHandler)
 {
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::DecorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void()>&& completionHandler)
+{
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::SetSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& elementID)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2470,9 +2470,7 @@ public:
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
@@ -2483,8 +2481,9 @@ public:
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange&, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&) const;
-    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, CompletionHandler<void()>&&);
+    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     bool isWritingToolsActive() const { return m_isWritingToolsActive; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2474,6 +2474,8 @@ public:
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
+    void willEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted, CompletionHandler<void()>&&);
+
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
     void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
@@ -2484,6 +2486,7 @@ public:
     void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
+    void setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     bool isWritingToolsActive() const { return m_isWritingToolsActive; }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -40,7 +40,7 @@ protocol PlatformIntelligenceTextEffectChunk: Identifiable {
 }
 
 /// Either a pondering or replacement effect.
-@MainActor protocol PlatformIntelligenceTextEffect: Equatable, Identifiable where ID == PlatformIntelligenceTextEffectID {
+@MainActor protocol PlatformIntelligenceTextEffect<Chunk>: Equatable, Identifiable where ID == PlatformIntelligenceTextEffectID {
     associatedtype Chunk: PlatformIntelligenceTextEffectChunk
 
     var chunk: Chunk { get }
@@ -72,11 +72,11 @@ extension PlatformIntelligenceTextEffect {
     /// the provided animation parameters.
     func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>, animation: PlatformIntelligenceReplacementTextEffect<Chunk>.AnimationParameters) async -> PlatformTextPreview?
 
-    /// This function is invoked after an effect has been added and set-up, but before the effect actually begins.
+    /// This function is invoked after preparing the replacement effect, but before the effect is added.
     func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async
 
     /// This function is invoked once both parts of the replacement effect are complete.
-    func replacementEffectDidComplete(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>)
+    func replacementEffectDidComplete(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async
 }
 
 // MARK: Platform type adapters.
@@ -91,23 +91,25 @@ extension PlatformIntelligenceTextEffect {
     }
 
     func targetedPreview(for chunk: UITextEffectTextChunk) async -> UITargetedPreview {
-        guard let chunk = chunk as? UITextEffectTextChunkAdapter<Wrapped.Chunk> else {
-            fatalError("Failed to create a targeted preview: parameter was of unexpected type \(type(of: chunk)).")
+        if let chunk = chunk as? UIPonderingTextEffectTextChunkAdapter<Wrapped.Chunk> {
+            return chunk.preview
         }
 
-        guard let preview = await self.wrapped.textPreview(for: chunk.wrapped) else {
-            fatalError("Failed to create a targeted preview: unable to create a preview from the given chunk.")
+        if let chunk = chunk as? UIReplacementTextEffectTextChunkAdapter<Wrapped.Chunk> {
+            return chunk.source
         }
 
-        return preview
+        fatalError("Failed to create a targeted preview: parameter was of unexpected type \(type(of: chunk)).")
     }
 
     func updateTextChunkVisibilityForAnimation(_ chunk: UITextEffectTextChunk, visible: Bool) async {
-        guard let chunk = chunk as? UITextEffectTextChunkAdapter<Wrapped.Chunk> else {
-            fatalError("Failed to update text chunk visibility: parameter was of unexpected type \(type(of: chunk)).")
+        if let chunk = chunk as? UIPonderingTextEffectTextChunkAdapter<Wrapped.Chunk> {
+            await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: visible)
         }
 
-        await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: visible)
+        if let chunk = chunk as? UIReplacementTextEffectTextChunkAdapter<Wrapped.Chunk> {
+            await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: visible)
+        }
     }
 }
 
@@ -131,41 +133,45 @@ extension PlatformIntelligenceTextEffect {
             return
         }
 
-        self.wrapped.replacementEffectDidComplete(effect)
+        Task { @MainActor in
+            await self.wrapped.replacementEffectDidComplete(effect)
+        }
     }
 
     func performReplacementAndGeneratePreview(for chunk: UITextEffectTextChunk, effect: UITextEffectView.ReplacementTextEffect, animation: UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UITargetedPreview? {
-        guard let view = self.view else {
-            assertionFailure("Failed to perform replacement and generate preview: view was unexpectedly nil.")
-            return nil
-        }
-
-        guard let effect = view.wrappedEffectIDToPlatformEffects[effect.id] as? PlatformIntelligenceReplacementTextEffect<Wrapped.Chunk> else {
-            assertionFailure("Failed to perform replacement and generate preview: effect was unexpectedly nil.")
-            return nil
-        }
-
-        guard let chunk = chunk as? UITextEffectTextChunkAdapter<Wrapped.Chunk> else {
+        guard let chunk = chunk as? UIReplacementTextEffectTextChunkAdapter<Wrapped.Chunk> else {
             fatalError("Failed to perform replacement and generate preview: parameter was of unexpected type \(type(of: chunk)).")
         }
 
-        let animationParameters = PlatformIntelligenceReplacementTextEffect<Wrapped.Chunk>.AnimationParameters(duration: animation.duration, delay: animation.delay)
-
-        return await self.wrapped.performReplacementAndGeneratePreview(for: chunk.wrapped, effect: effect, animation: animationParameters)
+        return chunk.destination
     }
 }
 
-private final class UITextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
+private final class UIPonderingTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
     let wrapped: Wrapped
+    let preview: UITargetedPreview
 
-    init(wrapping wrapped: Wrapped) {
+    init(wrapping wrapped: Wrapped, preview: UITargetedPreview) {
         self.wrapped = wrapped
+        self.preview = preview
+    }
+}
+
+private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
+    let wrapped: Wrapped
+    let source: UITargetedPreview
+    let destination: UITargetedPreview
+
+    init(wrapping wrapped: Wrapped, source: UITargetedPreview, destination: UITargetedPreview) {
+        self.wrapped = wrapped
+        self.source = source
+        self.destination = destination
     }
 }
 
 #else
 
-private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextPreviewAsyncSource where Wrapped: PlatformIntelligenceTextEffectViewSource {
+@MainActor private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextPreviewAsyncSource where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private let wrapped: Wrapped
 
     init(wrapping wrapped: Wrapped) {
@@ -173,15 +179,11 @@ private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextP
     }
 
     func textPreviews(for chunk: _WTTextChunk) async -> [_WTTextPreview]? {
-        if let chunk = chunk as? WTPonderingTextChunkAdapter<Wrapped.Chunk> {
-            return await self.wrapped.textPreview(for: chunk.wrapped)
+        guard let chunk = chunk as? WTTextChunkAdapter<Wrapped.Chunk> else {
+            fatalError("Failed to update text chunk visibility: parameter was of unexpected type \(type(of: chunk)).")
         }
 
-        if let chunk = chunk as? WTReplacementTextChunkAdapter<Wrapped.Chunk> {
-            return chunk.preview
-        }
-
-        fatalError("Failed to create a text preview: parameter was of unexpected type \(type(of: chunk)).")
+        return chunk.preview
     }
     
     func textPreview(for rect: CGRect) async -> _WTTextPreview? {
@@ -190,37 +192,21 @@ private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextP
     }
 
     func updateIsTextVisible(_ isTextVisible: Bool, for chunk: _WTTextChunk) async {
-        if let chunk = chunk as? WTPonderingTextChunkAdapter<Wrapped.Chunk> {
-            await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: isTextVisible)
-            return
+        guard let chunk = chunk as? WTTextChunkAdapter<Wrapped.Chunk> else {
+            fatalError("Failed to update text chunk visibility: parameter was of unexpected type \(type(of: chunk)).")
         }
 
-        if let chunk = chunk as? WTReplacementTextChunkAdapter<Wrapped.Chunk> {
-            await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: isTextVisible)
-            return
-        }
-
-        fatalError("Failed to update text chunk visibility: parameter was of unexpected type \(type(of: chunk)).")
+        await self.wrapped.updateTextChunkVisibility(chunk.wrapped, visible: isTextVisible)
     }
 }
 
-private final class WTReplacementTextChunkAdapter<Wrapped>: _WTTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
+private final class WTTextChunkAdapter<Wrapped>: _WTTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
     let wrapped: Wrapped
     let preview: PlatformTextPreview?
 
     init(wrapping wrapped: Wrapped, preview: PlatformTextPreview?) {
         self.wrapped = wrapped
         self.preview = preview
-
-        super.init(chunkWithIdentifier: UUID().uuidString)
-    }
-}
-
-private final class WTPonderingTextChunkAdapter<Wrapped>: _WTTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
-    let wrapped: Wrapped
-
-    init(wrapping wrapped: Wrapped) {
-        self.wrapped = wrapped
 
         super.init(chunkWithIdentifier: UUID().uuidString)
     }
@@ -257,6 +243,7 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     fileprivate var wrappedEffectIDToPlatformEffects: [UITextEffectView.EffectID : any PlatformIntelligenceTextEffect] = [:]
     fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID : UITextEffectView.EffectID] = [:]
 #else
+    fileprivate var wrappedEffectIDToPlatformEffects: [UUID : any PlatformIntelligenceTextEffect<Source.Chunk>] = [:]
     fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID : Set<UUID>] = [:]
 #endif
 
@@ -275,6 +262,8 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         self.wrapped = Wrapped(asyncSource: self.viewSource)
 #endif
 
+        self.wrapped.clipsToBounds = true
+
         super.init(frame: .zero)
 
         self.addSubview(self.wrapped)
@@ -291,6 +280,16 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         }
     }
 
+    override var frame: PlatformBounds {
+        get {
+            super.frame
+        }
+        set {
+            super.frame = newValue
+            self.wrapped.frame = self.bounds
+        }
+    }
+
     /// Prepares and adds an effect to be presented within the view.
     @discardableResult func addEffect<Effect>(_ effect: Effect) async -> Effect.ID where Effect: PlatformIntelligenceTextEffect, Effect.Chunk == Source.Chunk {
         await effect._add(to: self)
@@ -298,7 +297,7 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     }
 
     /// Removes the effect with the specified id.
-    func removeEffect(_ effectID: PlatformIntelligenceTextEffectID) {
+    func removeEffect(_ effectID: PlatformIntelligenceTextEffectID) async {
         guard let wrappedEffectIDs = self.platformEffectIDToWrappedEffectIDs.removeValue(forKey: effectID) else {
             return
         }
@@ -308,6 +307,19 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         self.wrapped.removeEffect(wrappedEffectIDs)
 #else
         for wrappedEffectID in wrappedEffectIDs {
+            if let platformEffect = self.wrappedEffectIDToPlatformEffects.removeValue(forKey: wrappedEffectID), platformEffect is PlatformIntelligencePonderingTextEffect<Source.Chunk> {
+                // When WTUI starts a pondering effect, it creates a 0.75s opacity CA animation to fade out the text, so it is possible
+                // that this is still ongoing by the time `removeEffect` is called. This may lead to issues if subsequent effects start
+                // immediately after the effect is removed and the animation has yet to stop.
+                //
+                // To workaround this, manually try to find the applicable sublayer that WTUI adds the animation to, and remove it directly.
+                // FIXME: This is a fragile workaround, and should be removed once WTUI has proper support for removing effects at any point.
+                for sublayer in self.wrapped.layer?.sublayers ?? [] {
+                    sublayer.removeAnimation(forKey: "opacity")
+                }
+            }
+
+            self.wrappedEffectIDToPlatformEffects[wrappedEffectID] = nil
             self.wrapped.removeEffect(wrappedEffectID)
         }
 #endif
@@ -317,10 +329,7 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     func removeAllEffects() {
         self.wrapped.removeAllEffects()
         self.platformEffectIDToWrappedEffectIDs = [:]
-
-#if canImport(UIKit)
         self.wrappedEffectIDToPlatformEffects = [:]
-#endif
     }
 }
 
@@ -344,20 +353,60 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     }
 
 #if canImport(AppKit)
-    private func createEffects<Source>(using view: PlatformIntelligenceTextEffectView<Source>, sourceChunk: WTReplacementTextChunkAdapter<Chunk>, destinationChunk: WTReplacementTextChunkAdapter<Chunk>) where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
-        let wrappedDestinationEffect = _WTReplaceTextEffect(chunk: destinationChunk, effectView: view.wrapped)
+    private func didCompletePartialWrappedEffect<Source>(for source: Source) where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+        if self.hasCompletedPartialWrappedEffect {
+            Task { @MainActor in
+                await source.replacementEffectDidComplete(self)
+            }
+        }
+
+        self.hasCompletedPartialWrappedEffect = true
+    }
+#endif
+
+    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+        // The WT interfaces expect the replacement operation to be performed synchronously, else the source
+        // and destination effects become disjoint and begin at different times.
+        //
+        // To workaround this, the replacement is performed immediately (with the text hidden prior so that
+        // it is not visible to the user) before the actual effects begins. The source preview is generated
+        // prior to this, and the destination preview is generated after. This allows the previews to be cached
+        // so that they can later be retrieved by the WT interface delegates.
+
+        let sourcePreview = await view.source.textPreview(for: self.chunk)!
+        await view.source.updateTextChunkVisibility(self.chunk, visible: false)
+
+        let destinationPreview = await view.source.performReplacementAndGeneratePreview(for: self.chunk, effect: self, animation: .init(duration: 0, delay: 0))!
+
+#if canImport(UIKit)
+        let chunkAdapter = UIReplacementTextEffectTextChunkAdapter(wrapping: self.chunk, source: sourcePreview, destination: destinationPreview)
+
+        let delegateAdapter = UIReplacementTextEffectDelegateAdapter(wrapping: view.source, view: view)
+        let wrappedEffect = UITextEffectView.ReplacementTextEffect(chunk: chunkAdapter, view: view.wrapped, delegate: delegateAdapter)
+
+        await view.source.replacementEffectWillBegin(self)
+
+        view.wrapped.addEffect(wrappedEffect)
+        view.wrappedEffectIDToPlatformEffects[wrappedEffect.id] = self
+        view.platformEffectIDToWrappedEffectIDs[self.id] = wrappedEffect.id
+#else
+        // The WTUI interface on macOS exposes the replacement effect as two separate effects, a source effect
+        // and a destination effect. To abstract this disparity between the platforms, the effects are modeled
+        // as a single replacement effect, to match the iOS interface and provide a cohesive API.
+
+        let sourceChunkAdapter = WTTextChunkAdapter(wrapping: self.chunk, preview: sourcePreview)
+        let destinationChunkAdapter = WTTextChunkAdapter(wrapping: self.chunk, preview: destinationPreview)
+
+        let wrappedDestinationEffect = _WTReplaceTextEffect(chunk: destinationChunkAdapter, effectView: view.wrapped)
         wrappedDestinationEffect.isDestination = true
         wrappedDestinationEffect.animateRemovalWhenDone = true
 
         wrappedDestinationEffect.completion = {
-            if self.hasCompletedPartialWrappedEffect {
-                view.source.replacementEffectDidComplete(self)
-            }
-
-            self.hasCompletedPartialWrappedEffect = true
+            // The destination completion handler is invoked right before it starts its opacity animation.
+            self.didCompletePartialWrappedEffect(for: view.source)
         }
 
-        let wrappedSourceEffect = _WTReplaceTextEffect(chunk: sourceChunk, effectView: view.wrapped)
+        let wrappedSourceEffect = _WTReplaceTextEffect(chunk: sourceChunkAdapter, effectView: view.wrapped)
         wrappedSourceEffect.animateRemovalWhenDone = false
 
         wrappedSourceEffect.preCompletion = {
@@ -365,86 +414,20 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             // It's intended for the destination effect to be added here, synchronously.
 
             let destinationEffectID = view.wrapped.add(wrappedDestinationEffect)!
+            view.wrappedEffectIDToPlatformEffects[destinationEffectID] = self
             view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(destinationEffectID)
         }
 
         wrappedSourceEffect.completion = {
-            if self.hasCompletedPartialWrappedEffect {
-                view.source.replacementEffectDidComplete(self)
-            }
-
-            self.hasCompletedPartialWrappedEffect = true
+            // The source completion handler is invoked right after it ends its opacity animation.
+            self.didCompletePartialWrappedEffect(for: view.source)
         }
 
-        let sourceEffectID = view.wrapped.add(wrappedSourceEffect)!
-        view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(sourceEffectID)
-    }
-#endif
-
-    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
-#if canImport(UIKit)
-        // The UIKit effects interface natively supports async operations such as replacing text, since the source and destination previews
-        // are generated before any animation actually begins.
-
-        let chunkAdapter = UITextEffectTextChunkAdapter(wrapping: self.chunk)
-        let delegateAdapter = UIReplacementTextEffectDelegateAdapter(wrapping: view.source, view: view)
-        let wrappedEffect = UITextEffectView.ReplacementTextEffect(chunk: chunkAdapter, view: view.wrapped, delegate: delegateAdapter)
-        view.wrapped.addEffect(wrappedEffect)
-
-        view.wrappedEffectIDToPlatformEffects[wrappedEffect.id] = self
-        view.platformEffectIDToWrappedEffectIDs[self.id] = wrappedEffect.id
-#else
-        // WritingToolsUI usually performs a replacement effect using the following flow:
-        //
-        //  1. A source effect is created
-        //  2. WTUI then requests a text preview of the source text.
-        //  3. WTUI requests the relevant text to become invisible.
-        //  4. WTUI invokes the 'pre-completion' block associated with the source effect. This gets invokes after the preview is generated
-        //     but before the effect actually begins. In this block, it is intended that the client performs the replacement, and then
-        //     begins a destination effect.
-        //  5. After adding the destination effect, WTUI requests a text preview of the now-replaced text.
-        //  6. WTUI then uses this text preview to begin the destination effect.
-        //  7. This results in the destination effect beginning immediately after the source effect begins, with no delay.
-        //
-        // However, if the replacement must happen asynchronously, the destination effect cannot begin immediately after the source effect,
-        // since it needs to wait for the text to be replaced so that it can then request a preview of the replaced text. Consequently, the
-        // whole replacement effect will not look correct, since the destination effect will lag behind the source effect.
-        //
-        // To address this gap in the interface of WTUI, the source and destination effect are abstracted into a single replacement effect.
-        // When adding this replacement effect, the replacement happens prior to both the source and destination effects starting. Specifically,
-        // this effectively works the way the UIKit interface does things. This allows the destination effect to happen immediately when needed,
-        // since the preview generation and replacement has already happened.
-
-        // First, a text preview of the source text is manually generated and saved.
-        // When WTUI requests the text preview of the source, this preview can be synchronously returned in the delegate method rather than
-        // a new preview being generated on-demand.
-        let sourcePreview = await view.source.textPreview(for: self.chunk)
-        let sourceChunkAdapter = WTReplacementTextChunkAdapter(wrapping: self.chunk, preview: sourcePreview)
-
-        // The replacement is then immediately performed. At this point, the text should be hidden
-        // so the user does not see the text update yet.
-        //
-        // At the moment, this really only works if there is an existing effect ongoing when this happens so that the user would see that
-        // effect instead of disappearing text. In practice, a pondering effect should always precede a replacement effect, so this shouldn't
-        // be a problem, but strictly speaking this is not a general solution.
-        //
-        // The UIKit interface does not have this issue since they can just present the source preview anyways while this is happening.
-
-        // FIXME: Don't assume that the text will be hidden at this point by a prior effect.
-        // FIXME: Mimic what UIKit does and add the source preview during this time, above the underlying text but below any prior effects.
-
-        // When the FIXMEs are addressed, this will allow replacement effects to be seamlessly added without any prior effects needed.
-
-        let destinationPreview = await view.source.performReplacementAndGeneratePreview(for: self.chunk, effect: self, animation: .init(duration: 0, delay: 0))
-
-        let destinationChunkAdapter = WTReplacementTextChunkAdapter(wrapping: self.chunk, preview: destinationPreview)
-
-        // Inform the view source that all async operations have completed, and the source and destination effects are about to actually begin.
-        // This is needed so that clients know when to stop any prior effects, since they should only be stopped when there will be no gap
-        // between effects.
         await view.source.replacementEffectWillBegin(self)
 
-        self.createEffects(using: view, sourceChunk: sourceChunkAdapter, destinationChunk: destinationChunkAdapter)
+        let sourceEffectID = view.wrapped.add(wrappedSourceEffect)!
+        view.wrappedEffectIDToPlatformEffects[sourceEffectID] = self
+        view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(sourceEffectID)
 #endif
     }
 }
@@ -452,9 +435,9 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 /// An effect which adds a shimmer animation to some text, intended to indicate that some operation is pending.
 class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
 #if canImport(UIKit)
-    private typealias ChunkAdapter = UITextEffectTextChunkAdapter
+    private typealias ChunkAdapter = UIPonderingTextEffectTextChunkAdapter
 #else
-    private typealias ChunkAdapter = WTPonderingTextChunkAdapter
+    private typealias ChunkAdapter = WTTextChunkAdapter
 #endif
 
     let id = PlatformIntelligenceTextEffectID()
@@ -465,7 +448,8 @@ class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEf
     }
 
     func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
-        let chunkAdapter = ChunkAdapter(wrapping: self.chunk)
+        let preview = await view.source.textPreview(for: self.chunk)!
+        let chunkAdapter = ChunkAdapter(wrapping: self.chunk, preview: preview)
 
 #if canImport(UIKit)
         let wrappedEffect = UITextEffectView.PonderingEffect(chunk: chunkAdapter, view: view.wrapped)
@@ -477,6 +461,7 @@ class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEf
         let wrappedEffect = _WTSweepTextEffect(chunk: chunkAdapter, effectView: view.wrapped)
         view.wrapped.add(wrappedEffect)
 
+        view.wrappedEffectIDToPlatformEffects[wrappedEffect.identifier] = self
         view.platformEffectIDToWrappedEffectIDs[self.id] = [wrappedEffect.identifier]
 #endif
     }

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -25,7 +25,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if !TARGET_OS_WATCH && !TARGET_OS_TV
+#if !TARGET_OS_WATCH && !TARGET_OS_TV && __has_include(<WritingTools/WritingTools.h>)
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -34,17 +34,18 @@
 #import <WebKit/_WKTextPreview.h>
 #endif
 
+#import <WebKit/WKWebView.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class WKIntelligenceTextEffectCoordinator;
 
+@class WTTextSuggestion;
+
+NS_SWIFT_UI_ACTOR
 @protocol WKIntelligenceTextEffectCoordinatorDelegate <NSObject>
 
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-- (UIView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator;
-#else
-- (NSView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator;
-#endif
+- (WKWebView *)viewForIntelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator;
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator textPreviewsForRange:(NSRange)range completion:(void (^)(UITargetedPreview *))completion;
@@ -54,11 +55,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator rectsForProofreadingSuggestionsInRange:(NSRange)range completion:(void (^)(NSArray<NSValue *> *))completion;
 
-- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible completion:(void (^)(void))completion;
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator updateTextVisibilityForRange:(NSRange)range visible:(BOOL)visible identifier:(NSUUID *)identifier completion:(void (^)(void))completion;
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator decorateReplacementsForRange:(NSRange)range completion:(void (^)(void))completion;
 
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKIntelligenceTextEffectCoordinator : NSObject
+
++ (NSInteger)characterDeltaForReceivedSuggestions:(NSArray<WTTextSuggestion *> *)suggestions;
+
+- (instancetype)initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)delegate;
+
+- (void)startAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
+
+- (void)requestReplacementWithProcessedRange:(NSRange)range characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
+
+- (void)flushReplacementsWithCompletion:(void (^)(void))completion;
 
 @end
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -59,6 +59,8 @@ NS_SWIFT_UI_ACTOR
 
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator decorateReplacementsForRange:(NSRange)range completion:(void (^)(void))completion;
 
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator setSelectionForRange:(NSRange)range completion:(void (^)(void))completion;
+
 @end
 
 NS_SWIFT_UI_ACTOR
@@ -70,9 +72,11 @@ NS_SWIFT_UI_ACTOR
 
 - (void)startAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
 
-- (void)requestReplacementWithProcessedRange:(NSRange)range characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
+- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
 
 - (void)flushReplacementsWithCompletion:(void (^)(void))completion;
+
+- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completion:(void (^)(void))completion;
 
 @end
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
@@ -2,13 +2,438 @@
 // Copyright (C) 2024 Apple Inc. All rights reserved.
 //
 
+#if canImport(WritingTools)
+
 import Foundation
 import WebKit
 import WebKitSwift
+@_spi(Private) import WebKit
+@_spiOnly import WritingTools
+@_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
 
-@objc(WKIntelligenceTextEffectCoordinator)
-public final class WKIntelligenceTextEffectCoordinator: NSObject {
-    @objc
-    override public init() {
+// MARK: Implementation
+
+@_objcImplementation extension WKIntelligenceTextEffectCoordinator {
+    private struct ReplacementOperationRequest {
+        let processedRange: Range<Int>
+        let characterDelta: Int
+        let operation: (() async -> Void)
+    }
+
+    @nonobjc final private let delegate: (any WKIntelligenceTextEffectCoordinatorDelegate)
+    @nonobjc final private var effectView: PlatformIntelligenceTextEffectView<WKIntelligenceTextEffectCoordinator>? = nil
+
+    @nonobjc final private var processedRangeOffset = 0
+    @nonobjc final private var contextRange: Range<Int>? = nil
+
+    // Use the corresponding setter functions instead of setting these directly.
+    @nonobjc final private var activePonderingEffect: PlatformIntelligencePonderingTextEffect<Chunk>? = nil
+    @nonobjc final private var activeReplacementEffect: PlatformIntelligenceReplacementTextEffect<Chunk>? = nil
+
+    // The transparent content document markers associated with the visibility of each chunk need to
+    // maintain identifiers so that if chunk A makes range R hidden, chunk B makes R hidden, then chunk A makes
+    // R visible, R must still be hidden due to B.
+    @nonobjc final private var textVisibilityRegionIdentifiers: [Chunk: UUID] = [:]
+
+    // Maintain a replacement operation queue to ensure that no matter how many batches of replacements are received,
+    // there is only ever one ongoing effect at a time.
+    @nonobjc final private var replacementQueue: [ReplacementOperationRequest] = []
+
+    // If there are still pending replacements/animations when the user has accepted or rejected the Writing Tools
+    // suggestions, they first need to all be flushed out and invoked so that the state is not incomplete, and then
+    // the acceptance/rejection can properly occur.
+    @nonobjc final private var onFlushCompletion: (() async -> Void)? = nil
+
+    @objc(characterDeltaForReceivedSuggestions:)
+    public class func characterDelta(forReceivedSuggestions suggestions: [WTTextSuggestion]) -> Int {
+        suggestions.reduce(0) { partialResult, suggestion in
+            partialResult + (suggestion.replacement.count - suggestion.originalRange.length)
+        }
+    }
+
+    @objc(initWithDelegate:)
+    public init(delegate: any WKIntelligenceTextEffectCoordinatorDelegate) {
+        self.delegate = delegate
+    }
+
+    @objc(startAnimationForRange:completion:)
+    public func startAnimation(for range: NSRange) async {
+        self.reset()
+
+        assert(self.activePonderingEffect == nil, "Intelligence text effect coordinator: cannot start a new animation while a pondering effect is already active")
+        assert(self.activeReplacementEffect == nil, "Intelligence text effect coordinator: cannot start a new animation while a replacement effect is already active")
+
+        guard let contextRange = Range(range) else {
+            assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange (\(range)")
+            return
+        }
+
+        self.contextRange = contextRange
+
+        let chunk = Self.Chunk.Pondering(range: contextRange)
+        let effect = PlatformIntelligencePonderingTextEffect(chunk: chunk as Chunk)
+
+        await self.setActivePonderingEffect(effect)
+    }
+
+    @objc(requestReplacementWithProcessedRange:characterDelta:operation:completion:)
+    public func requestReplacement(withProcessedRange processedRange: NSRange, characterDelta: Int, operation: @escaping (@escaping () -> Void) -> Void) async {
+        let asyncBlock = async(operation)
+        let request = Self.ReplacementOperationRequest(processedRange: Range(processedRange)!, characterDelta: characterDelta, operation: asyncBlock)
+
+        self.replacementQueue.append(request)
+
+        if self.replacementQueue.count == 1 {
+            await self.startReplacementAnimation(using: request)
+        }
+    }
+
+    @objc(flushReplacementsWithCompletion:)
+    public func flushReplacements() async {
+        assert(self.onFlushCompletion == nil)
+
+        // If the replacement queue is empty, there's no effects pending completion and nothing to flush,
+        // so no need to create a completion block, and instead just invoke `removeActiveEffects` immediately.
+
+        if self.replacementQueue.isEmpty {
+            await self.removeActiveEffects()
+            return
+        }
+
+        // This can't be performed immediately since a replacement animation may be ongoing, and they are not interruptible.
+        // So instead, the completion of this async method is stored in state, so that when the current replacement is complete,
+        // the actual flush can occur.
+
+        await withCheckedContinuation { continuation in
+            self.onFlushCompletion = {
+                await self.removeActiveEffects()
+                continuation.resume()
+            }
+        }
+    }
+
+    @nonobjc final private func removeActiveEffects() async {
+        if self.activePonderingEffect != nil {
+            await self.setActivePonderingEffect(nil)
+        }
+
+        if self.activeReplacementEffect != nil {
+            await self.setActiveReplacementEffect(nil)
+        }
+    }
+
+    @nonobjc final private func startReplacementAnimation(using request: WKIntelligenceTextEffectCoordinator.ReplacementOperationRequest) async {
+        assert(self.activeReplacementEffect == nil, "Intelligence text effect coordinator: cannot start a new replacement animation while one is already active")
+
+        let processedRange = request.processedRange
+        let characterDelta = request.characterDelta
+
+        let processedRangeRelativeToCurrentText = (processedRange.lowerBound + self.processedRangeOffset)..<(processedRange.upperBound + self.processedRangeOffset)
+
+        let chunk = Self.Chunk.Replacement(
+            range: processedRangeRelativeToCurrentText,
+            rangeAfterReplacement: processedRangeRelativeToCurrentText.lowerBound..<(processedRangeRelativeToCurrentText.upperBound + characterDelta),
+            replacement: request.operation
+        )
+
+        let effect = PlatformIntelligenceReplacementTextEffect(chunk: chunk as Chunk)
+
+        // Start the replacement effect while the pondering effect is still ongoing, so that it can perform
+        // the async replacement without it being visible to the user and without any flickering.
+        await self.setActiveReplacementEffect(effect)
+
+        self.processedRangeOffset += characterDelta
+    }
+
+    @nonobjc final private func setupViewIfNeeded() {
+        guard self.effectView == nil else {
+            return
+        }
+
+        let parent = self.delegate.view(for: self)
+        let effectView = PlatformIntelligenceTextEffectView(source: self)
+
+#if os(iOS)
+        effectView.isUserInteractionEnabled = false
+        effectView.frame = parent.scrollView.bounds
+        parent.scrollView.addSubview(effectView)
+#else
+        effectView.frame = parent.bounds
+        parent.addSubview(effectView)
+#endif
+
+        self.effectView = effectView
+    }
+
+    @nonobjc final private func destroyViewIfNeeded() {
+        guard self.activePonderingEffect == nil && self.activeReplacementEffect == nil else {
+            return
+        }
+
+        self.effectView?.removeFromSuperview()
+        self.effectView = nil
+    }
+
+    @nonobjc final private func setActivePonderingEffect(_ effect: PlatformIntelligencePonderingTextEffect<Chunk>?) async {
+        guard (self.activePonderingEffect == nil && effect != nil) || (self.activePonderingEffect != nil && effect == nil) else {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new pondering effect when there is an ongoing one, or trying to remove an effect when there are none.")
+            return
+        }
+
+        if let effect {
+            self.setupViewIfNeeded()
+            await self.effectView?.addEffect(effect)
+        } else {
+            // This needs to be manually invoked rather than relying on the associated delegate method being called. This is
+            // because when removing an effect, the delegate method is invoked after the effect removal function ends. Invoking
+            // this method manually ensures that the replacement effect doesn't start until the visibility has actually changed
+            // and this function terminates.
+            //
+            // Therefore, the delegate method itself must avoid any work so that it can be synchronous, which is what the platform
+            // interfaces expect.
+            await self.updateTextChunkVisibility(self.activePonderingEffect!.chunk, visible: true, force: true)
+
+            await self.effectView?.removeEffect(self.activePonderingEffect!.id)
+
+            self.destroyViewIfNeeded()
+        }
+
+        self.activePonderingEffect = effect
+    }
+
+    @nonobjc final private func setActiveReplacementEffect(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>?) async {
+        guard (self.activeReplacementEffect == nil && effect != nil) || (self.activeReplacementEffect != nil && effect == nil) else {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new replacement effect when there is an ongoing one, or trying to remove an effect when there are none.")
+            return
+        }
+
+        if let effect {
+            self.setupViewIfNeeded()
+            await self.effectView?.addEffect(effect)
+        } else {
+            await self.effectView?.removeEffect(self.activeReplacementEffect!.id)
+            self.destroyViewIfNeeded()
+        }
+
+        self.activeReplacementEffect = effect
+    }
+
+    @nonobjc final private func reset() {
+        self.effectView?.removeAllEffects()
+        self.effectView?.removeFromSuperview()
+        self.effectView = nil
+
+        self.processedRangeOffset = 0
+        self.contextRange = nil
+
+        self.activePonderingEffect = nil
+        self.activeReplacementEffect = nil
+
+        self.textVisibilityRegionIdentifiers = [:]
+        self.replacementQueue = []
     }
 }
+
+// MARK: WKIntelligenceTextEffectCoordinator + PlatformIntelligenceTextEffectViewSource conformance
+
+extension WKIntelligenceTextEffectCoordinator: PlatformIntelligenceTextEffectViewSource {
+    func textPreview(for chunk: Chunk) async -> PlatformTextPreview? {
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+
+#if canImport(UIKit)
+        return previews
+#else
+        return previews.map {
+            _WTTextPreview(snapshotImage: $0.previewImage, presentationFrame: $0.presentationFrame)
+        }
+#endif
+    }
+
+    private func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool, force: Bool) async {
+        if chunk is Chunk.Pondering && visible && !force {
+            // Typically, if `chunk` is part of a pondering effect, this delegate method will get called with `visible == true`
+            // once the pondering effect is removed. However, instead of performing that logic here, it is done in `setActivePonderingEffect`
+            // instead.
+            //
+            // This effectively makes this function synchronous in this case.
+            return
+        }
+
+        // Get the associated visibility identifier for the chunk, or make a new one if needed.
+
+        let id: UUID
+        if let cachedID = self.textVisibilityRegionIdentifiers[chunk] {
+            id = cachedID
+        } else {
+            id = UUID()
+            self.textVisibilityRegionIdentifiers[chunk] = id
+        }
+
+        await self.delegate.intelligenceTextEffectCoordinator(self, updateTextVisibilityFor: NSRange(chunk.range), visible: visible, identifier: id)
+    }
+
+    func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool) async {
+        await self.updateTextChunkVisibility(chunk, visible: visible, force: false)
+    }
+
+    func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>, animation: PlatformIntelligenceReplacementTextEffect<Chunk>.AnimationParameters) async -> PlatformTextPreview? {
+        guard let chunk = chunk as? Chunk.Replacement else {
+            fatalError()
+        }
+
+        let characterDelta = chunk.rangeAfterReplacement.upperBound - chunk.range.upperBound
+
+        await chunk.replacement()
+        chunk.range = chunk.rangeAfterReplacement
+
+        // If there is an active pondering effect ongoing that predated the replacement, adjust its range to account
+        // for the replacement character delta. This ensures that when the pondering effect ends, the semantic chunk
+        // remains the same so that the text visibility is restored for the updated range.
+        //
+        // Additionally, the range's start offset can be truncated to now start at the end of the replacement range,
+        // since the range [activePonderingEffect.chunk.range.lowerBound, chunk.range.upperBound] will be covered by
+        // the replacement range so there's no need for the pondering effect to also try to affect it.
+        if let activePonderingEffect = self.activePonderingEffect {
+            activePonderingEffect.chunk.range = chunk.range.upperBound..<(activePonderingEffect.chunk.range.upperBound + characterDelta)
+        }
+
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+
+#if canImport(UIKit)
+        return previews
+#else
+        let suggestionRects = await self.delegate.intelligenceTextEffectCoordinator(self, rectsForProofreadingSuggestionsIn: NSRange(chunk.range))
+        return previews.map {
+            _WTTextPreview(snapshotImage: $0.previewImage, presentationFrame: $0.presentationFrame, backgroundColor: nil, clippingPath: nil, scale: 1, candidateRects: suggestionRects)
+        }
+#endif
+    }
+
+    func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async {
+        // Stop the current pondering effect, and then create a new pondering effect once the replacement effect is complete.
+        await self.setActivePonderingEffect(nil)
+    }
+
+    @discardableResult private func flushRemainingReplacementsIfNeeded() async -> Bool {
+        guard let onFlushCompletion = self.onFlushCompletion else {
+            return false
+        }
+
+        // Iterate through all replacements in the queue (except for the first one, which will have been completed by this point,
+        // but not yet removed from the queue), and immediately apply their operations and update the offset state.
+
+        for request in self.replacementQueue.dropFirst() {
+            await request.operation()
+            self.processedRangeOffset += request.characterDelta
+        }
+
+        await onFlushCompletion()
+
+        self.replacementQueue = []
+        self.onFlushCompletion = nil
+
+        return true
+    }
+
+    func replacementEffectDidComplete(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async {
+        guard let contextRange = self.contextRange else {
+            assertionFailure("Intelligence text effect coordinator: Invariant failed (replacement effect completed without a context range)")
+            return
+        }
+
+        // At this point, the text has been replaced, and the effect's chunk's range has been updated to account for the latest character delta.
+        let rangeAfterReplacement = effect.chunk.range
+
+        // Inform the coordinator the active replacement effect is over, and then inform the delegate to decorate the replacements if needed.
+        await self.setActiveReplacementEffect(nil)
+        await self.delegate.intelligenceTextEffectCoordinator(self, decorateReplacementsFor: NSRange(rangeAfterReplacement))
+
+        // Now that the coordinator is in-between replacements, if a flush has previously been requested, flush out
+        // all the remaining replacements from the queue as fast as possible and without any effects.
+        //
+        // If the replacements are flushed, there's no need to continue adding effects for the unprocessed range.
+
+        let didFlush = await self.flushRemainingReplacementsIfNeeded()
+        guard !didFlush else {
+            return
+        }
+
+        // Add a new pondering effect, from the end of the most recently replaced range to the end of the context range, adjusted
+        // for the offset relative to the original text.
+
+        let endOfContextRangeRelativeToCurrentText = contextRange.upperBound + self.processedRangeOffset
+        let unprocessedRangeChunk = Self.Chunk.Pondering(range: rangeAfterReplacement.upperBound..<endOfContextRangeRelativeToCurrentText)
+        let ponderEffectForUnprocessedRange = PlatformIntelligencePonderingTextEffect(chunk: unprocessedRangeChunk as Chunk)
+
+        // When all text has been processed, the unprocessed range will be empty, and no pondering effect need be created.
+        if !unprocessedRangeChunk.range.isEmpty {
+            await self.setActivePonderingEffect(ponderEffectForUnprocessedRange)
+        }
+
+        // Now that the first replacement is complete, remove it from the queue, and start the next one in line.
+
+        self.replacementQueue.removeFirst()
+
+        if let next = self.replacementQueue.first {
+            await self.startReplacementAnimation(using: next)
+        }
+    }
+}
+
+// MARK: WKIntelligenceTextEffectCoordinator.Chunk
+
+extension WKIntelligenceTextEffectCoordinator {
+    class Chunk: PlatformIntelligenceTextEffectChunk {
+        fileprivate class Pondering: Chunk {
+            override init(range: Range<Int>) {
+                super.init(range: range)
+            }
+        }
+
+        fileprivate class Replacement: Chunk {
+            let rangeAfterReplacement: Range<Int>
+            let replacement: (() async -> Void)
+
+            init(range: Range<Int>, rangeAfterReplacement: Range<Int>, replacement: @escaping (() async -> Void)) {
+                self.rangeAfterReplacement = rangeAfterReplacement
+                self.replacement = replacement
+                super.init(range: range)
+            }
+        }
+
+        let id = UUID()
+
+        fileprivate var range: Range<Int>
+
+        private init(range: Range<Int>) {
+            self.range = range
+        }
+    }
+}
+
+// MARK: WKIntelligenceTextEffectCoordinator.Chunk + Hashable & Equatable
+
+extension WKIntelligenceTextEffectCoordinator.Chunk: Hashable, Equatable {
+    static func == (lhs: WKIntelligenceTextEffectCoordinator.Chunk, rhs: WKIntelligenceTextEffectCoordinator.Chunk) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        self.id.hash(into: &hasher)
+    }
+}
+
+// MARK: Misc. helper functions
+
+/// Converts a block with a completion handler into an async block.
+fileprivate func async<each Arg>(_ block: @escaping (@escaping (repeat each Arg) -> Void) -> Void) -> (() async -> (repeat each Arg)) {
+    { @MainActor in
+        await withCheckedContinuation { continuation in
+            block { (args: repeat each Arg) in
+                continuation.resume(returning: (repeat each args))
+            }
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -960,6 +960,12 @@ void WebPage::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::Writ
     corePage()->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
 }
 
+void WebPage::willEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted, CompletionHandler<void()>&& completionHandler)
+{
+    corePage()->willEndWritingToolsSession(session, accepted);
+    completionHandler();
+}
+
 void WebPage::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
     corePage()->didEndWritingToolsSession(session, accepted);
@@ -1069,6 +1075,12 @@ void WebPage::textPreviewDataForActiveWritingToolsSession(const WebCore::Charact
 void WebPage::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
 {
     corePage()->decorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    completionHandler();
+}
+
+void WebPage::setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
+{
+    corePage()->setSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -949,15 +949,9 @@ void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& 
     corePage()->didBeginWritingToolsSession(session, contexts);
 }
 
-void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
+void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::CharacterRange& processedRange, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    corePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
-    completionHandler();
-}
-
-void WebPage::proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
-{
-    corePage()->proofreadingSessionDidCompletePartialReplacement(session, suggestions, context, finished);
+    corePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
     completionHandler();
 }
 
@@ -1060,9 +1054,9 @@ void WebPage::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const 
     completionHandler(WTFMove(rects));
 }
 
-void WebPage::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, CompletionHandler<void()>&& completionHandler)
+void WebPage::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier, CompletionHandler<void()>&& completionHandler)
 {
-    corePage()->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible);
+    corePage()->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier);
     completionHandler();
 }
 
@@ -1070,6 +1064,12 @@ void WebPage::textPreviewDataForActiveWritingToolsSession(const WebCore::Charact
 {
     auto data = corePage()->textPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler(WTFMove(data));
+}
+
+void WebPage::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
+{
+    corePage()->decorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    completionHandler();
 }
 
 void WebPage::intelligenceTextAnimationsDidComplete()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2338,9 +2338,7 @@ private:
 
     void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
-
-    void proofreadingSessionDidCompletePartialReplacement(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
@@ -2351,8 +2349,9 @@ private:
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange&, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&) const;
-    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, CompletionHandler<void()>&&);
+    void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     // Old animation system methods:
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2342,6 +2342,8 @@ private:
 
     void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
+    void willEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted, CompletionHandler<void()>&&);
+
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
     void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
@@ -2352,6 +2354,7 @@ private:
     void updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange&, bool, const WTF::UUID&, CompletionHandler<void()>&&);
     void textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
+    void setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange&, CompletionHandler<void()>&&);
 
     // Old animation system methods:
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -794,6 +794,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     ProofreadingSessionDidUpdateStateForSuggestion(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::TextSuggestionState state, struct WebCore::WritingTools::TextSuggestion suggestion, struct WebCore::WritingTools::Context context)
 
+    WillEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted) -> ()
+
     DidEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted)
 
     CompositionSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished);
@@ -805,6 +807,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     UpdateTextVisibilityForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange, bool visible, WTF::UUID identifier) -> ()
 
     TextPreviewDataForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> (std::optional<WebCore::TextIndicatorData> data)
+
+    SetSelectionForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> ()
 
     DecorateTextReplacementsForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> ()
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -790,9 +790,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     DidBeginWritingToolsSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
 
-    ProofreadingSessionDidReceiveSuggestions(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::WritingTools::Context context, bool finished) -> ()
-
-    ProofreadingSessionDidCompletePartialReplacement(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::WritingTools::Context context, bool finished) -> ()
+    ProofreadingSessionDidReceiveSuggestions(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::CharacterRange processedRange, struct WebCore::WritingTools::Context context, bool finished) -> ()
 
     ProofreadingSessionDidUpdateStateForSuggestion(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::TextSuggestionState state, struct WebCore::WritingTools::TextSuggestion suggestion, struct WebCore::WritingTools::Context context)
 
@@ -804,9 +802,11 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     ProofreadingSessionSuggestionTextRectsInRootViewCoordinates(struct WebCore::CharacterRange enclosingRangeRelativeToSessionRange) -> (Vector<WebCore::FloatRect> rects)
 
-    UpdateTextVisibilityForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange, bool visible) -> ()
+    UpdateTextVisibilityForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange, bool visible, WTF::UUID identifier) -> ()
 
     TextPreviewDataForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> (std::optional<WebCore::TextIndicatorData> data)
+
+    DecorateTextReplacementsForActiveWritingToolsSession(struct WebCore::CharacterRange rangeRelativeToSessionRange) -> ()
 
     CreateTextIndicatorForTextAnimationID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
     UpdateUnderlyingTextVisibilityForTextAnimationID(WTF::UUID uuid, bool visible) -> ()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -3748,7 +3748,9 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilit
 
     NSRange subrange = NSMakeRange(17, 45); // "I didn't quite here him.\n\nWho's over they're."
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:NO completion:^{
+    RetainPtr identifier = [NSUUID UUID];
+
+    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:NO identifier:identifier.get() completion:^{
         finished = true;
     }];
 
@@ -3761,7 +3763,7 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilit
     moveSelectionToSecondNode();
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasTransparentContentMarker(0, 19);"] boolValue]);
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:YES completion:^{
+    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:YES identifier:identifier.get() completion:^{
         finished = true;
     }];
 


### PR DESCRIPTION
#### c74a32fdbe46246f03a8d65c02d22561a9d8957c
<pre>
[Intelligence Effects] Selection should be set to the context range after all effects are complete
<a href="https://bugs.webkit.org/show_bug.cgi?id=282486">https://bugs.webkit.org/show_bug.cgi?id=282486</a>
<a href="https://rdar.apple.com/139115567">rdar://139115567</a>

Reviewed by NOBODY (OOPS!).

Restore the selection to the context range after either the entire replacement animation is complete,
or the Writing Tools session ends; whichever comes first. However, even if the replacement animation
completes prior to the session ending, the selection must still be updated in the case where the session
is reverted.

* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::setSelection):
* Source/WebCore/page/IntelligenceTextEffectsSupport.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::willEndWritingToolsSession):
(WebCore::Page::setSelectionForActiveWritingToolsSession):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::willEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::willEndWritingToolsSession):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView intelligenceTextEffectCoordinator:setSelectionForRange:completion:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::willEndWritingToolsSession):
(WebKit::WebPageProxy::setSelectionForActiveWritingToolsSession):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift:
(requestReplacement(withProcessedRange:finished:characterDelta:operation:)):
(restoreSelection(_:)):
(startReplacementAnimation(using:)):
(WKIntelligenceTextEffectCoordinator.replacementEffectDidComplete(_:)):
(async(_:)):
(requestReplacement(withProcessedRange:characterDelta:operation:)): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willEndWritingToolsSession):
(WebKit::WebPage::setSelectionForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre>
----------------------------------------------------------------------
#### b4c3e1de0448df08c33d1b30c86a78b9c6bbeb74
<pre>
[Intelligence Effects] Support adding intelligence effects to Writing Tools Proofreading operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=282161">https://bugs.webkit.org/show_bug.cgi?id=282161</a>
<a href="https://rdar.apple.com/138751347">rdar://138751347</a>

Reviewed by NOBODY (OOPS!).

When performing Proofreading, the text will now animate using the intelligence text effects.

The implementation details are described throughout the change in comments.

* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::updateTextVisibility):
(WebCore::IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements):
* Source/WebCore/page/IntelligenceTextEffectsSupport.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::proofreadingSessionDidReceiveSuggestions):
(WebCore::Page::updateTextVisibilityForActiveWritingToolsSession):
(WebCore::Page::decorateTextReplacementsForActiveWritingToolsSession):
(WebCore::Page::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::didBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView intelligenceTextEffectCoordinator:updateTextVisibilityForRange:visible:identifier:completion:]):
(-[WKWebView intelligenceTextEffectCoordinator:decorateReplacementsForRange:completion:]):
(-[WKWebView intelligenceTextEffectCoordinator:updateTextVisibilityForRange:visible:completion:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
(PlatformIntelligenceTextEffectViewSource.replacementEffectDidComplete(_:)):
(UITextEffectViewSourceAdapter.targetedPreview(for:)):
(UITextEffectViewSourceAdapter.updateTextChunkVisibilityForAnimation(_:visible:)):
(UIReplacementTextEffectDelegateAdapter.replacementEffectDidComplete(_:)):
(UIReplacementTextEffectDelegateAdapter.performReplacementAndGeneratePreview(for:effect:animation:)):
(WTTextPreviewAsyncSourceAdapter.textPreviews(for:)):
(WTTextPreviewAsyncSourceAdapter.updateIsTextVisible(_:for:)):
(PlatformIntelligenceTextEffectView.wrappedEffectIDToPlatformEffects):
(PlatformIntelligenceTextEffectView.frame):
(PlatformIntelligenceTextEffectView.removeEffect(_:)):
(PlatformIntelligenceTextEffectView.removeAllEffects):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift:
(effectView):
(contextRange):
(activePonderingEffect):
(activeReplacementEffect):
(textVisibilityRegionIdentifiers):
(replacementQueue):
(onFlushCompletion):
(characterDelta(forReceivedSuggestions:)):
(startAnimation(for:)):
(requestReplacement(withProcessedRange:characterDelta:operation:)):
(flushReplacements):
(startReplacementAnimation(using:)):
(setupViewIfNeeded):
(destroyViewIfNeeded):
(setActivePonderingEffect(_:)):
(setActiveReplacementEffect(_:)):
(reset):
(WKIntelligenceTextEffectCoordinator.textPreview(for:)):
(WKIntelligenceTextEffectCoordinator.updateTextChunkVisibility(_:visible:force:)):
(WKIntelligenceTextEffectCoordinator.updateTextChunkVisibility(_:visible:)):
(WKIntelligenceTextEffectCoordinator.performReplacementAndGeneratePreview(for:effect:animation:)):
(WKIntelligenceTextEffectCoordinator.replacementEffectWillBegin(_:)):
(WKIntelligenceTextEffectCoordinator.flushRemainingReplacementsIfNeeded):
(WKIntelligenceTextEffectCoordinator.replacementEffectDidComplete(_:)):
(range):
(WKIntelligenceTextEffectCoordinator.hash(into:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPage::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPage::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPage::proofreadingSessionDidCompletePartialReplacement): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilityForRange)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c74a32fdbe46246f03a8d65c02d22561a9d8957c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16928 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66198 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8289 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4728 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->