### PR TITLE
[GStreamer] GStreamerTest.harnessParseMP4 is a constant API test failure

### DIFF
--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -211,13 +211,6 @@
             }
         }
     },
-    "TestWebCore": {
-        "subtests": {
-            "GStreamerTest.harnessParseMP4": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/282445"}}
-            }
-        }
-    },
     "TestWebKit": {
         "subtests": {
             "WebKit.NewFirstVisuallyNonEmptyLayoutForImages": {


### PR DESCRIPTION
#### 38e13112b5a10d7043a2c823b0e2aad593ded4a1
<pre>
[GStreamer] GStreamerTest.harnessParseMP4 is a constant API test failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=282445">https://bugs.webkit.org/show_bug.cgi?id=282445</a>

Reviewed by Xabier Rodriguez-Calvar.

Since GStreamer 1.24.9 the stream collection is stored on the pad and not forwarded by parsebin, so
update the harnessParseMP4 test accordingly.

* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, harnessParseMP4)):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/286072@main">https://commits.webkit.org/286072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e43bb8dec998fe02842a912c00e2ee7a1126c79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58671 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24235 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16453 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8295 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1947 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2895 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->