### PR TITLE
[bmalloc] Add Windows implementation of VMAllocate

### DIFF
--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -33,8 +33,13 @@
 #include "Range.h"
 #include "Sizes.h"
 #include <algorithm>
+
+#if BOS(WINDOWS)
+#include <windows.h>
+#else
 #include <sys/mman.h>
 #include <unistd.h>
+#endif
 
 #if BOS(DARWIN)
 #include <mach/vm_page_size.h>
@@ -54,17 +59,25 @@ namespace bmalloc {
 #define BMALLOC_NORESERVE 0
 #endif
 
-inline size_t vmPageSize()
-{
-    static size_t cached;
-    if (!cached) {
-        long pageSize = sysconf(_SC_PAGESIZE);
-        if (pageSize < 0)
-            BCRASH();
-        cached = pageSize;
-    }
-    return cached;
-}
+// The following require platform-specific implementations
+
+inline size_t vmPageSize();
+
+inline size_t vmPageSizePhysical();
+
+inline void* tryVMAllocate(size_t vmSize, VMTag usage = VMTag::Malloc);
+
+inline void vmDeallocate(void* p, size_t vmSize);
+
+inline void vmRevokePermissions(void* p, size_t vmSize);
+
+inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage = VMTag::Malloc);
+
+inline void vmDeallocatePhysicalPages(void* p, size_t vmSize);
+
+inline void vmAllocatePhysicalPages(void* p, size_t vmSize);
+
+// The following are platform-agnostic, implemented in terms of the above functions
 
 inline size_t vmPageShift()
 {
@@ -95,18 +108,6 @@ inline void vmValidate(void* p, size_t vmSize)
     BASSERT(p == mask(p, ~(vmPageSize() - 1)));
 }
 
-inline size_t vmPageSizePhysical()
-{
-#if BOS(DARWIN) && (BCPU(ARM64) || BCPU(ARM))
-    return vm_kernel_page_size;
-#else
-    static size_t cached;
-    if (!cached)
-        cached = sysconf(_SC_PAGESIZE);
-    return cached;
-#endif
-}
-
 inline void vmValidatePhysical(size_t vmSize)
 {
     BUNUSED(vmSize);
@@ -123,15 +124,6 @@ inline void vmValidatePhysical(void* p, size_t vmSize)
     BASSERT(p == mask(p, ~(vmPageSizePhysical() - 1)));
 }
 
-inline void* tryVMAllocate(size_t vmSize, VMTag usage = VMTag::Malloc)
-{
-    vmValidate(vmSize);
-    void* result = mmap(0, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
-    if (result == MAP_FAILED)
-        return nullptr;
-    return result;
-}
-
 inline void* vmAllocate(size_t vmSize, VMTag usage = VMTag::Malloc)
 {
     void* result = tryVMAllocate(vmSize, usage);
@@ -139,30 +131,8 @@ inline void* vmAllocate(size_t vmSize, VMTag usage = VMTag::Malloc)
     return result;
 }
 
-inline void vmDeallocate(void* p, size_t vmSize)
-{
-    vmValidate(p, vmSize);
-    munmap(p, vmSize);
-}
-
-inline void vmRevokePermissions(void* p, size_t vmSize)
-{
-    vmValidate(p, vmSize);
-    mprotect(p, vmSize, PROT_NONE);
-}
-
-inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage = VMTag::Malloc)
-{
-    vmValidate(p, vmSize);
-    // MAP_ANON guarantees the memory is zeroed. This will also cause
-    // page faults on accesses to this range following this call.
-    void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
-    RELEASE_BASSERT(result == p);
-}
-
 // Allocates vmSize bytes at a specified power-of-two alignment.
 // Use this function to create maskable memory regions.
-
 inline void* tryVMAllocate(size_t vmAlignment, size_t vmSize, VMTag usage = VMTag::Malloc)
 {
     vmValidate(vmSize);
@@ -196,38 +166,6 @@ inline void* vmAllocate(size_t vmAlignment, size_t vmSize, VMTag usage = VMTag::
     void* result = tryVMAllocate(vmAlignment, vmSize, usage);
     RELEASE_BASSERT(result);
     return result;
-}
-
-inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)
-{
-    vmValidatePhysical(p, vmSize);
-#if BOS(DARWIN)
-    SYSCALL(madvise(p, vmSize, MADV_FREE_REUSABLE));
-#elif BOS(FREEBSD)
-    SYSCALL(madvise(p, vmSize, MADV_FREE));
-#else
-    SYSCALL(madvise(p, vmSize, MADV_DONTNEED));
-#if BOS(LINUX)
-    SYSCALL(madvise(p, vmSize, MADV_DONTDUMP));
-#endif
-#endif
-}
-
-inline void vmAllocatePhysicalPages(void* p, size_t vmSize)
-{
-    vmValidatePhysical(p, vmSize);
-#if BOS(DARWIN)
-    BUNUSED_PARAM(p);
-    BUNUSED_PARAM(vmSize);
-    // For the Darwin platform, we don't need to call madvise(..., MADV_FREE_REUSE)
-    // to commit physical memory to back a range of allocated virtual memory.
-    // Instead the kernel will commit pages as they are touched.
-#else
-    SYSCALL(madvise(p, vmSize, MADV_NORMAL));
-#if BOS(LINUX)
-    SYSCALL(madvise(p, vmSize, MADV_DODUMP));
-#endif
-#endif
 }
 
 // Returns how much memory you would commit/decommit had you called
@@ -265,6 +203,183 @@ inline void vmAllocatePhysicalPagesSloppy(void* p, size_t size)
 
     vmAllocatePhysicalPages(begin, end - begin);
 }
+
+
+#if !BOS(WINDOWS)
+// POSIX
+inline size_t vmPageSize()
+{
+    static size_t cached;
+    if (!cached) {
+        long pageSize = sysconf(_SC_PAGESIZE);
+        if (pageSize < 0)
+            BCRASH();
+        cached = pageSize;
+    }
+    return cached;
+}
+
+inline size_t vmPageSizePhysical()
+{
+#if BOS(DARWIN) && (BCPU(ARM64) || BCPU(ARM))
+    return vm_kernel_page_size;
+#else
+    static size_t cached;
+    if (!cached)
+        cached = sysconf(_SC_PAGESIZE);
+    return cached;
+#endif
+}
+
+inline void* tryVMAllocate(size_t vmSize, VMTag usage)
+{
+    vmValidate(vmSize);
+    void* result = mmap(0, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
+    if (result == MAP_FAILED)
+        return nullptr;
+    return result;
+}
+
+inline void vmDeallocate(void* p, size_t vmSize)
+{
+    vmValidate(p, vmSize);
+    munmap(p, vmSize);
+}
+
+inline void vmRevokePermissions(void* p, size_t vmSize)
+{
+    vmValidate(p, vmSize);
+    mprotect(p, vmSize, PROT_NONE);
+}
+
+inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
+{
+    vmValidate(p, vmSize);
+    // MAP_ANON guarantees the memory is zeroed. This will also cause
+    // page faults on accesses to this range following this call.
+    void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
+    RELEASE_BASSERT(result == p);
+}
+
+inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)
+{
+    vmValidatePhysical(p, vmSize);
+#if BOS(DARWIN)
+    SYSCALL(madvise(p, vmSize, MADV_FREE_REUSABLE));
+#elif BOS(FREEBSD)
+    SYSCALL(madvise(p, vmSize, MADV_FREE));
+#else
+    SYSCALL(madvise(p, vmSize, MADV_DONTNEED));
+#if BOS(LINUX)
+    SYSCALL(madvise(p, vmSize, MADV_DONTDUMP));
+#endif
+#endif
+}
+
+inline void vmAllocatePhysicalPages(void* p, size_t vmSize)
+{
+    vmValidatePhysical(p, vmSize);
+#if BOS(DARWIN)
+    BUNUSED_PARAM(p);
+    BUNUSED_PARAM(vmSize);
+    // For the Darwin platform, we don't need to call madvise(..., MADV_FREE_REUSE)
+    // to commit physical memory to back a range of allocated virtual memory.
+    // Instead the kernel will commit pages as they are touched.
+#else
+    SYSCALL(madvise(p, vmSize, MADV_NORMAL));
+#if BOS(LINUX)
+    SYSCALL(madvise(p, vmSize, MADV_DODUMP));
+#endif
+#endif
+}
+#else
+// Windows
+inline size_t vmPageSize()
+{
+    static size_t cached;
+    if (!cached) {
+        SYSTEM_INFO systemInfo;
+        GetSystemInfo(&systemInfo);
+        cached = systemInfo.dwPageSize;
+    }
+    return cached;
+}
+
+inline size_t vmPageSizePhysical()
+{
+    static size_t cached;
+    if (!cached) {
+        SYSTEM_INFO systemInfo;
+        GetSystemInfo(&systemInfo);
+        cached = systemInfo.dwPageSize;
+    }
+    return cached;
+}
+
+static inline DWORD protection(bool writable, bool executable)
+{
+    return executable ?
+        (writable ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ) :
+        (writable ? PAGE_READWRITE : PAGE_READONLY);
+}
+
+inline void* tryVMAllocate(size_t vmSize, VMTag usage)
+{
+    BUNUSED_PARAM(usage);
+    const bool writable = true;
+    const bool executable = true;
+    return VirtualAlloc(nullptr, vmSize, MEM_RESERVE, protection(writable, executable));
+}
+
+inline void vmDeallocate(void* p, size_t vmSize)
+{
+    // https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc
+    // Use MEM_RESET to purge physical pages at timing of OS's preference. This is aligned to
+    // madvise MADV_FREE / MADV_FREE_REUSABLE.
+    // https://devblogs.microsoft.com/oldnewthing/20170113-00/?p=95185
+    // > The fact that MEM_RESET does not remove the page from the working set is not actually mentioned
+    // > in the documentation for the MEM_RESET flag. Instead, it’s mentioned in the documentation for
+    // > the Offer­Virtual­Memory function, and in a sort of backhanded way
+    // So, we need VirtualUnlock call.
+    if (!vmSize)
+        return;
+    void* result = VirtualAlloc(p, vmSize, MEM_RESET, PAGE_READWRITE);
+    if (!result)
+        BCRASH();
+    // Calling VirtualUnlock on a range of memory that is not locked releases the pages from the
+    // process's working set.
+    // https://devblogs.microsoft.com/oldnewthing/20170317-00/?p=95755
+    VirtualUnlock(p, vmSize);
+}
+
+inline void vmRevokePermissions(void* p, size_t vmSize)
+{
+    vmValidate(p, vmSize);
+    bool result = VirtualAlloc(p, vmSize, MEM_COMMIT, protection(false, false));
+    if (!result)
+        BCRASH();
+}
+
+inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
+{
+    BUNUSED_PARAM(usage);
+    vmValidate(p, vmSize);
+    void* result = VirtualAlloc2(nullptr, p, vmSize, MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS, nullptr, 0);
+    RELEASE_BASSERT(result == p);
+}
+
+inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)
+{
+    vmValidatePhysical(p, vmSize);
+    VirtualUnlock(p, vmSize);
+}
+
+inline void vmAllocatePhysicalPages(void* p, size_t vmSize)
+{
+    vmValidatePhysical(p, vmSize);
+    VirtualLock(p, vmSize);
+}
+#endif
 
 } // namespace bmalloc
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=255968

Reviewed by NOBODY (OOPS!).

Adds an Win32 API implementation of VMAllocate, taking ideas from WTF's OSAllocatorWin.

* Source/bmalloc/bmalloc/VMAllocate.h: (bmalloc::physicalPageSizeSloppy):
(bmalloc::vmDeallocatePhysicalPagesSloppy):
(bmalloc::vmAllocatePhysicalPagesSloppy):
(bmalloc::vmPageSize):
(bmalloc::vmPageSizePhysical):
(bmalloc::tryVMAllocate):
(bmalloc::vmDeallocate):
(bmalloc::vmRevokePermissions):
(bmalloc::vmZeroAndPurge):
(bmalloc::protection):
(bmalloc::vmDeallocatePhysicalPages):
(bmalloc::vmAllocatePhysicalPages):
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31364ddde78de26c60ec49137ac617b11137ddba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25913 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58658 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24246 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67812 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80587 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73933 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66211 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8303 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96204 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1958 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21014 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->