### PR TITLE
Port WebExtension Icons to C++

### DIFF
--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -211,6 +211,8 @@ protected:
     const_iterator begin() const { return m_map.begin(); }
     const_iterator end() const { return m_map.end(); }
 
+    DataStorage::KeysConstIteratorRange keys() const { return m_map.keys(); }
+
     unsigned size() const { return m_map.size(); }
 
     // FIXME: <http://webkit.org/b/179847> remove these functions when legacy InspectorObject symbols are no longer needed.
@@ -257,6 +259,8 @@ public:
 
     using ObjectBase::begin;
     using ObjectBase::end;
+
+    using ObjectBase::keys;
 
     using ObjectBase::size;
 };

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -136,9 +136,6 @@ NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
 
 void callAfterRandomDelay(Function<void()>&&);
 
-NSSet *availableScreenScales();
-CGFloat largestDisplayScale();
-
 NSDate *toAPI(const WallTime&);
 WallTime toImpl(NSDate *);
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -444,40 +444,6 @@ void callAfterRandomDelay(Function<void()>&& completionHandler)
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr(WTFMove(completionHandler)).get());
 }
 
-NSSet *availableScreenScales()
-{
-    NSMutableSet *screenScales = [NSMutableSet set];
-
-#if USE(APPKIT)
-    for (NSScreen *screen in NSScreen.screens)
-        [screenScales addObject:@(screen.backingScaleFactor)];
-#else
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    for (UIScreen *screen in UIScreen.screens)
-        [screenScales addObject:@(screen.scale)];
-    ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
-
-    if (screenScales.count)
-        return [screenScales copy];
-
-    // Assume 1x if we got no results. This can happen on headless devices (bots).
-    return [NSSet setWithObject:@1];
-}
-
-CGFloat largestDisplayScale()
-{
-    auto largestDisplayScale = 1.0;
-
-    for (NSNumber *scale in availableScreenScales()) {
-        auto doubleValue = scale.doubleValue;
-        if (doubleValue > largestDisplayScale)
-            largestDisplayScale = doubleValue;
-    }
-
-    return largestDisplayScale;
-}
-
 NSDate *toAPI(const WallTime& time)
 {
     if (time.isNaN())

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -60,6 +60,18 @@ Vector<String> makeStringVector(const JSON::Array& array)
     return vector;
 }
 
+double largestDisplayScale()
+{
+    auto largestDisplayScale = 1.0;
+
+    for (double scale : availableScreenScales()) {
+        if (scale > largestDisplayScale)
+            largestDisplayScale = scale;
+    }
+
+    return largestDisplayScale;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -48,6 +48,9 @@ Ref<JSON::Array> filterObjects(const JSON::Array&, WTF::Function<bool(const JSON
 
 Vector<String> makeStringVector(const JSON::Array&);
 
+Vector<double> availableScreenScales();
+double largestDisplayScale();
+
 #ifdef __OBJC__
 
 /// Verifies that a dictionary:

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -428,6 +428,27 @@ Markable<WTF::UUID> toDocumentIdentifier(WebFrame& frame)
     return document->identifier().object();
 }
 
+Vector<double> availableScreenScales()
+{
+    Vector<double> screenScales;
+
+#if USE(APPKIT)
+    for (NSScreen *screen in NSScreen.screens)
+        screenScales.append(screen.backingScaleFactor);
+#else
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    for (UIScreen *screen in UIScreen.screens)
+        screenScales.append(screen.scale);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
+
+    if (screenScales.size())
+        return screenScales;
+
+    // Assume 1x if we got no results. This can happen on headless devices (bots).
+    return { 1.0 };
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -223,12 +223,16 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return self._protectedWebExtension->icon(size);
+    if (RefPtr icon = self._protectedWebExtension->icon(WebCore::FloatSize(size)))
+        return icon->image().get();
+    return nil;
 }
 
 - (CocoaImage *)actionIconForSize:(CGSize)size
 {
-    return self._protectedWebExtension->actionIcon(size);
+    if (RefPtr icon = self._protectedWebExtension->actionIcon(WebCore::FloatSize(size)))
+        return icon->image().get();
+    return nil;
 }
 
 - (NSSet<WKWebExtensionPermission> *)requestedPermissions

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -77,7 +77,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return self._protectedWebExtensionAction->icon(size);
+    return self._protectedWebExtensionAction->icon(WebCore::FloatSize(size))->image().get();
 }
 
 - (NSString *)label

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -56,14 +56,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 #if PLATFORM(MAC)
 - (NSImage *)iconForSize:(CGSize)size
 {
-    return _webExtensionSidebar->icon(size).get();
+    return _webExtensionSidebar->icon(WebCore::FloatSize(size))->image().get();
 }
 #endif
 
 #if PLATFORM(IOS_FAMILY)
 - (UIImage *)iconForSize:(CGSize)size
 {
-    return _webExtensionSidebar->icon(size).get();
+    return _webExtensionSidebar->icon(WebCore::FloatSize(size))->image().get();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -125,19 +125,19 @@ void WebExtensionContext::actionSetIcon(std::optional<WebExtensionWindowIdentifi
         return;
     }
 
-    id parsedIcons = parseJSON(iconsJSON, JSONOptions::FragmentsAllowed);
+    RefPtr parsedIcons = JSON::Value::parseJSON(iconsJSON);
     Ref webExtensionAction = action.value();
 
-    if (auto *dictionary = dynamic_objc_cast<NSDictionary>(parsedIcons))
-        webExtensionAction->setIcons(dictionary);
+    if (RefPtr object = parsedIcons->asObject())
+        webExtensionAction->setIcons(object);
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-    else if (auto *array = dynamic_objc_cast<NSArray>(parsedIcons))
+    else if (RefPtr array = parsedIcons->asArray())
         webExtensionAction->setIconVariants(array);
 #endif
     else {
-        webExtensionAction->setIcons(nil);
+        webExtensionAction->setIcons(nullptr);
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-        webExtensionAction->setIconVariants(nil);
+        webExtensionAction->setIconVariants(nullptr);
 #endif
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -281,8 +281,10 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
 
     result.keyEquivalent = activationKey();
     result.keyEquivalentModifierMask = modifierFlags().toRaw();
-    if (RefPtr context = extensionContext())
-        result.image = context->extension().icon(NSMakeSize(16, 16));
+    if (RefPtr context = extensionContext()) {
+        if (RefPtr icon = context->extension().icon(WebCore::FloatSize(16, 16)))
+            result.image = icon->image().get();
+    }
 
     return result;
 #else

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -31,7 +31,10 @@
 #include "CocoaImage.h"
 #include "WebExtensionTab.h"
 #include "WebExtensionWindow.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/Icon.h>
 #include <wtf/Forward.h>
+#include <wtf/JSONValues.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -90,10 +93,10 @@ public:
 
     void propertiesDidChange();
 
-    CocoaImage *icon(CGSize);
-    void setIcons(NSDictionary *);
+    RefPtr<WebCore::Icon> icon(WebCore::FloatSize idealSize);
+    void setIcons(RefPtr<JSON::Object>);
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-    void setIconVariants(NSArray *);
+    void setIconVariants(RefPtr<JSON::Array>);
 #endif
 
     String label(FallbackWhenEmpty = FallbackWhenEmpty::Yes) const;
@@ -175,13 +178,13 @@ private:
     String m_customPopupPath;
     String m_popupWebViewInspectionName;
 
-    RetainPtr<CocoaImage> m_cachedIcon;
-    RetainPtr<NSSet> m_cachedIconScales;
-    CGSize m_cachedIconIdealSize { CGSizeZero };
+    RefPtr<WebCore::Icon> m_cachedIcon;
+    Vector<double> m_cachedIconScales;
+    WebCore::FloatSize m_cachedIconIdealSize;
 
-    RetainPtr<NSDictionary> m_customIcons;
+    RefPtr<JSON::Object> m_customIcons;
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-    RetainPtr<NSArray> m_customIconVariants;
+    RefPtr<JSON::Array> m_customIconVariants;
 #endif
     String m_customLabel;
     String m_customBadgeText;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "CocoaImage.h"
 #include "WebExtension.h"
 #include "WebExtensionCommand.h"
 #include "WebExtensionMenuItemContextType.h"
@@ -97,7 +96,7 @@ public:
 
     WebExtensionCommand* command() const { return m_command.get(); }
 
-    CocoaImage *icon(CGSize) const;
+    RefPtr<WebCore::Icon> icon(WebCore::FloatSize) const;
 
     bool isChecked() const { return m_checked; }
     void setChecked(bool checked) { ASSERT(isCheckedType(type())); m_checked = checked; }
@@ -135,13 +134,13 @@ private:
 
     RefPtr<WebExtensionCommand> m_command;
 
-    mutable RetainPtr<CocoaImage> m_cachedIcon;
-    mutable RetainPtr<NSSet> m_cachedIconScales;
-    mutable CGSize m_cachedIconIdealSize { CGSizeZero };
+    mutable RefPtr<WebCore::Icon> m_cachedIcon;
+    mutable Vector<double> m_cachedIconScales;
+    mutable WebCore::FloatSize m_cachedIconIdealSize;
 
-    RetainPtr<NSDictionary> m_icons;
+    RefPtr<JSON::Object> m_icons;
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-    RetainPtr<NSArray> m_iconVariants;
+    RefPtr<JSON::Array> m_iconVariants;
 #endif
 
     bool m_checked : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -38,7 +38,6 @@ using SidebarViewControllerType = NSViewController;
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 #include "APIObject.h"
-#include "CocoaImage.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -82,8 +81,8 @@ public:
     void propertiesDidChange();
 
     /// `icon()` will return the overridden icon of this sidebar, or the icon of the first parent sidebar in which the icon is set
-    RetainPtr<CocoaImage> icon(CGSize);
-    void setIconsDictionary(NSDictionary *);
+    RefPtr<WebCore::Icon> icon(WebCore::FloatSize);
+    void setIconsDictionary(RefPtr<JSON::Object>);
 
     /// `title()` will return the overridden title of this sidebar, or the title of the first parent sidebar in which the title is set
     String title() const;
@@ -131,7 +130,7 @@ private:
 
     void reloadWebView();
 
-    std::optional<RetainPtr<NSDictionary>> m_iconsOverride;
+    std::optional<RefPtr<JSON::Object>> m_iconsOverride;
     std::optional<String> m_titleOverride;
     std::optional<String> m_sidebarPathOverride;
     std::optional<bool> m_isEnabled;


### PR DESCRIPTION
#### 62bde3cd7c217887a36e2b8f10fe372684b7e6cf
<pre>
Port WebExtension Icons to C++
<a href="https://webkit.org/b/282500">https://webkit.org/b/282500</a>

Reviewed by Timothy Hatcher.

Replace CocoaImage with WebCore::Icon, as WebCore::Icon wraps CocoaImage already.
Port most icon utility functions to C++, and for those that cannot be ported,
update them to support a cross-platform API involving WebCore::Icon and JSON::Value.

* Source/WTF/wtf/JSONValues.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::availableScreenScales): Deleted.
(WebKit::largestDisplayScale): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::largestDisplayScale):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::availableScreenScales):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension iconForSize:]):
(-[WKWebExtension actionIconForSize:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionSetIcon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::clearCustomizations):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::setIcons):
(WebKit::WebExtensionAction::setIconVariants):
(WebKit::WebExtensionAction::clearIconCache):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::imageForPath):
(WebKit::WebExtension::bestImageInIconsDictionary):
(WebKit::WebExtension::bestImageForIconVariants):
(WebKit::WebExtension::icon): Deleted.
(WebKit::WebExtension::actionIcon): Deleted.
(WebKit::WebExtension::bestSizeInIconsDictionary): Deleted.
(WebKit::WebExtension::pathForBestImageInIconsDictionary): Deleted.
(WebKit::WebExtension::bestImageForIconsDictionaryManifestKey): Deleted.
(WebKit::toColorSchemes): Deleted.
(WebKit::WebExtension::iconsDictionaryForBestIconVariant): Deleted.
(WebKit::WebExtension::bestImageForIconVariantsManifestKey): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::WebExtensionMenuItem):
(WebKit::WebExtensionMenuItem::update):
(WebKit::WebExtensionMenuItem::icon const):
(WebKit::WebExtensionMenuItem::clearIconCache const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(WebKit::getDefaultIconsDictFromExtension):
(WebKit::WebExtensionSidebar::icon):
(WebKit::WebExtensionSidebar::setIconsDictionary):
(): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::icon):
(WebKit::WebExtension::actionIcon):
(WebKit::WebExtension::bestSizeInIconsDictionary):
(WebKit::WebExtension::pathForBestImageInIconsDictionary):
(WebKit::WebExtension::bestImageForIconsDictionaryManifestKey):
(WebKit::toColorSchemes):
(WebKit::WebExtension::iconsDictionaryForBestIconVariant):
(WebKit::WebExtension::bestImageForIconVariantsManifestKey):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::imageForPath):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h:

Canonical link: <a href="https://commits.webkit.org/286237@main">https://commits.webkit.org/286237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac00f860883605d82274269b34a7ed3a6c7b3d70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64681 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46667 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24871 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68434 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81233 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74550 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64678 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96818 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11624 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2578 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21147 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3533 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->