### PR TITLE
[WebGPU] Texture::bytesPerRow does not handle textureWidth which are not divisible by the blockWidth

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.html
@@ -1,0 +1,24281 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u6ccb\u{1ffc7}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 101107390, maxStorageBufferBindingSize: 144960095},
+});
+let imageData0 = new ImageData(72, 16);
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'smpte170m'} });
+let buffer0 = device0.createBuffer({
+  label: '\uc6e8\u{1fd5e}\ua4f8\u2dac\u{1fd7a}\uf0fa',
+  size: 3439,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture0 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 32},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture0.createView({mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 2});
+let sampler0 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.79,
+  lodMaxClamp: 79.84,
+  compare: 'always',
+});
+try {
+device0.queue.writeBuffer(buffer0, 184, new DataView(new ArrayBuffer(2084)), 118, 592);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+device0.queue.writeBuffer(buffer0, 1444, new BigUint64Array(3695), 892, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 316, y: 8, z: 27},
+  aspect: 'all',
+}, new Uint8Array(70).fill(218), /* required buffer size: 70 */
+{offset: 38}, {width: 16, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let buffer1 = device0.createBuffer({
+  size: 17545,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture1 = device0.createTexture({
+  label: '\u7a15\uedd5\u0669\uda4f\u8f6f\u{1f85b}\u{1fc63}',
+  size: [1032, 1, 1],
+  sampleCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView1 = texture0.createView({
+  label: '\u7293\u0a9c\u0b75\ud89f\u0f0b\u0a27\u{1fa0d}\u{1fbd4}\u0bf7\u0809\u{1f872}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 5,
+});
+let sampler1 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.14,
+  lodMaxClamp: 76.31,
+  maxAnisotropy: 3,
+});
+try {
+device0.queue.writeBuffer(buffer0, 320, new Float32Array(18845), 10285, 220);
+} catch {}
+let buffer2 = device0.createBuffer({
+  size: 675,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture2 = device0.createTexture({
+  label: '\u5c64\ud75f\u482f\u330d\u{1f781}\u6793\u7177\u0952\u0d09\u204d',
+  size: {width: 660, height: 96, depthOrArrayLayers: 7},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let commandEncoder1 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 289});
+let sampler2 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.23,
+  lodMaxClamp: 98.19,
+});
+let sampler3 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.33,
+  lodMaxClamp: 96.87,
+});
+try {
+computePassEncoder0.insertDebugMarker('\uf789');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 140, y: 6, z: 1},
+  aspect: 'all',
+}, new Uint8Array(56).fill(177), /* required buffer size: 56 */
+{offset: 56, bytesPerRow: 77}, {width: 17, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\u078d\u0f63\u0d35\u4937',
+  size: 5971,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder2 = device0.createCommandEncoder();
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 8, y: 12, z: 3},
+  aspect: 'all',
+}, new Uint8Array(16_188).fill(228), /* required buffer size: 16_188 */
+{offset: 12, bytesPerRow: 200, rowsPerImage: 26}, {width: 88, height: 12, depthOrArrayLayers: 4});
+} catch {}
+try {
+globalThis.someLabel = texture0.label;
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 135,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 99,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let texture3 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture4 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 46},
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData1 = new ImageData(36, 56);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\ub07e\u2f5c\u142c\ucc76\u08ea\uf228\u0c5a',
+  entries: [
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture5 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 16},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'eac-rg11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device0.createTexture({
+  label: '\u55bd\u02d2\u7dcc',
+  size: [82, 12, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+let renderBundle0 = renderBundleEncoder0.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 20, y: 4, z: 7},
+  aspect: 'all',
+}, new Uint8Array(135).fill(29), /* required buffer size: 135 */
+{offset: 135, bytesPerRow: 69}, {width: 0, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let imageData2 = new ImageData(32, 12);
+let buffer4 = device0.createBuffer({
+  size: 13377,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView2 = texture3.createView({mipLevelCount: 1});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+try {
+buffer0.unmap();
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u06ef\u{1fdd0}\u0381\u{1f8c7}\ub072',
+  entries: [
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 201, y: 28, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 1920, new BigUint64Array(2987), 790, 44);
+} catch {}
+let computePassEncoder3 = commandEncoder3.beginComputePass();
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 0, 388);
+} catch {}
+let buffer5 = device0.createBuffer({size: 5234, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView3 = texture1.createView({baseMipLevel: 0});
+let computePassEncoder4 = commandEncoder4.beginComputePass({});
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u02a2\u0c7f\ue0a8\u5049\ud0b4', bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1]});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer6 = device0.createBuffer({
+  size: 319,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet0, 98, 52, buffer2, 0);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let computePassEncoder5 = commandEncoder2.beginComputePass({});
+let commandEncoder5 = device0.createCommandEncoder({});
+let textureView4 = texture4.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 1});
+let computePassEncoder6 = commandEncoder5.beginComputePass({});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm']});
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer0, 0, 185);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let texture7 = device0.createTexture({size: [258], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer6, 'uint32', 28, 25);
+} catch {}
+let texture8 = device0.createTexture({
+  size: [516, 1, 51],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView5 = texture0.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer4, 0, 675);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer7 = device0.createBuffer({
+  label: '\u{1f716}\u0ff4\u57b7\u078f\u0d4f\u09fb\u4a23\u1f9e\u{1fda6}\ue368\u{1fd96}',
+  size: 6826,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder6 = device0.createCommandEncoder();
+let texture9 = device0.createTexture({
+  size: [1032, 1, 1],
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder6.beginComputePass();
+let renderBundle1 = renderBundleEncoder1.finish({});
+let bindGroup0 = device0.createBindGroup({
+  label: '\u{1ff09}\uc402\u41f8\ua124\u2aa3\u0496\u8d61\ue9c2\u3174',
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer1, offset: 2048, size: 1584}}],
+});
+let textureView6 = texture9.createView({dimension: '2d'});
+let textureView7 = texture5.createView({mipLevelCount: 1, baseArrayLayer: 9, arrayLayerCount: 1});
+try {
+buffer0.unmap();
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+@group(0) @binding(99) var tex0: texture_multisampled_2d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(7139) override override10: f16 = 3375.3;
+
+fn fn0(a0: array<array<array<vec2f, 1>, 1>, 6>, a1: mat3x2h, a2: T0, a3: ptr<workgroup, atomic<i32>>) {
+  var vf0: vec2f = a0[bitcast<vec2u>(a0[5][0][u32(unconst_u32(106))]).y][u32(unconst_u32(146))][u32(unconst_u32(199))];
+  let vf1: T0 = a2;
+  vf0 -= unpack2x16float(dot4U8Packed(u32(unconst_u32(391)), u32(unconst_u32(28))));
+  atomicAdd(&(*a3), bitcast<i32>(a2.f0));
+  let ptr0: ptr<private, vec2h> = &vp0[0].f0;
+  atomicStore(&(*a3), i32(unconst_i32(43)));
+  let ptr1: ptr<private, vec2h> = &vp0[0].f0;
+  var vf2: array<vec2f, 1> = a0[u32(unconst_u32(264))][u32(unconst_u32(48))];
+}
+
+override override9: i32;
+
+override override6 = 0.2649;
+
+override override0: i32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override7 = 0.1521;
+
+struct T1 {
+  @align(2) @size(24) f0: mat3x2h,
+  @align(2) @size(16) f1: vec4h,
+  @align(2) f2: array<array<f32, 1>, 1>,
+  @size(28) f3: T0,
+  @align(2) @size(40) f4: array<mat3x2h, 1>,
+}
+
+var<private> vp0: array<T0, 1> = array(T0(vec2h(5576.4, 358.3)));
+
+@id(64612) override override5: bool;
+
+override override2: i32 = 76;
+
+@id(385) override override4: f32;
+
+var<workgroup> vw3: array<atomic<u32>, 1>;
+
+var<workgroup> vw2: array<atomic<i32>, 42>;
+
+var<workgroup> vw0: mat3x4f;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(135) var tex1: texture_2d<f32>;
+
+@id(15283) override override8: u32;
+
+@id(27584) override override3: f32;
+
+struct T0 {
+  @align(1) @size(8) f0: vec2h,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override1: u32;
+
+var<workgroup> vw1: atomic<u32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 301,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 172,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture10 = device0.createTexture({
+  size: [258, 1, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView8 = texture2.createView({label: '\u53a7\ucabc', dimension: '2d', baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(506), 23, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 144, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture11 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture5.createView({dimension: '2d', mipLevelCount: 1});
+let sampler4 = device0.createSampler({
+  label: '\u3d5a\u0327\u9934\u{1fec8}\ucbc0\u{1fd0f}\u003b\u5cbc',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 58.62,
+  lodMaxClamp: 78.33,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 3528, new Float32Array(869), 418, 96);
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 3824,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 464});
+let texture12 = device0.createTexture({
+  label: '\u8877\u0b7a\u0dbd\u{1ffeb}',
+  size: [129, 1, 6],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let textureView10 = texture11.createView({dimension: '2d', baseArrayLayer: 2});
+let textureView11 = texture6.createView({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 29.35,
+  lodMaxClamp: 65.76,
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(3180), 248, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture13 = device0.createTexture({
+  size: [8, 8, 23],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder8 = commandEncoder7.beginComputePass({});
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer9 = device0.createBuffer({
+  size: 1212,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView12 = texture12.createView({arrayLayerCount: 1});
+let textureView13 = texture13.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 7});
+let textureView14 = texture12.createView({dimension: '2d', arrayLayerCount: 1});
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer4, offset: 4608, size: 444}}],
+});
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.76,
+  lodMaxClamp: 58.99,
+  maxAnisotropy: 19,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\ud6a3\u02c8\u6a2d\u07d2\u7bd6\u86b9\u3ed5\u50bc\u0ca1\u9e5e', source: videoFrame0});
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(2_896).fill(166), /* required buffer size: 2_896 */
+{offset: 16, bytesPerRow: 48, rowsPerImage: 15}, {width: 2, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let textureView15 = texture10.createView({dimension: '2d-array'});
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.84,
+  lodMaxClamp: 98.20,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.insertDebugMarker('\uad52');
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView9}, {binding: 99, resource: textureView2}],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 606,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 136,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder8 = device0.createCommandEncoder();
+let computePassEncoder9 = commandEncoder8.beginComputePass({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 77.71,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u99f9\u04d3',
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView2}, {binding: 135, resource: textureView8}],
+});
+let textureView16 = texture12.createView({arrayLayerCount: 1});
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 96, new DataView(new ArrayBuffer(16059)), 1202, 1384);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture14 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 61},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderPassEncoder0 = commandEncoder9.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: -120.7, g: -213.3, b: -719.9, a: 456.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 142403390,
+});
+let sampler9 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.557,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1]);
+} catch {}
+let buffer10 = device0.createBuffer({size: 27051, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture15 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(276), 193, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint32', 104, 25);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 64, new BigUint64Array(28796), 5884, 92);
+} catch {}
+let texture16 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 4_048, 1_539);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 207, resource: textureView12},
+    {binding: 172, resource: textureView13},
+    {binding: 0, resource: textureView10},
+    {binding: 84, resource: textureView13},
+    {binding: 301, resource: {buffer: buffer0, offset: 2048, size: 163}},
+  ],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\ud49b\u{1fb8f}\uc12d\u8ad8\udb42\u0747'});
+let textureView17 = texture12.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let texture17 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView18 = texture7.createView({});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(3920), 1_425, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 2_756);
+} catch {}
+let textureView19 = texture1.createView({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.88,
+  lodMaxClamp: 98.57,
+  compare: 'greater-equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup1, new Uint32Array(1429), 695, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 12, 122);
+} catch {}
+try {
+adapter0.label = '\u{1faed}\u0462\u{1fcfb}\u283c\u{1fc83}\u3360\u0220\u089f\u1b05';
+} catch {}
+let buffer11 = device0.createBuffer({
+  label: '\u3198\u{1fa3b}\u{1f7fa}\u8968\u{1f920}\u0e4e\u0a8f\u{1ffa8}\u06d2\u{1f6d0}',
+  size: 20293,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  size: [82, 12, 1],
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2, new Uint32Array(2242), 377, 0);
+} catch {}
+let arrayBuffer0 = buffer3.getMappedRange(8, 116);
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 172, resource: textureView13},
+    {binding: 207, resource: textureView16},
+    {binding: 301, resource: {buffer: buffer0, offset: 0, size: 1087}},
+    {binding: 0, resource: textureView10},
+    {binding: 84, resource: textureView13},
+  ],
+});
+let buffer12 = device0.createBuffer({
+  size: 9017,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler11 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 38.66,
+  lodMaxClamp: 42.50,
+});
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData2,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 170, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture19 = device0.createTexture({
+  size: [8, 8, 23],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(377), 166, 0);
+} catch {}
+let arrayBuffer1 = buffer8.getMappedRange();
+try {
+buffer3.unmap();
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData1);
+let buffer13 = device0.createBuffer({
+  label: '\u0439\u026b\u0c09\ue2c2\u0165\u8c96\udf5b\u0a49',
+  size: 6930,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let textureView20 = texture19.createView({dimension: 'cube-array', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer13, 'uint32', 1_032, 365);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer8);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\ud4a7\uee57\u1dd0',
+  colorFormats: ['rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let sampler12 = device0.createSampler({
+  label: '\uf983\u56f8\u0cc5',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 61.00,
+  lodMaxClamp: 86.39,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(651), 448, 0);
+} catch {}
+let textureView21 = texture3.createView({aspect: 'depth-only', baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundle2 = renderBundleEncoder2.finish({label: '\u{1fc3d}\u72fa\u{1f85f}\u2247\uca8c\u7f52\ua20e'});
+let sampler13 = device0.createSampler({
+  label: '\u06c3\u{1fb5b}\u0a31\u9ea9',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.96,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup5, new Uint32Array(2520), 128, 0);
+} catch {}
+let imageData3 = new ImageData(60, 24);
+try {
+computePassEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+await gc();
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture20 = device0.createTexture({
+  size: [330, 48, 223],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(2542), 1_247, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3, new Uint32Array(2121), 722, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 1_068, 1_919);
+} catch {}
+await gc();
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: [82, 12, 55],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder13 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup2, new Uint32Array(6802), 225, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let textureView22 = texture9.createView({});
+let renderPassEncoder1 = commandEncoder13.beginRenderPass({colorAttachments: [{view: textureView4, loadOp: 'clear', storeOp: 'store'}], maxDrawCount: 340535878});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5, new Uint32Array(1803), 24, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let buffer14 = device0.createBuffer({size: 13148, usage: GPUBufferUsage.STORAGE});
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView23 = texture13.createView({label: '\u2bc3\u21fa\u860b\ub008\u0382', arrayLayerCount: 5});
+let textureView24 = texture6.createView({});
+let computePassEncoder14 = commandEncoder15.beginComputePass({label: '\ue495\u6949\uc64e\u458f'});
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint16', 26, 262);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(15).fill(8), /* required buffer size: 15 */
+{offset: 15}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer15 = device0.createBuffer({
+  size: 378,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView25 = texture20.createView({baseMipLevel: 1, mipLevelCount: 1});
+let sampler14 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.809,
+  lodMaxClamp: 64.56,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, new Uint32Array(1339), 812, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let texture22 = device0.createTexture({size: [516, 1, 31], format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView26 = texture9.createView({mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(3, bindGroup0, new Uint32Array(2064), 93, 0);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer12, offset: 2816, size: 1777}}],
+});
+let buffer16 = device0.createBuffer({
+  size: 3007,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let computePassEncoder16 = commandEncoder17.beginComputePass();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer15, 44);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let texture23 = device0.createTexture({
+  size: [1032, 1, 20],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 84.22,
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 2304, new Int16Array(16012), 4156, 296);
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u0667\ud0ae\u0c3c\u0520',
+  size: 23671,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.420,
+  lodMaxClamp: 19.14,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup4, new Uint32Array(18), 3, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(348);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 174, 6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture24 = device0.createTexture({size: {width: 165}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView27 = texture22.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 0});
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint32', 76, 387);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer4, 0, 2_963);
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'hlg'} });
+let videoFrame2 = new VideoFrame(videoFrame0, {timestamp: 0});
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer16, offset: 768, size: 150}},
+    {binding: 606, resource: textureView27},
+  ],
+});
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView13}, {binding: 24, resource: textureView20}],
+});
+let texture25 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 173},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 67.55,
+  lodMaxClamp: 88.84,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup1, new Uint32Array(114), 3, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup8, new Uint32Array(416), 10, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint32', 508, 300);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer17, 0, 1_306);
+} catch {}
+try {
+computePassEncoder14.pushDebugGroup('\u0a3a');
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: [660, 96, 3],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup4, new Uint32Array(848), 76, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, []);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer12, offset: 1792, size: 623}}],
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 37});
+let computePassEncoder18 = commandEncoder19.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(0, bindGroup8, new Uint32Array(2032), 154, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(23_009).fill(96), /* required buffer size: 23_009 */
+{offset: 325, bytesPerRow: 214, rowsPerImage: 53}, {width: 40, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 0, resource: textureView10},
+    {binding: 172, resource: textureView13},
+    {binding: 84, resource: textureView13},
+    {binding: 301, resource: {buffer: buffer12, offset: 1536, size: 416}},
+    {binding: 207, resource: textureView12},
+  ],
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], sampleCount: 1});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5, new Uint32Array(2883), 800, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(12.892061015148435, 0.4245517281682958, 16.304545912939485, 0.397370114291674, 0.7431941078449598, 0.7885759606045947);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer17, 'uint32', 1_936, 591);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let texture27 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler18 = device0.createSampler({
+  label: '\u{1f981}\u7848\u{1fc29}\u05c7\uf174\ue961',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.68,
+  lodMaxClamp: 94.48,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(201), 13, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(2, 0, 2, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup5, new Uint32Array(1707), 20, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(1, buffer17, 8_056, 1_226);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 8 },
+  flipY: false,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 358,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup11 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 32, resource: {buffer: buffer8, offset: 1024}}]});
+let texture28 = device0.createTexture({
+  size: [1032, 1, 22],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture29 = device0.createTexture({
+  label: '\u5c55\uc922\u0ce6\u38c8\u{1f94d}\u067e\ue87b\u1862',
+  size: [8, 8, 23],
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView28 = texture19.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 2});
+let sampler19 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 42.04});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup9, new Uint32Array(3297), 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup7, new Uint32Array(1910), 310, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup9);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\ua86d\u74b9\ubba7\u6582\uf850\u{1feda}'});
+let textureView29 = texture28.createView({label: '\u{1fa6f}\u4e78\u3b10\ucb04\ue684\u00e3\uea5d\u{1ff9d}\u45e7\u059a', arrayLayerCount: 2});
+let texture30 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderPassEncoder2 = commandEncoder20.beginRenderPass({
+  label: '\u05dc\u87bc\u9876\u0556\u05b7\u0a2a\u9236\u03bd\u0d03\u00bc',
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: -444.5, g: 102.1, b: 681.5, a: 738.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 580264504,
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle2, renderBundle0, renderBundle0]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView30 = texture3.createView({aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(666), 142, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 247, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(73).fill(100), /* required buffer size: 73 */
+{offset: 73, bytesPerRow: 52}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let canvas0 = document.createElement('canvas');
+let buffer18 = device0.createBuffer({
+  size: 3510,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture31 = device0.createTexture({
+  label: '\ucb02\u8097\u1cb0\u0766\u{1ff1d}\ubea4\ub06c\u{1ff91}\uf908',
+  size: {width: 1032, height: 1, depthOrArrayLayers: 56},
+  mipLevelCount: 6,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture32 = device0.createTexture({
+  size: [258, 1, 1],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup1, new Uint32Array(4486), 1_275, 0);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let texture33 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(35);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 1864, new DataView(new ArrayBuffer(6692)), 323, 172);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+document.body.prepend(canvas0);
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0cd9\u0f90\u0997\u1c57\u080e\u{1fb70}\ubc46\u{1ff24}',
+  layout: bindGroupLayout3,
+  entries: [{binding: 23, resource: textureView6}, {binding: 271, resource: {buffer: buffer14, offset: 6144}}],
+});
+let buffer19 = device0.createBuffer({size: 17196, usage: GPUBufferUsage.VERTEX});
+let commandEncoder22 = device0.createCommandEncoder();
+let texture34 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView31 = texture28.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 2, arrayLayerCount: 2});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7, new Uint32Array(589), 178, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+await gc();
+let buffer20 = device0.createBuffer({
+  size: 38364,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView32 = texture11.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 6, arrayLayerCount: 1});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5392 */
+  offset: 5392,
+  buffer: buffer4,
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 52, y: 12, z: 1},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder14.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4, new Float32Array(44909), 7484, 168);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView22},
+    {binding: 271, resource: {buffer: buffer12, offset: 768, size: 132}},
+  ],
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let computePassEncoder19 = commandEncoder22.beginComputePass({});
+let renderPassEncoder3 = commandEncoder23.beginRenderPass({colorAttachments: [{view: textureView25, depthSlice: 43, loadOp: 'clear', storeOp: 'store'}]});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.53,
+  lodMaxClamp: 99.71,
+  compare: 'less-equal',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup3, new Uint32Array(1746), 810, 0);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer12, 768, buffer13, 56, 760);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\uefb2\u{1fecb}\u0a53\u184a\u163f\ub45e\u97c4\u0028\u9af1',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView27},
+    {binding: 136, resource: {buffer: buffer12, offset: 0, size: 4544}},
+  ],
+});
+let textureView33 = texture11.createView({baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 11});
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer1, offset: 2560, size: 14984}}],
+});
+let buffer21 = device0.createBuffer({
+  size: 4366,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder20 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer15, 80, buffer13, 5608, 104);
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 516 widthInBlocks: 258 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1768 */
+  offset: 1768,
+  buffer: buffer11,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 258, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: imageData2,
+  origin: { x: 7, y: 1 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder21 = commandEncoder17.beginComputePass();
+try {
+renderPassEncoder2.setIndexBuffer(buffer17, 'uint16', 400, 2_609);
+} catch {}
+let renderPassEncoder4 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView25,
+  depthSlice: 100,
+  clearValue: { r: 384.5, g: -965.7, b: 580.7, a: -835.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(2252), 35, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 35.13, g: 164.5, b: 122.3, a: -493.0, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 40, new Int16Array(13752), 396, 28);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer16, offset: 512, size: 1944}}],
+});
+let sampler21 = device0.createSampler({
+  label: '\u103e\u0281\ua37c\uc439\u3e45\uf4b0\u0648\u0e2b\u235d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.31,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup0, new Uint32Array(1610), 238, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup2, new Uint32Array(1523), 638, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer18, 'uint16', 110, 310);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer21, 0, 85);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(5).fill(183), /* required buffer size: 5 */
+{offset: 5}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\u07ab\ua54f\u5bd6\u0edd\u7f64',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer12, offset: 0, size: 514}},
+    {binding: 606, resource: textureView5},
+  ],
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup10, new Uint32Array(716), 46, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer10, 3000, buffer7, 336, 924);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u9cb7');
+} catch {}
+let buffer22 = device0.createBuffer({size: 1284, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder25 = device0.createCommandEncoder({});
+let computePassEncoder22 = commandEncoder25.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup9, new Uint32Array(6936), 1_534, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint32', 824, 47);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, undefined, 708_423_430, 77_556_085);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 916 widthInBlocks: 229 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3320 */
+  offset: 3320,
+  bytesPerRow: 16640,
+  rowsPerImage: 732,
+  buffer: buffer0,
+}, {width: 229, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 24, resource: textureView20}, {binding: 127, resource: textureView13}],
+});
+let commandEncoder26 = device0.createCommandEncoder();
+let texture36 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler22 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.33,
+  lodMaxClamp: 85.89,
+  compare: 'always',
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer13, 'uint32', 972, 3_681);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer16, 788);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer3, 1548, 804);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u3583\ueb98\ud5d4\u847f\udeec\u08c5',
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 217});
+let renderPassEncoder5 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: 968.3, g: 276.3, b: 81.65, a: -87.21, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup4, new Uint32Array(2032), 553, 0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(3, 6, 68, 3);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer16, 'uint32', 360, 637);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer9, 56, buffer3, 380, 256);
+} catch {}
+try {
+commandEncoder26.insertDebugMarker('\ud0df');
+} catch {}
+document.body.append(canvas0);
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(135) var tex3: texture_2d<f32>;
+
+var<workgroup> vw5: FragmentOutput0;
+
+struct T0 {
+  f0: array<atomic<u32>>,
+}
+
+@group(1) @binding(42) var<uniform> buffer23: vec2h;
+
+struct T2 {
+  f0: array<u32>,
+}
+
+var<private> vp1 = modf(f32(0.08355));
+
+var<workgroup> vw7: array<atomic<i32>, 48>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+fn fn1() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  vw4 = FragmentOutput0(bitcast<i32>(vw10[1].f2[1]), pack4xU8Clamp(vec4u(vw10[1].f2)), vw10[1].f2);
+  var vf10 = fn0();
+  let ptr5: ptr<workgroup, i32> = &(*&vw10)[1].f0;
+  vw6 = mat3x4h(f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract), f16(vp1.fract));
+  let ptr6: ptr<workgroup, i32> = &vw9.f0;
+  vp4 += i32((*&vw5).f1);
+  out.f1 ^= pack4x8snorm(vw5.f2);
+  let vf11: i32 = atomicLoad(&(*&vw7)[47]);
+  vp3 = mat4x2h(f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1), f16((*&vw10)[u32(unconst_u32(1))].f1));
+  return out;
+}
+
+var<workgroup> vw10: array<FragmentOutput0, 2>;
+
+fn fn0() -> vec4<bool> {
+  var out: vec4<bool>;
+  var vf3: i32 = vp2[u32(unconst_u32(112))];
+  vf3 += i32(vp1.fract);
+  var vf4: f16 = vp3[u32(unconst_u32(266))][u32(unconst_u32(153))];
+  vp3 = mat4x2h(vec2h(faceForward(vec4f(unconst_f32(-0.1788), unconst_f32(0.1157), unconst_f32(0.02486), unconst_f32(0.06338)), bitcast<vec4f>(firstLeadingBit(vec4i(unconst_i32(179), unconst_i32(62), unconst_i32(97), unconst_i32(277)))), vec4f(unconst_f32(0.1774), unconst_f32(0.02610), unconst_f32(0.05881), unconst_f32(0.08167))).xw), vec2h(faceForward(vec4f(unconst_f32(-0.1788), unconst_f32(0.1157), unconst_f32(0.02486), unconst_f32(0.06338)), bitcast<vec4f>(firstLeadingBit(vec4i(unconst_i32(179), unconst_i32(62), unconst_i32(97), unconst_i32(277)))), vec4f(unconst_f32(0.1774), unconst_f32(0.02610), unconst_f32(0.05881), unconst_f32(0.08167))).rr), vec2h(faceForward(vec4f(unconst_f32(-0.1788), unconst_f32(0.1157), unconst_f32(0.02486), unconst_f32(0.06338)), bitcast<vec4f>(firstLeadingBit(vec4i(unconst_i32(179), unconst_i32(62), unconst_i32(97), unconst_i32(277)))), vec4f(unconst_f32(0.1774), unconst_f32(0.02610), unconst_f32(0.05881), unconst_f32(0.08167))).ba), vec2h(faceForward(vec4f(unconst_f32(-0.1788), unconst_f32(0.1157), unconst_f32(0.02486), unconst_f32(0.06338)), bitcast<vec4f>(firstLeadingBit(vec4i(unconst_i32(179), unconst_i32(62), unconst_i32(97), unconst_i32(277)))), vec4f(unconst_f32(0.1774), unconst_f32(0.02610), unconst_f32(0.05881), unconst_f32(0.08167))).gb));
+  let vf5: vec3f = atan2(vec3f(unconst_f32(0.1710), unconst_f32(0.04517), unconst_f32(0.03576)), vec3f(insertBits(vec4i(vp3[u32(unconst_u32(671))].yxxx), vec4i(unconst_i32(309), unconst_i32(117), unconst_i32(365), unconst_i32(167)), u32(unconst_u32(186)), u32(unconst_u32(71))).xyz));
+  var vf6: f16 = vp3[u32(unconst_u32(98))][u32(unconst_u32(554))];
+  let vf7: vec3f = atan2(vec3f(unconst_f32(0.1284), unconst_f32(0.4226), unconst_f32(0.06726)), vec3f(unconst_f32(0.02911), unconst_f32(0.03037), unconst_f32(0.03130)));
+  vf6 = normalize(vec4h(unconst_f16(22095.3), unconst_f16(8590.2), unconst_f16(3297.2), unconst_f16(9490.5)))[0];
+  let ptr2 = &vp1;
+  var vf8: vec4i = firstLeadingBit(vec4i(unconst_i32(0), unconst_i32(225), unconst_i32(7), unconst_i32(120)));
+  let ptr3: ptr<private, vec4i> = &vp2;
+  let vf9: vec4f = asin(vec4f(unconst_f32(-0.1540), unconst_f32(0.00629), unconst_f32(0.1716), unconst_f32(0.00217)));
+  vp1.fract *= f32(normalize(vec4h(unconst_f16(26.54), unconst_f16(2106.9), unconst_f16(4784.5), unconst_f16(225.3)))[1]);
+  let ptr4: ptr<function, vec4i> = &vf8;
+  return out;
+}
+
+@group(0) @binding(99) var tex2: texture_multisampled_2d<f32>;
+
+var<private> vp2: vec4i = vec4i(170, -241, -8, 44);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw6: mat3x4h;
+
+var<workgroup> vw8: vec2i;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp3: mat4x2h = mat4x2h(44361.7, 3160.7, 15231.6, 8833.5, 5351.4, 2365.4, 2127.0, 9088.0);
+
+struct T3 {
+  @align(2) f0: array<u32>,
+}
+
+var<private> vp4: i32 = i32(237);
+
+var<workgroup> vw4: FragmentOutput0;
+
+var<workgroup> vw9: FragmentOutput0;
+
+struct FragmentOutput0 {
+  @location(4) f0: i32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(linear, center) f2: vec4f,
+}
+
+@vertex
+fn vertex0(@location(5) @interpolate(perspective, center) a0: vec2h, @location(2) a1: vec4f, @location(0) a2: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp2 &= vec4i(unpack4x8snorm(u32(unconst_u32(43))));
+  out -= bitcast<vec4f>(textureDimensions(tex3, i32(unconst_i32(199))).grgr);
+  let vf12: i32 = dot(bitcast<vec3i>(unpack4x8snorm(u32(unconst_u32(220))).zxx), vec3i(unconst_i32(415), unconst_i32(-223), unconst_i32(-88)));
+  vp3 -= mat4x2h(f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))), f16(asinh(f32(unconst_f32(0.2830)))));
+  let ptr7: ptr<private, vec4i> = &vp2;
+  let vf13: vec2h = a0;
+  vp4 -= bitcast<i32>(vp3[u32(unconst_u32(132))]);
+  vp1.whole = fma(vec4f(unconst_f32(0.2076), unconst_f32(0.1595), unconst_f32(-0.02806), unconst_f32(0.2700)), vec4f(unconst_f32(0.03024), unconst_f32(0.05767), unconst_f32(0.2226), unconst_f32(0.1763)), vec4f(unconst_f32(0.4281), unconst_f32(0.01635), unconst_f32(0.01223), unconst_f32(0.01960))).w;
+  var vf14: vec2i = a2;
+  vp3 += mat4x2h(vec2h(reverseBits(vec4u(tan(vec3f(unconst_f32(0.2997), unconst_f32(0.1888), unconst_f32(0.03712))).bbrb)).xw), vec2h(reverseBits(vec4u(tan(vec3f(unconst_f32(0.2997), unconst_f32(0.1888), unconst_f32(0.03712))).bbrb)).zx), vec2h(reverseBits(vec4u(tan(vec3f(unconst_f32(0.2997), unconst_f32(0.1888), unconst_f32(0.03712))).bbrb)).ar), vec2h(reverseBits(vec4u(tan(vec3f(unconst_f32(0.2997), unconst_f32(0.1888), unconst_f32(0.03712))).bbrb)).rg));
+  return out;
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf15 = fn0();
+  vp2 ^= vec4i(vp3[u32(unconst_u32(14))].xyxy);
+  discard;
+  var vf16 = fn0();
+  let vf17: f16 = radians(tan(vec3h(unconst_f16(5021.3), unconst_f16(-4380.8), unconst_f16(87.15))).r);
+  vp1.whole -= bitcast<f32>(dot4I8Packed(u32(unconst_u32(21)), u32(unconst_u32(166))));
+  var vf18: vec2h = vp3[u32(vf15[u32(unconst_u32(8))])];
+  fn0();
+  out.f0 ^= i32(length(vec2h(unconst_f16(681.1), unconst_f16(15996.1))));
+  var vf19 = fn0();
+  out.f0 = i32(radians(f16(unconst_f16(13052.9))));
+  fn0();
+  vp2 = vec4i(fract(vec4h(unconst_f16(6525.6), unconst_f16(5377.9), unconst_f16(2262.1), unconst_f16(9965.4))));
+  out.f1 <<= textureDimensions(tex2)[0];
+  return out;
+}`,
+  sourceMap: {},
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  label: '\u20b4\u0c09\u3637\u02bb\uba01',
+  size: [82, 12, 136],
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder6 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: -549.2, g: 369.2, b: 677.1, a: 526.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.91,
+  lodMaxClamp: 38.39,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 415.1, g: 961.1, b: -282.1, a: -971.9, });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture38 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder23 = commandEncoder26.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1316 */
+  offset: 1316,
+  bytesPerRow: 33536,
+  buffer: buffer11,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 31, y: 13, z: 0},
+  aspect: 'all',
+}, {width: 73, height: 17, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder29 = device0.createCommandEncoder({label: '\ue69f\ub800\u{1f9f6}\u0ef1\u08f0\ua646\u6f0a'});
+let texture39 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView34 = texture14.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 9});
+let computePassEncoder24 = commandEncoder29.beginComputePass();
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 26.03,
+  compare: 'greater-equal',
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 6, y: 4 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({size: {width: 165}, dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_SRC});
+let sampler25 = device0.createSampler({
+  label: '\u9450\u0842\u859b\u10f1\u{1fbf8}',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.01,
+  lodMaxClamp: 72.97,
+  compare: 'always',
+});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 1_296, 3_880);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let imageBitmap1 = await createImageBitmap(canvas0);
+let buffer24 = device0.createBuffer({
+  size: 3032,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let renderPassEncoder7 = commandEncoder27.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: -137.7, g: 602.8, b: 690.4, a: -788.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(107);
+} catch {}
+document.body.prepend(canvas0);
+let textureView35 = texture11.createView({baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 3});
+let computePassEncoder25 = commandEncoder30.beginComputePass();
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup16, new Uint32Array(712), 24, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(113);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer21, 'uint16', 1_806, 878);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let textureView36 = texture19.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let computePassEncoder26 = commandEncoder31.beginComputePass({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 54.26,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup10, new Uint32Array(742), 93, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer4, 3_320, 2_052);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder8 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  clearValue: { r: -948.9, g: 40.40, b: 987.3, a: 521.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 456, 1_039);
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 21685,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let textureView37 = texture39.createView({dimension: '2d', format: 'rg8sint', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder27 = commandEncoder33.beginComputePass({label: '\ua7fd\u{1ffc2}\u9ba6\ua954'});
+try {
+renderPassEncoder5.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer16, 0, 25);
+} catch {}
+try {
+externalTexture2.label = '\u0e15\ub1e4';
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 11209,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler27 = device0.createSampler({
+  label: '\u{1fa54}\u5826\u{1fe16}\u0e75\uf479',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.64,
+  lodMaxClamp: 80.75,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint32', 276, 1_319);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer22, offset: 0, size: 137}}],
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setViewport(32.45197094280015, 21.064376611958142, 41.639506445864576, 1.0613568258539692, 0.6662225741775873, 0.8068137670332363);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer19, 0);
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x4', offset: 68, shaderLocation: 2},
+          {format: 'sint8x2', offset: 210, shaderLocation: 0},
+          {format: 'float32x2', offset: 28, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte170m', transfer: 'hlg'} });
+try {
+globalThis.someLabel = renderBundle0.label;
+} catch {}
+let texture42 = device0.createTexture({
+  size: [1032, 1, 45],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup6, new Uint32Array(8787), 1_853, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer19, 0, 3_755);
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder34.beginComputePass({label: '\u05e7\u0d0c\u0558\u6d07\u0567\u47d9\u0487\u094d\u0809'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup14, new Uint32Array(521), 99, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 47, y: 1, z: 9},
+  aspect: 'all',
+}, new Uint8Array(5_066).fill(198), /* required buffer size: 5_066 */
+{offset: 8, bytesPerRow: 133, rowsPerImage: 19}, {width: 1, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  label: '\u0787\uccda\ub324\uae0f\u00fe\udcd0',
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView8}, {binding: 99, resource: textureView30}],
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView38 = texture21.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  size: [129, 1, 8],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder29 = commandEncoder35.beginComputePass({label: '\u9b70\uc38f\u4067\u{1fcb0}\u{1ffe1}\ud6a8\u9b92'});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup17, new Uint32Array(414), 57, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(238);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer26, 'uint32', 1_020, 2_213);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer19, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView39 = texture39.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+let texture44 = device0.createTexture({
+  size: {width: 129, height: 1, depthOrArrayLayers: 1},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler28 = device0.createSampler({
+  label: '\u39e8\u{1ffb5}\u2134\u41f4\ua361\uf6d3\u08e8\u0dd6\uf8fe\ud469\ufe1a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.46,
+  lodMaxClamp: 96.19,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer11, 996, buffer25, 892, 328);
+} catch {}
+document.body.prepend(canvas0);
+let imageData4 = new ImageData(32, 76);
+try {
+globalThis.someLabel = computePassEncoder4.label;
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer18, offset: 768, size: 19}},
+    {binding: 606, resource: textureView8},
+  ],
+});
+let computePassEncoder30 = commandEncoder36.beginComputePass();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(2, bindGroup2, new Uint32Array(1023), 12, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup8, new Uint32Array(3612), 250, 0);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer25, offset: 11520, size: 732}}],
+});
+let buffer27 = device0.createBuffer({
+  size: 11468,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView40 = texture42.createView({mipLevelCount: 2});
+let texture45 = device0.createTexture({
+  size: {width: 330},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer13, 'uint32', 704, 502);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let texture46 = device0.createTexture({size: {width: 129}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder9 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{view: textureView39, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+});
+let sampler29 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.71,
+});
+try {
+renderPassEncoder3.setStencilReference(304);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3632 */
+  offset: 1776,
+  bytesPerRow: 1792,
+  buffer: buffer7,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 3920, new BigUint64Array(2278), 302, 20);
+} catch {}
+let texture47 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder31 = commandEncoder38.beginComputePass({});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 98.85,
+  lodMaxClamp: 99.24,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup16, new Uint32Array(927), 51, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(2);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup2, new Uint32Array(668), 62, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup2, new Uint32Array(880), 136, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer20, 0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\u0ff0');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+canvas0.height = 264;
+let textureView41 = texture19.createView({
+  label: '\u88b6\u0973\uc286\u5dae\u0af6\u053b\ub99e\u{1ffa8}\u{1fdcd}\u{1fb09}\u{1fa4c}',
+  dimension: '2d',
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup0, new Uint32Array(31), 2, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer27, 0, 277);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let texture48 = device0.createTexture({
+  size: [258, 1, 186],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer15);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 2, y: 4, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 165, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 828, new BigUint64Array(10305), 4311, 84);
+} catch {}
+let buffer28 = device0.createBuffer({size: 5775, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder32 = commandEncoder30.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(765), 97, 0);
+} catch {}
+let textureView42 = texture10.createView({format: 'depth16unorm', baseMipLevel: 0});
+let texture49 = device0.createTexture({
+  size: [330, 48, 223],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer26, 508);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 10, resource: sampler23}]});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView43 = texture34.createView({dimension: '2d-array', mipLevelCount: 1});
+let textureView44 = texture8.createView({arrayLayerCount: 1});
+let computePassEncoder33 = commandEncoder39.beginComputePass({});
+let sampler31 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', magFilter: 'nearest', lodMinClamp: 29.31});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder();
+let texture50 = device0.createTexture({
+  size: [516, 1, 690],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder10 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: -8.786, g: 580.9, b: -490.6, a: 460.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup4, new Uint32Array(1760), 980, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup15, new Uint32Array(947), 213, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle0, renderBundle3]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 5_828, 455);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer0, 0, 634);
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 3372,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder41 = device0.createCommandEncoder();
+let texture51 = device0.createTexture({
+  size: [330, 48, 1],
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder11 = commandEncoder41.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -327.4, g: 146.6, b: -86.08, a: -405.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint16', 26, 21);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u0fd1');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+@group(0) @binding(99) var tex4: texture_multisampled_2d<f32>;
+
+fn fn0() -> mat4x2h {
+  var out: mat4x2h;
+  var vf20: u32 = textureNumSamples(tex4);
+  vf20 = u32(tan(f32(unconst_f32(0.06225))));
+  let ptr8: ptr<function, u32> = &vf20;
+  let ptr9: ptr<uniform, f16> = &buffer30[1];
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(135) var tex5: texture_2d<f32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(1) @binding(42) var<uniform> buffer30: array<f16, 2>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u) {
+  let ptr10: ptr<uniform, array<f16, 2>> = &(*&buffer30);
+  let ptr11: ptr<uniform, f16> = &buffer30[u32(unconst_u32(128))];
+  var vf21: vec3u = a0;
+  vf21 &= vec3u(u32(buffer30[1]));
+  let ptr12: ptr<uniform, f16> = &(*&buffer30)[u32(unconst_u32(175))];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup24 = device0.createBindGroup({
+  label: '\u7757\u{1f6d4}\u3f67\u06c9\u{1fbe4}\u0b51',
+  layout: bindGroupLayout8,
+  entries: [{binding: 10, resource: sampler24}],
+});
+let textureView45 = texture42.createView({mipLevelCount: 1});
+let sampler32 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.820,
+  lodMaxClamp: 66.28,
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer17, 'uint32', 2_132, 2_283);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({entries: [{binding: 482, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }}]});
+let buffer31 = device0.createBuffer({
+  label: '\u8495\u0ab8\u0574\u{1fd22}\uf3c0\ufc12\u19d8\u044f\u{1fc1b}\u8cc7\u0682',
+  size: 3343,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView46 = texture42.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.99,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u4054');
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout9]});
+let externalTexture6 = device0.importExternalTexture({label: '\u0b86\u953b\uc676\u{1ffe5}\u0992\u80b1', source: videoFrame1});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup6, new Uint32Array(2548), 163, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer21, 0);
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u{1ffea}\u54aa\ucdd6\u06f6\u7ffb\u{1f68f}\u1cb1\u{1fe21}\ub3a4\ud8e3'});
+let textureView47 = texture11.createView({label: '\u0cf7\u4b6e', baseArrayLayer: 3, arrayLayerCount: 11});
+let computePassEncoder34 = commandEncoder42.beginComputePass({});
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer8, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+}, new Uint8Array(8_436).fill(36), /* required buffer size: 8_436 */
+{offset: 21, bytesPerRow: 51, rowsPerImage: 33}, {width: 0, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroup25 = device0.createBindGroup({
+  label: '\u221b\u{1fd10}\u{1feb3}\u{1fbcd}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer21, offset: 2048, size: 760}}],
+});
+let buffer32 = device0.createBuffer({size: 14503, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer4, 'uint16', 966, 2_617);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder();
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.91,
+  lodMaxClamp: 83.22,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup25, []);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer26, 2_348);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer29);
+} catch {}
+let textureView48 = texture50.createView({label: '\u98b2\ufd5c\u3713\ube56\u{1f9bd}'});
+let computePassEncoder35 = commandEncoder19.beginComputePass({});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder43.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 96 */
+  offset: 96,
+  bytesPerRow: 3840,
+  buffer: buffer13,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 184, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\u1cdf\u{1fa75}\u07c6\u{1f8f2}\u86be\u655a\uec04\u3738\u{1f63c}\udce8';
+} catch {}
+let texture52 = device0.createTexture({
+  label: '\u0846\u7c00\u047d\u49e4\ub270\u{1f659}\u0905\u{1f656}\u7cc3\udae9',
+  size: {width: 1032},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView49 = texture9.createView({baseArrayLayer: 0});
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 42 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1158 */
+  offset: 1158,
+  bytesPerRow: 43264,
+  buffer: buffer31,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 3, y: 38 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 11, y: 6, z: 42},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(12, 32);
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView42}, {binding: 24, resource: textureView36}],
+});
+let textureView50 = texture15.createView({
+  label: '\u409b\u471a\uc88c\u26c0\u08f0\u10db\u3c0f\u{1fb59}\u101d\u{1f6b0}\u0e14',
+  dimension: '2d',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder36 = commandEncoder43.beginComputePass({});
+try {
+renderPassEncoder6.executeBundles([renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(154.53851761858112, 37.78753183342326, 36.267968287740864, 5.762128860000354, 0.8220978153598317, 0.8663248334827149);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer25, 'uint16', 394, 838);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4_294_967_295, undefined, 843_172_696, 967_077_246);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(52366) override override13 = 0.02007;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override11: f16 = 7724.7;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(17757) override override12: i32 = 43;
+
+struct T0 {
+  @align(2) f0: array<vec2u, 5>,
+  @size(64) f1: atomic<i32>,
+}
+
+@group(0) @binding(482) var sam0: sampler;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@id(63859) override override14 = 0.2374;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  var vf22: u32 = pack4x8snorm(vec4f(unconst_f32(0.2495), unconst_f32(0.3223), unconst_f32(0.1872), unconst_f32(0.2325)));
+  var vf23: f32 = override14;
+  let vf24: i32 = override12;
+  vf22 &= bitcast<u32>(ldexp(vec2h(unconst_f16(3449.0), unconst_f16(2626.5)), vec2i(unconst_i32(21), unconst_i32(-203))));
+  let ptr13: ptr<function, f32> = &vf23;
+  var vf25: vec4f = sin(vec4f(unconst_f32(0.2163), unconst_f32(0.03563), unconst_f32(0.03903), unconst_f32(0.3331)));
+  vf25 = unpack4x8snorm(dot4U8Packed(u32(unconst_u32(83)), u32(unconst_u32(110))));
+  vf23 += (*ptr13);
+  let vf26: vec2h = ldexp(vec2h(unconst_f16(508.2), unconst_f16(10567.0)), vec2i(unconst_i32(284), unconst_i32(447)));
+  _ = override12;
+  _ = override14;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder44 = device0.createCommandEncoder();
+let renderPassEncoder12 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  depthSlice: 4,
+  clearValue: { r: 334.9, g: -598.3, b: 544.2, a: -909.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler35 = device0.createSampler({
+  label: '\u79b3\uc0df\ufca1\u048b\u07db',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.947,
+  lodMaxClamp: 50.54,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup23, new Uint32Array(514), 280, 0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(1, 10, 10, 2);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer26, 3_404, 935);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+await gc();
+let textureView51 = texture10.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let texture53 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 446},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup13, new Uint32Array(979), 16, 0);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer20, offset: 6656, size: 5894}}],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f93b}\u4325\ua43d\u7f4d\u0ba0\u015c\u{1facd}\ue2b2\u0a86\ub7d9',
+  colorFormats: ['rgb10a2unorm'],
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData6 = new ImageData(72, 32);
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView52 = texture34.createView({mipLevelCount: 1});
+let renderPassEncoder13 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: -732.6, g: 622.5, b: 783.2, a: -917.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 310643806,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup1, new Uint32Array(618), 7, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(canvas1);
+try {
+adapter0.label = '\u0c01\u{1f87a}';
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u0b9d\u{1f6c2}\u66ae\u{1f9d4}\u01d0\u0702\u42e7\u04b1',
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+@group(1) @binding(42) var<uniform> buffer33: f32;
+
+struct FragmentOutput1 {
+  @location(5) @interpolate(flat, sample) f0: u32,
+  @location(0) f1: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct S0 {
+  @location(12) f0: vec2h,
+  @location(10) @interpolate(linear) f1: f32,
+  @location(6) f2: f16,
+  @location(13) f3: vec2i,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw11: mat4x3f;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0() -> vec4<bool> {
+  var out: vec4<bool>;
+  var vf27: vec2u = textureDimensions(tex7, i32(unconst_i32(73)));
+  vf27 <<= firstTrailingBit(vec4u(unconst_u32(111), unconst_u32(164), unconst_u32(68), unconst_u32(39))).ga;
+  let vf28: u32 = pack4xI8Clamp(vec4i(unconst_i32(184), unconst_i32(17), unconst_i32(48), unconst_i32(542)));
+  out = vec4<bool>(exp(vec3f(unconst_f32(-0.1532), unconst_f32(0.1254), unconst_f32(0.1915))).yxzx);
+  out = vec4<bool>(textureDimensions(tex7, i32(unconst_i32(145))).xxxx);
+  vf27 = bitcast<vec2u>(trunc(vec4h(unconst_f16(26744.4), unconst_f16(2577.4), unconst_f16(8649.0), unconst_f16(1088.5))));
+  var vf29: f16 = acos(f16(unconst_f16(11854.0)));
+  let ptr14: ptr<uniform, f32> = &buffer33;
+  vf29 = f16(vf28);
+  out = vec4<bool>(bool(vf28));
+  let ptr15: ptr<uniform, f32> = &buffer33;
+  vf29 *= f16(textureNumLevels(tex7));
+  out = vec4<bool>(bool((*&buffer33)));
+  vf27 <<= vec2u(vf27[u32(unconst_u32(36))]);
+  var vf30: vec4i = unpack4xI8(u32(unconst_u32(248)));
+  vf30 |= bitcast<vec4i>(unpack4x8snorm(u32(unconst_u32(172))));
+  var vf31: vec2u = textureDimensions(tex7, i32(unconst_i32(232)));
+  vf27 |= textureDimensions(tex7, i32(unconst_i32(214)));
+  vf29 -= f16((*&buffer33));
+  let vf32: vec2h = fma(vec2h(vf27), vec2h(unconst_f16(31907.6), unconst_f16(4536.7)), vec2h(unconst_f16(1105.3), unconst_f16(28736.1)));
+  vf31 += vec2u(ldexp(vec2f(unconst_f32(-0.1135), unconst_f32(0.4695)), vec2i(bitcast<i32>(pack4xI8Clamp(vec4i(bitcast<i32>(textureNumLevels(tex7))))))));
+  var vf33: vec2f = unpack2x16unorm(u32(unconst_u32(44)));
+  vf29 = f16(textureNumLevels(tex7));
+  vf27 >>= vec2u(u32(vf32[u32(unconst_u32(553))]));
+  return out;
+}
+
+fn fn1(a0: array<T0, 5>, a1: ptr<uniform, mat4x2h>, a2: ptr<workgroup, VertexOutput0>) -> bool {
+  var out: bool;
+  var vf34: vec3f = reflect(vec3f(unconst_f32(0.2351), unconst_f32(-0.00851), unconst_f32(0.00157)), vec3f(unconst_f32(0.08173), unconst_f32(-0.4467), unconst_f32(0.04343)));
+  vf34 = vec3f(bitcast<f32>(pack4x8snorm(a0[4].f0[0].yxxx)));
+  let vf35: f16 = (*a1)[u32(unconst_u32(86))][u32(unconst_u32(93))];
+  (*a2) = VertexOutput0(vec4f(f32(all(vec2<bool>(unconst_bool(false), unconst_bool(true))))), vec4h(f16(all(vec2<bool>(unconst_bool(false), unconst_bool(true))))), vec4h(f16(all(vec2<bool>(unconst_bool(false), unconst_bool(true))))));
+  return out;
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+  @location(4) @interpolate(linear, sample) f1: vec4h,
+  @location(6) f2: vec4h,
+}
+
+@group(0) @binding(99) var tex6: texture_multisampled_2d<f32>;
+
+struct T0 {
+  f0: array<vec2f, 1>,
+}
+
+@group(0) @binding(135) var tex7: texture_2d<f32>;
+
+@vertex
+fn vertex1(@location(0) @interpolate(flat, sample) a0: vec4f, @location(9) a1: vec2f, a2: S0, @location(11) a3: vec2i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f0 += vec4f((*&buffer33));
+  let vf36: u32 = textureNumLevels(tex7);
+  out = VertexOutput0(bitcast<vec4f>(a2.f3.yyxx), bitcast<vec4h>(a2.f3), bitcast<vec4h>(a2.f3));
+  let vf37: vec2h = a2.f0;
+  let vf38: vec4f = textureLoad(tex7, vec2i(unconst_i32(194), unconst_i32(94)), i32(unconst_i32(153)));
+  let vf39: vec2u = textureDimensions(tex7, i32(unconst_i32(91)));
+  return out;
+}
+
+@fragment
+fn fragment1(@builtin(sample_index) a0: u32, @location(6) a1: vec4h, @location(4) @interpolate(linear, sample) a2: vec4h) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f0 >>= vec4u(sin(vec4h(unconst_f16(4598.3), unconst_f16(13097.1), unconst_f16(12994.8), unconst_f16(8166.9))))[2];
+  var vf40: f16 = acosh(f16(unconst_f16(370.1)));
+  out.f0 &= pack4xU8Clamp(vec4u(sin(vec4h(unconst_f16(2709.9), unconst_f16(17625.6), unconst_f16(6426.2), unconst_f16(2112.1)))));
+  let vf41: vec4f = log2(vec4f(unconst_f32(-0.02558), unconst_f32(0.4255), unconst_f32(0.07051), unconst_f32(-0.06040)));
+  out.f0 <<= pack4x8unorm(tanh(vec4f(vf41[u32(unconst_u32(67))])));
+  out.f1 = vec4f(min(vec3h(unconst_f16(711.8), unconst_f16(4575.3), unconst_f16(5047.4)), vec3h(unconst_f16(2491.0), unconst_f16(1222.4), unconst_f16(2365.4))).ggbb);
+  var vf42: vec2f = cosh(vec2f(f32(a2[u32(unconst_u32(135))])));
+  out = FragmentOutput1(pack4x8unorm(unpack4x8snorm(u32(unconst_u32(55)))), unpack4x8snorm(u32(unconst_u32(55))));
+  vf40 = f16(vf42.x);
+  out = FragmentOutput1(pack2x16float(vf42), vf42.yyxy);
+  out.f1 -= vec4f(bitcast<f32>(textureNumSamples(tex6)));
+  var vf43: f16 = a1[u32(unconst_u32(7))];
+  vf42 = vec2f(acos(f32(unconst_f32(0.02692))));
+  discard;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  size: [516],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler36 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 86.94,
+  lodMaxClamp: 96.30,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(6732), 1_743, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer4, 'uint32', 576, 2_580);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer4, 3_492, 2_523);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer15, 112, buffer6, 108, 68);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder();
+let texture56 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 55},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView53 = texture41.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder14 = commandEncoder47.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: 344.5, g: 564.3, b: -719.8, a: 637.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup13, new Uint32Array(4439), 454, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let renderPassEncoder15 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView25,
+  depthSlice: 15,
+  clearValue: { r: -102.6, g: 40.68, b: 628.1, a: -635.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder10.setIndexBuffer(buffer6, 'uint16', 38, 41);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup16, new Uint32Array(568), 85, 0);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer18, 608, buffer29, 560, 452);
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer24, 312);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(71).fill(162), /* required buffer size: 71 */
+{offset: 71}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView54 = texture12.createView({dimension: '2d'});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer16, 'uint32', 1_568, 23);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer19, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 18 },
+  flipY: true,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 419,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 445,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 569,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let textureView55 = texture46.createView({
+  label: '\ue53c\uc9ae\u04b4\u1c46\u{1f7ec}\u0d1f\u{1fa8d}\u{1fece}\u04cd\u1891\ufe74',
+  baseMipLevel: 0,
+});
+let texture57 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 234},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder37 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup10, new Uint32Array(2030), 75, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup15, new Uint32Array(606), 50, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup6, new Uint32Array(1378), 104, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer31, 'uint16', 138, 428);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer29, 0, 82);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer7, offset: 2560, size: 96}},
+    {binding: 23, resource: textureView26},
+  ],
+});
+let computePassEncoder38 = commandEncoder49.beginComputePass({});
+let renderBundle4 = renderBundleEncoder4.finish({label: '\u{1f879}\u0573\u0947\ud218\u05ee'});
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.71,
+  lodMaxClamp: 99.00,
+  maxAnisotropy: 6,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup7, new Uint32Array(264), 20, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup10, new Uint32Array(2072), 348, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u009a\u86df\u7073\u19f6\u0217\u0fc5\u70c8\u6697\u4b9e',
+  entries: [
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer34 = device0.createBuffer({label: '\uba5b\u{1fe6c}\u{1fc5d}\u5bab', size: 9260, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder50 = device0.createCommandEncoder({});
+let textureView56 = texture56.createView({});
+let computePassEncoder39 = commandEncoder50.beginComputePass();
+let sampler38 = device0.createSampler({
+  label: '\ue431\uce6e\u{1fb8b}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 29.58,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(1332), 861, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(926), 241, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -652.6, g: 383.7, b: -394.3, a: 682.2, });
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer8, 'uint16', 1_162, 762);
+} catch {}
+let imageData7 = new ImageData(32, 28);
+let texture58 = device0.createTexture({
+  label: '\ue710\u0bda\ubf19\u061c\u05dd\ucbb2',
+  size: [165, 24, 23],
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture37.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 21});
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer4, 'uint32', 800, 1_845);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 32);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer6, 56);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer4, 7_848);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView21}, {binding: 135, resource: textureView9}],
+});
+let commandEncoder51 = device0.createCommandEncoder();
+let computePassEncoder40 = commandEncoder51.beginComputePass({});
+let sampler39 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.07,
+  lodMaxClamp: 76.64,
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup18, new Uint32Array(538), 12, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer6, 'uint16', 68, 180);
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer15, offset: 0, size: 12}},
+    {binding: 23, resource: textureView26},
+  ],
+});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup4, new Uint32Array(243), 20, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer4, 'uint32', 2_000, 2_721);
+} catch {}
+let imageData8 = new ImageData(4, 60);
+let bindGroup31 = device0.createBindGroup({
+  label: '\u{1fa5e}\u3201\u272f\u0b0d',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView42}, {binding: 24, resource: textureView20}],
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.draw(568_788_386, 44, 250_554_847, 146_010_577);
+} catch {}
+let imageData9 = new ImageData(32, 20);
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 227,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup32 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 127, resource: textureView37}]});
+let texture59 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView58 = texture7.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView31}]});
+let textureView59 = texture46.createView({});
+let computePassEncoder41 = commandEncoder9.beginComputePass({});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer25, 'uint32', 21_684, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+document.body.prepend(canvas1);
+let imageData10 = new ImageData(24, 4);
+let commandEncoder52 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 296});
+let textureView60 = texture54.createView({});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup19, new Uint32Array(2874), 273, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer17, 'uint16', 6_270, 5_016);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer27, 228, 3_116);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer9, 32, buffer13, 28, 16);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet4, 93, 3, buffer32, 1280);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+try {
+adapter0.label = '\u8918\u04c1';
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 569, resource: sampler5},
+    {binding: 419, resource: {buffer: buffer16, offset: 256, size: 380}},
+    {binding: 445, resource: textureView55},
+    {binding: 167, resource: {buffer: buffer20, offset: 2560}},
+  ],
+});
+let buffer35 = device0.createBuffer({
+  size: 18729,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView61 = texture3.createView({});
+let renderPassEncoder16 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: -699.2, g: -322.7, b: 494.0, a: -629.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 141706656,
+});
+let sampler40 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.51,
+  lodMaxClamp: 77.32,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup26, new Uint32Array(79), 19, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 927.9, g: -157.2, b: 160.3, a: 63.03, });
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer26);
+} catch {}
+try {
+globalThis.someLabel = externalTexture6.label;
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView4},
+    {binding: 136, resource: {buffer: buffer4, offset: 2560, size: 20}},
+  ],
+});
+let buffer36 = device0.createBuffer({
+  size: 4840,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer26, 'uint32', 4_996, 364);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer21, 872, 1_327);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView62 = texture18.createView({dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder42 = commandEncoder53.beginComputePass({});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup26, new Uint32Array(48), 1, 0);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(146), 23, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let sampler41 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.45,
+  lodMaxClamp: 94.63,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(7, 1, 78, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 21, y: 1, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img0 = await imageWithData(35, 85, '#10101010', '#20202020');
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView8}, {binding: 99, resource: textureView61}],
+});
+let sampler42 = device0.createSampler({
+  label: '\u{1fcd5}\u0d93\u119e\u097a\u08dc\u{1f77a}\ufe09\u{1f9b6}\u0f97\u09b3\u022d',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.00,
+  lodMaxClamp: 67.96,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4]);
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView63 = texture57.createView({dimension: '3d'});
+let computePassEncoder44 = commandEncoder55.beginComputePass({label: '\ueb5c\u{1fd7d}\u0af9\u0266\u23c5\u{1f683}\u10ca\u0da1\uff8d\u1efc\u0cdc'});
+let sampler43 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 64.71,
+  lodMaxClamp: 71.00,
+  compare: 'always',
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup2, new Uint32Array(6721), 70, 0);
+} catch {}
+document.body.append(img0);
+let offscreenCanvas0 = new OffscreenCanvas(22, 285);
+let bindGroup37 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView0}]});
+let buffer37 = device0.createBuffer({
+  size: 5691,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView64 = texture28.createView({baseArrayLayer: 2, arrayLayerCount: 2});
+let texture61 = device0.createTexture({
+  label: '\u{1ffb8}\u98b7\u1473',
+  size: [1032],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder45 = commandEncoder56.beginComputePass();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+let renderBundle5 = renderBundleEncoder5.finish();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(3, bindGroup25, new Uint32Array(786), 26, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer16, 0, 8);
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0(a0: ptr<storage, array<u32>, read_write>) -> VertexOutput1 {
+  var out: VertexOutput1;
+  (*a0)[u32(unconst_u32(14))] = (*a0)[arrayLength(&(*a0)) - 1];
+  let vf44: vec2i = firstTrailingBit(vec2i(unconst_i32(8), unconst_i32(1)));
+  let vf45: vec2h = min(vec2h(unconst_f16(14610.9), unconst_f16(27812.6)), bitcast<vec2h>((*a0)[u32(unconst_u32(21))]));
+  let ptr16: ptr<storage, u32, read_write> = &(*a0)[i32(unconst_i32(245))];
+  let vf46: i32 = vf44[u32(unconst_u32(405))];
+  out = VertexOutput1(transpose(mat3x2f(unconst_f32(0.1932), unconst_f32(-0.3027), unconst_f32(-0.08517), unconst_f32(0.09879), unconst_f32(0.1652), unconst_f32(0.02627)))[0].ggbr);
+  out.f3 *= unpack4x8snorm((*a0)[i32(unconst_i32(245))]);
+  var vf47: vec4i = countLeadingZeros(vec4i(unconst_i32(11), unconst_i32(7), unconst_i32(29), unconst_i32(13)));
+  let vf48: i32 = vf44[u32(unconst_u32(222))];
+  let ptr17: ptr<function, vec4i> = &vf47;
+  var vf49: vec3h = ceil(vec3h(unconst_f16(11380.7), unconst_f16(1726.9), unconst_f16(9611.1)));
+  var vf50: u32 = dot4U8Packed(u32(unconst_u32(340)), u32(unconst_u32(264)));
+  vf50 = u32(ceil(vec3h(unconst_f16(10511.9), unconst_f16(7260.9), unconst_f16(15236.4))).y);
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(482) var sam1: sampler;
+
+var<workgroup> vw12: mat2x4f;
+
+struct VertexOutput1 {
+  @invariant @builtin(position) f3: vec4f,
+}
+
+struct T0 {
+  f0: array<f16>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex2(@location(0) a0: vec4h) -> VertexOutput1 {
+  var out: VertexOutput1;
+  var vf51: vec4h = trunc(vec4h(unconst_f16(12701.9), unconst_f16(2173.7), unconst_f16(7846.1), unconst_f16(-5944.4)));
+  out.f3 = vec4f(bitcast<f32>(insertBits(i32(unconst_i32(127)), i32(unconst_i32(151)), u32(unconst_u32(405)), u32(unconst_u32(147)))));
+  var vf52: vec4i = insertBits(vec4i(unconst_i32(30), unconst_i32(-152), unconst_i32(180), unconst_i32(96)), vec4i(unconst_i32(171), unconst_i32(203), unconst_i32(135), unconst_i32(307)), u32(unconst_u32(0)), u32(unconst_u32(98)));
+  vf52 -= vec4i(trunc(vec4h(unconst_f16(5466.4), unconst_f16(3518.8), unconst_f16(1704.7), unconst_f16(24818.6))));
+  var vf53: vec4h = trunc(vec4h(unconst_f16(6185.3), unconst_f16(5160.1), unconst_f16(-15367.0), unconst_f16(9174.2)));
+  return out;
+}
+
+@fragment
+fn fragment2() -> @location(200) @interpolate(flat, sample) vec4f {
+  var out: vec4f;
+  discard;
+  var vf54: f32 = ceil(f32(unconst_f32(0.2529)));
+  vf54 -= step(vec2f(unconst_f32(0.03316), unconst_f32(-0.2016)), vec2f(unconst_f32(0.01140), unconst_f32(0.01376)))[0];
+  var vf55: u32 = pack4xU8(vec4u(unconst_u32(98), unconst_u32(2), unconst_u32(130), unconst_u32(355)));
+  vf54 = f32(determinant(mat2x2h(unconst_f16(27949.5), unconst_f16(3548.6), unconst_f16(2190.7), unconst_f16(6884.2))));
+  vf55 = u32(determinant(mat2x2h()));
+  let vf56: f32 = determinant(mat4x4f(unconst_f32(0.05069), unconst_f32(0.3579), unconst_f32(0.01789), unconst_f32(0.00816), unconst_f32(0.3493), unconst_f32(0.1685), unconst_f32(0.02032), unconst_f32(0.06615), unconst_f32(0.03977), unconst_f32(0.2131), unconst_f32(0.08963), unconst_f32(0.04809), unconst_f32(-0.04835), unconst_f32(0.1392), unconst_f32(0.03593), unconst_f32(0.05205)));
+  vf55 = u32(degrees(vec3f(unconst_f32(0.04398), unconst_f32(0.02461), unconst_f32(0.00105)))[2]);
+  let vf57: f32 = determinant(mat4x4f());
+  vf54 = determinant(mat4x4f(unconst_f32(0.09882), unconst_f32(0.01558), unconst_f32(0.01340), unconst_f32(0.3904), unconst_f32(0.03339), unconst_f32(0.1510), unconst_f32(0.1283), unconst_f32(0.03015), unconst_f32(0.07073), unconst_f32(0.1884), unconst_f32(0.04488), unconst_f32(-0.1034), unconst_f32(0.01245), unconst_f32(-0.5444), unconst_f32(0.4715), unconst_f32(0.02509)));
+  var vf58: vec2f = mix(vec2f(unconst_f32(0.2545), unconst_f32(0.1375)), vec2f(unconst_f32(0.09360), unconst_f32(0.08712)), vec2f(unconst_f32(0.06404), unconst_f32(0.00638)));
+  vf58 += unpack2x16float(pack2x16float(vec2f(unconst_f32(0.05127), unconst_f32(0.2420))));
+  vf58 = degrees(vec4f(unconst_f32(0.1157), unconst_f32(0.1875), unconst_f32(0.2735), unconst_f32(0.07986))).ba;
+  vf58 = unpack2x16unorm(u32(unconst_u32(8)));
+  vf55 = u32(dot(vec3h(unconst_f16(19955.4), unconst_f16(1079.6), unconst_f16(13478.1)), vec3h(unconst_f16(21290.9), unconst_f16(4077.1), unconst_f16(3975.2))));
+  var vf59: vec3f = degrees(vec3f(unconst_f32(0.01908), unconst_f32(0.04012), unconst_f32(0.2249)));
+  out = vec4f(f32(vf55));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  vw12 += mat2x4f((*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))], (*&vw12)[u32(unconst_u32(82))][u32(unconst_u32(70))]);
+  vw12 += mat2x4f(pow(vec4f(unconst_f32(0.2937), unconst_f32(0.5002), unconst_f32(0.02098), unconst_f32(0.08221)), unpack4x8snorm(pack4xU8Clamp(vec4u(unconst_u32(147), unconst_u32(678), unconst_u32(168), unconst_u32(5))))), pow(vec4f(unconst_f32(0.2937), unconst_f32(0.5002), unconst_f32(0.02098), unconst_f32(0.08221)), unpack4x8snorm(pack4xU8Clamp(vec4u(unconst_u32(147), unconst_u32(678), unconst_u32(168), unconst_u32(5))))));
+  var vf60: vec4h = asin(vec4h(unconst_f16(17987.3), unconst_f16(3795.2), unconst_f16(12126.9), unconst_f16(3228.2)));
+  let vf61: vec4h = asin(vec4h(unconst_f16(19425.8), unconst_f16(5612.6), unconst_f16(5092.8), unconst_f16(4584.8)));
+  vf60 -= vec4h((*&vw12)[0]);
+  vf60 = vec4h(pow(vec4f(unconst_f32(0.05925), unconst_f32(0.00788), unconst_f32(0.08852), unconst_f32(0.2328)), vec4f(unconst_f32(0.1215), unconst_f32(-0.2374), unconst_f32(0.4637), unconst_f32(0.06292))));
+  vw12 = mat2x4f(f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]), f32(vf61[u32(unconst_u32(41))]));
+  var vf62: vec4h = asin(vec4h(unconst_f16(8884.0), unconst_f16(8035.5), unconst_f16(24734.3), unconst_f16(3947.0)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u3a00\u{1fce7}\u760d\uba54\u39b1', colorFormats: ['r8uint'], stencilReadOnly: true});
+let sampler44 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 97.78,
+  lodMaxClamp: 99.41,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup20, new Uint32Array(590), 33, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup25, new Uint32Array(112), 10, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer16, 'uint16', 130, 406);
+} catch {}
+let pipeline1 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule5}});
+let imageData11 = new ImageData(4, 60);
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1ff69}\u0417\ud319\u{1f716}\ue19d'});
+let texture62 = device0.createTexture({
+  label: '\ubbe9\u42e2\u0c07',
+  size: [1032, 1, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture63 = device0.createTexture({size: {width: 330}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder46 = commandEncoder57.beginComputePass({});
+let sampler45 = device0.createSampler({
+  label: '\u06d3\u67e9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 34.74,
+  lodMaxClamp: 79.05,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup27, new Uint32Array(36), 0, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer29, 'uint16', 258, 371);
+} catch {}
+document.body.prepend(img0);
+await gc();
+let shaderModule6 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+struct T1 {
+  f0: array<u32>,
+}
+
+fn fn2(a0: array<array<S1, 1>, 6>, a1: ptr<uniform, array<S1, 57>>) -> array<T0, 1> {
+  var out: array<T0, 1>;
+  var vf80 = fn0(mat3x3h(faceForward(vec3h(unconst_f16(8905.5), unconst_f16(10344.9), unconst_f16(1907.1)), vec3h(unconst_f16(24345.4), unconst_f16(15552.1), unconst_f16(9969.3)), vec3h(unconst_f16(927.3), unconst_f16(4925.4), unconst_f16(3063.0))), faceForward(vec3h(unconst_f16(8905.5), unconst_f16(10344.9), unconst_f16(1907.1)), vec3h(unconst_f16(24345.4), unconst_f16(15552.1), unconst_f16(9969.3)), vec3h(unconst_f16(927.3), unconst_f16(4925.4), unconst_f16(3063.0))), faceForward(vec3h(unconst_f16(8905.5), unconst_f16(10344.9), unconst_f16(1907.1)), vec3h(unconst_f16(24345.4), unconst_f16(15552.1), unconst_f16(9969.3)), vec3h(unconst_f16(927.3), unconst_f16(4925.4), unconst_f16(3063.0)))));
+  vf80[u32(unconst_u32(0))][u32(unconst_u32(61))][u32(unconst_u32(213))] += faceForward(vec3h(unconst_f16(8085.2), unconst_f16(5527.3), unconst_f16(-2737.9)), vec3h(unconst_f16(33533.1), unconst_f16(22784.4), unconst_f16(599.8)), vec3h(unconst_f16(2052.3), unconst_f16(6195.1), unconst_f16(9353.9))).bb;
+  vf80[u32(unconst_u32(5))][u32(unconst_u32(23))][u32(unconst_u32(10))] -= vec2h(f16(a0[u32(unconst_u32(136))][u32(unconst_u32(94))].f0));
+  let ptr26: ptr<function, vec2h> = &vf80[u32(unconst_u32(41))][u32(unconst_u32(87))][0];
+  let ptr27: ptr<function, vec2h> = &vf80[u32(unconst_u32(36))][u32(unconst_u32(30))][u32(unconst_u32(67))];
+  let vf81: f16 = (*ptr26)[u32(unconst_u32(116))];
+  return out;
+  _ = override16;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T3 {
+  @align(2) @size(28) f0: array<T0, 3>,
+  @align(1) @size(8) f1: array<i32, 1>,
+  @align(2) f2: array<T0, 1>,
+  @align(2) f3: array<array<array<array<vec2h, 1>, 1>, 1>, 2>,
+  @align(2) @size(80) f4: mat3x2h,
+  @align(1) @size(16) f5: array<vec2f, 1>,
+}
+
+fn fn0(a0: mat3x3h) -> array<array<array<vec2h, 1>, 4>, 1> {
+  var out: array<array<array<vec2h, 1>, 4>, 1>;
+  var vf63: vec3h = trunc(vec3h(unconst_f16(5027.2), unconst_f16(7641.5), unconst_f16(6193.8)));
+  let ptr18: ptr<function, vec3h> = &vf63;
+  var vf64: f16 = floor(f16(unconst_f16(1974.9)));
+  vf64 = vf63[vec4u(saturate(vec4h(unconst_f16(9781.1), unconst_f16(-6223.2), unconst_f16(20530.6), unconst_f16(14699.6)))).g];
+  var vf65: f32 = atanh(f32(unconst_f32(0.05494)));
+  var vf66: vec3f = normalize(vec3f(unconst_f32(0.04386), unconst_f32(0.4724), unconst_f32(0.3045)));
+  let vf67: vec3h = trunc(vec3h(unconst_f16(19762.3), unconst_f16(8504.0), unconst_f16(4878.5)));
+  out[0][u32(unconst_u32(5))][u32(unconst_u32(86))] = vec2h(a0[u32(unconst_u32(119))][u32(unconst_u32(38))]);
+  var vf68: bool = override16;
+  var vf69: f16 = vf67[u32(unconst_u32(152))];
+  var vf70: f16 = a0[u32(unconst_u32(79))][pack4x8snorm(unpack4x8unorm(u32(unconst_u32(245))))];
+  var vf71: vec2h = sign(vec2h(unconst_f16(34270.6), unconst_f16(1991.6)));
+  vf70 = cos(vec2h(unconst_f16(-1150.7), unconst_f16(15670.9)))[1];
+  vf70 *= saturate(vec4h(unconst_f16(9919.1), unconst_f16(7843.0), unconst_f16(1769.2), unconst_f16(-1724.2)))[1];
+  vf68 = bool(determinant(mat2x2f(unconst_f32(0.05897), unconst_f32(0.2133), unconst_f32(0.00391), unconst_f32(0.03222))));
+  vf65 = f32(transpose(mat3x2h())[1].r);
+  vf65 *= vec3f(transpose(mat3x2h())[1])[1];
+  var vf72: f16 = vf71[u32(unconst_u32(1000))];
+  vf65 -= vec3f(trunc(vec3h(unconst_f16(9218.0), unconst_f16(4219.4), unconst_f16(8479.7))))[1];
+  vf69 = vec3h(vf66).y;
+  let ptr19: ptr<function, vec3h> = &(*ptr18);
+  vf64 += f16(clamp(vec4i(unconst_i32(-191), unconst_i32(288), unconst_i32(164), unconst_i32(126)), vec4i(unconst_i32(311), unconst_i32(192), unconst_i32(71), unconst_i32(131)), vec4i(unconst_i32(1), unconst_i32(157), unconst_i32(111), unconst_i32(348)))[0]);
+  vf66 += vec3f(trunc(vec3h((*ptr18)[u32(vf68)])));
+  vf66 = vec3f(atanh(f32(unconst_f32(0.6916))));
+  var vf73: vec3h = trunc(vec3h(unconst_f16(10076.1), unconst_f16(-18677.2), unconst_f16(10275.6)));
+  return out;
+  _ = override16;
+}
+
+var<workgroup> vw15: f16;
+
+var<workgroup> vw16: VertexOutput2;
+
+struct T2 {
+  f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw13: S1;
+
+@id(52953) override override15: i32 = 230;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput2 {
+  @location(0) @interpolate(flat, sample) f4: vec2u,
+  @location(5) f5: f32,
+  @location(13) f6: vec2i,
+  @builtin(position) f7: vec4f,
+  @location(6) f8: vec4h,
+  @location(2) @interpolate(flat, centroid) f9: i32,
+  @location(1) @interpolate(flat) f10: vec4f,
+}
+
+fn fn1(a0: ptr<storage, array<u32>, read_write>) -> array<T0, 17> {
+  var out: array<T0, 17>;
+  var vf74: u32 = pack4xU8Clamp(vec4u(unconst_u32(13), unconst_u32(143), unconst_u32(199), unconst_u32(129)));
+  (*a0)[u32(unconst_u32(346))] = u32((*&vw13).f0);
+  let ptr20: ptr<workgroup, f16> = &vw15;
+  out[u32(unconst_u32(224))].f0 ^= i32((*&vw16).f5);
+  vw15 = f16(override16);
+  atomicStore(&vw14, u32(unconst_u32(54)));
+  let vf75: vec2f = unpack2x16unorm(u32(unconst_u32(131)));
+  let ptr21: ptr<workgroup, vec4h> = &vw16.f8;
+  vw13 = S1(bool((*&vw16).f6.y));
+  var vf76: vec3u = abs(vec3u(unconst_u32(72), unconst_u32(50), unconst_u32(26)));
+  (*a0)[u32(unconst_u32(554))] >>= bitcast<vec3u>(round(vec3f(unconst_f32(0.1238), unconst_f32(-0.04826), unconst_f32(0.02323)))).g;
+  vw15 = (*&vw16).f8[2];
+  let ptr22: ptr<workgroup, vec2u> = &vw16.f4;
+  let ptr23: ptr<storage, u32, read_write> = &(*a0)[arrayLength(&(*a0)) - 1];
+  let ptr24: ptr<workgroup, f16> = &(*&vw15);
+  let ptr25: ptr<workgroup, vec2i> = &vw16.f6;
+  let vf77: f32 = vw16.f7[u32(unconst_u32(429))];
+  out[u32(unconst_u32(116))] = T0(bitcast<i32>(vf76.r));
+  out[u32(unconst_u32(180))].f0 += i32(buffer38[u32(unconst_u32(36))]);
+  let vf78: u32 = arrayLength(&(*a0));
+  var vf79: u32 = vf78;
+  return out;
+  _ = override16;
+}
+
+struct T0 {
+  @size(8) f0: i32,
+}
+
+@group(0) @binding(135) var tex9: texture_2d<f32>;
+
+var<workgroup> vw14: atomic<u32>;
+
+@group(1) @binding(42) var<uniform> buffer38: vec2h;
+
+@group(0) @binding(99) var tex8: texture_multisampled_2d<f32>;
+
+struct S1 {
+  @builtin(front_facing) f0: bool,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override16: bool;
+
+@vertex
+fn vertex3(@location(12) a0: i32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f9 = i32(pack4x8snorm(unpack4x8snorm(pack4xU8(vec4u(unconst_u32(130), unconst_u32(9), unconst_u32(45), unconst_u32(18))))));
+  out.f4 >>= vec2u(pack4x8snorm(vec4f(unconst_f32(0.00640), unconst_f32(0.2017), unconst_f32(0.07615), unconst_f32(0.03645))));
+  var vf82 = fn0(mat3x3h(unconst_f16(-5187.4), unconst_f16(509.9), unconst_f16(40284.4), unconst_f16(19406.0), unconst_f16(2321.8), unconst_f16(175.0), unconst_f16(4879.6), unconst_f16(7595.8), unconst_f16(7404.9)));
+  out.f6 |= unpack4xI8(u32(unconst_u32(538))).ww;
+  out.f5 -= vec2f(textureDimensions(tex9)).g;
+  return out;
+  _ = override16;
+}
+
+@fragment
+fn fragment3(a0: S1) -> @location(200) @interpolate(linear) vec4u {
+  var out: vec4u;
+  out = vec4u(trunc(vec2h(unconst_f16(12637.4), unconst_f16(1492.9))).rggr);
+  let vf83: vec3h = sinh(vec3h(unconst_f16(18891.0), unconst_f16(8995.2), unconst_f16(6546.3)));
+  var vf84: vec4h = sqrt(vec4h(unconst_f16(7690.8), unconst_f16(6119.4), unconst_f16(-1983.0), unconst_f16(19651.4)));
+  vf84 = vec4h(normalize(vec3f(unconst_f32(0.00640), unconst_f32(0.04011), unconst_f32(0.4597))).xzzy);
+  let vf85: bool = a0.f0;
+  var vf86 = fn0(mat3x3h(f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0), f16(a0.f0)));
+  var vf87: vec3h = vf83;
+  fn0(mat3x3h(vf86[u32(unconst_u32(188))][u32(unconst_u32(435))][u32(unconst_u32(71))].rrr, vf86[u32(unconst_u32(188))][u32(unconst_u32(435))][u32(unconst_u32(71))].xxy, vf86[u32(unconst_u32(188))][u32(unconst_u32(435))][u32(unconst_u32(71))].rrg));
+  return out;
+  _ = override16;
+}
+
+@fragment
+fn fragment4(@location(5) a0: f32) -> @location(200) @interpolate(perspective, center) vec2i {
+  var out: vec2i;
+  let vf88: vec2u = textureDimensions(tex8);
+  let vf89: vec2f = degrees(vec2f(refract(vec3h(unconst_f16(17665.2), unconst_f16(6087.0), unconst_f16(25973.8)), vec3h(unconst_f16(361.9), unconst_f16(23295.3), unconst_f16(19861.4)), f16(unconst_f16(762.8))).xy));
+  fn0(mat3x3h(f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8)), f16(textureNumSamples(tex8))));
+  out ^= vec2i(degrees(vec2f(unconst_f32(0.4960), unconst_f32(-0.4807))));
+  fn0(mat3x3h(cos(vec2h(unconst_f16(-2726.5), unconst_f16(3745.3))).grr, cos(vec2h(unconst_f16(-2726.5), unconst_f16(3745.3))).xyx, cos(vec2h(unconst_f16(-2726.5), unconst_f16(3745.3))).rrg));
+  let vf90: u32 = pack4xI8Clamp(vec4i(unconst_i32(21), unconst_i32(-18), unconst_i32(441), unconst_i32(185)));
+  let vf91: f32 = a0;
+  out += vec2i(refract(vec3h(unconst_f16(22026.9), unconst_f16(6702.3), unconst_f16(5553.2)), vec3h(unconst_f16(10891.1), unconst_f16(7836.0), unconst_f16(26414.0)), f16(unconst_f16(3153.2))).yz);
+  let vf92: f32 = vf89[u32(unconst_u32(22))];
+  out *= vec2i(bitcast<i32>(textureNumSamples(tex8)));
+  var vf93: vec2h = cos(vec2h(unconst_f16(3441.5), unconst_f16(14082.1)));
+  fn0(mat3x3h(f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))]), f16(vf88[u32(unconst_u32(327))])));
+  out &= vec2i(textureDimensions(tex8));
+  vf93 = vec2h(vf88);
+  fn0(mat3x3h());
+  return out;
+  _ = override16;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute3(@builtin(workgroup_id) a0: vec3u) {
+  vw15 += (*&vw16).f8[1];
+  let vf94: u32 = vw16.f4[u32(unconst_u32(29))];
+  vw16 = VertexOutput2(vec2u((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]]), bitcast<f32>((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]]), vec2i(i32((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]])), unpack4x8unorm((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]]), vec4h(f16((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]])), i32((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]]), vec4f(bitcast<f32>((*&vw16).f4[vec4u(sin(vec4h(unconst_f16(7334.2), unconst_f16(10476.8), unconst_f16(7871.3), unconst_f16(485.7))))[0]])));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder58 = device0.createCommandEncoder({label: '\ued85\u9bab\u027f\ubc46\u49b9'});
+let texture64 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView65 = texture42.createView({mipLevelCount: 1});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u{1fc40}\ubdce\ue99c\u0bf3\u0e30\uaaee\u{1f62d}\ue384\u6698\ua55c\u5744',
+  colorFormats: ['r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle6 = renderBundleEncoder7.finish({label: '\udb53\ud6c3\u0092\u9713\ub12c\u04a9\u656f\u01cd\u{1f64c}'});
+let sampler46 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.69,
+  maxAnisotropy: 1,
+});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer8, 632, buffer26, 1816, 80);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let textureView66 = texture19.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder47 = commandEncoder58.beginComputePass();
+let renderBundle7 = renderBundleEncoder6.finish();
+let sampler47 = device0.createSampler({
+  label: '\u5d24\u0aa9\ua7f6\u26dc',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup29, new Uint32Array(741), 21, 0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer27, 'uint16', 1_576, 1_189);
+} catch {}
+document.body.prepend(canvas0);
+await gc();
+let buffer39 = device0.createBuffer({
+  size: 169,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u4f54\u2159\u20aa\u2807\u44f1\u9aff\u4a80'});
+let texture65 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 79},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder48 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup0, new Uint32Array(170), 25, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(2, bindGroup1, new Uint32Array(958), 57, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+let img1 = await imageWithData(30, 5, '#10101010', '#20202020');
+let buffer40 = device0.createBuffer({size: 653, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder60 = device0.createCommandEncoder({label: '\u02e7\u{1fdb0}'});
+let computePassEncoder49 = commandEncoder60.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(3, bindGroup16, new Uint32Array(619), 24, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView67 = texture19.createView({label: '\u067a\u980c\u815b', dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 6});
+let computePassEncoder50 = commandEncoder61.beginComputePass({});
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer16, 'uint32', 516, 207);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer27);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u3116');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 172, resource: textureView42},
+    {binding: 84, resource: textureView42},
+    {binding: 207, resource: textureView12},
+    {binding: 301, resource: {buffer: buffer22, offset: 0, size: 228}},
+    {binding: 0, resource: textureView10},
+  ],
+});
+let textureView68 = texture19.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup13, new Uint32Array(5670), 2_439, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer29, 0, 969);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+document.body.prepend(canvas1);
+let commandEncoder62 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder62.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer4, 'uint16', 2_630, 284);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u{1f738}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'unspecified'} });
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1478});
+let textureView69 = texture62.createView({baseArrayLayer: 0});
+let sampler48 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 19.21});
+try {
+renderPassEncoder13.setIndexBuffer(buffer21, 'uint32', 768, 372);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+await gc();
+let textureView70 = texture29.createView({
+  label: '\u0d9c\u0b8e\u3f7e\u{1f650}\u4b59\u72b0\u{1f76c}\u3629\u7f86',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup18, new Uint32Array(4530), 6, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer31, 'uint32', 716, 106);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer27);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  label: '\ud005\u040a\ubbc3\u{1fedd}\u0cf2\ua5a7\u938d\uc841\u078e\u3690',
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView61}, {binding: 135, resource: textureView27}],
+});
+let textureView71 = texture44.createView({dimension: '2d-array', baseMipLevel: 0});
+let texture66 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 228},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup27, new Uint32Array(1247), 21, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 807},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer17, 0, 2_048);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u7ac3\u516a\u{1f8e6}\u{1fef8}\u{1f614}',
+  entries: [
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 378,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup40 = device0.createBindGroup({
+  label: '\u0111\ub1c8',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 0, resource: textureView10},
+    {binding: 172, resource: textureView42},
+    {binding: 301, resource: {buffer: buffer4, offset: 0, size: 2323}},
+    {binding: 84, resource: textureView13},
+    {binding: 207, resource: textureView16},
+  ],
+});
+let buffer41 = device0.createBuffer({label: '\u0bc9\u32a7\u764e', size: 16161, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder64 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 981});
+let texture68 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 35},
+  dimension: '2d',
+  format: 'eac-rg11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder64.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(59, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer27, 'uint32', 352, 1_167);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 140 */
+  offset: 140,
+  bytesPerRow: 5632,
+  buffer: buffer1,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 164, new DataView(new ArrayBuffer(410)), 88, 60);
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\u0d86\u0ff8\u6839\u52fb\u2438\u8c05\u6eb0\u{1f999}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment3',
+  constants: {override16: 0},
+  targets: [{format: 'r8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule6,
+    constants: {override16: 0},
+    buffers: [
+      {
+        arrayStride: 668,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 388, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture69 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 16},
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView72 = texture18.createView({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(1, bindGroup31, new Uint32Array(764), 136, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  label: '\u016c\u{1fb29}\u49d9\u31cd',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer37, offset: 1024, size: 2640}},
+    {binding: 23, resource: textureView22},
+  ],
+});
+let textureView73 = texture13.createView({dimension: 'cube'});
+let textureView74 = texture6.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder53 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(3, bindGroup23, new Uint32Array(231), 45, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer15, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+texture11.label = '\u01ab\u0d7d\ubefe\u0fe7\u9ee6';
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let computePassEncoder54 = commandEncoder65.beginComputePass();
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup28, new Uint32Array(110), 13, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer39, 'uint16', 0, 9);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+document.body.prepend(img1);
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer31, offset: 1280, size: 12}}],
+});
+let buffer42 = device0.createBuffer({size: 19876, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 33.72,
+  lodMaxClamp: 62.61,
+});
+try {
+computePassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup6, new Uint32Array(2721), 535, 0);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -826.8, g: -57.47, b: 110.2, a: -782.1, });
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 3, depthOrArrayLayers: 13}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 3, y: 107 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 335});
+let texture70 = device0.createTexture({
+  label: '\u0bdd\u{1fef8}\u2fa4\u2c46\u140f\u{1fca3}\u3e2b\u{1ff4b}\u{1f694}',
+  size: [129, 1, 17],
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView75 = texture14.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder55 = commandEncoder66.beginComputePass({});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer18, 'uint32', 284, 467);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(281).fill(179), /* required buffer size: 281 */
+{offset: 281, rowsPerImage: 147}, {width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView76 = texture58.createView({
+  label: '\u639a\u06f3\ue9e4\u82c2\u{1fb70}\u05e1\ua00b\ue0eb\u3566\ud848\u{1f6e8}',
+  baseArrayLayer: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -543.8, g: 616.2, b: -373.3, a: 277.2, });
+} catch {}
+let textureView77 = texture70.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer19, 0);
+} catch {}
+let imageData12 = new ImageData(32, 36);
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer18, 'uint16', 168, 1_006);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer41, 0, 7_852);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(174).fill(50), /* required buffer size: 174 */
+{offset: 174, bytesPerRow: 78}, {width: 21, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(201);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint16', 118, 1_379);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4, new Float32Array(3161), 118, 0);
+} catch {}
+let buffer43 = device0.createBuffer({size: 1295, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder67 = device0.createCommandEncoder({});
+let textureView78 = texture36.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup16, new Uint32Array(3287), 7, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\ue26d\u0630\u{1fc61}\u7c03\uded9',
+  entries: [
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 101, hasDynamicOffset: true },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup43 = device0.createBindGroup({
+  label: '\u{1f9b6}\u1c35',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView1},
+    {binding: 136, resource: {buffer: buffer25, offset: 3840, size: 41}},
+  ],
+});
+let buffer44 = device0.createBuffer({
+  size: 8508,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView79 = texture50.createView({arrayLayerCount: 1});
+let computePassEncoder57 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup38, new Uint32Array(211), 3, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 21_180, 623);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4_294_967_294, undefined, 334_496_022);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: [8, 8, 23],
+  mipLevelCount: 2,
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView80 = texture8.createView({format: 'rgb10a2unorm', baseMipLevel: 0});
+let renderPassEncoder17 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 8,
+  clearValue: { r: -567.1, g: 533.2, b: -607.7, a: -807.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 372725414,
+});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup35, new Uint32Array(1442), 33, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 640.5, g: 839.8, b: -354.5, a: -849.3, });
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 103, y: 25, z: 0},
+  aspect: 'all',
+}, new Uint8Array(3_428).fill(87), /* required buffer size: 3_428 */
+{offset: 206, bytesPerRow: 538}, {width: 133, height: 6, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise4;
+} catch {}
+let textureView81 = texture18.createView({format: 'rgb10a2unorm', baseMipLevel: 0});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup4, new Uint32Array(619), 336, 0);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 389.6, g: -530.8, b: -155.0, a: 230.5, });
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+await gc();
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+requires pointer_composite_access;
+
+struct T2 {
+  f0: array<u32>,
+}
+
+@group(0) @binding(99) var tex10: texture_multisampled_2d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(135) var tex11: texture_2d<f32>;
+
+var<workgroup> vw18: mat2x4h;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<private> vp5: f16 = f16(-5907.7);
+
+fn fn0() -> T1 {
+  var out: T1;
+  vp5 *= vec4h(sinh(vec4f(unconst_f32(0.08051), unconst_f32(-0.1173), unconst_f32(0.1384), unconst_f32(0.09261)))).y;
+  let ptr28: ptr<uniform, f32> = &buffer45;
+  out.f0[u32(unconst_u32(105))] &= vec2i(inverseSqrt(vec4f(unconst_f32(0.08916), unconst_f32(0.05185), unconst_f32(0.3071), unconst_f32(0.02168))).bb);
+  out.f0[u32(unconst_u32(9))] ^= vec2i(atan2(vec2f(unconst_f32(0.03051), unconst_f32(-0.4653)), vec2f(unconst_f32(0.09102), unconst_f32(0.03293))));
+  out.f0[u32(unconst_u32(572))] = bitcast<vec2i>(pow(vec4f(unconst_f32(0.07541), unconst_f32(0.04051), unconst_f32(0.1102), unconst_f32(0.3028)), vec4f(unconst_f32(0.4623), unconst_f32(0.2495), unconst_f32(0.1295), unconst_f32(-0.05919))).bb);
+  vp5 = f16(pow(vec4f(unconst_f32(0.01813), unconst_f32(0.01440), unconst_f32(0.07964), unconst_f32(0.08790)), vec4f(unconst_f32(0.2892), unconst_f32(0.08080), unconst_f32(0.04215), unconst_f32(0.02367)))[1]);
+  let vf95: vec4f = pow(vec4f(unconst_f32(0.00219), unconst_f32(0.02909), unconst_f32(0.1728), unconst_f32(0.04779)), vec4f(unconst_f32(0.1901), unconst_f32(0.4541), unconst_f32(0.00883), unconst_f32(0.08209)));
+  out = T1(array<vec2i, 1>(vec2i(faceForward(vec3h(insertBits(vec3i(unconst_i32(90), unconst_i32(76), unconst_i32(-567)), vec3i(unconst_i32(333), unconst_i32(60), unconst_i32(93)), u32(unconst_u32(235)), u32(unconst_u32(170)))), vec3h(unconst_f16(689.4), unconst_f16(50186.9), unconst_f16(1841.3)), vec3h(unconst_f16(15417.1), unconst_f16(28454.8), unconst_f16(19265.0))).gb)));
+  vp5 = log(vec2h(unconst_f16(5952.0), unconst_f16(-7237.5)))[0];
+  let vf96: vec2f = atan2(vec2f(unconst_f32(0.4076), unconst_f32(0.1953)), vec2f(unconst_f32(0.04111), unconst_f32(0.1513)));
+  out.f0[u32(unconst_u32(1000))] -= vec2i(sqrt(vec2h(unconst_f16(-1700.5), unconst_f16(136.6))));
+  var vf97: bool = any(bool(unconst_bool(true)));
+  out.f0[u32(unconst_u32(56))] |= bitcast<vec2i>(sinh(vec4f(unconst_f32(0.01891), unconst_f32(-0.02403), unconst_f32(0.00297), unconst_f32(-0.07504))).rb);
+  let vf98: f32 = length(vec2f(unconst_f32(0.1135), unconst_f32(0.1114)));
+  out.f0[u32(unconst_u32(302))] = vec2i(sqrt(vec2h(unconst_f16(63.78), unconst_f16(-13428.7))));
+  let vf99: vec4f = unpack4x8snorm(u32(unconst_u32(55)));
+  vp5 = f16(unpack4x8unorm(bitcast<u32>(saturate(f32(unconst_f32(0.01289))))).g);
+  var vf100: vec4f = unpack4x8unorm(u32(unconst_u32(378)));
+  return out;
+}
+
+struct T3 {
+  @align(2) f0: array<u32>,
+}
+
+var<workgroup> vw17: array<array<atomic<i32>, 1>, 19>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @align(2) @size(16) f0: array<vec2i, 1>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(1) @binding(42) var<uniform> buffer45: f32;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() {
+  var vf101: i32 = dot4I8Packed(u32(unconst_u32(275)), u32(unconst_u32(96)));
+  vf101 = vf101;
+  let vf102: vec2f = atan(vec2f(unconst_f32(0.1066), unconst_f32(0.03828)));
+  let ptr29: ptr<function, i32> = &vf101;
+  vp5 = vec2h(atan(vec2f(unconst_f32(0.08701), unconst_f32(0.07735))))[0];
+  vf101 = vec2i(vf102).r;
+  let vf103: i32 = dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.1065), unconst_f32(0.1429))), u32(unconst_u32(308)));
+  vp5 -= f16((*ptr29));
+  let vf104: vec2f = atan(vec2f(unconst_f32(0.05385), unconst_f32(0.1951)));
+  vf101 ^= vf101;
+}
+
+@vertex
+fn vertex4(@location(8) @interpolate(flat) a0: vec2i, @builtin(instance_index) a1: u32, @location(11) @interpolate(flat, sample) a2: vec4u, @location(13) @interpolate(flat, centroid) a3: vec2u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf105 = fn0();
+  let ptr30: ptr<function, vec2i> = &vf105.f0[u32(unconst_u32(81))];
+  var vf106 = fn0();
+  vf106 = T1(array<vec2i, 1>(vf106.f0[u32(unconst_u32(61))]));
+  vf106.f0[textureNumLevels(tex11)] = vec2i(i32(vp5));
+  vp5 = f16(countTrailingZeros(vec3i(unconst_i32(36), unconst_i32(34), unconst_i32(534)))[1]);
+  let ptr31: ptr<function, array<vec2i, 1>> = &vf105.f0;
+  var vf107: i32 = (*ptr31)[0][u32(unconst_u32(150))];
+  vf105 = T1(array<vec2i, 1>(vec2i(sqrt(vec4f(unconst_f32(0.1693), unconst_f32(0.04034), unconst_f32(0.09192), unconst_f32(0.01694))).yw)));
+  let ptr32: ptr<function, array<vec2i, 1>> = &vf106.f0;
+  vf105.f0[u32(unconst_u32(31))] = (*ptr32)[u32(unconst_u32(8))];
+  vf106 = T1(array<vec2i, 1>((*ptr32)[0]));
+  vf106.f0[u32(unconst_u32(165))] = vec2i(atan(bitcast<vec4f>(a2)).bg);
+  fn1();
+  vf105.f0[u32(unconst_u32(78))] &= (*ptr30);
+  fn1();
+  fn1();
+  vf106 = T1(array<vec2i, 1>(vec2i(bitcast<i32>(buffer45))));
+  var vf108 = fn0();
+  fn0();
+  return out;
+}
+
+@fragment
+fn fragment5() -> @location(200) @interpolate(perspective, sample) vec2i {
+  var out: vec2i;
+  let vf109: u32 = textureNumSamples(tex10);
+  fn1();
+  fn1();
+  let vf110: vec3u = clamp(vec3u(unconst_u32(41), unconst_u32(9), unconst_u32(273)), vec3u(unconst_u32(0), unconst_u32(12), unconst_u32(409)), vec3u(unconst_u32(7), unconst_u32(386), unconst_u32(41)));
+  fn1();
+  let vf111: vec2f = atan(vec2f(unconst_f32(0.09429), unconst_f32(0.04903)));
+  let vf112: vec2h = smoothstep(vec2h(unconst_f16(10193.4), unconst_f16(19428.3)), vec2h(unconst_f16(20418.3), unconst_f16(2004.8)), vec2h(unconst_f16(30841.8), unconst_f16(6153.8)));
+  let vf113: vec3f = fma(vec3f(unconst_f32(0.02917), unconst_f32(0.2815), unconst_f32(0.2280)), vec3f(unconst_f32(0.03963), unconst_f32(0.2434), unconst_f32(0.6887)), vec3f(unconst_f32(0.02335), unconst_f32(0.1670), unconst_f32(0.2456)));
+  var vf114: vec3f = fma(vec3f(unconst_f32(0.1793), unconst_f32(0.1544), unconst_f32(0.2848)), vec3f(unconst_f32(0.01146), unconst_f32(0.1162), unconst_f32(0.2309)), vec3f(unconst_f32(0.1080), unconst_f32(0.03491), unconst_f32(0.2294)));
+  vp5 = f16(dot(vec4i(vf114.yxzx), vec4i(unconst_i32(84), unconst_i32(-878), unconst_i32(118), unconst_i32(178))));
+  out -= vec2i(i32(vf111[u32(inverseSqrt(f32(vf109)))]));
+  vf114 *= vec3f(f32(countLeadingZeros(u32(unconst_u32(79)))));
+  vp5 = f16(inverseSqrt(f32(unconst_f32(0.09081))));
+  vp5 = atan2(vec2h(unconst_f16(6144.6), unconst_f16(1579.5)), vec2h(unconst_f16(1601.9), unconst_f16(10092.3))).r;
+  var vf115: i32 = dot(vec4i(unconst_i32(-64), unconst_i32(127), unconst_i32(-190), unconst_i32(316)), vec4i(bitcast<i32>(vf114[u32(unconst_u32(17))])));
+  let vf116: vec3f = fma(vec3f(unconst_f32(0.1285), unconst_f32(0.3850), unconst_f32(0.1306)), vec3f(unconst_f32(0.04732), unconst_f32(0.00026), unconst_f32(-0.2306)), vec3f(unconst_f32(0.1955), unconst_f32(0.04487), unconst_f32(0.05959)));
+  fn1();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  vw18 = mat2x4h(f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)), f16((*&buffer45)));
+  vp5 *= f16(atomicLoad(&(*&vw17)[18][0]));
+  atomicXor(&vw17[u32(unconst_u32(102))][u32(unconst_u32(67))], i32(pack4x8unorm(vec4f(unconst_f32(0.02407), unconst_f32(0.01926), unconst_f32(-0.06609), unconst_f32(0.00577)))));
+  let ptr33: ptr<workgroup, array<array<atomic<i32>, 1>, 19>> = &vw17;
+  let ptr34: ptr<workgroup, atomic<i32>> = &vw17[18][u32(unconst_u32(125))];
+  atomicStore(&vw17[u32(unconst_u32(318))][u32(unconst_u32(184))], i32(unconst_i32(97)));
+  atomicOr(&vw17[u32(unconst_u32(254))][u32(unconst_u32(378))], i32(unconst_i32(179)));
+  atomicAnd(&vw17[u32(unconst_u32(122))][u32(unconst_u32(7))], i32(unconst_i32(4)));
+  var vf117: i32 = atomicExchange(&(*ptr34), i32(unconst_i32(29)));
+  fn1();
+  fn0();
+  var vf118 = fn0();
+  let ptr35: ptr<workgroup, atomic<i32>> = &vw17[18][0];
+  vw18 = mat2x4h(f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))), f16(atomicExchange(&(*ptr34), i32(unconst_i32(-40)))));
+  fn0();
+  let vf119: mat2x4h = workgroupUniformLoad(&vw18);
+  vf118 = T1(array<vec2i, 1>(vec2i(atomicLoad(&(*ptr33)[u32(unconst_u32(206))][u32(unconst_u32(122))]))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView82 = texture11.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u002c');
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView83 = texture11.createView({
+  label: '\u{1f829}\u3de5\u{1fe1f}\u{1fb11}\ud810\u5874\u0c1d\uf026\u0439\u5143',
+  dimension: 'cube',
+  format: 'r32uint',
+  baseArrayLayer: 3,
+});
+let texture72 = device0.createTexture({
+  label: '\udabb\u{1f8c8}\u2f1a\u{1fe34}\ub359',
+  size: {width: 516},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup19, new Uint32Array(591), 41, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+adapter0.label = '\u1c55\u{1ff56}\u{1f762}\u27e8\uba0d\uf4d1\u8f07';
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder();
+let textureView84 = texture37.createView({label: '\u9ace\u466f\u06d9', dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 18});
+let textureView85 = texture31.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder58 = commandEncoder70.beginComputePass({});
+let renderPassEncoder18 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  clearValue: { r: 9.672, g: 392.8, b: -500.4, a: -736.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup43, new Uint32Array(654), 122, 0);
+} catch {}
+try {
+renderPassEncoder6.pushDebugGroup('\uf349');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 3384, new DataView(new ArrayBuffer(18683)), 1480, 5408);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 569, resource: sampler17},
+    {binding: 167, resource: {buffer: buffer0, offset: 512, size: 1339}},
+    {binding: 445, resource: textureView59},
+    {binding: 419, resource: {buffer: buffer39, offset: 0, size: 64}},
+  ],
+});
+let buffer46 = device0.createBuffer({
+  label: '\u01e3\u{1fbb0}\ue513\uf4ed\u71fd\u{1fdfb}\uac37\ue091\u3a3f\u3e03',
+  size: 220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup32, new Uint32Array(1329), 485, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(102), /* required buffer size: 63 */
+{offset: 63}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt2020', transfer: 'smpte240m'} });
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 378, resource: textureView73}, {binding: 160, resource: textureView12}],
+});
+let texture73 = device0.createTexture({
+  size: [258, 1, 1],
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView86 = texture31.createView({aspect: 'stencil-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 19});
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+let buffer47 = device0.createBuffer({size: 566, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView87 = texture13.createView({label: '\u{1fff4}\u2941\ucfed\u0aa0', dimension: 'cube', baseArrayLayer: 2});
+let texture74 = device0.createTexture({
+  size: {width: 258},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup31, new Uint32Array(50), 50, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer16, 'uint32', 628, 370);
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder();
+try {
+computePassEncoder39.setBindGroup(1, bindGroup37, new Uint32Array(1030), 71, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+renderPassEncoder6.popDebugGroup();
+} catch {}
+try {
+commandEncoder72.insertDebugMarker('\u{1ff49}');
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let commandEncoder73 = device0.createCommandEncoder({});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.88,
+  lodMaxClamp: 37.40,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer26, 0);
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 160, resource: textureView12}, {binding: 378, resource: textureView87}],
+});
+let renderPassEncoder19 = commandEncoder72.beginRenderPass({colorAttachments: [{view: textureView46, depthSlice: 39, loadOp: 'load', storeOp: 'store'}]});
+try {
+renderPassEncoder12.executeBundles([renderBundle0, renderBundle1, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(384.9321986498553, 27.5938740948642, 172.35621775951705, 3.3508209343293607, 0.4827465711458565, 0.5259239013093556);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer18, 'uint32', 180, 177);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4_294_967_294, undefined, 0, 127_690_618);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let computePassEncoder59 = commandEncoder73.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup19, new Uint32Array(252), 89, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer17, 'uint16', 5_342, 2_416);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u1ac3');
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let commandEncoder74 = device0.createCommandEncoder({label: '\uc7d2\u0e18\u{1fb7d}\u949b\u{1fec1}\udf69\u6e0a\u6793\uece6\ua913'});
+let computePassEncoder60 = commandEncoder74.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup23, new Uint32Array(945), 945, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup40, new Uint32Array(913), 98, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer27, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 11, y: 8 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup47 = device0.createBindGroup({
+  label: '\ufaa3\u5409\u0c9e\uf551\u1db9\u245c\u{1f6ac}\uc5ce\u09ec\u{1fcf3}\u0bc9',
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer20, offset: 7680, size: 1723}}],
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture75 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder75.beginComputePass({label: '\u1a7e\u{1fed0}\u2248\u80da\u0b2c\u8abe\u{1f7bb}\ub14e'});
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(127);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline0);
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer21, offset: 0, size: 1544}},
+    {binding: 23, resource: textureView26},
+  ],
+});
+let buffer48 = device0.createBuffer({size: 7426, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture76 = device0.createTexture({
+  size: [258],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler51 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.76,
+  lodMaxClamp: 89.75,
+  compare: 'never',
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup14);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule7, targets: [{format: 'rg8sint'}]},
+  vertex: {
+    module: shaderModule6,
+    constants: {override16: 0},
+    buffers: [{arrayStride: 120, attributes: [{format: 'sint16x4', offset: 4, shaderLocation: 12}]}],
+  },
+});
+try {
+  await promise5;
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 446},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler52 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.378,
+  lodMaxClamp: 43.63,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer25, 'uint32', 792, 410);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer49 = device0.createBuffer({size: 4075, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture78 = device0.createTexture({
+  label: '\u5770\uebcd\u00f4\u3c38\uee44\ufd07\ua5aa\u{1f661}\u43b2\u3a23',
+  size: {width: 1032},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup16, new Uint32Array(7297), 14, 0);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1192 */
+  offset: 1192,
+  bytesPerRow: 768,
+  buffer: buffer13,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer50 = device0.createBuffer({size: 9809, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder77 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder76.beginComputePass();
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(236), 31, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(120.48008504198238, 27.544326268977564, 118.78468828808676, 17.936717538998867, 0.18826001500133704, 0.42527389311074393);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer29, 168, buffer26, 1884, 404);
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer51 = device0.createBuffer({
+  size: 14084,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer46, 'uint32', 4, 48);
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture79 = device0.createTexture({
+  size: {width: 1032},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView88 = texture27.createView({
+  label: '\u69e6\u{1fca3}\u{1fffe}\u3b07\u9068\u079b\u{1f664}\ue815\u2623\u0b30\u6447',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder63 = commandEncoder79.beginComputePass({});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.40,
+  lodMaxClamp: 83.64,
+  compare: 'less',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+externalTexture3.label = '\ue7fb\ua89b\u{1f748}\u1513\uda65\u{1f913}\u8c7a';
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 378, resource: textureView87}, {binding: 160, resource: textureView12}],
+});
+let commandEncoder80 = device0.createCommandEncoder();
+let textureView89 = texture18.createView({dimension: '2d-array'});
+let computePassEncoder64 = commandEncoder78.beginComputePass({});
+let renderPassEncoder20 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -338.9, g: -783.3, b: -438.9, a: -967.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer25, 2_712);
+} catch {}
+try {
+commandEncoder80.clearBuffer(buffer47, 120, 92);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let computePassEncoder65 = commandEncoder80.beginComputePass({});
+try {
+renderPassEncoder18.setIndexBuffer(buffer31, 'uint16', 208, 605);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 15},
+  aspect: 'all',
+}, new Uint8Array(153_581).fill(14), /* required buffer size: 153_581 */
+{offset: 113, bytesPerRow: 87, rowsPerImage: 49}, {width: 15, height: 0, depthOrArrayLayers: 37});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let texture80 = device0.createTexture({size: [8], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView90 = texture58.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 4});
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer20);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder81.copyTextureToBuffer({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48 */
+  offset: 48,
+  buffer: buffer25,
+}, {width: 27, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 136, resource: {buffer: buffer36, offset: 1280}}, {binding: 606, resource: textureView72}],
+});
+let sampler54 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 75.21});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup18, new Uint32Array(345), 141, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer15, 0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture6.label;
+} catch {}
+let textureView91 = texture45.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder66 = commandEncoder24.beginComputePass();
+let renderPassEncoder21 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 7,
+  clearValue: { r: 940.8, g: 272.9, b: 262.3, a: -295.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(1, bindGroup14, new Uint32Array(2069), 600, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup38, new Uint32Array(2043), 194, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3, renderBundle4]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 197, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(11_820).fill(143), /* required buffer size: 11_820 */
+{offset: 336, bytesPerRow: 33, rowsPerImage: 87}, {width: 0, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let textureView92 = texture18.createView({});
+let computePassEncoder67 = commandEncoder83.beginComputePass();
+let renderPassEncoder22 = commandEncoder82.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: -211.9, g: 267.3, b: 635.0, a: -231.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 35, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 13, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer52 = device0.createBuffer({
+  label: '\u0cd3\u691c\u{1ff3a}\ucf4c\u0af0\u{1fc77}\u5824\u0e15\u303e\ub8b5\u0bb5',
+  size: 1602,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder84 = device0.createCommandEncoder();
+let computePassEncoder68 = commandEncoder84.beginComputePass({});
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup36, new Uint32Array(4492), 53, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 160, resource: textureView12}, {binding: 378, resource: textureView73}],
+});
+let textureView93 = texture27.createView({label: '\u251f\u7b59', mipLevelCount: 1});
+let sampler56 = device0.createSampler({
+  label: '\u0c90\u{1f702}\u3bae\u{1faee}\ub65d\u14cb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.45,
+  compare: 'less-equal',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder68.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({entries: [{binding: 92, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}]});
+let bindGroup52 = device0.createBindGroup({
+  label: '\u{1ff0e}\u02fd\u02f1\u071b\u0c8f\u85e8',
+  layout: bindGroupLayout8,
+  entries: [{binding: 10, resource: sampler25}],
+});
+let buffer53 = device0.createBuffer({size: 2262, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView94 = texture28.createView({dimension: '2d', baseArrayLayer: 0});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer27, 'uint32', 892, 789);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer15, 0, 51);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder66.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer15, 0, 44);
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 136, resource: {buffer: buffer22, offset: 0}}, {binding: 606, resource: textureView94}],
+});
+let textureView95 = texture28.createView({
+  label: '\u{1fc89}\uccc4\u0d6b\u92ce\u578c\u0941\u{1f7f5}\u5a10\u024b',
+  dimension: '2d',
+  format: 'rgba8snorm',
+  baseArrayLayer: 5,
+});
+let textureView96 = texture31.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 1, baseArrayLayer: 16});
+let sampler57 = device0.createSampler({
+  label: '\u737c\u{1fa72}\u{1f8cd}\u0c25\u2cc3\u1604\u{1feca}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 55.77,
+  lodMaxClamp: 69.67,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup21, new Uint32Array(187), 9, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup16, new Uint32Array(2185), 1_209, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer41, 'uint32', 4_316, 76);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+await gc();
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'gamma28curve'} });
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({size: [516], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView97 = texture1.createView({label: '\u02f5\ueb8d\u2b0e\u0589\uf109\ub747\u{1f830}\ucb87\u8fe0\uff51'});
+let computePassEncoder69 = commandEncoder85.beginComputePass();
+try {
+computePassEncoder14.setBindGroup(1, bindGroup19);
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 516});
+let texture82 = device0.createTexture({
+  label: '\u3315\u0edf\u{1f6c7}\ud51d\u375b\u{1f7d5}\u0de5\u0b23\u0242\ufdfc\u0c48',
+  size: {width: 165},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture13.createView({dimension: 'cube', format: 'depth16unorm', baseArrayLayer: 1});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup29, new Uint32Array(3557), 60, 0);
+} catch {}
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer27, 1_736, 73);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 436, new Int16Array(17607), 1252, 488);
+} catch {}
+try {
+externalTexture10.label = '\uddf1\u{1fc56}\u{1feb2}\u3368\u{1fbc6}';
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  label: '\u07b8\uf8c0\u70f3\u61a8',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 84, resource: textureView13},
+    {binding: 301, resource: {buffer: buffer48, offset: 256, size: 3046}},
+    {binding: 172, resource: textureView85},
+    {binding: 207, resource: textureView12},
+    {binding: 0, resource: textureView10},
+  ],
+});
+let commandEncoder86 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder70 = commandEncoder76.beginComputePass({});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.50,
+  lodMaxClamp: 56.48,
+});
+try {
+computePassEncoder29.setPipeline(pipeline3);
+} catch {}
+let arrayBuffer2 = buffer51.getMappedRange(0, 84);
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 450 */
+  offset: 450,
+  buffer: buffer47,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer54 = device0.createBuffer({
+  size: 26522,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView99 = texture51.createView({
+  label: '\u0921\u{1fcb6}\u{1fa49}\ud720\ud68f\u004c\u{1f9b1}\u0749\u0c64',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let computePassEncoder71 = commandEncoder87.beginComputePass();
+try {
+computePassEncoder70.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+await gc();
+let commandEncoder88 = device0.createCommandEncoder({});
+let computePassEncoder72 = commandEncoder86.beginComputePass();
+let sampler59 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.15,
+  lodMaxClamp: 47.44,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup45, new Uint32Array(30), 2, 0);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u48bc\ud33f\u03b4\u358a\u{1fbfa}', bindGroupLayouts: []});
+let texture84 = device0.createTexture({size: [8, 8, 23], format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder73 = commandEncoder88.beginComputePass();
+let externalTexture12 = device0.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup9, new Uint32Array(1078), 17, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle1]);
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+try {
+commandEncoder89.resolveQuerySet(querySet5, 218, 0, buffer29, 1280);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler60 = device0.createSampler({
+  label: '\ue9e3\u1810\u0471\ude8c\u060c\u{1f742}\uf168\u59b8',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 31.83,
+  lodMaxClamp: 44.52,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup9, new Uint32Array(235), 0, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer31, 'uint32', 416, 346);
+} catch {}
+let arrayBuffer3 = buffer51.getMappedRange(88, 7772);
+let buffer55 = device0.createBuffer({
+  size: 1473,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture85 = device0.createTexture({
+  size: [516],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView100 = texture35.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder74 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup21, new Uint32Array(21), 0, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint32', 6_472, 5_478);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer55, 0, 24);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u029b');
+} catch {}
+canvas2.width = 115;
+let commandEncoder91 = device0.createCommandEncoder();
+let texture86 = device0.createTexture({
+  size: {width: 129, height: 1, depthOrArrayLayers: 162},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder75 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer37, 'uint16', 42, 1_149);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+canvas2.getContext('bitmaprenderer');
+} catch {}
+try {
+commandEncoder37.label = '\u{1f8bb}\uc9aa\u07d2\u083e\u02d8\u08cb\u06f9\uce52';
+} catch {}
+let texture87 = device0.createTexture({
+  size: [1032],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder76 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer6, 'uint32', 52, 2);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView81}, {binding: 99, resource: textureView21}],
+});
+let buffer56 = device0.createBuffer({size: 4647, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder92 = device0.createCommandEncoder();
+let texture88 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 234},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup29, new Uint32Array(287), 10, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup18, new Uint32Array(2114), 426, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4_294_967_294, undefined, 473_722_805);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4).fill(2), /* required buffer size: 4 */
+{offset: 4, bytesPerRow: 60, rowsPerImage: 132}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer4, offset: 512, size: 3488}}],
+});
+let commandEncoder93 = device0.createCommandEncoder({});
+let sampler61 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.38,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup51, new Uint32Array(1279), 8, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer31, 'uint16', 1_946, 215);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer54, 6_820, 969);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder92.beginComputePass();
+let externalTexture13 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer40);
+} catch {}
+try {
+  await shaderModule6.getCompilationInfo();
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.append(canvas1);
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let computePassEncoder78 = commandEncoder93.beginComputePass({});
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let bindGroup57 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 127, resource: textureView37}]});
+let buffer57 = device0.createBuffer({
+  size: 11909,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder79 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder17.setViewport(701.8276720954941, 0.16225049766588473, 207.31679048296962, 0.46727387174383933, 0.9007387555747834, 0.9577749238491593);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer13, 'uint32', 2_544, 646);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+  /* bytesInLastRow: 42 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6 */
+  offset: 6,
+  buffer: buffer28,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3104 */
+  offset: 3104,
+  bytesPerRow: 4608,
+  rowsPerImage: 180,
+  buffer: buffer49,
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData13 = new ImageData(8, 16);
+let renderPassEncoder23 = commandEncoder94.beginRenderPass({colorAttachments: [{view: textureView4, loadOp: 'load', storeOp: 'store'}]});
+let sampler62 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.38,
+  lodMaxClamp: 91.33,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u{1f7ad}');
+} catch {}
+await gc();
+try {
+renderPassEncoder7.executeBundles([renderBundle1]);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer41, 'uint32', 1_752, 11_062);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas1);
+let imageData14 = new ImageData(44, 72);
+let bindGroup58 = device0.createBindGroup({
+  label: '\u1e15\u0514\u{1fb67}\ub2b6\u2417\ua4f8\ub1ec',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 84, resource: textureView85},
+    {binding: 172, resource: textureView13},
+    {binding: 207, resource: textureView16},
+    {binding: 301, resource: {buffer: buffer12, offset: 1792, size: 2097}},
+    {binding: 0, resource: textureView10},
+  ],
+});
+let textureView101 = texture65.createView({label: '\u0ec8\u1be6\u{1fb7d}\uf7bb\u0205\u6648\u19c1\u8ff5\u08e9\u0fe4\u08dc', mipLevelCount: 1});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.81,
+  lodMaxClamp: 72.94,
+  compare: 'less',
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup2, new Uint32Array(91), 2, 0);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer58 = device0.createBuffer({size: 17350, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup14, []);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 236, new BigUint64Array(1697), 557, 240);
+} catch {}
+let buffer59 = device0.createBuffer({
+  size: 19100,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 24, resource: textureView36}, {binding: 127, resource: textureView13}],
+});
+let textureView102 = texture10.createView({label: '\u0c18\u{1fe98}\ubac3\u9979', dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 94},
+  aspect: 'all',
+}, new Uint8Array(35_670).fill(22), /* required buffer size: 35_670 */
+{offset: 63, bytesPerRow: 83, rowsPerImage: 11}, {width: 17, height: 0, depthOrArrayLayers: 40});
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer48);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+texture27.label = '\u0380\u051b\u{1f686}\u0ab9\u{1f699}\u0b92\u002c\u0ea9\u{1f601}';
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder();
+let textureView103 = texture4.createView({mipLevelCount: 1, baseArrayLayer: 41, arrayLayerCount: 1});
+let computePassEncoder80 = commandEncoder96.beginComputePass();
+try {
+computePassEncoder63.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(2, bindGroup4, new Uint32Array(3957), 74, 0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer57, 0, 231);
+} catch {}
+let arrayBuffer4 = buffer51.getMappedRange(8664, 2204);
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await promise8;
+} catch {}
+let img2 = await imageWithData(14, 62, '#10101010', '#20202020');
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView104 = texture72.createView({});
+let renderPassEncoder24 = commandEncoder97.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -716.5, g: 160.8, b: 618.9, a: -916.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(330, 5, 0, 12);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer8, 'uint32', 0, 129);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer21, 0);
+} catch {}
+try {
+externalTexture0.label = '\u{1f986}\u650b\u01db\ue519\uce3c\u{1fc95}';
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let buffer60 = device0.createBuffer({size: 5146, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder80.setPipeline(pipeline3);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 2412);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 41356,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder98 = device0.createCommandEncoder({label: '\u0346\udd70\u5a66\u07b5'});
+let texture89 = device0.createTexture({
+  size: [82],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder25 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  clearValue: { r: 47.06, g: -99.13, b: -201.7, a: -269.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 343063617,
+});
+document.body.prepend(img1);
+let commandEncoder99 = device0.createCommandEncoder({});
+let sampler64 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.99,
+  lodMaxClamp: 59.84,
+  compare: 'equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup7, new Uint32Array(3554), 1_327, 0);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer44, 'uint32', 792, 111);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer36, 0, 83);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 208,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView6},
+    {binding: 271, resource: {buffer: buffer25, offset: 20224, size: 68}},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({label: '\u0561\u9b6b\ud7a0\u{1f6e4}\u7f85\u316f\u{1fd4c}\ua8b5', bindGroupLayouts: []});
+let textureView105 = texture65.createView({mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder99.beginComputePass({});
+let sampler65 = device0.createSampler({
+  label: '\u5c1f\u0f39\uefec\u19e8\u6b3d\u0c2b\u4a77\u0170\u0d19\u3f74',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 40.49,
+  lodMaxClamp: 88.74,
+});
+try {
+computePassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle0, renderBundle4, renderBundle3]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let commandEncoder100 = device0.createCommandEncoder();
+let textureView106 = texture64.createView({dimension: '2d-array', format: 'r8uint', arrayLayerCount: 1});
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer17);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 16 */
+  offset: 16,
+  buffer: buffer28,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 173, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 44, new DataView(new ArrayBuffer(4623)), 160, 996);
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let textureView107 = texture62.createView({label: '\uf8ee\ub9f3\u0203\u0e58\u{1f7c4}\udbfc'});
+let computePassEncoder82 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup54, new Uint32Array(1378), 5, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup0, new Uint32Array(1994), 637, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer62 = device0.createBuffer({
+  label: '\u071f\u{1fab4}\ued5a\ud285\u{1ff9e}\uad08\u379a',
+  size: 24738,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup18, new Uint32Array(393), 21, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer27, 'uint32', 8_044, 88);
+} catch {}
+try {
+computePassEncoder68.pushDebugGroup('\ua8cb');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData15 = new ImageData(52, 68);
+let commandEncoder101 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 329});
+let computePassEncoder83 = commandEncoder101.beginComputePass({});
+let sampler66 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 33.98,
+  lodMaxClamp: 41.23,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup20, new Uint32Array(431), 38, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup17, new Uint32Array(1228), 548, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer29);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 2652, new BigUint64Array(24563), 949, 156);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 50, resource: textureView65},
+    {binding: 80, resource: {buffer: buffer36, offset: 1024}},
+    {binding: 131, resource: {buffer: buffer14, offset: 1024}},
+  ],
+});
+let buffer63 = device0.createBuffer({size: 957, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder102 = device0.createCommandEncoder({});
+let computePassEncoder84 = commandEncoder102.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup25, new Uint32Array(169), 27, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+let buffer64 = device0.createBuffer({size: 13380, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let sampler67 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.9903,
+  lodMaxClamp: 29.61,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u0c42');
+} catch {}
+let texture90 = device0.createTexture({
+  label: '\ua52e\u0898\u{1fac3}\u{1f7d0}\u0d41\udc20\u2848\u7f0d\u3ed8\u0352',
+  size: {width: 8, height: 8, depthOrArrayLayers: 308},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer25, 'uint16', 1_938, 7_150);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer0, 308);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+canvas1.width = 25;
+let textureView108 = texture86.createView({});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer48, 0);
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder();
+let texture91 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder85 = commandEncoder103.beginComputePass({label: '\u7675\u3462\u5dd1\u9b10\uf30f\u00ac\u02a1\u5415\ub4b0\u0cd6'});
+try {
+renderPassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer36);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture92 = device0.createTexture({
+  size: [330, 48, 18],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder86 = commandEncoder104.beginComputePass({label: '\u05c5\u01fc\uc2ad\u03dd\u7b4c'});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup7, new Uint32Array(6171), 2_929, 0);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer39, 'uint16', 58, 5);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer5 = buffer10.getMappedRange(64, 144);
+try {
+buffer26.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(178).fill(244), /* required buffer size: 178 */
+{offset: 178}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView109 = texture62.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup52, new Uint32Array(108), 3, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup23, new Uint32Array(933), 159, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer55);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer54, 'uint16', 26_522, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder10.setViewport(241.33122947900844, 33.48222922362618, 62.677587654475396, 10.925877765715974, 0.0024496118904835384, 0.6806405783134412);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer20, 'uint32', 5_248, 3_743);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+let textureView110 = texture4.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup41, new Uint32Array(2751), 130, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 8, new Float32Array(1978), 828, 24);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({});
+let textureView111 = texture9.createView({baseMipLevel: 0});
+let computePassEncoder87 = commandEncoder105.beginComputePass();
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.49,
+  lodMaxClamp: 87.97,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup46, new Uint32Array(2395), 885, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer41, 'uint32', 7_936, 692);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 22, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_511).fill(175), /* required buffer size: 6_511 */
+{offset: 118, bytesPerRow: 67, rowsPerImage: 47}, {width: 14, height: 2, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  label: '\u2a3d\u65cf\u001a\u03b9\ubc45',
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView2}, {binding: 135, resource: textureView5}],
+});
+let buffer65 = device0.createBuffer({
+  size: 5127,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture93 = device0.createTexture({size: [330, 48, 1], format: 'rgb10a2unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler69 = device0.createSampler({
+  label: '\u16be\u{1f862}\ue397\ua68d\u1729\u780e\u48a8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 1.245,
+  lodMaxClamp: 22.35,
+});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup38, new Uint32Array(7), 2, 0);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer39, 'uint32', 40, 8);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup44, new Uint32Array(564), 67, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: imageData6,
+  origin: { x: 28, y: 3 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise6;
+} catch {}
+let canvas3 = document.createElement('canvas');
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder106 = device0.createCommandEncoder({});
+let computePassEncoder88 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup16, new Uint32Array(669), 189, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer41, 'uint32', 5_960, 625);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let texture94 = device0.createTexture({
+  label: '\u0d2c\u0a09\ud1be\u0b3f',
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup28, new Uint32Array(5120), 778, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint16', 872, 202);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer6, 'uint16', 46, 25);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer48);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 184, new BigUint64Array(63), 44, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise10;
+} catch {}
+let canvas4 = document.createElement('canvas');
+let textureView112 = texture62.createView({dimension: '2d-array'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.76,
+  lodMaxClamp: 91.31,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup19, new Uint32Array(1517), 260, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint32', 316, 40);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup10, new Uint32Array(2104), 690, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+let sampler71 = device0.createSampler({
+  label: '\u{1fa47}\u{1fa75}\uaae2\u0739\ue350\u01ae\u2922',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 68.94,
+});
+try {
+computePassEncoder58.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup21, new Uint32Array(765), 103, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer39, 'uint16', 12, 35);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer65, 304, 468);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup52, new Uint32Array(105), 8, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer41, 'uint16', 902, 5_989);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+await gc();
+let bindGroup63 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer7, offset: 1536, size: 528}},
+    {binding: 23, resource: textureView26},
+  ],
+});
+let commandEncoder107 = device0.createCommandEncoder();
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 64});
+let texture95 = device0.createTexture({
+  label: '\u06d1\u7bb4\u2637\u02a7\ude11\u42e7\uf409\u413b',
+  size: {width: 258, height: 1, depthOrArrayLayers: 158},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView113 = texture16.createView({dimension: '2d'});
+let computePassEncoder89 = commandEncoder107.beginComputePass({});
+let sampler72 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 90.76,
+  lodMaxClamp: 91.04,
+});
+try {
+computePassEncoder64.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer15, 0);
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView9}, {binding: 99, resource: textureView30}],
+});
+let commandEncoder108 = device0.createCommandEncoder();
+let textureView114 = texture86.createView({});
+let texture96 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder90 = commandEncoder108.beginComputePass({});
+let externalTexture14 = device0.importExternalTexture({
+  label: '\u{1ffe4}\uc6fa\u9c93\u{1fdcf}\u{1f8f3}\u{1fecf}\u3299\u{1f8f5}',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+document.body.append(canvas2);
+await gc();
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer52);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+await gc();
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView42}, {binding: 24, resource: textureView36}],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup54, new Uint32Array(931), 0, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle4, renderBundle1, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer20, 'uint32', 3_584, 2_684);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer55);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup4, new Uint32Array(3894), 40, 0);
+} catch {}
+let buffer66 = device0.createBuffer({size: 8028, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture97 = device0.createTexture({
+  label: '\u8cc6\u32d2\u0de8\u8fb5\u{1feea}\u{1f9f4}',
+  size: [660],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler73 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 13.99,
+});
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer15, 0, 15);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+globalThis.someLabel = textureView57.label;
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView115 = texture57.createView({});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup15, new Uint32Array(2929), 468, 0);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer17, 0, 10_409);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let texture98 = device0.createTexture({
+  size: {width: 82},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView116 = texture90.createView({format: 'r8uint'});
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+computePassEncoder31.pushDebugGroup('\u6dab');
+} catch {}
+try {
+canvas3.getContext('2d');
+} catch {}
+let bindGroup66 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView62}]});
+let computePassEncoder91 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(14);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer41, 1_272, 1_619);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let textureView117 = texture97.createView({});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup6, new Uint32Array(952), 10, 0);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup26, new Uint32Array(359), 57, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer55, 0, 1_167);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 432, new DataView(new ArrayBuffer(3711)), 1258, 36);
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 2170});
+let texture99 = device0.createTexture({
+  size: [82],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture13.createView({dimension: 'cube-array', aspect: 'depth-only', arrayLayerCount: 6});
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+computePassEncoder68.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder110 = device0.createCommandEncoder({label: '\ue53e\u0be6\u8694\u0b7f\u4add\u17f3\u{1f88e}\u79e4\u3cf4\u0820\u2be0'});
+let texture100 = device0.createTexture({
+  size: [660, 96, 446],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView119 = texture84.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+renderPassEncoder5.setVertexBuffer(6, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup32, new Uint32Array(1418), 131, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer44, 'uint16', 2_290, 99);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 133, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture101 = device0.createTexture({
+  label: '\u0b6d\u{1fa48}\u0a10',
+  size: [165, 24, 22],
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup28, []);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let computePassEncoder92 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup13, new Uint32Array(207), 106, 0);
+} catch {}
+let arrayBuffer6 = buffer10.getMappedRange(400, 152);
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2160 */
+  offset: 2160,
+  bytesPerRow: 1536,
+  buffer: buffer29,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 13},
+  aspect: 'all',
+}, new Uint8Array(7_970).fill(159), /* required buffer size: 7_970 */
+{offset: 170, bytesPerRow: 12, rowsPerImage: 130}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let computePassEncoder93 = commandEncoder110.beginComputePass({});
+let sampler74 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.68,
+  lodMaxClamp: 87.46,
+  compare: 'always',
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 2,
+  origin: {x: 12, y: 4, z: 7},
+  aspect: 'all',
+}, new Uint8Array(43).fill(117), /* required buffer size: 43 */
+{offset: 43}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder31.popDebugGroup();
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt709', transfer: 'logSqrt'} });
+let textureView120 = texture28.createView({baseMipLevel: 0, baseArrayLayer: 5, arrayLayerCount: 1});
+try {
+computePassEncoder84.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline4);
+} catch {}
+let bindGroup67 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 92, resource: externalTexture4}]});
+let commandEncoder112 = device0.createCommandEncoder({label: '\u094e\u20b6\u{1fc07}\u0d9f\ua985'});
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer41, 0, 2_206);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 122 widthInBlocks: 61 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4116 */
+  offset: 4116,
+  bytesPerRow: 6912,
+  buffer: buffer62,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 61, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+let img3 = await imageWithData(36, 50, '#10101010', '#20202020');
+let videoFrame11 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer67 = device0.createBuffer({
+  size: 4130,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture102 = device0.createTexture({
+  size: [165, 24, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView121 = texture23.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+let sampler75 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  compare: 'equal',
+});
+try {
+renderPassEncoder13.setIndexBuffer(buffer39, 'uint32', 60, 2);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer16);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let canvas5 = document.createElement('canvas');
+let imageData16 = new ImageData(28, 80);
+let commandEncoder113 = device0.createCommandEncoder({label: '\u0c69\u{1fe25}\u{1fd3c}\ua0c6\ue319\ue65a\u0310'});
+let texture103 = device0.createTexture({
+  label: '\ub1a3\u{1fcc0}\ufc24\u97ad\uda49\u16a8',
+  size: [516, 1, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder26 = commandEncoder112.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  clearValue: { r: -563.8, g: 652.9, b: 396.6, a: -381.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup43, new Uint32Array(2211), 177, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 1296 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1040 */
+  offset: 1040,
+  rowsPerImage: 717,
+  buffer: buffer9,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView122 = texture97.createView({});
+let computePassEncoder94 = commandEncoder113.beginComputePass({label: '\u99ae\u08a0\u2239\u4eac\udec8\u3eae\u{1fb69}\uf459\u{1f80e}'});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline1);
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView22},
+    {binding: 271, resource: {buffer: buffer16, offset: 1024, size: 204}},
+  ],
+});
+let buffer68 = device0.createBuffer({size: 39992, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder114 = device0.createCommandEncoder({});
+let computePassEncoder95 = commandEncoder114.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.08,
+  lodMaxClamp: 40.83,
+});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup24, new Uint32Array(813), 257, 0);
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture104 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 446},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView123 = texture21.createView({});
+let sampler77 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.42,
+  compare: 'always',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup3, new Uint32Array(4274), 244, 0);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer60, 0);
+} catch {}
+document.body.prepend(img3);
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture105 = device0.createTexture({
+  size: [330, 48, 223],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder96 = commandEncoder115.beginComputePass({});
+let sampler78 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.36,
+  lodMaxClamp: 86.29,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup38, new Uint32Array(1319), 20, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer46, 'uint16', 42, 2);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer60);
+} catch {}
+try {
+  await buffer50.mapAsync(GPUMapMode.READ, 1952, 868);
+} catch {}
+let bindGroup69 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 92, resource: externalTexture5}]});
+let commandEncoder116 = device0.createCommandEncoder({});
+let renderPassEncoder27 = commandEncoder116.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -397.3, g: -829.1, b: 165.7, a: -713.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 2.183,
+  lodMaxClamp: 43.44,
+  compare: 'greater',
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder91.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(3, 10, 6, 6);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer26, 'uint16', 5_582, 1_393);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let img4 = await imageWithData(6, 132, '#10101010', '#20202020');
+try {
+computePassEncoder92.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(3, bindGroup13, new Uint32Array(1377), 107, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(10);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(854);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer52, 136, 102);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData17 = new ImageData(12, 76);
+let texture106 = device0.createTexture({
+  size: [165, 24, 1],
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame9});
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer39, 'uint32', 32, 82);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+document.body.append(canvas0);
+let imageData18 = new ImageData(44, 16);
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 136, resource: {buffer: buffer22, offset: 0}}, {binding: 606, resource: textureView5}],
+});
+let texture107 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView124 = texture48.createView({mipLevelCount: 1});
+let computePassEncoder97 = commandEncoder82.beginComputePass({});
+let sampler80 = device0.createSampler({
+  label: '\u0f3e\u1372\u067d\u{1f89d}\u{1f861}\u0992\u2d21\u{1f69e}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 80.97,
+});
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer60, 0, 181);
+} catch {}
+let buffer69 = device0.createBuffer({
+  size: 17463,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture108 = device0.createTexture({
+  label: '\u4a81\u0241\u381f\u31d0\u036e\ua1d9\u18aa\u3b95\u9fbf\u5293\u999f',
+  size: [8, 8, 23],
+  format: 'etc2-rgb8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+globalThis.someLabel = bindGroupLayout7.label;
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer21, offset: 0, size: 1004}},
+    {binding: 23, resource: textureView26},
+  ],
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let textureView125 = texture21.createView({dimension: '3d', arrayLayerCount: 1});
+let renderPassEncoder28 = commandEncoder117.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  depthSlice: 41,
+  clearValue: { r: -468.5, g: 477.4, b: 439.3, a: -688.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 214387024,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true});
+try {
+computePassEncoder78.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder11.setViewport(227.48057639042906, 19.05123080719329, 93.08893941871649, 8.553024923817098, 0.7309195913762148, 0.9438250863688953);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer69, 'uint32', 600, 2_716);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup56);
+} catch {}
+let arrayBuffer7 = buffer10.getMappedRange(320, 8);
+await gc();
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView8},
+    {binding: 136, resource: {buffer: buffer4, offset: 3584, size: 1704}},
+  ],
+});
+let buffer70 = device0.createBuffer({size: 15158, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder118 = device0.createCommandEncoder({});
+let computePassEncoder98 = commandEncoder118.beginComputePass({});
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer46, 'uint32', 0, 46);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer59);
+} catch {}
+let arrayBuffer8 = buffer51.getMappedRange(8176, 24);
+try {
+commandEncoder41.copyBufferToBuffer(buffer62, 1188, buffer37, 1384, 208);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer59);
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({});
+let renderPassEncoder29 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{
+  view: textureView108,
+  depthSlice: 117,
+  clearValue: { r: 839.6, g: 87.61, b: -9.668, a: -759.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer27, 0, 35);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer69, 'uint16', 2_834, 1_330);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'linear'} });
+let commandEncoder120 = device0.createCommandEncoder({label: '\u267f\u{1fab3}\u3b40\uabaa'});
+let texture109 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup45, new Uint32Array(3887), 2_303, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setViewport(61.68644412675852, 0.7801378301340228, 0.570348904775717, 0.07805408673760549, 0.6134762054252435, 0.9151191604589815);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer17, 'uint16', 3_264, 777);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup16, new Uint32Array(2442), 111, 0);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 352 widthInBlocks: 352 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3171 */
+  offset: 3171,
+  bytesPerRow: 2560,
+  buffer: buffer57,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 175, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 352, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView126 = texture34.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 26.20,
+  lodMaxClamp: 75.73,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(2, buffer27);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup43, new Uint32Array(836), 98, 0);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer8);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte240m', transfer: 'unspecified'} });
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 326,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture110 = device0.createTexture({
+  size: {width: 129},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder30 = commandEncoder120.beginRenderPass({
+  label: '\ucfdc\u0058\u{1ff73}\u0554\u{1ffbd}\u109d\u{1f67d}\u0be5\u{1f8b9}',
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -139.8, g: -48.03, b: 589.5, a: 113.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'hlg'} });
+let buffer71 = device0.createBuffer({
+  label: '\uafdf\u02db\u75ab\u089d',
+  size: 11240,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let texture111 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder99 = commandEncoder121.beginComputePass({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint']});
+let sampler82 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.94,
+  lodMaxClamp: 97.65,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder28.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer27, 0);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer70, 824, buffer48, 564, 320);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u{1fbc0}');
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  label: '\u2d07\u286a\u{1f639}\ubc24\u0b8b\ufa34\u0b2b\ube5e\ue256\ubb53',
+  layout: bindGroupLayout3,
+  entries: [{binding: 271, resource: {buffer: buffer22, offset: 512}}, {binding: 23, resource: textureView6}],
+});
+let buffer72 = device0.createBuffer({size: 4831, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture112 = device0.createTexture({size: {width: 1032}, dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView127 = texture94.createView({dimension: 'cube', baseArrayLayer: 2});
+let renderPassEncoder31 = commandEncoder41.beginRenderPass({
+  label: '\u{1f64e}\ucacd\u43c2\ufeca',
+  colorAttachments: [{
+  view: textureView113,
+  clearValue: { r: 583.9, g: -318.6, b: 476.1, a: 910.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.170,
+  lodMaxClamp: 27.01,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup4, new Uint32Array(582), 26, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer6, 'uint16', 32, 10);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer67, 28, 276);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.prepend(img3);
+let texture113 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 955},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder100 = commandEncoder122.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder87.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(22);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer18, 'uint32', 596, 1);
+} catch {}
+try {
+  await buffer42.mapAsync(GPUMapMode.WRITE, 0, 1624);
+} catch {}
+try {
+computePassEncoder82.insertDebugMarker('\u042d');
+} catch {}
+let buffer73 = device0.createBuffer({
+  label: '\u{1f739}\u0dd5\u09ca\u9a91\uc81c\u0ce1\u02da\u1832\u4705\u5728',
+  size: 15074,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture114 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder94.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer17, 'uint32', 3_000, 268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(5_500).fill(255), /* required buffer size: 5_500 */
+{offset: 209, bytesPerRow: 143, rowsPerImage: 37}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView120}]});
+let commandEncoder123 = device0.createCommandEncoder({});
+let texture115 = gpuCanvasContext3.getCurrentTexture();
+let textureView128 = texture66.createView({arrayLayerCount: 1});
+let computePassEncoder101 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(2, bindGroup57, new Uint32Array(831), 71, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder80.pushDebugGroup('\uac5b');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer0, offset: 1536, size: 82}}],
+});
+let computePassEncoder102 = commandEncoder123.beginComputePass({label: '\u0caf\ufad0\ua0c3'});
+let sampler84 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.2774,
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup48, []);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup69, new Uint32Array(944), 438, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer52, 'uint16', 162, 36);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer52, 4, 68);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(77), /* required buffer size: 34 */
+{offset: 34, bytesPerRow: 192}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder103 = commandEncoder124.beginComputePass({});
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer19, 0, 1_352);
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 12556,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView129 = texture91.createView({mipLevelCount: 1});
+let renderPassEncoder32 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView114,
+  depthSlice: 124,
+  clearValue: { r: -742.7, g: 275.2, b: -809.6, a: -206.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+await gc();
+let bindGroup76 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 482, resource: sampler12}]});
+let commandEncoder126 = device0.createCommandEncoder({label: '\u011e\ucf92\u01ef\ubea8\u0103\u{1fe30}\u{1fd7a}\u4a34\ubebe\u0851\u00d0'});
+let texture116 = device0.createTexture({
+  label: '\u{1ffbc}\u06c8\u7fd0\u0791\uf8c6\u{1f6ed}\u9b45\u021c',
+  size: [8, 8, 23],
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder104 = commandEncoder126.beginComputePass({});
+try {
+computePassEncoder101.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setViewport(298.4078233730949, 0.2516547857527921, 177.55899451008486, 0.4419063610095037, 0.40643257862946847, 0.6950912511833548);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer26, 'uint32', 1_252, 1_887);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer74, 5_452);
+} catch {}
+document.body.append(img3);
+let buffer75 = device0.createBuffer({
+  size: 14929,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder127 = device0.createCommandEncoder({label: '\u1d06\u0efa\u4134'});
+let computePassEncoder105 = commandEncoder127.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(3, bindGroup48, new Uint32Array(483), 32, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup26, new Uint32Array(4940), 750, 0);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(151, 0, 107, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(273).fill(90), /* required buffer size: 273 */
+{offset: 273, rowsPerImage: 9}, {width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext4 = canvas5.getContext('webgpu');
+let imageData19 = new ImageData(24, 52);
+try {
+computePassEncoder60.setBindGroup(2, bindGroup52, new Uint32Array(1819), 9, 0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer25, 'uint16', 11_002, 4_744);
+} catch {}
+document.body.append(img0);
+await gc();
+let buffer76 = device0.createBuffer({
+  size: 4332,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder128 = device0.createCommandEncoder();
+let texture117 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder106 = commandEncoder128.beginComputePass({});
+let sampler85 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.51,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData0,
+  origin: { x: 49, y: 2 },
+  flipY: true,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let promise12 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+let buffer77 = device0.createBuffer({
+  label: '\u{1fddc}\u0519',
+  size: 5763,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView130 = texture84.createView({dimension: 'cube', aspect: 'all'});
+let textureView131 = texture110.createView({});
+let texture118 = gpuCanvasContext2.getCurrentTexture();
+let externalTexture18 = device0.importExternalTexture({source: videoFrame14, colorSpace: 'srgb'});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+computePassEncoder75.setBindGroup(0, bindGroup10, new Uint32Array(1131), 491, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle12]);
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  label: '\u21a9\u072a\u0779',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView110},
+    {binding: 136, resource: {buffer: buffer0, offset: 0, size: 1396}},
+  ],
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let computePassEncoder107 = commandEncoder129.beginComputePass({});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup25, new Uint32Array(2566), 197, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle11, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\u02e4');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer78 = device0.createBuffer({
+  size: 9284,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder130 = device0.createCommandEncoder();
+let textureView132 = texture13.createView({dimension: 'cube-array', aspect: 'all', baseArrayLayer: 4, arrayLayerCount: 6});
+try {
+renderPassEncoder20.executeBundles([renderBundle12, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer4, 'uint32', 932, 658);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(5, buffer55);
+} catch {}
+await gc();
+let textureView133 = texture22.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder108 = commandEncoder130.beginComputePass({});
+let sampler86 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.59,
+  lodMaxClamp: 69.41,
+});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(6, 0, 5, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline4);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'bt2020_10bit'} });
+let sampler87 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.455,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer2, 'uint16', 222, 236);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline0);
+} catch {}
+await gc();
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'logSqrt'} });
+let texture119 = device0.createTexture({
+  label: '\u102d\ud7b2\u{1f91b}\u848a\u86b6\u095d\u{1fe78}\u0940',
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup77, new Uint32Array(1244), 456, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup14, new Uint32Array(1427), 42, 0);
+} catch {}
+try {
+renderPassEncoder28.setViewport(373.0637225839414, 0.18371183357860899, 496.0511266101209, 0.031067685998112646, 0.583735743423809, 0.9142593616357269);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer75, 'uint16', 5_424, 1_167);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer62, 3668, new Int16Array(6840), 6167, 48);
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+let textureView134 = texture108.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 12});
+let textureView135 = texture97.createView({aspect: 'all'});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup22, []);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(0, bindGroup62, new Uint32Array(1116), 284, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup27, new Uint32Array(891), 5, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer62, 'uint32', 7_612, 4_567);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer36, 0, 2_378);
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte240m', transfer: 'smpte240m'} });
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+requires unrestricted_pointer_parameters;
+
+fn fn1() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f1 = vec4i(bitcast<i32>(log2(f32(unconst_f32(-0.1435)))));
+  fn0(array<S2, 1>(S2(bitcast<vec4u>(textureLoad(tex12, vec2i(unconst_i32(260), unconst_i32(-14)), i32(unconst_i32(142)))))));
+  out = FragmentOutput2(firstTrailingBit(vec4i(unconst_i32(237), unconst_i32(5), unconst_i32(384), unconst_i32(22))).z, firstTrailingBit(vec4i(unconst_i32(237), unconst_i32(5), unconst_i32(384), unconst_i32(22))));
+  out.f0 *= i32(all(vec2<bool>(exp2(vec2h(unconst_f16(6804.5), unconst_f16(4626.8))))));
+  let vf132: u32 = reverseBits(u32(unconst_u32(302)));
+  return out;
+  _ = override17;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(99) var tex12: texture_multisampled_2d<f32>;
+
+var<workgroup> vw25: array<vec2i, 5>;
+
+var<workgroup> vw27: atomic<u32>;
+
+var<workgroup> vw29: FragmentOutput2;
+
+alias vec3b = vec3<bool>;
+
+@id(10624) override override17: bool;
+
+var<workgroup> vw32: vec2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw23: FragmentOutput2;
+
+var<workgroup> vw34: atomic<u32>;
+
+var<workgroup> vw31: atomic<i32>;
+
+var<workgroup> vw24: atomic<u32>;
+
+struct S2 {
+  @location(4) f0: vec4u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput2 {
+  @location(4) f0: i32,
+  @location(0) f1: vec4i,
+}
+
+var<workgroup> vw22: S2;
+
+var<workgroup> vw30: array<atomic<i32>, 27>;
+
+var<workgroup> vw28: atomic<u32>;
+
+var<workgroup> vw20: atomic<u32>;
+
+var<workgroup> vw26: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(135) var tex13: texture_2d<f32>;
+
+@group(1) @binding(42) var<uniform> buffer79: array<array<array<array<f16, 2>, 1>, 1>, 1>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<workgroup> vw21: atomic<i32>;
+
+fn fn0(a0: array<S2, 1>) -> vec4i {
+  var out: vec4i;
+  out ^= bitcast<vec4i>(a0[u32(unconst_u32(335))].f0);
+  out = bitcast<vec4i>(a0[u32(unconst_u32(307))].f0);
+  let vf120: array<S2, 1> = a0;
+  var vf121: S2 = a0[vec3u(cross(vec3f(unconst_f32(0.03454), unconst_f32(0.1050), unconst_f32(0.02121)), vec3f(unconst_f32(0.3435), unconst_f32(0.1659), unconst_f32(0.1310))))[1]];
+  vf121 = a0[u32(unconst_u32(515))];
+  let vf122: u32 = vf121.f0[u32(unconst_u32(211))];
+  out |= vec4i(log(vec2h(unconst_f16(726.1), unconst_f16(16451.8))).yxyx);
+  let vf123: S2 = a0[0];
+  var vf124: vec4h = ldexp(vec4h(unconst_f16(12575.4), unconst_f16(-6142.0), unconst_f16(39857.4), unconst_f16(7721.1)), vec4i(unconst_i32(-44), unconst_i32(988), unconst_i32(2), unconst_i32(191)));
+  let ptr36: ptr<function, vec4u> = &vf121.f0;
+  let vf125: u32 = vf122;
+  let vf126: S2 = vf120[u32(unconst_u32(153))];
+  out = unpack4xI8(vf120[0].f0[u32(unconst_u32(284))]);
+  vf121.f0 &= unpack4xU8(vf121.f0[u32(unconst_u32(251))]);
+  let ptr37: ptr<function, vec4u> = &(*ptr36);
+  out = bitcast<vec4i>(vf126.f0);
+  let vf127: vec2h = log(vec2h(a0[u32(unconst_u32(251))].f0.bb));
+  var vf128: S2 = a0[0];
+  var vf129: bool = override17;
+  var vf130: u32 = vf120[0].f0[u32(unconst_u32(324))];
+  let vf131: u32 = vf121.f0[u32(unconst_u32(42))];
+  return out;
+  _ = override17;
+}
+
+var<workgroup> vw33: mat2x3h;
+
+var<workgroup> vw19: array<atomic<u32>, 2>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex5(@location(3) @interpolate(flat) a0: vec4f, @location(15) @interpolate(flat) a1: vec4i, @location(13) a2: i32, a3: S2, @location(10) a4: vec4h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(f32((*&buffer79)[u32(unconst_u32(394))][0][0][1]));
+  let ptr38: ptr<uniform, f16> = &buffer79[0][0][a3.f0[u32(unconst_u32(204))]][1];
+  let ptr39: ptr<uniform, f16> = &buffer79[u32(unconst_u32(223))][0][u32(unconst_u32(96))][1];
+  out *= vec4f(f32((*&buffer79)[0][u32(unconst_u32(194))][0][1]));
+  let ptr40: ptr<uniform, array<array<array<f16, 2>, 1>, 1>> = &buffer79[u32(unconst_u32(60))];
+  let ptr41: ptr<uniform, f16> = &buffer79[0][u32(unconst_u32(199))][u32(unconst_u32(79))][1];
+  let vf133: i32 = a2;
+  let ptr42: ptr<uniform, array<array<array<f16, 2>, 1>, 1>> = &(*&buffer79)[u32(unconst_u32(632))];
+  let ptr43: ptr<uniform, array<f16, 2>> = &buffer79[0][0][0];
+  out = vec4f(f32(buffer79[0][0][0][1]));
+  out = vec4f(f32(buffer79[0][0][u32(unconst_u32(48))][1]));
+  let ptr44: ptr<uniform, array<array<f16, 2>, 1>> = &(*&buffer79)[u32(unconst_u32(677))][u32(unconst_u32(19))];
+  let ptr45: ptr<uniform, array<f16, 2>> = &(*ptr40)[0][u32(unconst_u32(203))];
+  let vf134: vec4i = a1;
+  let ptr46: ptr<uniform, array<f16, 2>> = &buffer79[0][0][0];
+  var vf135: f32 = a0[u32(unconst_u32(84))];
+  let ptr47: ptr<uniform, f16> = &(*ptr42)[0][u32(unconst_u32(192))][u32(unconst_u32(279))];
+  return out;
+}
+
+@fragment
+fn fragment6() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 = i32(saturate(vec3h(unconst_f16(10956.6), unconst_f16(12244.4), unconst_f16(21229.9)))[0]);
+  var vf136 = fn1();
+  fn1();
+  out.f0 = bitcast<i32>(textureNumSamples(tex12));
+  let vf137: vec3h = saturate(vec3h(unconst_f16(14026.7), unconst_f16(2685.0), unconst_f16(17772.7)));
+  let vf138: vec3u = countOneBits(vec3u(unconst_u32(317), unconst_u32(352), unconst_u32(233)));
+  vf136.f1 &= vec4i(countOneBits(vec3u(unconst_u32(505), unconst_u32(212), unconst_u32(186))).yyxx);
+  out.f1 = vec4i(saturate(vec3h(unconst_f16(10165.7), unconst_f16(11908.7), unconst_f16(323.4))).yyxx);
+  out.f1 = vec4i(saturate(vec3h(unconst_f16(11217.6), unconst_f16(4414.6), unconst_f16(15326.9))).bbbr);
+  let vf139: vec4h = faceForward(vec4h(unconst_f16(24907.6), unconst_f16(36.39), unconst_f16(8658.3), unconst_f16(2134.9)), vec4h(unconst_f16(3024.3), unconst_f16(-17564.4), unconst_f16(7660.6), unconst_f16(2066.0)), vec4h(unconst_f16(23408.6), unconst_f16(18.19), unconst_f16(-3485.7), unconst_f16(4691.3)));
+  fn0(array<S2, 1>(S2(vec4u(saturate(vec3h(unconst_f16(3095.4), unconst_f16(600.8), unconst_f16(4439.2))).rbbr))));
+  vf136.f0 = vec3i(vf137).y;
+  var vf140 = fn1();
+  let ptr48: ptr<function, i32> = &vf140.f0;
+  vf136 = FragmentOutput2(i32(faceForward(vec4h(unconst_f16(10736.6), unconst_f16(2273.8), unconst_f16(19879.4), unconst_f16(-21060.2)), vec4h(unconst_f16(1118.4), unconst_f16(1139.6), unconst_f16(8698.2), unconst_f16(18113.2)), vec4h(unconst_f16(5952.2), unconst_f16(7077.7), unconst_f16(12924.3), unconst_f16(7554.9)))[0]), vec4i(faceForward(vec4h(unconst_f16(10736.6), unconst_f16(2273.8), unconst_f16(19879.4), unconst_f16(-21060.2)), vec4h(unconst_f16(1118.4), unconst_f16(1139.6), unconst_f16(8698.2), unconst_f16(18113.2)), vec4h(unconst_f16(5952.2), unconst_f16(7077.7), unconst_f16(12924.3), unconst_f16(7554.9)))));
+  var vf141: f16 = vf137[u32(unconst_u32(195))];
+  fn1();
+  fn1();
+  out.f1 -= unpack4xI8(pack2x16float(vec2f(unconst_f32(0.07240), unconst_f32(0.01775))));
+  let ptr49: ptr<function, FragmentOutput2> = &vf136;
+  let vf142: vec2i = extractBits(vec2i(unconst_i32(224), unconst_i32(39)), u32(unconst_u32(384)), u32(unconst_u32(51)));
+  return out;
+  _ = override17;
+}`,
+  sourceMap: {},
+});
+let bindGroup78 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 23, resource: textureView111}, {binding: 271, resource: {buffer: buffer71, offset: 256}}],
+});
+let buffer80 = device0.createBuffer({size: 3404, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder132 = device0.createCommandEncoder({label: '\u9068\ud978\u0159\u5a0d\u04d8\u0022\u09f5\ueed5\uaeac\u00ae\u{1fa84}'});
+let texture120 = device0.createTexture({
+  label: '\uf2e1\u5fc0',
+  size: {width: 330, height: 48, depthOrArrayLayers: 51},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder109 = commandEncoder132.beginComputePass({});
+let renderPassEncoder33 = commandEncoder131.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: -134.1, g: 140.2, b: 961.1, a: -339.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 59927498,
+});
+let sampler88 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.78,
+  lodMaxClamp: 77.31,
+});
+try {
+computePassEncoder99.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer27);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 636, new DataView(new ArrayBuffer(777)), 30, 12);
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({});
+let texture121 = gpuCanvasContext3.getCurrentTexture();
+let sampler89 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 29.47,
+  lodMaxClamp: 91.65,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle0, renderBundle2, renderBundle1]);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer13, offset: 1024, size: 2432}}],
+});
+let commandEncoder134 = device0.createCommandEncoder();
+let renderPassEncoder34 = commandEncoder133.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 141.8, g: 867.9, b: 202.2, a: -831.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 92558747,
+});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer44, 'uint32', 976, 144);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 144 */
+  offset: 144,
+  buffer: buffer73,
+}, {
+  texture: texture65,
+  mipLevel: 1,
+  origin: {x: 50, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline5 = await promise12;
+document.body.prepend(canvas0);
+let commandEncoder135 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup52, new Uint32Array(1721), 26, 0);
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 270 widthInBlocks: 135 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1242 */
+  offset: 1242,
+  buffer: buffer60,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 135, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder4.insertDebugMarker('\u{1f699}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(100).fill(71), /* required buffer size: 100 */
+{offset: 58, bytesPerRow: 17, rowsPerImage: 58}, {width: 2, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let texture123 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder110 = commandEncoder112.beginComputePass({});
+let renderPassEncoder35 = commandEncoder135.beginRenderPass({
+  label: '\u9751\u70f5\u9d06',
+  colorAttachments: [{
+  view: textureView106,
+  clearValue: { r: -30.48, g: -209.3, b: -190.0, a: -471.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder108.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 725.5, g: 925.7, b: 45.41, a: -4.235, });
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer26, 0, 536);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 78 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 832 */
+  offset: 832,
+  buffer: buffer8,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer0 = commandEncoder4.finish({});
+let texture124 = device0.createTexture({
+  size: [1032, 1, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder111 = commandEncoder134.beginComputePass({});
+let sampler90 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 43.32,
+  lodMaxClamp: 85.16,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer26, 1_016, 180);
+} catch {}
+let buffer81 = device0.createBuffer({size: 8072, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder136 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 2253});
+let computePassEncoder112 = commandEncoder136.beginComputePass({});
+let sampler91 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.67,
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup79, new Uint32Array(1313), 291, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let textureView136 = texture70.createView({arrayLayerCount: 2});
+let computePassEncoder113 = commandEncoder117.beginComputePass({});
+let sampler92 = device0.createSampler({addressModeU: 'repeat', mipmapFilter: 'nearest', lodMinClamp: 20.47, lodMaxClamp: 57.92});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup69, new Uint32Array(654), 134, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup80 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 42, resource: {buffer: buffer81, offset: 3328}}]});
+let commandEncoder137 = device0.createCommandEncoder({});
+let texture125 = device0.createTexture({
+  label: '\u0429\u23a4\ub7b1\u0a53\u0a02\u{1fd60}\u0949\u5a39',
+  size: {width: 165, height: 24, depthOrArrayLayers: 44},
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder36 = commandEncoder137.beginRenderPass({
+  label: '\u0c90\ud935\u089b\u29ca\u{1fb54}\u{1fcf6}\u035f\u48c7\uba1f\u6068',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 107,
+  clearValue: { r: 338.1, g: 202.8, b: -184.4, a: 377.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder100.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle9]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(50).fill(148), /* required buffer size: 50 */
+{offset: 50}, {width: 248, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer12, offset: 4352, size: 265}}],
+});
+let buffer82 = device0.createBuffer({size: 4837, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer78, 0, 1_304);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup56, new Uint32Array(680), 19, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer27, 'uint32', 1_840, 54);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(347).fill(164), /* required buffer size: 347 */
+{offset: 347}, {width: 239, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView137 = texture28.createView({dimension: '2d', baseArrayLayer: 10});
+let sampler93 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.91,
+  lodMaxClamp: 68.62,
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer76, 724);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer55, 'uint16', 98, 10);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule7, constants: {}}});
+let commandEncoder138 = device0.createCommandEncoder({});
+let texture126 = device0.createTexture({size: [660], dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder114 = commandEncoder138.beginComputePass({});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer69, 'uint32', 3_392, 3_027);
+} catch {}
+try {
+computePassEncoder80.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 18, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(668_379).fill(116), /* required buffer size: 668_379 */
+{offset: 76, bytesPerRow: 601, rowsPerImage: 5}, {width: 148, height: 2, depthOrArrayLayers: 223});
+} catch {}
+await gc();
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture127 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 7},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView138 = texture72.createView({});
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer25, 'uint16', 8_766, 1_023);
+} catch {}
+try {
+commandEncoder139.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2316 */
+  offset: 2316,
+  buffer: buffer70,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder139.resolveQuerySet(querySet2, 8, 15, buffer73, 5120);
+} catch {}
+document.body.prepend(canvas3);
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1883});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(0, bindGroup3, new Uint32Array(1003), 203, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({label: '\u3191\u0d70\u0340\u{1f986}\u{1f897}\u044d\ua223\u03a3\u18fc\u{1fe00}\u024c'});
+let computePassEncoder115 = commandEncoder140.beginComputePass({});
+let renderPassEncoder37 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{
+  view: textureView108,
+  depthSlice: 133,
+  clearValue: { r: 170.1, g: 710.7, b: -416.4, a: -516.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.94,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder95.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 5180, new Int16Array(23216), 3004, 52);
+} catch {}
+let bindGroup82 = device0.createBindGroup({
+  label: '\u0d04\u0371\u0f57\u079b\u5739\u{1f70b}\u37a2',
+  layout: bindGroupLayout7,
+  entries: [{binding: 358, resource: textureView64}],
+});
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture128 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder116 = commandEncoder141.beginComputePass({label: '\u011d\uce6d\ua46e\u03e7\u38d5\u{1f840}\u2abf\u0962\u1b11'});
+let bindGroup83 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 326, resource: textureView42}]});
+let textureView139 = texture68.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let bindGroup84 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 16, resource: textureView117}]});
+let buffer83 = device0.createBuffer({
+  size: 26822,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture129 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup71, new Uint32Array(214), 26, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer13, 'uint32', 3_684, 422);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer8, 32, 327);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 11961,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder142 = device0.createCommandEncoder({label: '\u{1fb33}\u2e48\u0388\u03d4'});
+let renderPassEncoder38 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -729.4, g: 645.9, b: -522.2, a: -421.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer39, 'uint16', 58, 38);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer41, 1_132, 1_205);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 158}
+*/
+{
+  source: imageData8,
+  origin: { x: 2, y: 8 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 50},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler95 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 55.69,
+  lodMaxClamp: 69.79,
+  maxAnisotropy: 1,
+});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup25, new Uint32Array(2017), 682, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder14.draw(11, 200, 3, 245_314_667);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer36, 2_704);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer15, 24);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(12, 270, 42, 123_222_360, 1_184_111_834);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let textureView140 = texture32.createView({label: '\u370a\uff8a\u{1f835}\u0bc4\u0411\u2f39\ue46a', dimension: '2d-array'});
+let computePassEncoder117 = commandEncoder143.beginComputePass({label: '\u25f6\u496b\u{1fe89}'});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup41, new Uint32Array(2711), 434, 0);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer9, 632);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup85 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 16, resource: textureView135}]});
+let sampler96 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.33,
+  lodMaxClamp: 19.40,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder29.setViewport(17.047149048719522, 0.28010774955664386, 73.85264973927215, 0.1704396008792602, 0.44638742817924193, 0.5696323137258194);
+} catch {}
+try {
+renderPassEncoder14.draw(2, 144, 8, 974_264_958);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer1, 528);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer49, 204);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer44, 'uint32', 120, 806);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 436, new Float32Array(20985), 2880, 1460);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder31.label;
+} catch {}
+let textureView141 = texture52.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup0, new Uint32Array(372), 169, 0);
+} catch {}
+let buffer85 = device0.createBuffer({size: 16656, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder144 = device0.createCommandEncoder({label: '\u{1feaf}\u5f79\uc6ed\ub990\u048e\u{1ff6a}\u5a8a\ueaed\ub1bf'});
+let computePassEncoder118 = commandEncoder144.beginComputePass({});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup3, new Uint32Array(2142), 23, 0);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer49, 1_796);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer40);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+document.body.append(canvas3);
+let textureView142 = texture67.createView({label: '\u2688\u{1ffb5}\u{1f7e3}\ucfbb\uc415\u3a6d\u01c8'});
+try {
+computePassEncoder97.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder14.draw(2, 125, 4, 980_910_426);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer25, 652);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer65, 872);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer6, 'uint32', 36, 51);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer59, 2_060, 5_436);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'smpteSt4281'} });
+try {
+globalThis.someLabel = texture58.label;
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer86 = device0.createBuffer({
+  label: '\u{1fd76}\u{1fad0}\u7cfe\u0a47\u1715\u03c8\u1e30\u{1faff}',
+  size: 19976,
+  usage: GPUBufferUsage.COPY_SRC,
+});
+let texture130 = device0.createTexture({
+  label: '\u655c\u{1fa1b}',
+  size: [129, 1, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler97 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 30.36,
+  lodMaxClamp: 83.10,
+});
+try {
+computePassEncoder97.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+renderPassEncoder14.draw(0, 72, 4, 394_098_535);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer2, 100);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 436, new BigUint64Array(7110), 540, 44);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(19, 10, 8, 69_517_199, 257_976_200);
+} catch {}
+let texture131 = device0.createTexture({
+  label: '\ue19f\u02f9\u6b42\u0747\uec21\u04b3\u0c8f\u43b9\u48c5\u695f',
+  size: [165, 24, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView143 = texture1.createView({});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder14.draw(2, 201, 0, 2_607_440_757);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer0, 80);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer25, 2_324);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer54, 'uint32', 1_732, 6_428);
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer31, offset: 0, size: 1083}},
+    {binding: 606, resource: textureView9},
+  ],
+});
+let commandEncoder145 = device0.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder145.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup8, new Uint32Array(79), 3, 0);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder12.setViewport(853.5032319620678, 0.22554969791398083, 174.43769792516161, 0.41464613461768923, 0.2917008762105995, 0.38201514393856045);
+} catch {}
+try {
+renderPassEncoder14.draw(2, 61, 6, 213_413_634);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(95, 160, 3, -2_014_126_374, 2_367_114_270);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer4, 'uint32', 4_796, 2_715);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  label: '\u165d\u{1ff32}\ubae9\ue0a8\ud3c0\u0f36\u0c6e\u0fae\ua498',
+  layout: bindGroupLayout12,
+  entries: [{binding: 227, resource: textureView89}],
+});
+let texture132 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 167},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder14.drawIndexed(16, 39, 3, 1_308_966_613, 153_584_285);
+} catch {}
+try {
+computePassEncoder97.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup44, new Uint32Array(2786), 2_137, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder14.draw(0, 7, 1, 1_895_551_986);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(43, 46, 28, 282_043_578, 688_030_270);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer40);
+} catch {}
+let texture133 = device0.createTexture({
+  size: [516, 1, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView144 = texture68.createView({dimension: '2d-array', baseArrayLayer: 2, arrayLayerCount: 14});
+try {
+computePassEncoder118.setBindGroup(2, bindGroup6, new Uint32Array(465), 57, 0);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle4]);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 478 */
+  offset: 478,
+  buffer: buffer1,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 38, y: 8, z: 30},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet8, 156, 0, buffer6, 0);
+} catch {}
+document.body.append(img2);
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 92, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 237,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView145 = texture85.createView({});
+let renderPassEncoder39 = commandEncoder47.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -803.9, g: 368.3, b: -796.2, a: 269.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 362947477,
+});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup37, new Uint32Array(449), 198, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer39, 'uint16', 18, 99);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [{binding: 237, resource: sampler30}, {binding: 92, resource: {buffer: buffer55, offset: 0, size: 184}}],
+});
+let commandEncoder146 = device0.createCommandEncoder();
+let texture134 = device0.createTexture({size: [165, 24, 4], mipLevelCount: 5, format: 'rgba32float', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder120 = commandEncoder146.beginComputePass({label: '\u{1fd07}\u6fea\u9dc0\u047a\u04d7\u{1ff09}\u{1fc13}\u4f57\u9ae8'});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup53, new Uint32Array(812), 213, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker('\u{1fbb9}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(213_269).fill(27), /* required buffer size: 213_269 */
+{offset: 77, bytesPerRow: 690, rowsPerImage: 152}, {width: 168, height: 20, depthOrArrayLayers: 3});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+document.body.prepend(canvas2);
+let buffer87 = device0.createBuffer({size: 13899, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder147 = device0.createCommandEncoder();
+let computePassEncoder121 = commandEncoder147.beginComputePass({});
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 77.29,
+  lodMaxClamp: 78.12,
+});
+try {
+computePassEncoder117.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(8, 0, 7, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer31, 'uint16', 220, 611);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 12, new BigUint64Array(3451), 902, 4);
+} catch {}
+let buffer88 = device0.createBuffer({
+  size: 4307,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer20, 'uint32', 25_540, 1_776);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.append(img4);
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup17, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 165, height: 24, depthOrArrayLayers: 111}
+*/
+{
+  source: imageData16,
+  origin: { x: 2, y: 24 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let buffer89 = device0.createBuffer({
+  label: '\u20d2\u{1fa23}',
+  size: 2734,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView146 = texture78.createView({mipLevelCount: 1});
+let sampler99 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.95,
+  lodMaxClamp: 28.67,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder91.setBindGroup(2, bindGroup69);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, undefined, 0, 131_467_266);
+} catch {}
+let textureView147 = texture63.createView({arrayLayerCount: 1});
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 92.89,
+  lodMaxClamp: 96.71,
+});
+try {
+computePassEncoder0.setPipeline(pipeline3);
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({label: '\u04b8\u926b\ub434\u0aad\u0f21\u00f8\ub9ca\u0dcf\uc47e'});
+let texture135 = device0.createTexture({
+  label: '\u{1fc1d}\u098c\u08b2\uf7a0\ucc82\u32e2\u4a4c',
+  size: {width: 129, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let renderPassEncoder40 = commandEncoder148.beginRenderPass({
+  label: '\u2895\u0e80\u0af3\u3525\u6b7f\u07be',
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: -584.6, g: 597.7, b: 265.2, a: 291.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+let sampler101 = device0.createSampler({
+  label: '\u7a0c\uef7e\u3ff0\u8879\ua8d2',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.35,
+  lodMaxClamp: 63.97,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder121.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer83, 'uint32', 52, 4_806);
+} catch {}
+let img5 = await imageWithData(91, 78, '#10101010', '#20202020');
+let buffer90 = device0.createBuffer({
+  label: '\u{1f793}\uc05c\u0265',
+  size: 4139,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture136 = device0.createTexture({
+  size: [165],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler102 = device0.createSampler({addressModeW: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 13.69, lodMaxClamp: 74.86});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame14});
+let bindGroup89 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView31}]});
+let commandEncoder149 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder149.finish();
+let sampler103 = device0.createSampler({
+  label: '\u00dd\u8e41',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 61.65,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder24.setViewport(67.12330639257044, 25.470891541787346, 162.8897048228938, 7.124524059643733, 0.77917617581824, 0.8220980715957149);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(149_283).fill(19), /* required buffer size: 149_283 */
+{offset: 57, bytesPerRow: 154, rowsPerImage: 51}, {width: 1, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(videoFrame18);
+let bindGroup90 = device0.createBindGroup({
+  label: '\u2141\u815f\u3dd5',
+  layout: bindGroupLayout15,
+  entries: [{binding: 92, resource: externalTexture13}],
+});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 379});
+let textureView148 = texture99.createView({});
+let textureView149 = texture33.createView({dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(32, 0, 84, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer48, 0, 1_861);
+} catch {}
+await gc();
+let texture137 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup16, new Uint32Array(1607), 263, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 2,
+  origin: {x: 69, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(145).fill(165), /* required buffer size: 145 */
+{offset: 145, bytesPerRow: 102}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView150 = texture87.createView({dimension: '1d'});
+let sampler104 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 76.80,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder112.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer55, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 3756, new DataView(new ArrayBuffer(15257)), 10, 3868);
+} catch {}
+let imageData20 = new ImageData(28, 104);
+let texture138 = device0.createTexture({
+  label: '\ub46f\u032b\u{1fa07}\u{1fcfe}\ue32d',
+  size: {width: 165, height: 24, depthOrArrayLayers: 93},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView151 = texture131.createView({dimension: '2d-array'});
+try {
+computePassEncoder115.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder40.setViewport(53.95629862440749, 8.917518173491123, 257.8990548753609, 34.08236985667061, 0.5466384419975286, 0.6781360629965428);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(0, buffer88, 0, 473);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 464, new Float32Array(11108), 3788, 180);
+} catch {}
+try {
+computePassEncoder105.setBindGroup(3, bindGroup71, []);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(1, bindGroup13, new Uint32Array(171), 86, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle1]);
+} catch {}
+let textureView152 = texture15.createView({mipLevelCount: 1});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup69, new Uint32Array(1169), 142, 0);
+} catch {}
+let arrayBuffer9 = buffer10.getMappedRange(8, 4);
+try {
+renderPassEncoder27.pushDebugGroup('\u09ae');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 32, new Int16Array(4261), 58, 176);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'smpte170m'} });
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView153 = texture135.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup65, new Uint32Array(2104), 94, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup32, new Uint32Array(237), 18, 0);
+} catch {}
+try {
+renderPassEncoder34.beginOcclusionQuery(373);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer75, 'uint32', 744, 4_989);
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({label: '\u74d3\u6775\u3b3d\u0283\u0e31\ueace\ub5c1\u{1f8cc}', bindGroupLayouts: []});
+let texture139 = device0.createTexture({
+  size: [516, 1, 27],
+  mipLevelCount: 3,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup82, new Uint32Array(1152), 204, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline6);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+  await buffer34.mapAsync(GPUMapMode.WRITE, 0, 576);
+} catch {}
+document.body.append(canvas0);
+let imageBitmap3 = await createImageBitmap(imageData1);
+let buffer91 = device0.createBuffer({
+  size: 429,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder150 = device0.createCommandEncoder({});
+try {
+computePassEncoder67.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(54);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder150.copyBufferToBuffer(buffer63, 12, buffer49, 768, 160);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'unspecified'} });
+let computePassEncoder122 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup41, new Uint32Array(2678), 414, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup31, new Uint32Array(2197), 1_113, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule5, targets: [{format: 'rgb10a2unorm', writeMask: 0}]},
+  vertex: {
+    module: shaderModule5,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 556,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x2', offset: 92, shaderLocation: 0}],
+      },
+    ],
+  },
+});
+let buffer92 = device0.createBuffer({size: 6959, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder122.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(2, buffer91, 0, 16);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 108, new DataView(new ArrayBuffer(8866)), 835, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(395).fill(38), /* required buffer size: 395 */
+{offset: 395, bytesPerRow: 24}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData21 = new ImageData(28, 40);
+try {
+computePassEncoder118.setBindGroup(0, bindGroup47, new Uint32Array(1114), 153, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer29, 'uint32', 900, 204);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+renderPassEncoder27.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: imageData12,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({label: '\u5f49\u{1ffe1}\u{1f8a7}\uc468'});
+let computePassEncoder123 = commandEncoder151.beginComputePass({label: '\ufed9\u0c9f\u{1ff47}\ufb45\u0413\uaa1f\u3dab'});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule3, constants: {}}});
+try {
+globalThis.someLabel = commandEncoder98.label;
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder({});
+let textureView154 = texture100.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder124 = commandEncoder152.beginComputePass({label: '\u{1fd47}\ud1ad\u548b\u8f18\u055c\u{1f649}\u{1f7b7}'});
+try {
+computePassEncoder120.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle4, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer17, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder();
+try {
+computePassEncoder124.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup0, new Uint32Array(1418), 712, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer37, 'uint16', 678, 1_215);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(515).fill(86), /* required buffer size: 515 */
+{offset: 515, rowsPerImage: 123}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = textureView108.label;
+} catch {}
+let textureView155 = texture128.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder125 = commandEncoder153.beginComputePass({});
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.80,
+  lodMaxClamp: 98.71,
+  compare: 'less-equal',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(66);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer80, 'uint32', 52, 447);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4, buffer8, 228);
+} catch {}
+document.body.append(img0);
+try {
+computePassEncoder110.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer91, 52, 168);
+} catch {}
+let textureView156 = texture12.createView({aspect: 'all', baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup14, new Uint32Array(918), 220, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer21, 'uint32', 2_680, 932);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer16, 0, 610);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: canvas4,
+  origin: { x: 139, y: 38 },
+  flipY: true,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer93 = device0.createBuffer({size: 5941, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder154 = device0.createCommandEncoder({label: '\u0862\ub772\uab34\ue249\uf012\uc4ea\u2ee2\u0b25\u{1ff7d}'});
+let textureView157 = texture1.createView({});
+let computePassEncoder126 = commandEncoder154.beginComputePass({});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup41, new Uint32Array(637), 41, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer60, 268);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 9740, new Float32Array(5815));
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let texture140 = device0.createTexture({
+  size: [258],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32uint'],
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup49, new Uint32Array(2228), 13, 0);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup25, new Uint32Array(139), 5, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer52, 44, 40);
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder({});
+let texture141 = device0.createTexture({
+  size: [82, 12, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder127 = commandEncoder155.beginComputePass();
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup41, new Uint32Array(1693), 119, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer46, 'uint16', 16, 6);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let texture142 = device0.createTexture({size: {width: 8}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_SRC});
+let textureView158 = texture49.createView({mipLevelCount: 1});
+let sampler106 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.92,
+  lodMaxClamp: 67.27,
+});
+try {
+computePassEncoder127.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(0, bindGroup54, new Uint32Array(1321), 179, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer91, 'uint16', 150, 24);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer10 = buffer42.getMappedRange(0, 624);
+try {
+renderPassEncoder34.insertDebugMarker('\uf6a5');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 26,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer94 = device0.createBuffer({
+  size: 7882,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture143 = device0.createTexture({
+  size: [82],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup89);
+} catch {}
+try {
+renderPassEncoder34.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(2, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer75, 'uint32', 1_440, 2_006);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let texture144 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture145 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder40.beginOcclusionQuery(69);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'pq'} });
+try {
+externalTexture10.label = '\u{1fd73}\u30d3';
+} catch {}
+let buffer95 = device0.createBuffer({size: 7450, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder156 = device0.createCommandEncoder();
+let textureView159 = texture144.createView({dimension: '1d'});
+let texture146 = device0.createTexture({
+  size: [165, 24, 60],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder10.setIndexBuffer(buffer76, 'uint16', 480, 61);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder();
+let texture147 = device0.createTexture({
+  size: [82, 12, 55],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler107 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.39,
+  lodMaxClamp: 74.77,
+});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer64);
+} catch {}
+try {
+commandEncoder156.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1040 */
+  offset: 1040,
+  buffer: buffer88,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture9.label;
+} catch {}
+let commandEncoder158 = device0.createCommandEncoder();
+let textureView160 = texture143.createView({});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(3, bindGroup66, new Uint32Array(935), 24, 0);
+} catch {}
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer8, 'uint32', 308, 257);
+} catch {}
+try {
+commandEncoder157.copyBufferToBuffer(buffer64, 1064, buffer72, 736, 984);
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer7, 604, 596);
+} catch {}
+let texture148 = device0.createTexture({
+  size: [1032, 1, 1],
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder41 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView113,
+  clearValue: { r: -119.9, g: -513.1, b: 125.5, a: 56.96, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder29.setIndexBuffer(buffer80, 'uint16', 24, 600);
+} catch {}
+let arrayBuffer11 = buffer34.getMappedRange(24, 52);
+try {
+computePassEncoder98.insertDebugMarker('\uea33');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img3);
+let renderPassEncoder42 = commandEncoder158.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 170,
+  clearValue: { r: -245.3, g: -375.0, b: 832.7, a: -992.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+let externalTexture21 = device0.importExternalTexture({label: '\u49a6\u7ab7\uda26', source: videoFrame15, colorSpace: 'display-p3'});
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+await gc();
+let canvas7 = document.createElement('canvas');
+let buffer96 = device0.createBuffer({
+  size: 6577,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture149 = device0.createTexture({
+  label: '\uc141\u{1f770}',
+  size: [660, 96, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler108 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.76,
+  lodMaxClamp: 99.82,
+  compare: 'equal',
+});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup37, new Uint32Array(438), 78, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer20, 'uint32', 780, 29_553);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer76, 0, 703);
+} catch {}
+try {
+buffer94.unmap();
+} catch {}
+try {
+commandEncoder156.copyTextureToBuffer({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2412 */
+  offset: 2412,
+  bytesPerRow: 82688,
+  buffer: buffer73,
+}, {width: 27, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise14 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule7, constants: {}}});
+let buffer97 = device0.createBuffer({
+  size: 1464,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder159 = device0.createCommandEncoder({});
+let computePassEncoder128 = commandEncoder159.beginComputePass({label: '\ub896\u{1fb8e}\ua1f2\u00ce\u0bdc\u{1f8cc}\ua33f'});
+let renderPassEncoder43 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: 465.4, g: 144.7, b: 200.1, a: -283.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+let sampler109 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.30,
+  lodMaxClamp: 92.22,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder43.setIndexBuffer(buffer62, 'uint32', 2_172, 1_774);
+} catch {}
+try {
+texture97.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 864, new Float32Array(606), 16, 24);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let shaderModule9 = device0.createShaderModule({
+  label: '\u7f64\u04a0\u8044\uc290\u4f43\ue54b\u9efa\u{1ff41}\u0f47\u327e',
+  code: `
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp6: array<array<vec4<bool>, 1>, 10> = array<array<vec4<bool>, 1>, 10>();
+
+struct T1 {
+  @align(1) @size(16) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput3 {
+  @location(15) @interpolate(flat, centroid) f11: vec2i,
+  @location(2) @interpolate(perspective, sample) f12: vec4h,
+  @builtin(position) f13: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(12) f0: array<f32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(227) var tex14: texture_2d_array<f32>;
+
+struct S3 {
+  @location(12) @interpolate(flat, centroid) f0: i32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput4 {
+  @location(6) f0: vec2i,
+  @location(0) f1: vec4f,
+}
+
+struct FragmentOutput3 {
+  @location(0) @interpolate(linear, sample) f0: vec4f,
+  @location(4) f1: vec4f,
+}
+
+@id(2312) override override18: i32;
+
+@vertex
+fn vertex6(@location(13) @interpolate(flat) a0: vec2i, @location(4) a1: vec4f, @location(7) a2: u32, @builtin(instance_index) a3: u32, @location(2) a4: vec4h, @location(10) @interpolate(flat, sample) a5: vec4u, a6: S3, @location(8) @interpolate(flat, center) a7: f16, @location(5) @interpolate(flat) a8: vec2i, @location(3) @interpolate(linear) a9: vec4h, @location(11) a10: f16, @location(6) a11: vec2i) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f12 = vec4h(f16(a11[u32(unconst_u32(187))]));
+  var vf143: vec2i = a11;
+  let vf144: i32 = a6.f0;
+  vf143 ^= vec2i(i32(a7));
+  var vf145: i32 = a6.f0;
+  let ptr50: ptr<private, vec4<bool>> = &vp6[9][0];
+  var vf146: vec2i = a0;
+  out.f11 = vec2i(i32(vp6[9][u32(unconst_u32(105))][a5[u32(unconst_u32(440))]]));
+  return out;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let ptr51: ptr<private, vec4<bool>> = &vp6[u32(unconst_u32(336))][bitcast<u32>(override18)];
+  var vf147: bool = vp6[9][0][u32(unconst_u32(268))];
+  var vf148: f16 = max(f16(unconst_f16(6318.9)), f16(unconst_f16(-3513.2)));
+  vp6[9][u32(unconst_u32(53))] = vec4<bool>(firstLeadingBit(vec4u(unconst_u32(347), unconst_u32(334), unconst_u32(194), unconst_u32(198))));
+  let ptr52: ptr<private, vec4<bool>> = &vp6[9][u32(unconst_u32(175))];
+  let vf149: bool = vp6[9][u32(unconst_u32(76))][u32(unconst_u32(50))];
+  out.f1 = vec4f(vp6[9][u32(unconst_u32(163))]);
+  var vf150: vec4u = firstLeadingBit(vec4u(unconst_u32(39), unconst_u32(301), unconst_u32(182), unconst_u32(87)));
+  vf147 = bool(override18);
+  let vf151: bool = (*ptr52)[u32(unconst_u32(72))];
+  let vf152: vec4u = firstLeadingBit(vec4u(unconst_u32(173), unconst_u32(417), unconst_u32(109), unconst_u32(44)));
+  let ptr53: ptr<private, vec4<bool>> = &vp6[9][u32(unconst_u32(11))];
+  let vf153: vec3f = fma(vec3f(unconst_f32(-0.1555), unconst_f32(0.04366), unconst_f32(0.2557)), vec3f(unconst_f32(0.01170), unconst_f32(0.2699), unconst_f32(0.09494)), vec3f(unconst_f32(0.2017), unconst_f32(0.6019), unconst_f32(0.1314)));
+  let vf154: vec4u = vf152;
+  vf147 = all(vp6[9][0]);
+  let ptr54: ptr<private, array<vec4<bool>, 1>> = &vp6[9];
+  let ptr55: ptr<private, vec4<bool>> = &vp6[9][u32(unconst_u32(48))];
+  out = FragmentOutput3(vec4f(vp6[u32(unconst_u32(95))][0]), vec4f(vp6[u32(unconst_u32(95))][0]));
+  out.f1 = vec4f((*ptr51));
+  vf150 ^= unpack4xU8(u32((*ptr54)[u32(unconst_u32(136))][u32(unconst_u32(524))]));
+  vp6[u32(unconst_u32(142))][u32(unconst_u32(98))] = (*ptr53);
+  return out;
+  _ = override18;
+}
+
+@fragment
+fn fragment8(@builtin(sample_mask) a0: u32, @invariant @builtin(position) a1: vec4f) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  out.f1 += vec4f(vp6[9][0]);
+  let vf155: bool = vp6[9][u32(unconst_u32(25))][u32(unconst_u32(451))];
+  let vf156: vec4f = a1;
+  out.f0 = vec2i(vp6[u32(unconst_u32(20))][0].ra);
+  var vf157: f32 = a1[u32(unconst_u32(214))];
+  var vf158: f32 = a1[u32(unconst_u32(63))];
+  var vf159: u32 = pack2x16snorm(vec2f(unconst_f32(0.3343), unconst_f32(-0.8950)));
+  out = FragmentOutput4(vec2i(inverseSqrt(vec2h(unconst_f16(-8160.4), unconst_f16(6847.6)))), vec4f(inverseSqrt(vec2h(unconst_f16(-8160.4), unconst_f16(6847.6))).grgr));
+  let ptr56: ptr<function, f32> = &vf158;
+  var vf160: f32 = a1[u32(unconst_u32(167))];
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute5() {
+  let vf161: i32 = override18;
+  vp6[u32(unconst_u32(160))][u32(unconst_u32(23))] = vp6[u32(unconst_u32(223))][0];
+  let vf162: vec2u = textureDimensions(tex14);
+  vp6[u32(vp6[9][u32(any(vp6[9][0]))][u32(unconst_u32(3))])][pack4xI8Clamp(vec4i(unconst_i32(15), unconst_i32(60), unconst_i32(887), unconst_i32(171)))] = vec4<bool>(acos(vec4h(f16(vp6[u32(unconst_u32(146))][u32(unconst_u32(4))][u32(unconst_u32(706))]))));
+  vp6[u32(unconst_u32(101))][u32(unconst_u32(623))] = vec4<bool>(vf162.rrgg);
+  vp6[u32(unconst_u32(51))][0] = vec4<bool>(bool(pack2x16unorm(vec2f(unconst_f32(0.00942), unconst_f32(0.1614)))));
+  let vf163: u32 = insertBits(u32(unconst_u32(188)), u32(unconst_u32(170)), u32(unconst_u32(334)), u32(unconst_u32(184)));
+  vp6[bitcast<u32>(normalize(vec2h(unconst_f16(16591.9), unconst_f16(28581.4))))][0] = vec4<bool>(vf162.grgr);
+  let ptr57: ptr<private, vec4<bool>> = &vp6[u32(unconst_u32(578))][0];
+  let ptr58: ptr<private, vec4<bool>> = &(*ptr57);
+  let ptr59: ptr<private, array<vec4<bool>, 1>> = &vp6[u32(unconst_u32(356))];
+  var vf164: i32 = override18;
+  let vf165: bool = (*ptr57)[bitcast<vec3u>(normalize(vec3f(unconst_f32(-0.07164), unconst_f32(0.1395), unconst_f32(0.04148))))[0]];
+  let ptr60: ptr<private, array<vec4<bool>, 1>> = &vp6[9];
+  vf164 &= vf164;
+  var vf166: bool = vp6[9][u32(unconst_u32(193))][u32(unconst_u32(110))];
+  let vf167: u32 = textureNumLayers(tex14);
+  vp6[u32(unconst_u32(121))][u32(any(vp6[9][0]))] = vec4<bool>(bool(acos(f32(unconst_f32(0.4743)))));
+  var vf168: u32 = pack2x16snorm(vec2f(unconst_f32(-0.2547), unconst_f32(0.06651)));
+  let vf169: bool = (*ptr59)[0][u32(unconst_u32(302))];
+  vf168 &= bitcast<u32>(radians(vec2h(unconst_f16(-35280.5), unconst_f16(2756.1))));
+  _ = override18;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer98 = device0.createBuffer({size: 1746, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(0, bindGroup3, new Uint32Array(1572), 212, 0);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline8);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 100, resource: textureView159},
+    {binding: 26, resource: {buffer: buffer39, offset: 0, size: 64}},
+  ],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder15.setViewport(46.198091300510235, 15.243746351753526, 46.876325722729156, 6.770749751647378, 0.7375668143752445, 0.7676977726708621);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+await gc();
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 97, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup68, new Uint32Array(960), 52, 0);
+} catch {}
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -142.2, g: -399.8, b: 835.2, a: 979.5, });
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup16, new Uint32Array(1006), 206, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(289_051_420, 509, 738_205_159, 1_204_845_554);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2392 */
+  offset: 2388,
+  bytesPerRow: 6144,
+  rowsPerImage: 56,
+  buffer: buffer21,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 2},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas2);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture150 = device0.createTexture({
+  size: [165, 24, 111],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler110 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.95,
+  lodMaxClamp: 37.44,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder3.drawIndirect(buffer7, 2_308);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData5,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'linear'} });
+let commandBuffer2 = commandEncoder51.finish();
+let sampler111 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 76.38, lodMaxClamp: 80.76});
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer92, 272);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer85, 112);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(1653);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer96, 236);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder();
+let sampler112 = device0.createSampler({
+  label: '\u52c7\u8ac5\uaa59',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.89,
+  lodMaxClamp: 97.75,
+  compare: 'equal',
+});
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup71);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(2660);
+} catch {}
+try {
+renderPassEncoder15.setViewport(100.04883253688263, 9.944296911281159, 32.75023878596127, 0.04793932532594693, 0.14218190152887422, 0.4876711712835165);
+} catch {}
+try {
+renderPassEncoder3.draw(1_206_852_869, 24, 1_328_689_652, 306_667_959);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer88, 736);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer8, 'uint16', 844, 373);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 41, height: 6, depthOrArrayLayers: 27}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData22 = new ImageData(40, 92);
+let bindGroup92 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView120}]});
+let buffer99 = device0.createBuffer({
+  label: '\u0c2b\u0e56',
+  size: 35316,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture151 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 39},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder129 = commandEncoder160.beginComputePass({label: '\u{1fc3d}\u9812\u0efe\u{1ff4c}\u{1f771}\u0c96'});
+try {
+computePassEncoder129.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer65, 1_164);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(13).fill(155), /* required buffer size: 13 */
+{offset: 13}, {width: 23, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+globalThis.someLabel = commandEncoder44.label;
+} catch {}
+let bindGroup93 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 32, resource: {buffer: buffer14, offset: 3840}}]});
+let buffer100 = device0.createBuffer({
+  size: 2689,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture152 = gpuCanvasContext0.getCurrentTexture();
+let sampler113 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.85,
+  lodMaxClamp: 57.50,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer0, 292);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer0, 208);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let promise17 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+let imageData23 = new ImageData(52, 32);
+let bindGroup94 = device0.createBindGroup({
+  label: '\u{1fd0c}\u{1fe04}\uec6e\u374f\u0f77\u{1fea1}',
+  layout: bindGroupLayout22,
+  entries: [{binding: 100, resource: textureView159}, {binding: 26, resource: {buffer: buffer22, offset: 0}}],
+});
+let commandEncoder161 = device0.createCommandEncoder({label: '\u{1fedf}\u{1fda7}\u{1fc9a}\u{1ff49}\u920f\u{1fea4}\u165c\uf5d4\u{1ff7f}'});
+let textureView161 = texture127.createView({aspect: 'all'});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup91, new Uint32Array(264), 6, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(954_145_672, 57, 278_242_674, 138_335_725);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer0, 808);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer25, 'uint16', 2_902, 2_894);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer68, 3972, buffer96, 1380, 2068);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: imageData23,
+  origin: { x: 11, y: 3 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder162 = device0.createCommandEncoder({});
+let computePassEncoder130 = commandEncoder161.beginComputePass({label: '\uc014\u{1fd87}\u019e\ucefe\u{1ffda}\u00df\u{1f96d}\ue49b'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float']});
+let sampler114 = device0.createSampler({
+  label: '\u163a\ue90c\u{1fe4e}\ue6a7\u{1ffc7}\u039b\u866f\u0c70\uea9b\ub644',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 45.80,
+});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -391.0, g: -864.6, b: -382.4, a: 148.7, });
+} catch {}
+try {
+renderPassEncoder3.draw(285_172_010, 88, 326_172_385, 400_906_538);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer97, 244);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer67);
+} catch {}
+document.body.append(img2);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+canvas7.getContext('webgl');
+} catch {}
+let computePassEncoder131 = commandEncoder162.beginComputePass();
+let sampler115 = device0.createSampler({
+  label: '\u2ac0\uc2d7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 11.80,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder131.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.draw(190_944_523, 98, 244_481_254, 726_748_678);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer83, 12_168);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer61, 'uint32', 8_992, 2_228);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(48_033).fill(148), /* required buffer size: 48_033 */
+{offset: 29, bytesPerRow: 40, rowsPerImage: 150}, {width: 1, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let buffer101 = device0.createBuffer({size: 1968, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture153 = device0.createTexture({
+  size: {width: 165},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder3.draw(603_374_629, 803, 183_147_218, 1_790_877_445);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer76, 460);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 40, resource: {buffer: buffer16, offset: 0, size: 263}},
+    {binding: 174, resource: {buffer: buffer89, offset: 512, size: 153}},
+    {binding: 83, resource: {buffer: buffer21, offset: 256, size: 132}},
+  ],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], depthReadOnly: true});
+let renderBundle16 = renderBundleEncoder16.finish({label: '\u0cb4\u2f10\u{1fde4}\u72ea\ub8e2\u675a\u0db5\u40b3\uda88'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup20, new Uint32Array(1447), 144, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img4);
+try {
+renderPassEncoder3.drawIndirect(buffer9, 420);
+} catch {}
+let arrayBuffer12 = buffer10.getMappedRange(328, 4);
+try {
+device0.queue.writeBuffer(buffer65, 384, new BigUint64Array(4271), 594, 28);
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 621,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let renderBundle17 = renderBundleEncoder17.finish({label: '\u45a7\ud965\ud657\u681a\u0fbd\u32d7\u{1fe08}\u2cc2'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+computePassEncoder130.setBindGroup(1, bindGroup43, new Uint32Array(618), 105, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+renderPassEncoder3.draw(31_670_271, 165, 241_658_799, 230_784_859);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer65, 1_008);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer83, 580);
+} catch {}
+document.body.append(img5);
+let buffer103 = device0.createBuffer({
+  label: '\u26de\u{1f6fa}\u00bb',
+  size: 4760,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder164 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder164.beginComputePass({});
+let renderPassEncoder44 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  clearValue: { r: 413.2, g: -20.11, b: 110.4, a: 863.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup15, new Uint32Array(1259), 197, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(3_026_280_708, 291, 544_609_188, 288_419_857);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer54, 'uint32', 1_864, 2_438);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer60);
+} catch {}
+let bindGroup96 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer102, offset: 0, size: 273}}],
+});
+let buffer104 = device0.createBuffer({
+  size: 14898,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder165 = device0.createCommandEncoder();
+let texture154 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 21},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder133 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder131.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder82.setBindGroup(0, bindGroup91, new Uint32Array(197), 2, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup67);
+} catch {}
+let arrayBuffer13 = buffer42.getMappedRange(816, 152);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup97 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView29}]});
+let texture155 = device0.createTexture({
+  label: '\u{1f610}\u{1f992}\u10d3\u09a8\u0f11\u{1fe12}\u952f\u{1fb95}\u9704',
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame22, colorSpace: 'display-p3'});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup18, new Uint32Array(5178), 450, 0);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.beginOcclusionQuery(107);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle14, renderBundle14, renderBundle14, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder3.draw(234_962_845, 70, 485_102_853, 9_471_153);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, buffer55, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer29);
+} catch {}
+try {
+canvas6.getContext('webgl');
+} catch {}
+try {
+globalThis.someLabel = externalTexture20.label;
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 288,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture156 = device0.createTexture({
+  size: [516, 1, 1],
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder92.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup91, new Uint32Array(3593), 404, 0);
+} catch {}
+try {
+renderPassEncoder34.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint16', 296, 448);
+} catch {}
+document.body.append(canvas0);
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'hlg'} });
+let bindGroup98 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 208, resource: {buffer: buffer48, offset: 512, size: 1462}}],
+});
+let buffer105 = device0.createBuffer({
+  label: '\u09a9\u4c8f\u0f89\u{1f6df}\u{1ff89}\u0ce2',
+  size: 6548,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder166 = device0.createCommandEncoder({});
+let texture157 = device0.createTexture({size: [8, 8, 23], format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, viewFormats: []});
+let texture158 = device0.createTexture({
+  size: [129],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder45 = commandEncoder166.beginRenderPass({
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: 818.8, g: 807.4, b: 149.7, a: 596.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler116 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.56,
+  lodMaxClamp: 66.03,
+});
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup51, new Uint32Array(6297), 59, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer36, 520);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData24 = new ImageData(64, 20);
+let videoFrame24 = new VideoFrame(videoFrame2, {timestamp: 0});
+let commandEncoder167 = device0.createCommandEncoder({});
+let textureView162 = texture62.createView({dimension: '2d-array'});
+let texture159 = device0.createTexture({
+  label: '\u9a08\uc298\u0d9f\ud748\u6620\uac5a\u{1ffde}\uf55a\u156b\u0b7a\u81c7',
+  size: {width: 330, height: 48, depthOrArrayLayers: 5},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler117 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 3.658, lodMaxClamp: 42.57});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup47, new Uint32Array(1125), 229, 0);
+} catch {}
+try {
+renderPassEncoder45.setStencilReference(1090);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 3584, new Int16Array(2896), 399, 8);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let imageBitmap4 = await createImageBitmap(canvas3);
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView30}, {binding: 135, resource: textureView13}],
+});
+let textureView163 = texture157.createView({label: '\u{1fb87}\u0b95\u{1ffe0}', arrayLayerCount: 6});
+let computePassEncoder134 = commandEncoder167.beginComputePass({label: '\u2fbc\ucd48\u03b4\u0f04\u{1f604}\u0314\ufee7\u0ae7\ube67\u0069\ub105'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+computePassEncoder120.setBindGroup(3, bindGroup8, new Uint32Array(575), 101, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder3.draw(208_222_645, 230, 943_044_377, 359_043_726);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+document.body.append(img0);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup100 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 84, resource: textureView13},
+    {binding: 301, resource: {buffer: buffer4, offset: 4352, size: 1725}},
+    {binding: 0, resource: textureView32},
+    {binding: 207, resource: textureView16},
+    {binding: 172, resource: textureView13},
+  ],
+});
+let texture160 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 19},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView164 = texture8.createView({});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup87, new Uint32Array(508), 84, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+let arrayBuffer14 = buffer51.getMappedRange(8200, 168);
+document.body.append(img1);
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 428,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 332,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup101 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer61, offset: 4608, size: 6588}}],
+});
+let commandEncoder168 = device0.createCommandEncoder({});
+let textureView165 = texture160.createView({baseArrayLayer: 2, arrayLayerCount: 7});
+let texture161 = device0.createTexture({
+  size: [516, 1, 845],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder19.setIndexBuffer(buffer29, 'uint32', 528, 966);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+let textureView166 = texture155.createView({});
+let textureView167 = texture128.createView({
+  label: '\u06e2\u{1fa7f}\u04aa\u45dd\u{1fa24}\u06d5\u{1fb55}\u040c\u069d\u9e69',
+  dimension: '2d-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let renderBundle19 = renderBundleEncoder19.finish();
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer17);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let bindGroup102 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 61, resource: textureView165}]});
+let texture162 = device0.createTexture({
+  size: {width: 82},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder135 = commandEncoder168.beginComputePass({});
+try {
+computePassEncoder123.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup89, new Uint32Array(2367), 1_453, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer31, 'uint32', 1_136, 532);
+} catch {}
+try {
+  await promise16;
+} catch {}
+try {
+sampler99.label = '\ude70\u{1f79f}\u{1f705}\u58ef\u5062\u{1f9c2}\u6943\ufc68\uacaf\u{1fbd0}';
+} catch {}
+let textureView168 = texture156.createView({label: '\u{1f6c6}\u3781\u{1fab3}\u710a\u4e4d\ua95b\u2b4a\uba33\u6fae\ub334', aspect: 'all'});
+let textureView169 = texture56.createView({});
+let renderPassEncoder46 = commandEncoder23.beginRenderPass({
+  label: '\u0faa\u{1f878}\ue041\u{1f91a}',
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 34,
+  clearValue: { r: -969.7, g: 471.7, b: -300.7, a: -329.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder135.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 271, resource: {buffer: buffer8, offset: 0}}, {binding: 23, resource: textureView49}],
+});
+let buffer106 = device0.createBuffer({
+  size: 20150,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder169 = device0.createCommandEncoder({label: '\u55f0\u{1fe88}\u{1f745}'});
+let textureView170 = texture162.createView({});
+let computePassEncoder136 = commandEncoder169.beginComputePass({});
+let sampler118 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 94.49,
+  lodMaxClamp: 97.84,
+  compare: 'never',
+});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup77, new Uint32Array(820), 52, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline3);
+} catch {}
+try {
+  await buffer68.mapAsync(GPUMapMode.WRITE, 3528);
+} catch {}
+document.body.append(img3);
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'pq'} });
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 569, resource: sampler18},
+    {binding: 167, resource: {buffer: buffer48, offset: 0, size: 119}},
+    {binding: 445, resource: textureView147},
+    {binding: 419, resource: {buffer: buffer31, offset: 1792, size: 396}},
+  ],
+});
+let buffer107 = device0.createBuffer({size: 5316, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture163 = device0.createTexture({
+  size: {width: 516},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture164 = device0.createTexture({
+  label: '\u8033\u{1fa49}\u0776\u900e\u07ab\ue5c8\ud4b4\uca63\uea61',
+  size: {width: 8, height: 8, depthOrArrayLayers: 4},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView171 = texture29.createView({dimension: 'cube-array', baseArrayLayer: 5, arrayLayerCount: 6});
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer15, 0);
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({});
+let texture165 = device0.createTexture({
+  size: [1032, 1, 12],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder137 = commandEncoder170.beginComputePass({});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup28, new Uint32Array(1919), 22, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle14, renderBundle17, renderBundle14, renderBundle14, renderBundle17, renderBundle17, renderBundle17, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint32', 60, 39);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData9,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView172 = texture37.createView({
+  label: '\ud6c8\ub21c\u0517\u9299\u00a3\u5c15\u5d0c\u864a\u06af',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+  arrayLayerCount: 28,
+});
+try {
+renderPassEncoder24.setIndexBuffer(buffer8, 'uint32', 1_140, 125);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer104, 32, new Int16Array(65536), 8317, 372);
+} catch {}
+let texture166 = device0.createTexture({
+  label: '\ufd19\u0866\u00a9\udaa8\u77ed\u{1f68c}\u{1fad8}\u0ef4\u8361\u0e66\ubec9',
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler119 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 84.90,
+  maxAnisotropy: 1,
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame21});
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup63, new Uint32Array(1644), 187, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer61, 'uint32', 5_844, 3_962);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+await gc();
+let buffer108 = device0.createBuffer({
+  size: 2970,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView173 = texture144.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 191, resource: textureView168},
+    {binding: 19, resource: textureView122},
+    {binding: 52, resource: textureView163},
+    {binding: 288, resource: {buffer: buffer97, offset: 0}},
+    {binding: 78, resource: textureView81},
+  ],
+});
+let buffer109 = device0.createBuffer({size: 25042, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder171 = device0.createCommandEncoder({label: '\u{1f71b}\u{1f932}\u{1fbfd}\u1349\u9332\u5fe4\u{1ffbe}\ua6c7\u8186\u92fe\u90bb'});
+let textureView174 = texture16.createView({dimension: '2d', baseArrayLayer: 6});
+let computePassEncoder138 = commandEncoder171.beginComputePass();
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup51, new Uint32Array(2527), 693, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer80, 'uint16', 26, 2_214);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer106);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder();
+let renderPassEncoder47 = commandEncoder172.beginRenderPass({
+  colorAttachments: [{
+  view: textureView106,
+  clearValue: { r: -685.3, g: 39.67, b: -623.8, a: -294.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 188808563,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup76, new Uint32Array(1750), 486, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer2, 'uint32', 412, 86);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer60, 4_128, 161);
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({});
+let renderPassEncoder48 = commandEncoder173.beginRenderPass({
+  label: '\u3ddf\u0bb9\uaf0f\uf491\u0779',
+  colorAttachments: [{view: textureView108, depthSlice: 7, loadOp: 'clear', storeOp: 'discard'}],
+});
+let sampler120 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.34,
+  lodMaxClamp: 19.77,
+  maxAnisotropy: 1,
+});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder137.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer89, 'uint32', 548, 1_935);
+} catch {}
+try {
+  await shaderModule3.getCompilationInfo();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+let textureView175 = texture104.createView({label: '\u6a72\u2f36\u295f\u2a2a'});
+let renderPassEncoder49 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 129,
+  clearValue: { r: 959.6, g: 39.08, b: 403.8, a: 842.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 11128969,
+});
+let sampler121 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.85,
+  lodMaxClamp: 90.49,
+});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup70, new Uint32Array(6704), 87, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup0, new Uint32Array(766), 31, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 3460, new BigUint64Array(10058), 3663, 196);
+} catch {}
+try {
+adapter0.label = '\u5d80\ua94b\u0b8f\u{1f9a4}\u0fdb\u3cef\u{1fcaa}';
+} catch {}
+let texture167 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1207},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView176 = texture72.createView({format: 'rgb10a2unorm'});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup68, new Uint32Array(378), 1, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup85, new Uint32Array(1138), 101, 0);
+} catch {}
+try {
+renderPassEncoder16.setViewport(537.0394971442254, 82.58150643731395, 29.972700867096965, 1.6161243909748788, 0.3022486447660159, 0.5603101344343244);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer76);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let texture168 = device0.createTexture({
+  label: '\u0769\ub631\u0be9\u0ef1\u{1f600}\u220c',
+  size: [82, 12, 8],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView177 = texture159.createView({dimension: '2d', baseArrayLayer: 4});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup105, []);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer76, 'uint16', 854, 164);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 1604, new DataView(new ArrayBuffer(1571)), 401, 512);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(81).fill(56), /* required buffer size: 81 */
+{offset: 81, rowsPerImage: 38}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.append(canvas0);
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView111},
+    {binding: 271, resource: {buffer: buffer46, offset: 0, size: 36}},
+  ],
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let textureView178 = texture106.createView({label: '\u0be0\u0583\u06de\u7012'});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup62, new Uint32Array(263), 66, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 660, height: 96, depthOrArrayLayers: 446}
+*/
+{
+  source: canvas0,
+  origin: { x: 35, y: 58 },
+  flipY: false,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 5, y: 60, z: 53},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 86, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 569, resource: sampler32},
+    {binding: 419, resource: {buffer: buffer21, offset: 0, size: 300}},
+    {binding: 167, resource: {buffer: buffer20, offset: 4352}},
+    {binding: 445, resource: textureView131},
+  ],
+});
+let renderPassEncoder50 = commandEncoder175.beginRenderPass({
+  colorAttachments: [{
+  view: textureView167,
+  clearValue: { r: -887.2, g: -11.56, b: -255.8, a: -390.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler122 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 37.95,
+  lodMaxClamp: 46.97,
+});
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup24);
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 23951,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder176 = device0.createCommandEncoder({});
+let computePassEncoder139 = commandEncoder176.beginComputePass({});
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+let bindGroup108 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 127, resource: textureView37}]});
+let buffer111 = device0.createBuffer({
+  size: 5655,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture169 = device0.createTexture({size: [660], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup2, new Uint32Array(372), 105, 0);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(15);
+} catch {}
+let buffer112 = device0.createBuffer({size: 521, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder177 = device0.createCommandEncoder({});
+let textureView179 = texture79.createView({});
+let renderPassEncoder51 = commandEncoder177.beginRenderPass({
+  colorAttachments: [{
+  view: textureView114,
+  depthSlice: 160,
+  clearValue: { r: 834.8, g: 23.31, b: 913.4, a: 112.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 5.982,
+  lodMaxClamp: 45.10,
+});
+try {
+computePassEncoder139.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(117);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer19, 832, 1_678);
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder({label: '\ub916\u{1f861}\u{1fb7e}'});
+let texture170 = device0.createTexture({
+  label: '\u02f7\u{1fbd3}\u045b\ub487\u9dc3\u{1fc1d}\u7c04\ufd0e',
+  size: [129, 1, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder52 = commandEncoder178.beginRenderPass({
+  colorAttachments: [{view: textureView44, depthSlice: 34, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet14,
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 67.18,
+  lodMaxClamp: 83.99,
+});
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup42, new Uint32Array(6571), 1_358, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer2, 'uint16', 318, 53);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: -725.9, g: -262.1, b: -682.2, a: 665.2, });
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer8, 'uint32', 484, 517);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+let buffer113 = device0.createBuffer({size: 15177, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder179 = device0.createCommandEncoder();
+let sampler125 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.46,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup69, new Uint32Array(1025), 9, 0);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+commandEncoder179.insertDebugMarker('\u4897');
+} catch {}
+let texture171 = device0.createTexture({size: [660, 96, 58], format: 'r32sint', usage: GPUTextureUsage.STORAGE_BINDING, viewFormats: []});
+let texture172 = device0.createTexture({
+  label: '\u788e\u0cd1\u{1fdc6}\ub3cd\u{1fbbe}\u{1f8de}',
+  size: [165, 24, 18],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder140 = commandEncoder179.beginComputePass({});
+let sampler126 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.91,
+  lodMaxClamp: 99.51,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup44, new Uint32Array(344), 61, 0);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer54, 'uint16', 4_056, 3_109);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup109 = device0.createBindGroup({
+  label: '\u{1f8f3}\u5d11\uc670\u3441',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer84, offset: 768, size: 2023}},
+    {binding: 606, resource: textureView139},
+  ],
+});
+let commandEncoder180 = device0.createCommandEncoder({label: '\u28dd\u57ba\u{1fade}\u{1f94f}\u4308\u0e3b\u99e4\ua36b\u{1fae0}\u{1ff0f}'});
+let texture173 = device0.createTexture({
+  size: [8, 8, 449],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder141 = commandEncoder180.beginComputePass();
+try {
+computePassEncoder60.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup75, []);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup31, new Uint32Array(860), 26, 0);
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({});
+let computePassEncoder142 = commandEncoder181.beginComputePass();
+let sampler127 = device0.createSampler({
+  label: '\u0c8f\u0458',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.34,
+  lodMaxClamp: 81.31,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer83, 'uint16', 100, 383);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView180 = texture113.createView({format: 'r8uint', baseArrayLayer: 0});
+try {
+computePassEncoder115.setBindGroup(3, bindGroup106, new Uint32Array(1289), 357, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle15, renderBundle0, renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer26, 'uint32', 1_096, 3_751);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(178).fill(231), /* required buffer size: 178 */
+{offset: 178, bytesPerRow: 2233}, {width: 139, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup110 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [{binding: 100, resource: textureView173}, {binding: 26, resource: {buffer: buffer24, offset: 256}}],
+});
+let commandEncoder182 = device0.createCommandEncoder({});
+try {
+computePassEncoder142.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer75, 'uint16', 2_814, 5_872);
+} catch {}
+try {
+commandEncoder182.clearBuffer(buffer67, 744, 304);
+} catch {}
+let buffer114 = device0.createBuffer({
+  size: 1650,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder183 = device0.createCommandEncoder();
+let computePassEncoder143 = commandEncoder182.beginComputePass();
+let sampler128 = device0.createSampler({
+  label: '\u{1ffe6}\u0aba',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.995,
+  lodMaxClamp: 71.75,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup90, new Uint32Array(6922), 811, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder183.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 36, y: 18, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder144 = commandEncoder183.beginComputePass({});
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.61,
+  lodMaxClamp: 91.19,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup8, new Uint32Array(1394), 99, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup1, new Uint32Array(199), 0, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer37, 'uint16', 82, 859);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(5, buffer78);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 160, resource: textureView16}, {binding: 378, resource: textureView87}],
+});
+let texture174 = device0.createTexture({
+  size: [165, 24, 23],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView181 = texture16.createView({dimension: '2d', baseArrayLayer: 5, arrayLayerCount: 1});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup77, new Uint32Array(4628), 711, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle11, renderBundle9]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup3, new Uint32Array(821), 360, 0);
+} catch {}
+try {
+renderPassEncoder47.insertDebugMarker('\u9d24');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  label: '\u0881\u{1fc2e}\u020a\u254e\u0a78\u040c\u874d\u{1fd2d}',
+  layout: bindGroupLayout17,
+  entries: [{binding: 16, resource: textureView122}],
+});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup13, new Uint32Array(959), 109, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer73, 'uint16', 136, 428);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 16, resource: textureView117}]});
+let commandEncoder184 = device0.createCommandEncoder({});
+let textureView182 = texture11.createView({dimension: 'cube', baseArrayLayer: 1, arrayLayerCount: 6});
+let textureView183 = texture67.createView({});
+let computePassEncoder145 = commandEncoder184.beginComputePass({});
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(274).fill(105), /* required buffer size: 274 */
+{offset: 274}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer115 = device0.createBuffer({
+  size: 16905,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView184 = texture100.createView({dimension: '3d', mipLevelCount: 2});
+try {
+computePassEncoder142.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(3, bindGroup62, new Uint32Array(50), 7, 0);
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(5, buffer100, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer4, 'uint16', 1_944, 174);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+externalTexture14.label = '\u{1fcce}\u0d17\u{1f64d}';
+} catch {}
+let texture175 = device0.createTexture({
+  size: {width: 660},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView185 = texture78.createView({arrayLayerCount: 1});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup3, new Uint32Array(723), 31, 0);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer76, 'uint16', 392, 2_195);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer64);
+} catch {}
+let imageData25 = new ImageData(36, 20);
+let texture176 = device0.createTexture({size: [330], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup33, new Uint32Array(3787), 986, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup38, new Uint32Array(4880), 754, 0);
+} catch {}
+let textureView186 = texture151.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 11});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup84, new Uint32Array(965), 58, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder({});
+let texture177 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 6},
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder53 = commandEncoder185.beginRenderPass({
+  colorAttachments: [{
+  view: textureView125,
+  depthSlice: 40,
+  clearValue: { r: -829.8, g: 835.6, b: -973.2, a: 884.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 133593250,
+});
+try {
+computePassEncoder145.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline0);
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 61, resource: {buffer: buffer14, offset: 1280}},
+    {binding: 97, resource: {buffer: buffer71, offset: 2304}},
+  ],
+});
+try {
+buffer17.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise19;
+} catch {}
+document.body.append(img0);
+try {
+computePassEncoder120.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer69, 0, 1_914);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer94, 'uint16', 828, 726);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer77, 0);
+} catch {}
+try {
+buffer98.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 4, y: 21 },
+  flipY: true,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup115 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 92, resource: externalTexture11}]});
+let commandEncoder186 = device0.createCommandEncoder({});
+let computePassEncoder146 = commandEncoder186.beginComputePass({});
+let sampler130 = device0.createSampler({
+  label: '\u{1fc2c}\u00b6\uc6d2\u46ef',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.405,
+  lodMaxClamp: 8.762,
+});
+try {
+computePassEncoder146.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer105);
+} catch {}
+await gc();
+let buffer116 = device0.createBuffer({
+  size: 13726,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder187 = device0.createCommandEncoder({});
+let renderPassEncoder54 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView92,
+  clearValue: { r: 732.0, g: 274.0, b: -509.5, a: -896.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+});
+try {
+computePassEncoder118.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer78, 'uint16', 252, 584);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup66);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 208, resource: {buffer: buffer89, offset: 0, size: 534}}],
+});
+let textureView187 = texture162.createView({});
+let texture178 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup111);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder42.setBlendConstant({ r: -905.4, g: 639.0, b: -478.6, a: -885.9, });
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer97, 0, 184);
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder({});
+let texture179 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder55 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -307.4, g: 904.5, b: -552.0, a: -612.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 262064612,
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup32, new Uint32Array(1678), 162, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup20, new Uint32Array(2347), 732, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer52, 'uint32', 92, 665);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer99, 'uint16', 35_316);
+} catch {}
+document.body.append(img0);
+let img6 = await imageWithData(5, 197, '#10101010', '#20202020');
+let textureView188 = texture78.createView({aspect: 'all'});
+let sampler131 = device0.createSampler({
+  label: '\u03f9\u9cac\ubf8e\u{1fd4b}\u0acf\u0150\u0cdb\uba44',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 95.43,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup8, new Uint32Array(1398), 881, 0);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup112, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 99, resource: textureView30}, {binding: 135, resource: textureView72}],
+});
+let texture180 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 1361},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler132 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 93.81,
+});
+try {
+computePassEncoder129.setBindGroup(2, bindGroup87, new Uint32Array(1565), 1_185, 0);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle5, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(0, buffer57, 0, 303);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 80, resource: {buffer: buffer83, offset: 1280, size: 6776}},
+    {binding: 131, resource: {buffer: buffer78, offset: 0, size: 1436}},
+    {binding: 50, resource: textureView45},
+  ],
+});
+let buffer117 = device0.createBuffer({size: 14453, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture181 = gpuCanvasContext1.getCurrentTexture();
+let externalTexture26 = device0.importExternalTexture({source: videoFrame16});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup108, new Uint32Array(2557), 641, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer62, 'uint32', 988, 10_321);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer105, 456);
+} catch {}
+let texture182 = device0.createTexture({
+  size: [82],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView189 = texture29.createView({arrayLayerCount: 1});
+let renderBundle20 = renderBundleEncoder20.finish({label: '\u1808\u08b3\ufef9\u515e\u0bce\u9486'});
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(3, buffer111, 0);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer17, 17160, buffer99, 0, 32);
+} catch {}
+try {
+commandEncoder7.insertDebugMarker('\uf129');
+} catch {}
+let textureView190 = texture162.createView({label: '\u6e78\u{1f686}'});
+let texture183 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 72},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder56 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView106,
+  clearValue: { r: 943.1, g: 919.5, b: -969.6, a: -84.32, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler133 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.8220,
+  lodMaxClamp: 34.30,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+computePassEncoder146.setBindGroup(1, bindGroup89, new Uint32Array(1909), 68, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+buffer69.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let canvas8 = document.createElement('canvas');
+let buffer118 = device0.createBuffer({
+  size: 816,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder189 = device0.createCommandEncoder();
+let renderPassEncoder57 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView177,
+  clearValue: { r: -487.1, g: -659.1, b: 981.3, a: -146.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 65168449,
+});
+try {
+renderPassEncoder54.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer21, 'uint16', 126, 463);
+} catch {}
+let buffer119 = device0.createBuffer({size: 5554, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture184 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup55, new Uint32Array(3397), 810, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup87);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle12]);
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 42, resource: {buffer: buffer48, offset: 256, size: 66}}],
+});
+let sampler134 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.20,
+  lodMaxClamp: 90.13,
+});
+try {
+buffer4.unmap();
+} catch {}
+let bindGroup120 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 127, resource: textureView39}]});
+let sampler135 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.67,
+  lodMaxClamp: 71.16,
+  maxAnisotropy: 10,
+});
+let textureView191 = texture157.createView({baseArrayLayer: 13, arrayLayerCount: 1});
+let texture185 = device0.createTexture({size: {width: 516}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup105);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup101, new Uint32Array(199), 101, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer94, 1_048, 273);
+} catch {}
+let gpuCanvasContext5 = canvas8.getContext('webgpu');
+let bindGroup121 = device0.createBindGroup({
+  label: '\u32fb\u{1f882}\uc32c\u9d8e\u6346\u{1fc4a}',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer104, offset: 1792, size: 2144}},
+    {binding: 606, resource: textureView81},
+  ],
+});
+let textureView192 = texture94.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+renderPassEncoder40.executeBundles([renderBundle12, renderBundle8, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer89, 'uint32', 984, 104);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 174, resource: {buffer: buffer84, offset: 0, size: 3319}},
+    {binding: 40, resource: {buffer: buffer104, offset: 0, size: 2046}},
+    {binding: 83, resource: {buffer: buffer15, offset: 0, size: 44}},
+  ],
+});
+let commandEncoder190 = device0.createCommandEncoder({});
+let computePassEncoder147 = commandEncoder190.beginComputePass({});
+let sampler136 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 95.80,
+  lodMaxClamp: 96.50,
+});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup121, new Uint32Array(236), 10, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer59, 0, 656);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 16, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(809_312).fill(190), /* required buffer size: 809_312 */
+{offset: 94, bytesPerRow: 97, rowsPerImage: 65}, {width: 11, height: 23, depthOrArrayLayers: 129});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder67.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+computePassEncoder74.setBindGroup(0, bindGroup31, new Uint32Array(183), 19, 0);
+} catch {}
+let imageData26 = new ImageData(68, 12);
+try {
+textureView19.label = '\u0acc\u{1fae9}\ub650\uea2f\u987a\u0c4d\u4ea1\ud446\u0519\u0e05';
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture186 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView193 = texture33.createView({label: '\u03e1\ufcf4', dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+try {
+computePassEncoder146.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(2, bindGroup92, new Uint32Array(174), 2, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(167).fill(240), /* required buffer size: 167 */
+{offset: 4, bytesPerRow: 139}, {width: 6, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let buffer120 = device0.createBuffer({size: 1308, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder192 = device0.createCommandEncoder({});
+let texture187 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 28},
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder58 = commandEncoder192.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 220,
+  clearValue: { r: -801.5, g: 332.7, b: -599.3, a: 261.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 9039014,
+});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(10, 0, 70, 0);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer118);
+} catch {}
+let textureView194 = texture144.createView({});
+let renderPassEncoder59 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView180,
+  depthSlice: 464,
+  clearValue: { r: -4.892, g: 459.3, b: 330.1, a: -428.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 51345623,
+});
+try {
+renderPassEncoder30.executeBundles([renderBundle11]);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+document.body.append(canvas2);
+try {
+adapter0.label = '\ua011\u71a0';
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [{binding: 92, resource: {buffer: buffer103, offset: 0}}, {binding: 237, resource: sampler18}],
+});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup72, new Uint32Array(923), 479, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup17, new Uint32Array(1212), 89, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+computePassEncoder80.setBindGroup(1, bindGroup14, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer121 = device0.createBuffer({size: 135, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture188 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 106},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder107.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer4, 'uint32', 2_276, 3_143);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+let commandEncoder193 = device0.createCommandEncoder({});
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup69, new Uint32Array(2141), 728, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer15, 92, 57);
+} catch {}
+try {
+commandEncoder193.copyBufferToTexture({
+  /* bytesInLastRow: 126 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 880 */
+  offset: 880,
+  bytesPerRow: 9984,
+  buffer: buffer87,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder193.clearBuffer(buffer76);
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 83,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 383,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 591,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 373,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 253,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 123,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let textureView195 = texture59.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder148 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup102, new Uint32Array(1478), 55, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer0);
+} catch {}
+let bindGroup124 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView192}]});
+let textureView196 = texture160.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder148.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder({});
+let computePassEncoder149 = commandEncoder194.beginComputePass({});
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.65,
+  lodMaxClamp: 88.03,
+});
+try {
+computePassEncoder149.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup53, new Uint32Array(1560), 292, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let bindGroup125 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView29}]});
+let texture189 = device0.createTexture({
+  size: [82, 12, 1],
+  mipLevelCount: 3,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView197 = texture104.createView({});
+let sampler138 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.28,
+  maxAnisotropy: 10,
+});
+try {
+  await promise20;
+} catch {}
+let imageData27 = new ImageData(24, 84);
+let textureView198 = texture179.createView({dimension: 'cube', baseArrayLayer: 6});
+let texture190 = device0.createTexture({
+  size: [82, 12, 13],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder9.setIndexBuffer(buffer73, 'uint32', 3_120, 1_025);
+} catch {}
+let arrayBuffer15 = buffer68.getMappedRange(3528, 144);
+document.body.prepend(img5);
+let imageData28 = new ImageData(12, 140);
+let buffer122 = device0.createBuffer({
+  size: 7444,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder195 = device0.createCommandEncoder({});
+let texture191 = device0.createTexture({
+  label: '\u3598\u{1f726}\u3d9d\u{1fa64}\u{1fb84}\u0f3a\u0976\u7493\ue7d3\u0ef2',
+  size: [516],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView199 = texture167.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let buffer123 = device0.createBuffer({size: 34055, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder196 = device0.createCommandEncoder({});
+try {
+renderPassEncoder15.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder195.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3628 */
+  offset: 3628,
+  bytesPerRow: 30976,
+  buffer: buffer50,
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let renderPassEncoder60 = commandEncoder195.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: 190.1, g: 96.45, b: -554.7, a: -331.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup120, new Uint32Array(4219), 110, 0);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder196.finish();
+let renderPassEncoder61 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: -708.5, g: 341.6, b: -181.3, a: 449.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup43, new Uint32Array(766), 110, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup64, new Uint32Array(1778), 620, 0);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(0, buffer36, 0, 374);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+}, new Uint8Array(10_633).fill(32), /* required buffer size: 10_633 */
+{offset: 535, bytesPerRow: 34, rowsPerImage: 33}, {width: 0, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView200 = texture156.createView({baseMipLevel: 0});
+let texture192 = device0.createTexture({
+  size: {width: 516},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup35, new Uint32Array(651), 267, 0);
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData6);
+try {
+computePassEncoder112.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle6]);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let commandEncoder198 = device0.createCommandEncoder({});
+try {
+commandEncoder198.copyBufferToBuffer(buffer26, 1068, buffer101, 204, 688);
+} catch {}
+try {
+commandEncoder198.copyTextureToBuffer({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 136, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1760 */
+  offset: 1760,
+  bytesPerRow: 28160,
+  buffer: buffer108,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  label: '\ub62e\u{1fba4}',
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 332, resource: sampler55},
+    {binding: 428, resource: {buffer: buffer99, offset: 5376}},
+    {binding: 116, resource: {buffer: buffer88, offset: 0, size: 1176}},
+    {binding: 57, resource: textureView187},
+  ],
+});
+let renderPassEncoder62 = commandEncoder198.beginRenderPass({
+  label: '\u5d75\u7d0e\u0b40\u{1f998}\u52ed\u7cb4\u0b0f\u{1f81b}',
+  colorAttachments: [{
+  view: textureView155,
+  clearValue: { r: 953.4, g: 93.04, b: 589.2, a: 795.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer105, 'uint16', 1_356, 451);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 1096, new BigUint64Array(13403), 1722, 4);
+} catch {}
+try {
+computePassEncoder146.setBindGroup(3, bindGroup69);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup97);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup84, new Uint32Array(868), 123, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer99, 'uint32', 4_640, 14_416);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer40);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+document.body.append(canvas6);
+let buffer124 = device0.createBuffer({size: 25606, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.89,
+  lodMaxClamp: 55.07,
+  compare: 'less',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer52, 'uint16', 46, 77);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer116, 1_020);
+} catch {}
+let arrayBuffer16 = buffer42.getMappedRange(976, 44);
+try {
+buffer88.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer125 = device0.createBuffer({
+  size: 34575,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture193 = device0.createTexture({size: [330, 48, 37], format: 'rg8sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+renderPassEncoder41.setViewport(6.829573732711836, 1.1989090260072928, 0.03664400920094993, 1.8810377261706812, 0.9326876133481887, 0.9376728347903454);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer26, 'uint16', 1_716, 1_233);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer118, 0, 29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(453).fill(211), /* required buffer size: 453 */
+{offset: 453}, {width: 77, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView201 = texture51.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler140 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.31,
+  lodMaxClamp: 89.30,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup10, new Uint32Array(2215), 295, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 36, new DataView(new ArrayBuffer(18633)), 418, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(444).fill(117), /* required buffer size: 444 */
+{offset: 444}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u4e69\ue0ca\u0c1e\u{1f907}\u9958\u0203\u83c4\u0fb3\u17d0\u0477\ue30b';
+} catch {}
+let texture194 = device0.createTexture({
+  size: {width: 82},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView202 = texture147.createView({label: '\u04ac\u28b1\u575e\u05fd\ud54e\udd88\u0121\uf11d\u{1fd05}\uaa37\u0026', aspect: 'all'});
+let sampler141 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.93,
+  lodMaxClamp: 93.30,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder97.setBindGroup(1, bindGroup24, new Uint32Array(1203), 198, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup116);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(5, buffer60);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(482) var sam2: sampler;
+
+struct T0 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp8: S4 = S4();
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw42: vec2i;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw43: array<atomic<u32>, 1>;
+
+var<workgroup> vw44: atomic<i32>;
+
+var<workgroup> vw35: mat2x4h;
+
+var<private> vp10 = modf(vec2f(0.3199, 0.2503));
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S4 {
+  @builtin(global_invocation_id) @size(16) f0: vec3u,
+  @builtin(local_invocation_id) @size(16) f1: vec3u,
+}
+
+var<workgroup> vw45: mat3x3h;
+
+var<workgroup> vw36: array<mat2x2h, 14>;
+
+var<private> vp7: S4 = S4();
+
+var<workgroup> vw46: mat2x2h;
+
+var<workgroup> vw37: atomic<u32>;
+
+var<workgroup> vw41: atomic<u32>;
+
+var<workgroup> vw40: atomic<u32>;
+
+var<workgroup> vw38: array<array<array<f16, 1>, 1>, 45>;
+
+fn fn0() -> vec2u {
+  var out: vec2u;
+  vp8 = S4(vec3u(floor(vec3h(ldexp(vec3f(f32(vp7.f1[u32(unconst_u32(57))])), vec3i(unconst_i32(186), unconst_i32(51), unconst_i32(-169)))))), vec3u(floor(vec3h(ldexp(vec3f(f32(vp7.f1[u32(unconst_u32(57))])), vec3i(unconst_i32(186), unconst_i32(51), unconst_i32(-169)))))));
+  vp9[u32(vp9[6][u32(unconst_u32(113))][u32(unconst_u32(133))])] = mat2x4h(f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))), f16(sign(f32(unconst_f32(0.04857)))));
+  var vf170: vec3h = floor(vec3h(unconst_f16(8282.2), unconst_f16(4422.9), unconst_f16(4134.2)));
+  let ptr61: ptr<private, vec3u> = &vp8.f0;
+  var vf171: vec4h = tan(vec4h(unconst_f16(3628.2), unconst_f16(-33905.9), unconst_f16(-1472.1), unconst_f16(3289.0)));
+  var vf172: f32 = sign(bitcast<vec3f>((*ptr61))[0]);
+  vp7.f1 <<= vp8.f1;
+  var vf173: vec4f = unpack4x8snorm(u32(unconst_u32(646)));
+  vp7 = S4(vec3u(vp9[u32(unconst_u32(304))][u32(unconst_u32(25))].ggr), vec3u(vp9[u32(unconst_u32(304))][u32(unconst_u32(25))].gra));
+  var vf174: f32 = sign(f32(unconst_f32(0.2868)));
+  let ptr62: ptr<function, vec4h> = &vf171;
+  vp8.f0 = vec3u(vp7.f1[u32(unconst_u32(39))]);
+  vp8 = S4(vec3u(vp7.f0[u32(vp9[6][u32(unconst_u32(48))][u32(unconst_u32(111))])]), vec3u(vp7.f0[u32(vp9[6][u32(unconst_u32(48))][u32(unconst_u32(111))])]));
+  out = vec2u(vp10.whole);
+  vf172 = vec4f(reflect(vec4h(unconst_f16(4663.0), unconst_f16(6132.5), unconst_f16(1147.5), unconst_f16(-18247.2)), vec4h(unconst_f16(4518.0), unconst_f16(32129.1), unconst_f16(1484.8), unconst_f16(27618.7)))).b;
+  var vf175: f16 = vf170[u32(unconst_u32(317))];
+  let vf176: vec4h = tan(vec4h(unconst_f16(2810.5), unconst_f16(26720.7), unconst_f16(19028.6), unconst_f16(10387.2)));
+  let ptr63: ptr<function, vec4h> = &(*ptr62);
+  let ptr64: ptr<private, vec3u> = &vp7.f1;
+  return out;
+}
+
+var<workgroup> vw39: S4;
+
+var<private> vp9: array<mat2x4h, 7> = array<mat2x4h, 7>();
+
+fn fn1() -> mat2x2h {
+  var out: mat2x2h;
+  out += mat2x2h(f16(vp8.f1[u32(unconst_u32(114))]), f16(vp8.f1[u32(unconst_u32(114))]), f16(vp8.f1[u32(unconst_u32(114))]), f16(vp8.f1[u32(unconst_u32(114))]));
+  let ptr65 = &vp10;
+  var vf177: u32 = vp7.f0[u32(unconst_u32(477))];
+  vp9[u32(unconst_u32(82))] = mat2x4h(vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))], vp9[vp8.f1[2]][u32(unconst_u32(23))][u32(unconst_u32(139))]);
+  let ptr66: ptr<private, mat2x4h> = &vp9[u32(unconst_u32(174))];
+  vp9[u32(unconst_u32(0))] = (*ptr66);
+  vp7.f1 = vec3u(vp7.f1[u32(unconst_u32(19))]);
+  let ptr67: ptr<private, vec3u> = &vp8.f0;
+  let vf178: f16 = vp9[u32(unconst_u32(57))][u32(unconst_u32(53))][u32(unconst_u32(116))];
+  vp9[u32(unconst_u32(50))] = mat2x4h(vec4h(vp7.f0.zyzy), vec4h(vp7.f0.ggbr));
+  vf177 = u32((*ptr66)[1][3]);
+  let ptr68: ptr<function, u32> = &vf177;
+  let vf179: u32 = vp7.f0[u32(unconst_u32(382))];
+  return out;
+}
+
+@compute @workgroup_size(3, 2, 1)
+fn compute6(a0: S4) {
+  vp7 = S4(vw39.f0, vw39.f0);
+  fn0();
+  fn0();
+  let ptr69: ptr<private, vec3u> = &vp8.f0;
+  vw35 += mat2x4h(f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])), f16(atomicLoad(&vw43[u32(unconst_u32(293))])));
+  vp8 = S4(vec3u(atomicLoad(&vw43[u32(unconst_u32(340))])), vec3u(atomicLoad(&vw43[u32(unconst_u32(340))])));
+  atomicSub(&vw37, u32(unconst_u32(323)));
+  let ptr70: ptr<workgroup, mat2x2h> = &vw36[u32(unconst_u32(59))];
+  var vf180: vec2h = vw36[13][u32((*&vw38)[u32(unconst_u32(16))][0][0])];
+  let ptr71: ptr<workgroup, array<f16, 1>> = &vw38[44][u32(unconst_u32(271))];
+  vw45 += mat3x3h(f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])), f16(atomicLoad(&(*&vw43)[0])));
+  let vf181: f16 = vw35[u32(unconst_u32(175))][u32(unconst_u32(163))];
+  vw35 += mat2x4h(f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])), f16(atomicLoad(&vw43[u32(unconst_u32(352))])));
+  vw42 = vec2i(i32((*&vw38)[u32(unconst_u32(61))][u32(unconst_u32(3))][u32(unconst_u32(321))]));
+  var vf182: u32 = (*&vw39).f1[u32(unconst_u32(139))];
+}`,
+  hints: {},
+});
+let buffer126 = device0.createBuffer({size: 13737, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder199 = device0.createCommandEncoder({});
+let texture195 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder150 = commandEncoder199.beginComputePass();
+try {
+computePassEncoder36.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(6, buffer104, 0, 1_787);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData25,
+  origin: { x: 6, y: 0 },
+  flipY: true,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let imageData29 = new ImageData(20, 16);
+let buffer127 = device0.createBuffer({size: 5885, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler142 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.60,
+});
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer69, 'uint32', 824, 838);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer77, 0);
+} catch {}
+document.body.append(img0);
+let sampler143 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 72.86});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame23, colorSpace: 'display-p3'});
+try {
+computePassEncoder150.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer20, 'uint16', 5_362, 8_567);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(3, buffer15, 0, 6);
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+let textureView203 = texture17.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 12.44, g: 846.8, b: -961.6, a: -194.1, });
+} catch {}
+try {
+renderPassEncoder42.insertDebugMarker('\u0afe');
+} catch {}
+let gpuCanvasContext6 = canvas9.getContext('webgpu');
+let textureView204 = texture34.createView({mipLevelCount: 1});
+let computePassEncoder151 = commandEncoder200.beginComputePass({});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'display-p3'});
+try {
+computePassEncoder129.setBindGroup(0, bindGroup66, new Uint32Array(4746), 97, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer76, 'uint16', 0, 520);
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder();
+let texture196 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 223},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder152 = commandEncoder201.beginComputePass({});
+try {
+renderPassEncoder24.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer89, 'uint32', 20, 28);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline2);
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let textureView205 = texture93.createView({arrayLayerCount: 1});
+try {
+computePassEncoder132.setBindGroup(1, bindGroup115, new Uint32Array(1462), 572, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer25);
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 31 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2288 */
+  offset: 2288,
+  rowsPerImage: 346,
+  buffer: buffer84,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 5},
+  aspect: 'all',
+}, new Uint8Array(46_518).fill(252), /* required buffer size: 46_518 */
+{offset: 505, bytesPerRow: 47, rowsPerImage: 89}, {width: 0, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(img2);
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+requires pointer_composite_access;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct T0 {
+  @align(2) f0: atomic<i32>,
+}
+
+struct S5 {
+  @builtin(vertex_index) f0: u32,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(135) var tex16: texture_2d<f32>;
+
+var<workgroup> vw47: array<atomic<u32>, 54>;
+
+fn fn0() -> array<VertexOutput4, 9> {
+  var out: array<VertexOutput4, 9>;
+  let ptr72: ptr<workgroup, atomic<u32>> = &vw47[u32(unconst_u32(71))];
+  let vf183: i32 = atomicExchange(&(*&vw48).f0, i32(unconst_i32(21)));
+  workgroupBarrier();
+  out[u32(unconst_u32(34))].f14 += vec4f(f32(distance(f16(unconst_f16(3928.1)), f16(unconst_f16(10307.3)))));
+  let ptr73: ptr<workgroup, atomic<i32>> = &(*&vw48).f0;
+  var vf184: vec2h = log2(vec2h(unconst_f16(670.4), unconst_f16(22443.3)));
+  atomicAdd(&vw48.f0, i32(unconst_i32(223)));
+  let vf185: u32 = atomicExchange(&(*&vw47)[u32(unconst_u32(16))], buffer128.f0);
+  vf184 = vf184;
+  let ptr74: ptr<workgroup, atomic<u32>> = &vw47[u32(unconst_u32(378))];
+  let vf186: u32 = atomicLoad(&(*ptr72));
+  var vf187: vec3f = cos(vec3f(unconst_f32(0.1497), unconst_f32(0.1683), unconst_f32(0.07578)));
+  let vf188: i32 = atomicLoad(&(*&vw48).f0);
+  var vf189: vec2f = radians(vec2f(unconst_f32(0.04688), unconst_f32(0.1430)));
+  return out;
+}
+
+@id(54364) override override20: f32;
+
+@group(0) @binding(99) var tex15: texture_multisampled_2d<f32>;
+
+var<workgroup> vw48: T0;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput4 {
+  @builtin(position) f14: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput5 {
+  @location(0) @interpolate(flat) f0: vec2i,
+  @location(5) f1: vec2i,
+  @location(3) f2: i32,
+}
+
+@group(1) @binding(42) var<uniform> buffer128: S5;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(24744) override override19: f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex7(@location(4) @interpolate(linear) a0: vec4h, @location(7) @interpolate(flat) a1: u32, @location(15) a2: i32, @location(12) @interpolate(flat) a3: vec2u, @location(8) a4: vec2h, a5: S5, @builtin(instance_index) a6: u32, @location(3) a7: vec4i) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f14 = vec4f(a4.grrr);
+  let ptr75: ptr<uniform, u32> = &(*&buffer128).f0;
+  let ptr76: ptr<uniform, u32> = &(*&buffer128).f0;
+  let vf190: u32 = a5.f0;
+  var vf191: i32 = a2;
+  let ptr77: ptr<function, i32> = &vf191;
+  out.f14 = vec4f(determinant(mat2x2f(determinant(mat2x2f(unconst_f32(0.2411), unconst_f32(0.2297), unconst_f32(0.07830), unconst_f32(0.6527))), determinant(mat2x2f(unconst_f32(0.2411), unconst_f32(0.2297), unconst_f32(0.07830), unconst_f32(0.6527))), determinant(mat2x2f(unconst_f32(0.2411), unconst_f32(0.2297), unconst_f32(0.07830), unconst_f32(0.6527))), determinant(mat2x2f(unconst_f32(0.2411), unconst_f32(0.2297), unconst_f32(0.07830), unconst_f32(0.6527))))));
+  return out;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  out.f0 -= vec2i(bitcast<i32>(pack4xI8(vec4i(unconst_i32(182), unconst_i32(428), unconst_i32(20), unconst_i32(32)))));
+  out.f0 = bitcast<vec2i>(reverseBits(vec4u(unconst_u32(301), unconst_u32(108), unconst_u32(38), unconst_u32(143))).xw);
+  var vf192: vec3f = fma(vec3f(unconst_f32(0.09728), unconst_f32(0.02940), unconst_f32(0.04718)), vec3f(unconst_f32(0.3599), unconst_f32(0.1060), unconst_f32(0.03712)), vec3f(unconst_f32(0.00483), unconst_f32(0.02560), unconst_f32(0.6669)));
+  let vf193: vec4i = min(vec4i(unconst_i32(13), unconst_i32(27), unconst_i32(299), unconst_i32(116)), vec4i(unconst_i32(111), unconst_i32(104), unconst_i32(15), unconst_i32(18)));
+  var vf194: vec3h = round(vec3h(unconst_f16(2866.6), unconst_f16(9211.1), unconst_f16(6330.2)));
+  var vf195: u32 = textureNumSamples(tex15);
+  vf195 |= u32(vf194[u32(unconst_u32(46))]);
+  var vf196: vec4i = min(vec4i(unconst_i32(101), unconst_i32(28), unconst_i32(254), unconst_i32(9)), vec4i(unconst_i32(486), unconst_i32(104), unconst_i32(107), unconst_i32(175)));
+  vf196 = vec4i(dot4I8Packed(u32(unconst_u32(42)), u32(unconst_u32(32))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  var vf197 = fn0();
+}`,
+  hints: {},
+});
+let texture197 = device0.createTexture({
+  label: '\u70a0\u{1f79c}\u{1ffc3}\u0dee\u635f\ubf15\u{1f8f3}',
+  size: {width: 82},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder153 = commandEncoder202.beginComputePass({});
+try {
+computePassEncoder153.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(109, 0, 154, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer77, 2_716, 110);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView42}, {binding: 24, resource: textureView20}],
+});
+let texture198 = device0.createTexture({
+  label: '\u08a3\u029a\u9374',
+  size: {width: 660, height: 96, depthOrArrayLayers: 446},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup8, new Uint32Array(60), 4, 0);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline4);
+} catch {}
+let sampler144 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.50,
+  lodMaxClamp: 49.17,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder37.executeBundles([renderBundle19, renderBundle5]);
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment8',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule9,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 296,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 24, shaderLocation: 6},
+          {format: 'sint16x2', offset: 16, shaderLocation: 13},
+          {format: 'float32x2', offset: 12, shaderLocation: 8},
+          {format: 'sint8x2', offset: 6, shaderLocation: 5},
+          {format: 'float32x4', offset: 4, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 4},
+          {format: 'uint32x4', offset: 24, shaderLocation: 7},
+          {format: 'float32x4', offset: 92, shaderLocation: 2},
+          {format: 'uint16x2', offset: 44, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 268,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 48, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 96, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup128 = device0.createBindGroup({
+  label: '\u13b0\u{1fb46}\u1886\u{1fb3d}\u317b\u{1f65e}\u0656',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 45, resource: textureView190},
+    {binding: 118, resource: {buffer: buffer104, offset: 3072, size: 2064}},
+    {binding: 253, resource: {buffer: buffer104, offset: 7168, size: 387}},
+    {binding: 373, resource: textureView198},
+    {binding: 132, resource: textureView112},
+    {binding: 167, resource: textureView37},
+    {binding: 55, resource: textureView40},
+    {binding: 311, resource: textureView42},
+    {binding: 83, resource: {buffer: buffer21, offset: 0, size: 112}},
+    {binding: 123, resource: textureView5},
+    {binding: 591, resource: {buffer: buffer0, offset: 0, size: 1132}},
+    {binding: 383, resource: textureView13},
+  ],
+});
+let buffer129 = device0.createBuffer({
+  size: 28918,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup123);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer75, 'uint32', 2_824, 6_552);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 80, y: 16, z: 1},
+  aspect: 'all',
+}, new Uint8Array(720).fill(67), /* required buffer size: 720 */
+{offset: 36, bytesPerRow: 57}, {width: 0, height: 52, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 288, resource: {buffer: buffer8, offset: 256}},
+    {binding: 78, resource: textureView113},
+    {binding: 191, resource: textureView200},
+    {binding: 19, resource: textureView104},
+    {binding: 52, resource: textureView191},
+  ],
+});
+let buffer130 = device0.createBuffer({
+  size: 1439,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture199 = gpuCanvasContext1.getCurrentTexture();
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+computePassEncoder52.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer6, 'uint32', 92, 49);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer130, 88);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer48, 2_532);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 380,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 136,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder203 = device0.createCommandEncoder();
+let texture200 = device0.createTexture({
+  size: [165, 24, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture201 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder154 = commandEncoder203.beginComputePass();
+try {
+computePassEncoder116.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder147.setBindGroup(2, bindGroup42, new Uint32Array(3063), 97, 0);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup29, new Uint32Array(2535), 3, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer54, 'uint32', 812, 4_191);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer59, 3_216, 1_550);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+try {
+computePassEncoder66.insertDebugMarker('\u416a');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 1180, new BigUint64Array(1336), 51, 432);
+} catch {}
+document.body.append(img0);
+let textureView206 = texture59.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], depthReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup123, new Uint32Array(530), 242, 0);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup5, new Uint32Array(2159), 51, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+let bindGroup130 = device0.createBindGroup({
+  label: '\uc802\u441b\u20a1\u{1feb8}\u0ccb\ue954\u085e\uac23\u03e5',
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView95}, {binding: 99, resource: textureView21}],
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup46, new Uint32Array(4830), 159, 0);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setViewport(145.82860312119857, 23.694063722983095, 18.25602876502493, 0.14648413874715246, 0.946998030989673, 0.9891191930385613);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer17 = buffer122.getMappedRange();
+try {
+commandEncoder204.copyTextureToTexture({
+  texture: texture183,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer47, 368, new DataView(new ArrayBuffer(12073)), 968, 28);
+} catch {}
+let texture202 = gpuCanvasContext6.getCurrentTexture();
+let computePassEncoder155 = commandEncoder204.beginComputePass({});
+let renderBundle21 = renderBundleEncoder22.finish({label: '\u055c\u2175\u03df\ud4c4\u023c\u8188\ua44c\u0ed7\u{1fa6f}'});
+try {
+computePassEncoder155.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer18, 'uint32', 256, 419);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, buffer109);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer114, 'uint16', 750, 23);
+} catch {}
+try {
+buffer100.unmap();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let computePassEncoder156 = commandEncoder205.beginComputePass({});
+try {
+computePassEncoder156.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup53, new Uint32Array(4631), 146, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer97, 180, 134);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 2},
+  aspect: 'all',
+}, new Uint8Array(116).fill(51), /* required buffer size: 116 */
+{offset: 116}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 829,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 273,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView64}]});
+let commandEncoder206 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({
+  label: '\u2b35\u5f27\ue9d1\uddf9\u3d7a\ucf57\u0860\u0134\u4c23\u04c9',
+  size: [516, 1, 273],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup123);
+} catch {}
+try {
+  await shaderModule5.getCompilationInfo();
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let renderPassEncoder63 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 115,
+  clearValue: { r: 978.1, g: 494.1, b: 977.7, a: -838.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle14, renderBundle14, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer13, 'uint32', 228, 260);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, undefined, 0);
+} catch {}
+document.body.append(canvas8);
+try {
+externalTexture4.label = '\ua33f\u{1f7a7}';
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup23, new Uint32Array(1510), 8, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 258, height: 1, depthOrArrayLayers: 158}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let texture204 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 69},
+  mipLevelCount: 5,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer4, 388, 958);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup43, new Uint32Array(475), 13, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer105, 'uint32', 1_172, 905);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer88, 0, 1_024);
+} catch {}
+let pipeline10 = await promise17;
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let buffer131 = device0.createBuffer({
+  size: 35061,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler145 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.60,
+  lodMaxClamp: 95.58,
+  compare: 'equal',
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup85, new Uint32Array(2023), 137, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer103, 1428, new Int16Array(13298), 1726, 1664);
+} catch {}
+let videoFrame26 = new VideoFrame(videoFrame14, {timestamp: 0});
+let buffer132 = device0.createBuffer({size: 1581, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView207 = texture80.createView({label: '\u4c09\uf552\uaa58\ued79\ubec5\u95d1\u3a6c'});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup81, new Uint32Array(1089), 110, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer104, 0, 3_042);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer133 = device0.createBuffer({
+  size: 1107,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let renderBundle22 = renderBundleEncoder21.finish({});
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup108, new Uint32Array(628), 37, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 4112, new BigUint64Array(10739), 3604, 32);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer25, 'uint16', 1_906, 406);
+} catch {}
+try {
+renderPassEncoder19.pushDebugGroup('\u9357');
+} catch {}
+try {
+  await promise21;
+} catch {}
+let texture205 = device0.createTexture({
+  size: [258, 1, 68],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(60, 0, 52, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup132 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer46, offset: 0, size: 48}},
+    {binding: 23, resource: textureView49},
+  ],
+});
+let commandEncoder207 = device0.createCommandEncoder({});
+let commandEncoder208 = device0.createCommandEncoder();
+let texture206 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView208 = texture168.createView({label: '\u002f\ucae0', dimension: '2d-array', baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder157 = commandEncoder207.beginComputePass({label: '\u{1fa92}\u{1f8eb}'});
+try {
+computePassEncoder157.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup36, new Uint32Array(718), 135, 0);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer62, 'uint16', 5_280, 533);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer106, 644, 16_068);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder208.copyBufferToTexture({
+  /* bytesInLastRow: 516 widthInBlocks: 258 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3388 */
+  offset: 3388,
+  buffer: buffer37,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {width: 258, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder19.popDebugGroup();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer134 = device0.createBuffer({size: 8210, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let texture207 = device0.createTexture({
+  label: '\ub584\u7418\ua7d8\u{1fb4a}',
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView209 = texture161.createView({baseMipLevel: 1, mipLevelCount: 1});
+let arrayBuffer18 = buffer10.getMappedRange(336, 16);
+let buffer135 = device0.createBuffer({size: 23055, usage: GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup89);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle19, renderBundle7, renderBundle7]);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+try {
+commandEncoder208.copyBufferToTexture({
+  /* bytesInLastRow: 11 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 65 */
+  offset: 65,
+  bytesPerRow: 17152,
+  buffer: buffer84,
+}, {
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder208.resolveQuerySet(querySet3, 2, 12, buffer32, 2304);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 53},
+  aspect: 'all',
+}, new Uint8Array(16_047).fill(65), /* required buffer size: 16_047 */
+{offset: 391, bytesPerRow: 132, rowsPerImage: 116}, {width: 5, height: 3, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder209 = device0.createCommandEncoder();
+let textureView210 = texture179.createView({label: '\u0988\u0b8b', dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 12});
+try {
+computePassEncoder142.setBindGroup(1, bindGroup119, new Uint32Array(1466), 308, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer52, 0, 89);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 36, y: 13, z: 0},
+  aspect: 'all',
+}, new Uint8Array(404).fill(80), /* required buffer size: 404 */
+{offset: 280}, {width: 31, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({entries: [{binding: 244, visibility: GPUShaderStage.VERTEX, externalTexture: {}}]});
+let bindGroup133 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 445, resource: textureView147},
+    {binding: 167, resource: {buffer: buffer100, offset: 0, size: 376}},
+    {binding: 419, resource: {buffer: buffer114, offset: 1024, size: 16}},
+    {binding: 569, resource: sampler30},
+  ],
+});
+let textureView211 = texture23.createView({label: '\u0957\u09ac\u89d1\u04f7\u84d1\u8ad0', baseArrayLayer: 4, arrayLayerCount: 1});
+let texture208 = device0.createTexture({size: [82, 12, 55], dimension: '3d', format: 'rg8sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder158 = commandEncoder209.beginComputePass({});
+let renderPassEncoder64 = commandEncoder208.beginRenderPass({
+  colorAttachments: [{
+  view: textureView177,
+  clearValue: { r: -989.7, g: 295.1, b: 824.4, a: 256.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(2, bindGroup92, new Uint32Array(511), 62, 0);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup89, new Uint32Array(180), 12, 0);
+} catch {}
+try {
+renderPassEncoder50.setScissorRect(1, 2, 15, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer6, 'uint16', 94, 53);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 776, new DataView(new ArrayBuffer(32011)), 5349, 7396);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 82, height: 12, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData26,
+  origin: { x: 33, y: 0 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let texture209 = device0.createTexture({
+  size: [516, 1, 3],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup9, new Uint32Array(1641), 135, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(130).fill(216), /* required buffer size: 130 */
+{offset: 130, rowsPerImage: 52}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await promise14;
+let buffer136 = device0.createBuffer({
+  label: '\ud1bb\ue9e7\u4c62\ub4cf',
+  size: 1665,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture210 = device0.createTexture({
+  size: {width: 1032},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler146 = device0.createSampler({
+  label: '\u0f53\u{1fb39}\u{1ff4c}\ubb32\u09b0\u6d1f\u0d3c\u0d32\u{1f6b2}\u86ac\u{1fa11}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.63,
+  lodMaxClamp: 20.74,
+});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup41, new Uint32Array(3105), 612, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer16, 'uint16', 526, 71);
+} catch {}
+let bindGroup134 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 419, resource: {buffer: buffer61, offset: 3072}},
+    {binding: 167, resource: {buffer: buffer121, offset: 0, size: 74}},
+    {binding: 569, resource: sampler41},
+    {binding: 445, resource: textureView131},
+  ],
+});
+let texture211 = device0.createTexture({
+  size: [330, 48, 6],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer17, 'uint16', 1_296, 2_283);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 16, new Float32Array(4468), 878, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(28).fill(202), /* required buffer size: 28 */
+{offset: 28}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise22;
+} catch {}
+let texture212 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup7, new Uint32Array(2782), 63, 0);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer8, 712, 177);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder48.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder147.setBindGroup(1, bindGroup116, new Uint32Array(1496), 178, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup67, new Uint32Array(5302), 441, 0);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(4, buffer65, 816, 1_092);
+} catch {}
+let texture213 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 220},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView212 = texture82.createView({mipLevelCount: 1});
+try {
+computePassEncoder82.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST, alphaMode: 'opaque'});
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({
+  label: '\u7d08\u0a78\u6843\udf3f\u2233\u2404\u47e2\u478d\u{1f6c5}',
+  size: [129],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView213 = texture187.createView({});
+let computePassEncoder159 = commandEncoder210.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(0, bindGroup5, new Uint32Array(1049), 52, 0);
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer105, 'uint16', 1_186, 141);
+} catch {}
+try {
+computePassEncoder29.insertDebugMarker('\u1913');
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 50, resource: textureView124},
+    {binding: 80, resource: {buffer: buffer104, offset: 256, size: 3353}},
+    {binding: 131, resource: {buffer: buffer8, offset: 1792}},
+  ],
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let texture215 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder160 = commandEncoder211.beginComputePass();
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup125);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer134, 'uint16', 722, 2_271);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 396, new Int16Array(18452), 13417, 316);
+} catch {}
+try {
+globalThis.someLabel = externalTexture9.label;
+} catch {}
+let bindGroup136 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView29}]});
+let buffer137 = device0.createBuffer({size: 785, usage: GPUBufferUsage.INDIRECT});
+let texture216 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 6},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView214 = texture3.createView({});
+let computePassEncoder161 = commandEncoder133.beginComputePass({});
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup101, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup89, new Uint32Array(78), 14, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer138 = device0.createBuffer({
+  size: 14384,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder212 = device0.createCommandEncoder({});
+let texture217 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder162 = commandEncoder212.beginComputePass({label: '\u4c05\u7bc2\ueb82\u{1ff4f}\uf093\u7d56\u0071\udd9b\u034d\u0f73'});
+let sampler147 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.53,
+  lodMaxClamp: 97.71,
+});
+try {
+computePassEncoder159.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder213 = device0.createCommandEncoder({});
+let renderPassEncoder65 = commandEncoder213.beginRenderPass({
+  label: '\u{1f7e8}\u6035\uf683\u{1fd04}\u9569',
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 35,
+  clearValue: { r: 609.4, g: -996.1, b: 106.6, a: 902.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder17.setPipeline(pipeline0);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let buffer139 = device0.createBuffer({size: 21716, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 901});
+try {
+computePassEncoder128.end();
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup89, new Uint32Array(1655), 61, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(45.348901529679935, 0.08332027786771556, 12.486729875391315, 0.15838277613040985, 0.0015041905199075778, 0.1411690612781867);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint32', 4, 64);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer88);
+} catch {}
+await gc();
+let commandEncoder214 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder159.finish({label: '\ua3f7\u0017'});
+let texture218 = device0.createTexture({
+  size: [258, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler148 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.15,
+  lodMaxClamp: 65.05,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder53.setIndexBuffer(buffer44, 'uint16', 2_324, 30);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 131, resource: {buffer: buffer94, offset: 256, size: 576}},
+    {binding: 80, resource: {buffer: buffer84, offset: 0, size: 1256}},
+    {binding: 50, resource: textureView79},
+  ],
+});
+let commandEncoder215 = device0.createCommandEncoder({});
+let computePassEncoder163 = commandEncoder214.beginComputePass({label: '\ua381\u4929\u08a8\uc55b\u24be\u06fb\ue544\u3351\u{1f68e}\u4bca'});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup127, new Uint32Array(3087), 919, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setViewport(73.5676764077743, 40.84947806128543, 191.83439872899714, 3.6803346449563366, 0.3726237878119286, 0.9029233026253396);
+} catch {}
+try {
+commandEncoder215.copyBufferToTexture({
+  /* bytesInLastRow: 68 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3038 */
+  offset: 3038,
+  buffer: buffer32,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder215.copyTextureToTexture({
+  texture: texture141,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture150,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup130);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(0, buffer81, 0, 338);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'opaque'});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise23;
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'film', transfer: 'iec61966-2-1'} });
+let textureView215 = texture208.createView({format: 'rg8sint'});
+let computePassEncoder164 = commandEncoder215.beginComputePass({});
+let sampler149 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.52,
+  lodMaxClamp: 43.60,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup105, new Uint32Array(2425), 388, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle9, renderBundle9]);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw51: T3;
+
+override override22: i32 = 405;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(482) var sam3: sampler;
+
+var<workgroup> vw55: atomic<i32>;
+
+var<workgroup> vw53: atomic<i32>;
+
+struct T2 {
+  @align(2) @size(28) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<workgroup> vw52: array<array<atomic<i32>, 1>, 21>;
+
+var<workgroup> vw49: mat4x4f;
+
+var<workgroup> vw50: array<array<atomic<i32>, 1>, 44>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override21: i32 = 4;
+
+var<private> vp11: VertexOutput5 = VertexOutput5(vec2i(206, 16), vec4u(13, 259, 386, 302), vec4f(0.3172, 0.2145, 0.2160, 0.1065), u32(439), vec2h(892.7, 2296.0), f16(14675.5), vec4u(152, 90, 7, 189), vec2h(386.3, 14366.5));
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T3 {
+  f0: array<f16, 1>,
+}
+
+var<workgroup> vw54: mat3x2h;
+
+struct T1 {
+  @align(2) @size(24) f0: array<u32>,
+}
+
+struct VertexOutput5 {
+  @location(0) @interpolate(flat, centroid) f15: vec2i,
+  @location(2) @interpolate(flat, sample) f16: vec4u,
+  @builtin(position) f17: vec4f,
+  @location(9) @interpolate(flat, centroid) f18: u32,
+  @location(14) f19: vec2h,
+  @location(15) f20: f16,
+  @location(11) @interpolate(flat, centroid) f21: vec4u,
+  @location(12) f22: vec2h,
+}
+
+@vertex
+fn vertex8(@builtin(instance_index) a0: u32, @location(15) a1: vec4i, @location(1) @interpolate(flat) a2: vec4u, @location(8) a3: f16, @location(3) @interpolate(flat) a4: f16, @location(14) @interpolate(flat) a5: i32) -> VertexOutput5 {
+  var out: VertexOutput5;
+  var vf198: f32 = vp11.f17[u32(unconst_u32(56))];
+  let ptr78: ptr<private, vec4f> = &vp11.f17;
+  let ptr79: ptr<function, f32> = &vf198;
+  return out;
+}
+
+@fragment
+fn fragment10() -> @location(200) @interpolate(perspective, center) vec4f {
+  var out: vec4f;
+  let vf199: u32 = vp11.f21[u32(unconst_u32(12))];
+  let vf200: bool = any(bool(unconst_bool(false)));
+  vp11.f20 = f16(vp11.f17[u32(unconst_u32(89))]);
+  let ptr80: ptr<private, f16> = &vp11.f20;
+  vp11 = VertexOutput5(vec2i(i32(vp11.f22[u32(unconst_u32(15))])), unpack4xU8(u32(vp11.f22[u32(unconst_u32(15))])), vec4f(f32(vp11.f22[u32(unconst_u32(15))])), u32(vp11.f22[u32(unconst_u32(15))]), vec2h(vp11.f22[u32(unconst_u32(15))]), vp11.f22[u32(unconst_u32(15))], unpack4xU8(u32(vp11.f22[u32(unconst_u32(15))])), vec2h(vp11.f22[u32(unconst_u32(15))]));
+  var vf201: i32 = countTrailingZeros(i32(unconst_i32(46)));
+  vf201 = bitcast<i32>(pack4x8unorm(vec4f(unconst_f32(0.07262), unconst_f32(0.1155), unconst_f32(0.01302), unconst_f32(-0.04691))));
+  out -= vec4f(extractBits(vec2u(unconst_u32(96), unconst_u32(252)), u32(unconst_u32(142)), u32(unconst_u32(180))).yyxy);
+  let vf202: vec4i = firstTrailingBit(vec4i(unconst_i32(207), unconst_i32(313), unconst_i32(69), unconst_i32(152)));
+  let vf203: vec4i = firstTrailingBit(vec4i(unconst_i32(113), unconst_i32(-453), unconst_i32(208), unconst_i32(13)));
+  out += vec4f(vp11.f21);
+  let vf204: u32 = vp11.f21[u32(refract(vec2f(unconst_f32(0.03135), unconst_f32(0.00956)), vec2f(unconst_f32(-0.03345), unconst_f32(0.08778)), f32(unconst_f32(0.8369)))[0])];
+  var vf205: vec2u = extractBits(vec2u(unconst_u32(101), unconst_u32(250)), bitcast<u32>(countTrailingZeros(i32(unconst_i32(4)))), u32(unconst_u32(0)));
+  vp11.f22 -= vp11.f19;
+  vf201 *= i32(pack4x8unorm(vec4f(unconst_f32(0.09967), unconst_f32(0.08993), unconst_f32(0.1680), unconst_f32(0.04495))));
+  vf201 |= bitcast<i32>(vp11.f18);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  atomicCompareExchangeWeak(&vw52[u32(unconst_u32(2))][u32(unconst_u32(80))], unconst_i32(36), unconst_i32(25));
+  let vf206: i32 = atomicLoad(&(*&vw50)[u32(unconst_u32(91))][0]);
+  atomicMin(&vw50[43][u32(unconst_u32(555))], i32(unconst_i32(818)));
+  atomicOr(&vw52[u32(unconst_u32(61))][u32(unconst_u32(423))], i32(unconst_i32(-233)));
+  atomicCompareExchangeWeak(&vw52[u32(unconst_u32(224))][0], unconst_i32(6), unconst_i32(428));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder216 = device0.createCommandEncoder();
+let textureView216 = texture102.createView({label: '\u9b2d\ucd4d\u0bdb\u0cee\ucd93', format: 'depth16unorm'});
+let computePassEncoder165 = commandEncoder216.beginComputePass();
+try {
+computePassEncoder165.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup131, new Uint32Array(3837), 887, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer41, 'uint16', 5_462, 5_282);
+} catch {}
+let buffer140 = device0.createBuffer({
+  size: 8855,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler150 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.64,
+  lodMaxClamp: 99.80,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup104, new Uint32Array(4107), 1_166, 0);
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup86);
+} catch {}
+try {
+renderPassEncoder15.setViewport(27.77509407703661, 23.559610406250346, 9.76588990052236, 0.06180045134960193, 0.9597013959254572, 0.9657140724892782);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer136, 'uint32', 1_276, 144);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer27);
+} catch {}
+let imageData30 = new ImageData(20, 12);
+let buffer141 = device0.createBuffer({
+  size: 10846,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture219 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder161.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(3, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer25, 'uint32', 820, 810);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer99, 7568, new DataView(new ArrayBuffer(12172)));
+} catch {}
+document.body.append(canvas0);
+let commandEncoder217 = device0.createCommandEncoder({});
+let texture220 = device0.createTexture({
+  label: '\ub402\u{1f94b}\ub21b\u01d4\u85b8\ua32a\uff9a\u6ad9\u0e31',
+  size: [330, 48, 223],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder166 = commandEncoder217.beginComputePass({});
+try {
+renderPassEncoder62.setIndexBuffer(buffer76, 'uint16', 104, 72);
+} catch {}
+let arrayBuffer19 = buffer51.getMappedRange(7864, 12);
+document.body.append(canvas6);
+await gc();
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+let sampler151 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 99.25,
+  lodMaxClamp: 99.87,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder166.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup26, new Uint32Array(2070), 76, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle21, renderBundle17, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4, buffer140, 0);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup74, new Uint32Array(983), 5, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer55, 'uint16', 38, 103);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer81, 412);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 1752, new Int16Array(3421), 278, 188);
+} catch {}
+let commandEncoder218 = device0.createCommandEncoder({label: '\ue0bf\u{1ff48}\u38af\u6eb5\u3865'});
+let textureView217 = texture67.createView({label: '\uf194\u6561\u6e25\u2c82\u3283\u06e1\u{1f900}\u8f4f', dimension: '3d'});
+try {
+computePassEncoder164.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle5, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer29, 'uint32', 412, 843);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer4, 'uint32', 744, 201);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer74);
+} catch {}
+try {
+commandEncoder218.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(20, 12);
+let bindGroup138 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 71, resource: sampler88}]});
+let textureView218 = texture101.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+let computePassEncoder167 = commandEncoder218.beginComputePass({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({label: '\u43b8\u{1fee4}\u900e\uc3d0\u9ba1\u4ca0', colorFormats: ['r32uint'], stencilReadOnly: true});
+try {
+computePassEncoder88.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup19);
+} catch {}
+let arrayBuffer20 = buffer10.getMappedRange(0, 0);
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture167,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 35},
+  aspect: 'all',
+}, new Uint8Array(913).fill(147), /* required buffer size: 913 */
+{offset: 913}, {width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(101, 175);
+let imageData32 = new ImageData(12, 76);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder25.finish({label: '\ub620\u02db\u9ba3\ua244\ud845\u6e74\u0508'});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(102);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+document.body.append(canvas3);
+let imageData33 = new ImageData(140, 48);
+let bindGroup139 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 61, resource: {buffer: buffer78, offset: 3072}},
+    {binding: 97, resource: {buffer: buffer81, offset: 512}},
+  ],
+});
+try {
+computePassEncoder167.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup89, new Uint32Array(50), 0, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer78, 'uint32', 3_688, 679);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(6, buffer26, 5_928, 30);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup13, new Uint32Array(2271), 118, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas1.getContext('webgpu');
+let commandEncoder219 = device0.createCommandEncoder({});
+let textureView219 = texture198.createView({baseArrayLayer: 0});
+let texture221 = device0.createTexture({size: [129, 1, 1], mipLevelCount: 2, format: 'r32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler152 = device0.createSampler({
+  label: '\u24af\u05e5\u6af3\u{1fde5}\ua4ae\u0446\u824e\ub8d3\u9768\ub0ec',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 37.17,
+  lodMaxClamp: 97.06,
+});
+try {
+computePassEncoder162.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup38, new Uint32Array(709), 278, 0);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer26, 0, 1_698);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup28, new Uint32Array(1118), 129, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer99, 'uint16', 2_686, 2_780);
+} catch {}
+try {
+commandEncoder219.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1572 */
+  offset: 1572,
+  rowsPerImage: 520,
+  buffer: buffer87,
+}, {
+  texture: texture135,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder23.insertDebugMarker('\u7031');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData2,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView220 = texture173.createView({mipLevelCount: 1});
+let renderPassEncoder66 = commandEncoder219.beginRenderPass({
+  label: '\u{1f84a}\u504c\u03f5',
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 171,
+  clearValue: { r: 727.3, g: -387.9, b: -64.63, a: 697.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 421242820,
+});
+let sampler153 = device0.createSampler({
+  label: '\ud843\u5810\u0417\u{1f8f1}\u5d0c\u0f9a\uaec3\u{1fac2}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 62.31,
+  lodMaxClamp: 95.74,
+});
+try {
+computePassEncoder145.setBindGroup(3, bindGroup27, new Uint32Array(554), 100, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup36, new Uint32Array(98), 0, 0);
+} catch {}
+try {
+renderPassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4_294_967_295, undefined, 0, 1_563_701_949);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(6, buffer59, 0, 14);
+} catch {}
+try {
+commandEncoder192.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3984 */
+  offset: 3984,
+  buffer: buffer110,
+}, {
+  texture: texture214,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer142 = device0.createBuffer({size: 6256, usage: GPUBufferUsage.INDIRECT});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 246});
+let textureView221 = texture119.createView({baseArrayLayer: 0});
+let computePassEncoder168 = commandEncoder192.beginComputePass({label: '\u667a\u7d24\u008e\u0fe6\u{1fcf3}\u{1f6d8}\u3ad9\u35a5\u0cfc\u8ec5'});
+try {
+computePassEncoder168.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup60, new Uint32Array(3584), 2_356, 0);
+} catch {}
+try {
+renderPassEncoder43.beginOcclusionQuery(10);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer136);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 46, y: 4, z: 2},
+  aspect: 'all',
+}, new Uint8Array(3_019).fill(228), /* required buffer size: 3_019 */
+{offset: 113, bytesPerRow: 17, rowsPerImage: 21}, {width: 1, height: 3, depthOrArrayLayers: 9});
+} catch {}
+document.body.append(canvas4);
+let offscreenCanvas2 = new OffscreenCanvas(44, 230);
+try {
+offscreenCanvas2.getContext('2d');
+} catch {}
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer16, offset: 512, size: 46}},
+    {binding: 606, resource: textureView9},
+  ],
+});
+let sampler154 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.56,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle8, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(6, buffer27);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer13, 'uint16', 12, 638);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let img7 = await imageWithData(20, 24, '#10101010', '#20202020');
+try {
+externalTexture9.label = '\u{1fd86}\u60de\u{1f664}\u9292\u{1fd89}\uf397\u{1fb63}\u78cb';
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  label: '\u0846\ub6b5\u01c0\u4077\u1e68\u0cf1\u1cbf\u4622\u04df\u0ea9\u0847',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 50, resource: textureView45},
+    {binding: 80, resource: {buffer: buffer36, offset: 1536}},
+    {binding: 131, resource: {buffer: buffer44, offset: 1792}},
+  ],
+});
+let commandEncoder220 = device0.createCommandEncoder();
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint']});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup99);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(0, bindGroup13, new Uint32Array(3184), 792, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer60, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder24.insertDebugMarker('\u{1f713}');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup142 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 10, resource: sampler105}]});
+let textureView222 = texture166.createView({label: '\u9ac3\u3b3d\u01ac\u{1f858}\u0157', mipLevelCount: 1});
+let renderPassEncoder67 = commandEncoder220.beginRenderPass({
+  colorAttachments: [{
+  view: textureView169,
+  depthSlice: 32,
+  clearValue: { r: 305.3, g: -78.50, b: 15.10, a: 129.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 50117585,
+});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup119, new Uint32Array(2036), 14, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup136, new Uint32Array(4420), 394, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer64);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer125, 'uint16', 5_498, 1_418);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+buffer41.label = '\u09e8\u0b3d\ucde3\u02af\ufac4\u1d64';
+} catch {}
+let buffer143 = device0.createBuffer({size: 6064, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder221 = device0.createCommandEncoder({label: '\u1ab5\u{1f8be}\u{1fabc}\u{1fc8a}'});
+let computePassEncoder169 = commandEncoder221.beginComputePass({});
+let sampler155 = device0.createSampler({
+  label: '\u0d01\u032a\u1722\u5a22\ue58b\ua4eb\u{1f6d8}\u{1f937}\u0cfe\u1890\uad92',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 78.53,
+});
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup113);
+} catch {}
+try {
+renderPassEncoder59.setBlendConstant({ r: 663.7, g: -597.6, b: -497.8, a: -568.9, });
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(4, buffer131);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup55);
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  label: '\u095f\uc127',
+  layout: bindGroupLayout13,
+  entries: [{binding: 160, resource: textureView16}, {binding: 378, resource: textureView127}],
+});
+let commandEncoder222 = device0.createCommandEncoder({});
+let computePassEncoder170 = commandEncoder222.beginComputePass({});
+let renderBundle24 = renderBundleEncoder23.finish({label: '\u48b7\u0407'});
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroupsIndirect(buffer88, 976); };
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer74, 0, 1_206);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(2, bindGroup125, new Uint32Array(4545), 1_065, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroupsIndirect(buffer65, 2_600); };
+} catch {}
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder12.setViewport(155.42561724101313, 0.00615288841042172, 795.280212215439, 0.10764605051322672, 0.6297175231573617, 0.9948580838741845);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer13, 'uint32', 808, 2_071);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte240m', transfer: 'bt709'} });
+let texture222 = device0.createTexture({
+  label: '\u672f\u045a\u314b\u0c09\ub38a\u31e0\u1ce7\u02a1\u18da',
+  size: [330],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder171 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder164.setBindGroup(0, bindGroup57, new Uint32Array(538), 95, 0);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup98, []);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup9, new Uint32Array(730), 16, 0);
+} catch {}
+let imageData34 = new ImageData(164, 88);
+let bindGroup144 = device0.createBindGroup({
+  label: '\ub07c\u0704\u{1faf5}\u{1ffe7}',
+  layout: bindGroupLayout9,
+  entries: [{binding: 482, resource: sampler119}],
+});
+let commandEncoder223 = device0.createCommandEncoder({});
+let computePassEncoder172 = commandEncoder223.beginComputePass({});
+let renderBundle25 = renderBundleEncoder24.finish({label: '\u140e\u{1f9a4}\u05bb\u00d3\u34be\u{1f616}\u0134\u058d\u6d12\uf442\u7e25'});
+let sampler156 = device0.createSampler({
+  label: '\u012b\u{1f6eb}\u201c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 87.80,
+});
+try {
+computePassEncoder163.setBindGroup(3, bindGroup111, new Uint32Array(1920), 87, 0);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle19, renderBundle5, renderBundle5, renderBundle6, renderBundle6, renderBundle5, renderBundle6, renderBundle6, renderBundle7, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer52, 'uint16', 166, 355);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(16).fill(222), /* required buffer size: 16 */
+{offset: 16}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+let bindGroup145 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView144}]});
+let commandEncoder224 = device0.createCommandEncoder();
+try {
+computePassEncoder171.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle14, renderBundle17, renderBundle17, renderBundle25, renderBundle25, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint32', 1_100, 10);
+} catch {}
+try {
+commandEncoder224.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 48 */
+  offset: 48,
+  buffer: buffer131,
+}, {
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let img8 = await imageWithData(151, 14, '#10101010', '#20202020');
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 100, resource: textureView194},
+    {binding: 26, resource: {buffer: buffer0, offset: 256, size: 1852}},
+  ],
+});
+let texture223 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 446},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder173 = commandEncoder224.beginComputePass();
+try {
+computePassEncoder83.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer75, 'uint32', 9_752, 186);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer48, 1_904, 724);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup48, new Uint32Array(2260), 58, 0);
+} catch {}
+try {
+buffer131.unmap();
+} catch {}
+let bindGroup147 = device0.createBindGroup({
+  label: '\u8b8b\u{1fd2e}\u0334\u065c\u23cf\u{1fca8}\u0855\u01e1\u0088',
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 97, resource: {buffer: buffer44, offset: 3584}},
+    {binding: 61, resource: {buffer: buffer39, offset: 0, size: 16}},
+  ],
+});
+let commandEncoder225 = device0.createCommandEncoder({});
+let computePassEncoder174 = commandEncoder225.beginComputePass();
+let sampler157 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.55,
+  lodMaxClamp: 96.21,
+});
+try {
+renderPassEncoder35.setScissorRect(240, 0, 195, 0);
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(203);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 16, new Int16Array(25472), 4982, 24);
+} catch {}
+let textureView223 = texture128.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler158 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 43.19,
+  lodMaxClamp: 77.88,
+});
+try {
+computePassEncoder147.setBindGroup(0, bindGroup87, new Uint32Array(479), 196, 0);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer57, 0);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let bindGroup148 = device0.createBindGroup({
+  label: '\u067b\u077e\u0873\u8f5c\u0a1b',
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 61, resource: {buffer: buffer44, offset: 256, size: 292}},
+    {binding: 97, resource: {buffer: buffer1, offset: 512, size: 9992}},
+  ],
+});
+let textureView224 = texture102.createView({
+  label: '\u{1fe64}\ub4d1\ufd42\ub1f8\u{1ff4d}\u473c\u{1f65c}\uefa6\ubcee\u555f',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+});
+let sampler159 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 49.29,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup4, new Uint32Array(720), 7, 0);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, buffer81, 0, 321);
+} catch {}
+let buffer144 = device0.createBuffer({size: 1189, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture224 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder65.setBlendConstant({ r: -227.1, g: -321.6, b: 577.8, a: 860.7, });
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup122, new Uint32Array(2484), 331, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer91, 'uint32', 12, 8);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer0, 1_332, 3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 60, y: 4, z: 7},
+  aspect: 'all',
+}, new Uint8Array(441_525).fill(25), /* required buffer size: 441_525 */
+{offset: 117, bytesPerRow: 456, rowsPerImage: 88}, {width: 92, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView225 = texture201.createView({aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 9});
+let texture225 = gpuCanvasContext7.getCurrentTexture();
+let sampler160 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.11,
+  lodMaxClamp: 80.04,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup122, new Uint32Array(3485), 461, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 624.3, g: -511.5, b: 867.4, a: 507.9, });
+} catch {}
+try {
+buffer123.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 44, new DataView(new ArrayBuffer(4442)), 114, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 88, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(12).fill(22), /* required buffer size: 12 */
+{offset: 12}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder();
+let texture226 = device0.createTexture({
+  label: '\u0ad6\u{1f7cc}\u93c2\u1f86',
+  size: {width: 82, height: 12, depthOrArrayLayers: 140},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2unorm'],
+});
+let computePassEncoder175 = commandEncoder226.beginComputePass({});
+let renderBundle26 = renderBundleEncoder26.finish();
+try {
+renderPassEncoder21.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle12, renderBundle8, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer111, 0, 4_622);
+} catch {}
+try {
+renderPassEncoder21.pushDebugGroup('\u{1f666}');
+} catch {}
+try {
+renderPassEncoder21.popDebugGroup();
+} catch {}
+let externalTexture30 = device0.importExternalTexture({source: videoFrame24, colorSpace: 'display-p3'});
+try {
+computePassEncoder168.setBindGroup(0, bindGroup144);
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture227 = device0.createTexture({
+  label: '\u20e7\uc1d7\u5b46\ucdef\ud30d',
+  size: {width: 8},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup90, new Uint32Array(1439), 348, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer46, 'uint32', 4, 2);
+} catch {}
+document.body.prepend(canvas4);
+let commandEncoder227 = device0.createCommandEncoder({});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(0, buffer92, 0, 389);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer127, 588, new DataView(new ArrayBuffer(5732)), 662, 1252);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\ua245\u7ada\u2e12',
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override23: f32;
+
+struct T2 {
+  @size(16) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  f0: array<i32, 1>,
+}
+
+struct T1 {
+  @size(8) f0: atomic<i32>,
+}
+
+struct VertexOutput6 {
+  @location(6) f23: vec4i,
+  @builtin(position) f24: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput6 {
+  @location(0) f0: u32,
+  @location(2) @interpolate(perspective, center) f1: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(64082) override override25: f32;
+
+@id(63656) override override24: f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(482) var sam4: sampler;
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: FragmentOutput6) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f23 = vec4i(clamp(vec4h(unconst_f16(60000.0), unconst_f16(3363.0), unconst_f16(13003.1), unconst_f16(6863.0)), vec4h(f16(radians(f32(unconst_f32(-0.3694))))), vec4h(f16(a0.f0))));
+  out.f24 = unpack4x8snorm(pack2x16float(vec2f(unconst_f32(-0.2257), unconst_f32(0.2614))));
+  out.f24 = unpack4x8unorm(a0.f0);
+  out = VertexOutput6(vec4i(vp12.fract.xyyx), vp12.fract.grgg);
+  out.f24 -= vec4f(asin(vec4h(f16(radians(unpack4x8snorm(u32(unconst_u32(92))).g)))));
+  let vf207: f16 = fract(vec2h(vp12.fract)[0]);
+  out.f23 &= vec4i(atan2(vec2h(unconst_f16(2447.6), unconst_f16(33049.7)), vec2h(unconst_f16(1520.2), unconst_f16(3955.6))).yyxy);
+  vp12.fract = vec2f(atan2(vec2h(unpack4x8snorm(u32(unconst_u32(245))).ab), vec2h(unconst_f16(-11911.3), unconst_f16(3019.3))));
+  out = VertexOutput6(vec4i(vp12.whole.xyxx), vp12.whole.grgr);
+  var vf208: bool = all(vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  var vf209: FragmentOutput6 = a0;
+  var vf210: vec4h = clamp(vec4h(unconst_f16(5922.7), unconst_f16(4169.9), unconst_f16(8244.4), unconst_f16(8318.7)), vec4h(unconst_f16(22718.8), unconst_f16(-7341.2), unconst_f16(-12218.2), unconst_f16(5756.3)), vec4h(unconst_f16(19885.9), unconst_f16(-9797.2), unconst_f16(9270.4), unconst_f16(280.8)));
+  let vf211: vec4h = clamp(vec4h(unconst_f16(9121.8), unconst_f16(1494.1), unconst_f16(2835.3), unconst_f16(40447.1)), vec4h(unconst_f16(-753.6), unconst_f16(3617.9), unconst_f16(5482.0), unconst_f16(-5003.8)), vec4h(unconst_f16(14575.8), unconst_f16(6451.0), unconst_f16(1537.2), unconst_f16(8179.3)));
+  out = VertexOutput6(bitcast<vec4i>(insertBits(vec3u(unconst_u32(22), unconst_u32(148), unconst_u32(11)), vec3u(unconst_u32(99), unconst_u32(227), unconst_u32(42)), u32(unconst_u32(444)), u32(unconst_u32(76))).gbbb), vec4f(insertBits(vec3u(unconst_u32(22), unconst_u32(148), unconst_u32(11)), vec3u(unconst_u32(99), unconst_u32(227), unconst_u32(42)), u32(unconst_u32(444)), u32(unconst_u32(76))).yxzz));
+  out.f23 = bitcast<vec4i>(round(vec4f(unconst_f32(0.1185), unconst_f32(0.1462), unconst_f32(0.1404), unconst_f32(0.09678))));
+  var vf212: vec3u = insertBits(vec3u(unconst_u32(228), unconst_u32(66), unconst_u32(281)), vec3u(unconst_u32(81), unconst_u32(264), unconst_u32(502)), bitcast<u32>(round(vec4f(unconst_f32(0.1391), unconst_f32(0.3737), unconst_f32(0.00595), unconst_f32(0.1707))).w), u32(unconst_u32(406)));
+  let vf213: f32 = override23;
+  var vf214: vec4f = round(vec4f(unconst_f32(0.6867), unconst_f32(0.06349), unconst_f32(0.2508), unconst_f32(0.7766)));
+  var vf215: vec4h = vf211;
+  out.f24 += vec4f(vf213);
+  var vf216: vec4f = unpack4x8snorm(u32(unconst_u32(139)));
+  var vf217: vec2f = round(vec2f(unconst_f32(0.02118), unconst_f32(0.2464)));
+  return out;
+  _ = override23;
+}
+
+fn fn1() -> array<array<u32, 1>, 16> {
+  var out: array<array<u32, 1>, 16>;
+  out[u32(unconst_u32(148))][0] = pack2x16float(vec2f(unconst_f32(0.02048), unconst_f32(0.3462)));
+  return out;
+}
+
+var<workgroup> vw56: atomic<u32>;
+
+var<private> vp12 = modf(vec2f(-0.04061, 0.3093));
+
+fn fn2() -> vec2i {
+  var out: vec2i;
+  let vf218: f16 = distance(vec2h(vp12.whole), vec2h(unconst_f16(15807.0), unconst_f16(576.7)));
+  let vf219: vec4f = log2(vec4f(unconst_f32(0.1906), unconst_f32(0.2707), unconst_f32(0.3115), unconst_f32(0.03020)));
+  let vf220: f16 = distance(vec2h(unconst_f16(9162.0), unconst_f16(-7070.8)), vec2h(unconst_f16(499.9), unconst_f16(6297.1)));
+  vp12 = modf(vec2f(inverseSqrt(vec3h(unconst_f16(-32957.8), unconst_f16(3596.3), unconst_f16(6566.8))).bb));
+  let ptr81: ptr<private, vec2f> = &vp12.fract;
+  vp12.fract *= vec2f(f32(sinh(f16(unconst_f16(6492.4)))));
+  let vf221: f32 = (*ptr81)[u32(unconst_u32(18))];
+  let vf222: u32 = pack2x16unorm(fract(vec2f(unconst_f32(0.05996), unconst_f32(0.1341))));
+  out = vec2i(i32(vf219[u32(unconst_u32(76))]));
+  let vf223: vec4u = unpack4xU8(u32(unconst_u32(349)));
+  var vf224: vec2f = fract(vec2f(unconst_f32(0.1317), unconst_f32(-0.1864)));
+  let vf225: vec4u = vf223;
+  out *= bitcast<vec2i>(vp12.fract);
+  let vf226: u32 = vf222;
+  out = bitcast<vec2i>(fract(vec2f(unconst_f32(0.03018), unconst_f32(0.03817))));
+  vf224 = vec2f(f32(cosh(f16(unconst_f16(-1612.3)))));
+  let vf227: f32 = (*ptr81)[u32(unconst_u32(70))];
+  let vf228: vec4f = sin(vec4f(unconst_f32(-0.1459), unconst_f32(-0.00090), unconst_f32(0.3628), unconst_f32(0.06557)));
+  var vf229: vec4f = log2(vec4f(unconst_f32(0.06263), unconst_f32(0.01520), unconst_f32(0.1214), unconst_f32(0.08383)));
+  vf224 *= vf224;
+  vp12 = modf(vec2f(vf229[u32(unconst_u32(272))]));
+  let vf230: f32 = override23;
+  var vf231: vec4f = vf219;
+  return out;
+  _ = override23;
+}
+
+@vertex
+fn vertex9() -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vp12.fract.rgrg;
+  out -= vp12.fract.yyyy;
+  vp12 = modf(bitcast<vec2f>(acosh(vec4h(unconst_f16(6333.3), unconst_f16(10917.9), unconst_f16(2815.6), unconst_f16(188.7)))));
+  let vf232: f32 = pow(f32(unconst_f32(0.1003)), f32(unconst_f32(0.06195)));
+  out -= vp12.fract.rgrr;
+  fn0(FragmentOutput6(pack2x16float(unpack2x16unorm(u32(unconst_u32(2)))), unpack2x16unorm(u32(unconst_u32(2))).y));
+  var vf233 = fn0(FragmentOutput6(u32(override23), override23));
+  vp12 = modf(vf233.f24.zz);
+  var vf234: vec4i = unpack4xI8(u32(unconst_u32(100)));
+  return out;
+  _ = override23;
+}
+
+@vertex
+fn vertex10(@location(3) @interpolate(flat, center) a0: i32) -> VertexOutput6 {
+  var out: VertexOutput6;
+  vp12 = modf(vec2f(override25));
+  var vf235: vec3h = acosh(vec3h(unconst_f16(21234.2), unconst_f16(-8796.5), unconst_f16(7610.5)));
+  out.f24 += vec4f(unpack4xU8(u32(unconst_u32(8))));
+  let vf236: vec3f = quantizeToF16(vec3f(unconst_f32(0.1302), unconst_f32(0.1086), unconst_f32(0.1951)));
+  vf235 -= vec3h(override24);
+  fn2();
+  var vf237: f16 = log2(f16(unconst_f16(10059.5)));
+  out.f24 *= radians(vec3f(unconst_f32(0.1585), unconst_f32(0.2644), unconst_f32(0.03993))).bbgb;
+  out.f23 ^= bitcast<vec4i>(quantizeToF16(vec3f(unconst_f32(0.1806), unconst_f32(0.01488), unconst_f32(0.03112))).rbgg);
+  var vf238 = fn0(FragmentOutput6(vec3u(radians(vec3f(unconst_f32(0.1998), unconst_f32(0.05026), unconst_f32(0.01192)))).z, radians(vec3f(unconst_f32(0.1998), unconst_f32(0.05026), unconst_f32(0.01192))).x));
+  return out;
+  _ = override24;
+  _ = override25;
+  _ = override23;
+}
+
+@fragment
+fn fragment11() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  vp12 = modf(unpack4x8unorm(u32(unconst_u32(250))).xx);
+  var vf239: u32 = pack4xU8Clamp(vec4u(unconst_u32(187), unconst_u32(159), unconst_u32(184), unconst_u32(121)));
+  var vf240 = fn0(FragmentOutput6(u32(any(vec2<bool>(unconst_bool(false), unconst_bool(false)))), f32(any(vec2<bool>(unconst_bool(false), unconst_bool(false))))));
+  vp12.fract = vec2f(bitcast<f32>(dot4U8Packed(u32(unconst_u32(9)), u32(unconst_u32(148)))));
+  vp12.whole = vec2f(f32(any(vec2<bool>(unconst_bool(false), unconst_bool(false)))));
+  vf240 = VertexOutput6(unpack4xI8(vf239), unpack4x8snorm(vf239));
+  let ptr82: ptr<private, vec2f> = &vp12.fract;
+  vf240 = VertexOutput6(vec4i(i32(vf239)), vec4f(f32(vf239)));
+  return out;
+  _ = override23;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9(@builtin(local_invocation_id) a0: vec3u, @builtin(num_workgroups) a1: vec3u) {
+  fn2();
+  vp12 = modf(unpack2x16unorm(atomicExchange(&vw56, u32(unconst_u32(82)))));
+  fn2();
+  let vf241: u32 = atomicExchange(&(*&vw56), u32(unconst_u32(322)));
+  atomicAdd(&vw56, u32(unconst_u32(61)));
+  let ptr83: ptr<workgroup, atomic<u32>> = &vw56;
+  vp12 = modf(unpack2x16unorm(atomicLoad(&(*&vw56))));
+  vp12 = modf(vec2f(f32(a0[u32(unconst_u32(181))])));
+  atomicAdd(&vw56, u32(unconst_u32(100)));
+  vp12 = modf(log2(bitcast<vec3f>(extractBits(vec2u(unconst_u32(533), unconst_u32(335)), u32(unconst_u32(23)), u32(unconst_u32(85))).yxx)).yz);
+  let vf242: vec2h = tanh(vec2h(unconst_f16(6921.6), unconst_f16(26839.3)));
+  fn2();
+  var vf243: f32 = override25;
+  fn2();
+  let vf244: f32 = override23;
+  atomicMin(&vw56, u32(unconst_u32(54)));
+  fn2();
+  fn2();
+  fn2();
+  var vf245: u32 = a1[u32(unconst_u32(27))];
+  _ = override23;
+  _ = override25;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture228 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView226 = texture195.createView({dimension: 'cube'});
+let computePassEncoder176 = commandEncoder227.beginComputePass({label: '\u69ca\u0c7c\ud1d3\u{1fea5}\u078b\u0782\u{1fc5f}\u1837\u{1ffd0}\u0a4f'});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup19, new Uint32Array(1872), 198, 0);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer55, 'uint32', 640, 234);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(4_294_967_295, undefined, 885_554_956, 152_051_410);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer145 = device0.createBuffer({
+  label: '\ue735\uac98\uc2fe\uf48e\u01d3\u23d0\uccaa\ue2b3\u8c57\u6789',
+  size: 2369,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView227 = texture24.createView({});
+let sampler161 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 60.38,
+});
+try {
+computePassEncoder176.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer16, 'uint32', 80, 80);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: imageData14,
+  origin: { x: 9, y: 0 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder228 = device0.createCommandEncoder({});
+let renderPassEncoder68 = commandEncoder228.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 38,
+  clearValue: { r: -0.2078, g: -143.3, b: -122.5, a: 514.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler162 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 58.28, lodMaxClamp: 74.53});
+try {
+renderPassEncoder23.setScissorRect(0, 0, 4, 0);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder229 = device0.createCommandEncoder({});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 530});
+let texture229 = device0.createTexture({
+  label: '\udb2b\u73d9',
+  size: [82, 12, 27],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder69 = commandEncoder229.beginRenderPass({
+  colorAttachments: [{
+  view: textureView108,
+  depthSlice: 107,
+  clearValue: { r: -479.4, g: -488.7, b: 536.6, a: 300.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 140812916,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup145);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup149 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView144}]});
+let buffer146 = device0.createBuffer({
+  size: 3604,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup37, new Uint32Array(2305), 539, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer8, 'uint16', 1_794, 634);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup150 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 92, resource: externalTexture29}]});
+let texture230 = device0.createTexture({
+  label: '\u{1fb6f}\u1a91\u30c0\uc5c2\u{1fe10}',
+  size: [129, 1, 145],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture231 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder175.setBindGroup(0, bindGroup58, new Uint32Array(737), 88, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder45.setViewport(910.3382101075741, 0.8104248841078991, 121.14329195320221, 0.11654577995288576, 0.8661223230011932, 0.8985099408317114);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let bindGroup151 = device0.createBindGroup({
+  label: '\u3d9c\u{1f978}\u{1f714}\uda37\u81f1\uac1f\uff29\u07b3\u{1fbea}\u0524',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 301, resource: {buffer: buffer20, offset: 0, size: 33}},
+    {binding: 172, resource: textureView216},
+    {binding: 84, resource: textureView42},
+    {binding: 0, resource: textureView32},
+    {binding: 207, resource: textureView12},
+  ],
+});
+let textureView228 = texture230.createView({arrayLayerCount: 1});
+let texture232 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 35},
+  mipLevelCount: 5,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler163 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.81,
+  compare: 'greater',
+});
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup92);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup31, new Uint32Array(1576), 225, 0);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 660, height: 96, depthOrArrayLayers: 446}
+*/
+{
+  source: imageData26,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 608, y: 4, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup152 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 71, resource: sampler143}]});
+let buffer147 = device0.createBuffer({size: 5394, usage: GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup91, new Uint32Array(2267), 283, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup43, new Uint32Array(1791), 127, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer131, 'uint32', 11_420, 2_330);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer92, 456, 809);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture233 = device0.createTexture({
+  label: '\u{1f8fb}\u9864\u0b3c\u0e9e\u0adc\u{1fa64}\u7333\u7feb\u325f',
+  size: {width: 8, height: 8, depthOrArrayLayers: 170},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture234 = device0.createTexture({
+  size: [165, 24, 1],
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup15, new Uint32Array(834), 34, 0);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(4, buffer27, 0, 1_282);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 208, resource: {buffer: buffer102, offset: 0, size: 149}}],
+});
+let texture235 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 3},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView229 = texture114.createView({});
+try {
+computePassEncoder103.setBindGroup(3, bindGroup137, [512]);
+} catch {}
+let arrayBuffer21 = buffer10.getMappedRange(216, 8);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 9, y: 1 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder230 = device0.createCommandEncoder({});
+let promise25 = shaderModule4.getCompilationInfo();
+try {
+commandEncoder230.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2992 */
+  offset: 2992,
+  bytesPerRow: 3584,
+  rowsPerImage: 689,
+  buffer: buffer138,
+}, {
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 4848, new Int16Array(15187), 465, 3876);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(344, 104);
+try {
+globalThis.someLabel = externalTexture24.label;
+} catch {}
+let commandBuffer5 = commandEncoder230.finish();
+let texture236 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 7},
+  mipLevelCount: 5,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView230 = texture209.createView({});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder137.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer75, 'uint32', 324, 2_277);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer138, 1_488);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup16, new Uint32Array(1154), 171, 0);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'iec6196624'} });
+let texture237 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle27 = renderBundleEncoder27.finish({});
+let sampler164 = device0.createSampler({
+  label: '\u0555\u07cc',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.05,
+  lodMaxClamp: 60.50,
+});
+try {
+computePassEncoder168.setBindGroup(0, bindGroup63, new Uint32Array(1829), 50, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer61, 'uint32', 3_844, 1_436);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas3.getContext('webgpu');
+let sampler165 = device0.createSampler({
+  label: '\u56a4\u02e0\u3e4d\ucd54',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.00117,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer131, 2_600, 2_749);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1344, new BigUint64Array(7962), 164, 32);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let textureView231 = texture233.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let texture238 = gpuCanvasContext0.getCurrentTexture();
+let sampler166 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.50,
+  lodMaxClamp: 46.65,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(99), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 463, rowsPerImage: 22}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder231 = device0.createCommandEncoder({});
+let computePassEncoder177 = commandEncoder231.beginComputePass();
+try {
+computePassEncoder152.setBindGroup(1, bindGroup89, new Uint32Array(1595), 458, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(5, buffer118, 0, 82);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 68, new BigUint64Array(58594), 6408, 16);
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'iec6196624'} });
+let buffer148 = device0.createBuffer({
+  size: 8731,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder232 = device0.createCommandEncoder({label: '\ua61f\u{1f6be}\u333b\u0029\u09ec\ue76c\u98dd\u0d0c\u{1faea}\u057f\ufaf3'});
+let textureView232 = texture130.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup118, [0]);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup109, new Uint32Array(71), 59, 0);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline6);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder168.insertDebugMarker('\u0257');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer132, 96, new BigUint64Array(2890), 1041, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 13, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(114).fill(193), /* required buffer size: 114 */
+{offset: 114, bytesPerRow: 37, rowsPerImage: 42}, {width: 18, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let textureView233 = texture137.createView({dimension: '2d', baseArrayLayer: 3});
+let computePassEncoder178 = commandEncoder232.beginComputePass({});
+try {
+computePassEncoder178.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(128);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer22 = buffer34.getMappedRange(8, 0);
+try {
+buffer46.unmap();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte240m', transfer: 'gamma28curve'} });
+let textureView234 = texture169.createView({arrayLayerCount: 1});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup86, new Uint32Array(968), 26, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer44, 'uint32', 24, 547);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer17, 1_140);
+} catch {}
+let videoFrame32 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+computePassEncoder135.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(3, bindGroup130, new Uint32Array(247), 61, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup132, new Uint32Array(658), 80, 0);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(7, undefined);
+} catch {}
+await gc();
+let bindGroup154 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView133},
+    {binding: 136, resource: {buffer: buffer104, offset: 1280, size: 474}},
+  ],
+});
+let commandEncoder233 = device0.createCommandEncoder({});
+let textureView235 = texture237.createView({mipLevelCount: 1});
+let computePassEncoder179 = commandEncoder233.beginComputePass({label: '\u08e0\u1ea7\u03cf\u0987\uaa10\u56a3\u06f2\ue385\u{1f607}\ubbb6'});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup20, new Uint32Array(1528), 23, 0);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer111, 80, 474);
+} catch {}
+document.body.prepend(img5);
+let commandEncoder234 = device0.createCommandEncoder({});
+let texture239 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView236 = texture70.createView({dimension: '2d', baseArrayLayer: 0});
+let computePassEncoder180 = commandEncoder234.beginComputePass({label: '\u00f6\u6dee\u7ff2\u7c57\u0b86\ube02\u0655\udb45\u{1ff8c}\u9433\udb6e'});
+let sampler167 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.26,
+  lodMaxClamp: 56.48,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder180.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup23, new Uint32Array(164), 24, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder235 = device0.createCommandEncoder({});
+let renderPassEncoder70 = commandEncoder235.beginRenderPass({colorAttachments: [{view: textureView56, depthSlice: 2, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder3.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle12, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer39, 'uint16', 66, 1);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct T5 {
+  f0: array<u32>,
+}
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(135) var tex18: texture_2d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: i32,
+}
+
+struct T1 {
+  f0: array<T0, 1>,
+}
+
+struct FragmentOutput7 {
+  @location(5) f0: f32,
+  @location(0) @interpolate(flat) f1: vec4u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput7 {
+  @location(7) f25: vec4f,
+  @location(0) @interpolate(perspective, sample) f26: f16,
+  @location(8) @interpolate(flat, center) f27: vec2u,
+  @builtin(position) f28: vec4f,
+  @location(10) f29: i32,
+  @location(5) f30: vec2i,
+  @location(12) @interpolate(flat, center) f31: u32,
+  @location(1) @interpolate(flat, centroid) f32: vec2i,
+  @location(3) @interpolate(perspective, sample) f33: vec2h,
+  @location(14) @interpolate(flat) f34: i32,
+}
+
+@group(0) @binding(99) var tex17: texture_multisampled_2d<f32>;
+
+@id(12196) override override26 = true;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(1) @binding(42) var<uniform> buffer149: T1;
+
+struct T4 {
+  @align(1) f0: array<array<atomic<i32>, 1>>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T2 {
+  f0: array<array<array<atomic<i32>, 1>, 1>>,
+}
+
+struct T3 {
+  f0: T1,
+}
+
+@vertex @must_use
+fn vertex11(@location(15) @interpolate(perspective) a0: f32) -> VertexOutput7 {
+  var out: VertexOutput7;
+  let vf246: u32 = pack4x8snorm(vec4f(unconst_f32(0.1353), unconst_f32(0.04155), unconst_f32(-0.2506), unconst_f32(-0.08295)));
+  let vf247: vec4f = tanh(vec4f(unconst_f32(0.08107), unconst_f32(0.2188), unconst_f32(0.4575), unconst_f32(-0.1880)));
+  out.f26 = f16((*&buffer149).f0[u32(unconst_u32(22))].f0);
+  let vf248: f32 = a0;
+  out.f32 *= vec2i(buffer149.f0[0].f0);
+  out.f34 ^= (*&buffer149).f0[u32(unconst_u32(359))].f0;
+  let ptr84: ptr<uniform, i32> = &(*&buffer149).f0[u32(unconst_u32(420))].f0;
+  out.f34 = (*&buffer149).f0[0].f0;
+  let ptr85: ptr<uniform, i32> = &(*&buffer149).f0[u32(unconst_u32(70))].f0;
+  let ptr86: ptr<uniform, i32> = &(*&buffer149).f0[u32(unconst_u32(48))].f0;
+  let ptr87: ptr<uniform, i32> = &(*ptr84);
+  let ptr88: ptr<uniform, T0> = &buffer149.f0[0];
+  return out;
+}
+
+@fragment
+fn fragment12(@location(9) a0: u32, @builtin(sample_index) a1: u32, @location(14) @interpolate(perspective, centroid) a2: vec2h, @location(2) a3: vec4u, @location(11) @interpolate(flat, center) a4: vec4u, @location(0) @interpolate(flat, centroid) a5: vec2i, @location(12) @interpolate(perspective) a6: vec2h) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  discard;
+  let vf249: vec2h = fma(vec2h(unconst_f16(5816.8), unconst_f16(34771.9)), vec2h(unconst_f16(23647.8), unconst_f16(2821.4)), vec2h(unconst_f16(13194.3), unconst_f16(57373.3)));
+  let vf250: vec2h = a2;
+  let vf251: u32 = a3[u32(unconst_u32(111))];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute10() {
+  let vf252: u32 = textureNumSamples(tex17);
+  var vf253: vec4f = unpack4x8snorm(u32(override26));
+  let vf254: bool = override26;
+  var vf255: u32 = pack4xI8Clamp(vec4i(unconst_i32(1), unconst_i32(134), unconst_i32(54), unconst_i32(447)));
+  let ptr89: ptr<uniform, i32> = &(*&buffer149).f0[u32(unconst_u32(34))].f0;
+  let ptr90: ptr<uniform, i32> = &buffer149.f0[0].f0;
+  let ptr91: ptr<uniform, i32> = &(*&buffer149).f0[0].f0;
+  let ptr92: ptr<uniform, array<T0, 1>> = &(*&buffer149).f0;
+  let ptr93: ptr<uniform, i32> = &(*ptr92)[0].f0;
+  let ptr94: ptr<uniform, T0> = &(*&buffer149).f0[u32(unconst_u32(25))];
+  _ = override26;
+}`,
+  sourceMap: {},
+});
+let bindGroup155 = device0.createBindGroup({
+  layout: bindGroupLayout29,
+  entries: [{binding: 273, resource: textureView206}, {binding: 829, resource: textureView9}],
+});
+let commandEncoder236 = device0.createCommandEncoder();
+let texture240 = device0.createTexture({
+  size: [660, 96, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup113, new Uint32Array(597), 10, 0);
+} catch {}
+try {
+commandEncoder236.copyBufferToTexture({
+  /* bytesInLastRow: 50 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6558 */
+  offset: 6558,
+  bytesPerRow: 20480,
+  buffer: buffer141,
+}, {
+  texture: texture65,
+  mipLevel: 1,
+  origin: {x: 71, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture241 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView237 = texture127.createView({baseMipLevel: 0});
+let computePassEncoder181 = commandEncoder236.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer54, 'uint16', 1_872, 1_949);
+} catch {}
+let commandEncoder237 = device0.createCommandEncoder({});
+let texture242 = gpuCanvasContext4.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup65, new Uint32Array(1962), 413, 0);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer91, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder237.resolveQuerySet(querySet16, 2, 35, buffer75, 4864);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 83, resource: {buffer: buffer16, offset: 0, size: 1272}},
+    {binding: 174, resource: {buffer: buffer25, offset: 15104, size: 481}},
+    {binding: 40, resource: {buffer: buffer145, offset: 512, size: 21}},
+  ],
+});
+let commandEncoder238 = device0.createCommandEncoder({});
+let texture243 = device0.createTexture({size: {width: 660}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder41.setVertexBuffer(4, buffer118, 52);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 17, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(749).fill(240), /* required buffer size: 749 */
+{offset: 73, bytesPerRow: 62}, {width: 28, height: 11, depthOrArrayLayers: 1});
+} catch {}
+let texture244 = device0.createTexture({
+  size: {width: 82},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder182 = commandEncoder237.beginComputePass();
+let renderPassEncoder71 = commandEncoder238.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -234.2, g: -979.4, b: -99.98, a: -336.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder131.setBindGroup(0, bindGroup120, new Uint32Array(1342), 28, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer83, 348); };
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle7, renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer91, 'uint16', 76, 135);
+} catch {}
+try {
+adapter0.label = '\ud89d\u{1fe0e}\u{1ff2e}\u1a52\u54e1\u0d7b\ue0cd\u{1fa55}\u06a8';
+} catch {}
+let textureView238 = texture5.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 4});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer16, 'uint32', 388, 549);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline0);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(67, 95);
+let imageBitmap6 = await createImageBitmap(videoFrame8);
+let imageData35 = new ImageData(52, 176);
+let commandEncoder239 = device0.createCommandEncoder({label: '\u8725\u4f6c\u8204\u4af4\u0010\u{1fd5a}\u{1f6ab}\u4725\u0e0e\udd58'});
+try {
+computePassEncoder182.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 808 */
+  offset: 808,
+  buffer: buffer100,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup157 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 71, resource: sampler73}]});
+let buffer150 = device0.createBuffer({
+  size: 11377,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture245 = device0.createTexture({
+  size: [82, 12, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder72 = commandEncoder3.beginRenderPass({
+  label: '\u846d\u{1ff73}\u443a\u26c5\u003c',
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: 668.5, g: -932.2, b: -785.8, a: -0.5713, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 25092751,
+});
+let sampler168 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 87.87,
+  lodMaxClamp: 91.69,
+});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+computePassEncoder141.setBindGroup(2, bindGroup113, new Uint32Array(613), 172, 0);
+} catch {}
+try {
+commandEncoder239.copyBufferToTexture({
+  /* bytesInLastRow: 23 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2841 */
+  offset: 2841,
+  buffer: buffer75,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder240 = device0.createCommandEncoder({});
+let renderPassEncoder73 = commandEncoder240.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: 501.1, g: 525.8, b: -691.8, a: -501.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup148);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup81, new Uint32Array(258), 101, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup52, new Uint32Array(6031), 753, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer76, 'uint32', 240, 297);
+} catch {}
+try {
+commandEncoder239.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1448 */
+  offset: 1448,
+  buffer: buffer150,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder239.copyTextureToTexture({
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 25, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 108,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 434,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder241 = device0.createCommandEncoder({});
+let texture246 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer116, 0, 3_337);
+} catch {}
+try {
+commandEncoder239.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2048 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 272 */
+  offset: 272,
+  bytesPerRow: 8192,
+  buffer: buffer114,
+}, {width: 128, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder239.copyTextureToTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 57},
+  aspect: 'all',
+},
+{
+  texture: texture148,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise25;
+} catch {}
+document.body.prepend(canvas3);
+let offscreenCanvas5 = new OffscreenCanvas(197, 43);
+let buffer151 = device0.createBuffer({size: 2763, usage: GPUBufferUsage.STORAGE});
+let commandEncoder242 = device0.createCommandEncoder({label: '\u{1f641}\u{1f768}\u7c8d'});
+let computePassEncoder183 = commandEncoder239.beginComputePass();
+let sampler169 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.03,
+});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder183.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer134, 'uint16', 216, 961);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(0, buffer16);
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas4.getContext('webgpu');
+let buffer152 = device0.createBuffer({
+  label: '\u8424\ue7ff\u9f59\u011f\u54d1\u{1fc23}\u{1ff74}\uf9d4\u01ad\u{1faa3}',
+  size: 375,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView239 = texture51.createView({
+  label: '\u04fe\u{1fd40}\u05f9\u{1f6d5}\u0f94\u02b5',
+  dimension: '2d-array',
+  format: 'rg8sint',
+  baseArrayLayer: 0,
+});
+let computePassEncoder184 = commandEncoder241.beginComputePass({});
+try {
+computePassEncoder99.setBindGroup(1, bindGroup70, new Uint32Array(2827), 61, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup87, new Uint32Array(3857), 507, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle14, renderBundle21, renderBundle25, renderBundle14, renderBundle25, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(1, buffer27, 396, 1_558);
+} catch {}
+let bindGroup158 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 237, resource: sampler54},
+    {binding: 92, resource: {buffer: buffer110, offset: 3840, size: 12072}},
+  ],
+});
+let computePassEncoder185 = commandEncoder242.beginComputePass({});
+try {
+computePassEncoder185.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 567});
+let texture247 = device0.createTexture({
+  size: [8, 8, 23],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 82, height: 12, depthOrArrayLayers: 8}
+*/
+{
+  source: img8,
+  origin: { x: 3, y: 12 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 18, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder243 = device0.createCommandEncoder({});
+let texture248 = device0.createTexture({
+  size: [258, 1, 34],
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup59, new Uint32Array(746), 272, 0);
+} catch {}
+try {
+renderPassEncoder72.beginOcclusionQuery(161);
+} catch {}
+try {
+renderPassEncoder52.setBlendConstant({ r: 560.7, g: 511.5, b: 156.5, a: -305.6, });
+} catch {}
+try {
+commandEncoder243.copyBufferToBuffer(buffer130, 236, buffer57, 0, 4);
+} catch {}
+let textureView240 = texture239.createView({
+  label: '\u7f78\u{1f73e}\u2b81\u2b2a\u0990\u{1fe04}\u5bb6\uada3\u46f8\u{1ffb1}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder186 = commandEncoder243.beginComputePass({});
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(51_252).fill(239), /* required buffer size: 51_252 */
+{offset: 168, bytesPerRow: 172, rowsPerImage: 11}, {width: 1, height: 0, depthOrArrayLayers: 28});
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 52, resource: textureView208},
+    {binding: 288, resource: {buffer: buffer59, offset: 7936, size: 476}},
+    {binding: 19, resource: textureView55},
+    {binding: 78, resource: textureView9},
+    {binding: 191, resource: textureView168},
+  ],
+});
+let buffer153 = device0.createBuffer({
+  size: 9043,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder244 = device0.createCommandEncoder({});
+let texture249 = device0.createTexture({
+  label: '\u{1f6b6}\u9f47',
+  size: {width: 330, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder161.setBindGroup(1, bindGroup131);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder72.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle15, renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer76, 736, 1_824);
+} catch {}
+try {
+commandEncoder244.resolveQuerySet(querySet10, 63, 0, buffer110, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer62, 6996, new Int16Array(7124), 773, 336);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas5.getContext('webgpu');
+let textureView241 = texture240.createView({dimension: '2d'});
+let renderPassEncoder74 = commandEncoder244.beginRenderPass({
+  colorAttachments: [{
+  view: textureView177,
+  clearValue: { r: -466.5, g: -37.46, b: 389.6, a: 291.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 495006553,
+});
+try {
+computePassEncoder12.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView242 = texture48.createView({label: '\uc264\u484f\u270a\u7331\u0632', mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture32 = device0.importExternalTexture({label: '\u052f\u27f0\u{1f7d6}\uf354', source: videoFrame28});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup75, new Uint32Array(800), 90, 0);
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer29, 'uint32', 436, 665);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(7, buffer141, 0);
+} catch {}
+try {
+  await buffer28.mapAsync(GPUMapMode.WRITE, 0, 768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 16, new Float32Array(6200), 61, 180);
+} catch {}
+let commandEncoder245 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 1070});
+let renderPassEncoder75 = commandEncoder245.beginRenderPass({
+  label: '\u{1fea3}\u{1f7b4}\u42d5\u{1fc29}\u3ff5\u0d98\ufb50\u22f1\ud938',
+  colorAttachments: [{
+  view: textureView114,
+  depthSlice: 136,
+  clearValue: { r: 588.4, g: -282.2, b: 984.0, a: -39.40, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 82816347,
+});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup157, new Uint32Array(188), 23, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup127);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer16, 'uint32', 148, 487);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(3, buffer100, 276);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 51}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 1, y: 31 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise26;
+} catch {}
+let texture250 = device0.createTexture({
+  size: [330, 48, 30],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler170 = device0.createSampler({
+  label: '\uf943\ue033\ubb9b\uc5b0\u8512\u87f0\u{1fb3b}\u0132\u7e59\u4dc5',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.30,
+  lodMaxClamp: 93.86,
+  maxAnisotropy: 10,
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker('\u{1fd4f}');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder246 = device0.createCommandEncoder({label: '\ud124\u{1fa01}\u6cd6\u0307\u028b'});
+let sampler171 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 54.75,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup55, new Uint32Array(1744), 126, 0);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup0, new Uint32Array(912), 110, 0);
+} catch {}
+try {
+renderPassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 104, new Int16Array(14874), 4634, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture223,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 109},
+  aspect: 'all',
+}, new Uint8Array(521_023).fill(42), /* required buffer size: 521_023 */
+{offset: 251, bytesPerRow: 2657, rowsPerImage: 49}, {width: 660, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 135, resource: textureView1}, {binding: 99, resource: textureView30}],
+});
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u0f19\ufd3e', bindGroupLayouts: []});
+let commandEncoder247 = device0.createCommandEncoder({});
+let textureView243 = texture190.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder187 = commandEncoder247.beginComputePass({});
+let renderPassEncoder76 = commandEncoder198.beginRenderPass({
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: 552.6, g: -274.6, b: -663.5, a: -991.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 64520426,
+});
+let sampler172 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.42,
+  lodMaxClamp: 94.66,
+  compare: 'greater-equal',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup39, new Uint32Array(920), 236, 0);
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(3, bindGroup121, new Uint32Array(682), 269, 0);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle25, renderBundle21, renderBundle27, renderBundle27, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer75, 'uint16', 360, 1_252);
+} catch {}
+let promise27 = shaderModule3.getCompilationInfo();
+try {
+buffer59.unmap();
+} catch {}
+try {
+commandEncoder246.copyBufferToTexture({
+  /* bytesInLastRow: 5872 widthInBlocks: 367 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3504 */
+  offset: 3504,
+  bytesPerRow: 34048,
+  buffer: buffer104,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 367, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder({});
+let renderPassEncoder77 = commandEncoder248.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  clearValue: { r: -293.5, g: -440.7, b: -154.4, a: -433.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+let sampler173 = device0.createSampler({
+  label: '\u52f2\u0375\ud312\uac50',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.27,
+  lodMaxClamp: 87.35,
+});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(3, bindGroup146, new Uint32Array(523), 8, 0);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup64, new Uint32Array(4549), 380, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer122, 'uint16', 854, 2_147);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let buffer154 = device0.createBuffer({size: 9457, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let commandEncoder249 = device0.createCommandEncoder();
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer52, 'uint32', 336, 61);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline7);
+} catch {}
+let commandEncoder250 = device0.createCommandEncoder();
+let textureView244 = texture213.createView({});
+let renderPassEncoder78 = commandEncoder246.beginRenderPass({
+  colorAttachments: [{
+  view: textureView232,
+  clearValue: { r: 723.4, g: 210.8, b: -1.379, a: -92.20, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder35.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer54, 'uint32', 1_568, 3_045);
+} catch {}
+try {
+commandEncoder249.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1168 */
+  offset: 1168,
+  bytesPerRow: 40960,
+  buffer: buffer153,
+}, {
+  texture: texture249,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder249.copyTextureToBuffer({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 304 */
+  offset: 304,
+  bytesPerRow: 47616,
+  buffer: buffer115,
+}, {width: 11, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer103, 2888, new BigUint64Array(2424), 85, 140);
+} catch {}
+let buffer155 = device0.createBuffer({
+  size: 17832,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture251 = device0.createTexture({
+  size: {width: 330},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView245 = texture117.createView({dimension: 'cube', baseArrayLayer: 6});
+let computePassEncoder188 = commandEncoder250.beginComputePass({});
+let sampler174 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.74,
+  lodMaxClamp: 72.46,
+});
+try {
+computePassEncoder141.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup77, new Uint32Array(1398), 215, 0);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle21, renderBundle27, renderBundle27, renderBundle21, renderBundle21, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(2, buffer69, 1_984);
+} catch {}
+let commandEncoder251 = device0.createCommandEncoder({});
+let computePassEncoder189 = commandEncoder251.beginComputePass({});
+try {
+computePassEncoder189.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup85, new Uint32Array(1962), 166, 0);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer155, 'uint16', 3_016, 3_852);
+} catch {}
+try {
+computePassEncoder61.pushDebugGroup('\u375d');
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+document.body.append(img1);
+let bindGroup161 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 14, resource: {buffer: buffer103, offset: 256}}]});
+let computePassEncoder190 = commandEncoder249.beginComputePass({});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup152);
+} catch {}
+try {
+computePassEncoder148.setBindGroup(2, bindGroup100, new Uint32Array(3693), 1_158, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+try {
+externalTexture14.label = '\u080f\u0148\u7128\u116a\u7659\u29b4\ubd80\uce08\u90dd';
+} catch {}
+let bindGroup162 = device0.createBindGroup({
+  label: '\u{1fb50}\u0f01\u71b4\u970f\u0528\u{1f7be}',
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 78, resource: textureView1},
+    {binding: 191, resource: textureView168},
+    {binding: 288, resource: {buffer: buffer108, offset: 256, size: 416}},
+    {binding: 19, resource: textureView131},
+    {binding: 52, resource: textureView163},
+  ],
+});
+let buffer156 = device0.createBuffer({size: 22900, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder252 = device0.createCommandEncoder({});
+let computePassEncoder191 = commandEncoder252.beginComputePass({});
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer126, 1244, new DataView(new ArrayBuffer(29933)), 4123, 928);
+} catch {}
+let commandEncoder253 = device0.createCommandEncoder();
+let textureView246 = texture88.createView({});
+let sampler175 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.54,
+  lodMaxClamp: 87.60,
+});
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let computePassEncoder192 = commandEncoder253.beginComputePass({});
+let sampler176 = device0.createSampler({addressModeW: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 82.99, lodMaxClamp: 83.31});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup65, []);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2]);
+} catch {}
+try {
+textureView104.label = '\u04cf\u{1fac7}\u{1faa3}\udd46\u{1f963}\u0f0f\ubdf9\uf589\u46f6';
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 50, resource: textureView40},
+    {binding: 131, resource: {buffer: buffer52, offset: 0, size: 368}},
+    {binding: 80, resource: {buffer: buffer85, offset: 3328, size: 1774}},
+  ],
+});
+let commandEncoder254 = device0.createCommandEncoder({});
+let texture252 = gpuCanvasContext8.getCurrentTexture();
+let textureView247 = texture59.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup9, new Uint32Array(1642), 78, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder61.popDebugGroup();
+} catch {}
+let bindGroup164 = device0.createBindGroup({
+  label: '\u7143\ufeae\u3b90\u8e63\u3c27\u36c2\u{1f7f2}\u718c',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 83, resource: {buffer: buffer24, offset: 0, size: 120}},
+    {binding: 40, resource: {buffer: buffer103, offset: 1536}},
+    {binding: 174, resource: {buffer: buffer83, offset: 4352, size: 283}},
+  ],
+});
+let commandEncoder255 = device0.createCommandEncoder({});
+try {
+renderPassEncoder15.setIndexBuffer(buffer70, 'uint16', 1_518, 4_299);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise27;
+} catch {}
+let buffer157 = device0.createBuffer({size: 2404, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let computePassEncoder193 = commandEncoder255.beginComputePass();
+let renderPassEncoder79 = commandEncoder254.beginRenderPass({
+  colorAttachments: [{
+  view: textureView181,
+  clearValue: { r: 594.6, g: -103.4, b: 278.9, a: -668.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup45, new Uint32Array(143), 6, 0);
+} catch {}
+try {
+renderPassEncoder66.setScissorRect(7, 0, 251, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer125, 'uint16', 5_312, 1_783);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(0, buffer121, 0, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 330, height: 48, depthOrArrayLayers: 223}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture220,
+  mipLevel: 0,
+  origin: {x: 105, y: 10, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroup165 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 136, resource: {buffer: buffer133, offset: 0, size: 402}},
+    {binding: 606, resource: textureView81},
+  ],
+});
+let buffer158 = device0.createBuffer({
+  size: 6942,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture253 = device0.createTexture({
+  label: '\u00ba\u0958\u0647\ub77b\u38ec\u90ed\u1697\u674c\u65a3',
+  size: [258, 1, 1],
+  mipLevelCount: 4,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView248 = texture191.createView({baseArrayLayer: 0});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame33 = videoFrame29.clone();
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView249 = texture198.createView({label: '\u{1fe47}\u2a19\u{1f9af}\u0fd6\uf9c2\u0877\u{1fae4}', aspect: 'all'});
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let bindGroup166 = device0.createBindGroup({
+  layout: bindGroupLayout35,
+  entries: [
+    {binding: 108, resource: {buffer: buffer7, offset: 256, size: 1664}},
+    {binding: 434, resource: {buffer: buffer58, offset: 4096, size: 6288}},
+    {binding: 52, resource: textureView94},
+    {binding: 139, resource: textureView177},
+  ],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: false});
+try {
+computePassEncoder154.setBindGroup(1, bindGroup81, new Uint32Array(2897), 145, 0);
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(4, buffer116);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(5, buffer4, 1_368, 121);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture254 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(25, 2, 52, 1);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer125, 'uint16', 4_204, 1_464);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer130, 'uint32', 112, 253);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer105, 0, 11);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup167 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView31}]});
+let commandEncoder256 = device0.createCommandEncoder({});
+try {
+computePassEncoder159.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup106);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer104);
+} catch {}
+try {
+computePassEncoder161.insertDebugMarker('\ucded');
+} catch {}
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'film', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer159 = device0.createBuffer({size: 34656, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder257 = device0.createCommandEncoder({});
+let computePassEncoder194 = commandEncoder257.beginComputePass();
+try {
+computePassEncoder133.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup79, new Uint32Array(1387), 12, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup40, new Uint32Array(3490), 233, 0);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(4, buffer114, 1_040, 109);
+} catch {}
+try {
+commandEncoder256.clearBuffer(buffer9);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let imageData36 = new ImageData(40, 16);
+try {
+adapter0.label = '\u04e7\uaf0a\u{1f8f4}\u{1f743}\uea71\u8cc1\u{1f6d9}\u{1f762}\u{1f6c3}';
+} catch {}
+let texture255 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder80 = commandEncoder256.beginRenderPass({colorAttachments: [{view: textureView114, depthSlice: 75, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundle28 = renderBundleEncoder28.finish();
+try {
+computePassEncoder57.setBindGroup(0, bindGroup106);
+} catch {}
+try {
+computePassEncoder115.setBindGroup(0, bindGroup20, new Uint32Array(5258), 3, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: canvas2,
+  origin: { x: 20, y: 11 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 41},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(480, 279);
+let texture256 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup39, new Uint32Array(1164), 184, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+let commandEncoder258 = device0.createCommandEncoder();
+let textureView250 = texture239.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 2});
+let textureView251 = texture182.createView({dimension: '1d', baseMipLevel: 0});
+let computePassEncoder195 = commandEncoder258.beginComputePass({});
+let sampler177 = device0.createSampler({
+  label: '\u{1fa43}\ub4fc',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.17,
+  lodMaxClamp: 91.13,
+});
+try {
+computePassEncoder195.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup146, new Uint32Array(2704), 640, 0);
+} catch {}
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 248, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(298).fill(180), /* required buffer size: 298 */
+{offset: 298}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 129, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 8, y: 5 },
+  flipY: false,
+}, {
+  texture: texture218,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+let bindGroup168 = device0.createBindGroup({
+  label: '\u01ea\ua861\u07c3\u197e\u26c1\u1b26\u427e\uf04a',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 606, resource: textureView27},
+    {binding: 136, resource: {buffer: buffer140, offset: 2048, size: 667}},
+  ],
+});
+let commandEncoder259 = device0.createCommandEncoder({});
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(6, buffer140, 0);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let textureView252 = texture204.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 2});
+let computePassEncoder196 = commandEncoder259.beginComputePass({});
+try {
+renderPassEncoder68.setIndexBuffer(buffer89, 'uint32', 364, 38);
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 398,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 75, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 122,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder260 = device0.createCommandEncoder();
+let texture257 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder197 = commandEncoder260.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup22, new Uint32Array(375), 15, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 258, height: 1, depthOrArrayLayers: 220}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 75},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas6.getContext('webgpu');
+let texture258 = device0.createTexture({
+  size: [1032, 1, 90],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup41, new Uint32Array(609), 9, 0);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle4]);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let buffer160 = device0.createBuffer({size: 250, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder261 = device0.createCommandEncoder();
+let textureView253 = texture257.createView({dimension: '3d', baseMipLevel: 0});
+let texture259 = device0.createTexture({
+  size: {width: 1032},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder198 = commandEncoder261.beginComputePass({});
+try {
+computePassEncoder123.setBindGroup(2, bindGroup90, new Uint32Array(644), 83, 0);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView6},
+    {binding: 271, resource: {buffer: buffer145, offset: 512, size: 92}},
+  ],
+});
+let textureView254 = texture258.createView({});
+let texture260 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView255 = texture84.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let sampler178 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.80,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder177.setBindGroup(3, bindGroup41, new Uint32Array(2802), 32, 0);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer113, 948, new Int16Array(5634), 641, 1528);
+} catch {}
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 174, resource: {buffer: buffer140, offset: 512, size: 55}},
+    {binding: 40, resource: {buffer: buffer123, offset: 256, size: 8622}},
+    {binding: 83, resource: {buffer: buffer104, offset: 768, size: 852}},
+  ],
+});
+let buffer161 = device0.createBuffer({size: 8350, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+computePassEncoder156.setBindGroup(0, bindGroup130, new Uint32Array(196), 46, 0);
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(10, 17, 32, 0);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 636,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let texture261 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler179 = device0.createSampler({
+  label: '\u0bfc\u019b\u6cad\ufbe8\uaa02\u68b3\u0749\u{1f79c}\u{1fb31}\u2105\ua2f8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.49,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup35, new Uint32Array(6230), 246, 0);
+} catch {}
+try {
+computePassEncoder197.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup67, new Uint32Array(3942), 3_650, 0);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer106, 'uint16', 9_296, 2_063);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline4);
+} catch {}
+let textureView256 = texture261.createView({label: '\u{1fa0f}\u1575\u5980\u0e4a\ue811\ua697\u{1f838}\uf4cd\u0fab\u39ce', format: 'rgba16uint'});
+let texture262 = gpuCanvasContext6.getCurrentTexture();
+try {
+renderPassEncoder36.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(4, 0, 5, 0);
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'bt709'} });
+let bindGroup171 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 378, resource: textureView130}, {binding: 160, resource: textureView16}],
+});
+let texture263 = device0.createTexture({
+  label: '\ue966\u6a78\u{1fd81}',
+  size: {width: 1032},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({label: '\ud139\u04ca\ue5ee\u4be3\u{1fdbe}', colorFormats: ['r32uint'], depthReadOnly: true});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup81, new Uint32Array(1957), 7, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup168, new Uint32Array(779), 81, 0);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer114, 'uint16', 122, 24);
+} catch {}
+let texture264 = device0.createTexture({
+  size: [129, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup123, new Uint32Array(3823), 1_327, 0);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(1, buffer111, 0, 282);
+} catch {}
+let arrayBuffer23 = buffer68.getMappedRange(4184, 916);
+let buffer162 = device0.createBuffer({size: 34376, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let textureView257 = texture144.createView({label: '\u5045\uecb2\u{1f86c}\ubad6\u0788\u2663\ub0a7\u8e1d\u{1f767}\u0532\u{1fe04}'});
+let renderBundle29 = renderBundleEncoder29.finish({});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup138);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+computePassEncoder9.setBindGroup(0, bindGroup120);
+} catch {}
+try {
+renderPassEncoder69.setViewport(52.97632746188239, 0.12418899671899153, 54.640083135212784, 0.1371459778259947, 0.987888784610172, 0.9900983721032515);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 672, new Float32Array(6348), 830, 136);
+} catch {}
+let gpuCanvasContext12 = canvas10.getContext('webgpu');
+try {
+globalThis.someLabel = externalTexture31.label;
+} catch {}
+let buffer163 = device0.createBuffer({size: 11291, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup112);
+} catch {}
+try {
+  await shaderModule14.getCompilationInfo();
+} catch {}
+document.body.append(img5);
+let imageData37 = new ImageData(12, 44);
+let textureView258 = texture208.createView({arrayLayerCount: 1});
+let sampler180 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.71,
+  lodMaxClamp: 96.93,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder178.setBindGroup(3, bindGroup125);
+} catch {}
+let texture265 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 5},
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView259 = texture96.createView({label: '\u{1fab9}\ufdda\ud96e\u44ed\u26f8\u0cda\uc609\u{1fc36}\u0655\u6b98', dimension: '2d'});
+try {
+renderPassEncoder77.setIndexBuffer(buffer103, 'uint16', 712, 1_962);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(3, buffer27, 0, 2_236);
+} catch {}
+let texture266 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup101, new Uint32Array(877), 88, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup87, []);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer131, 'uint32', 1_936, 536);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline2);
+} catch {}
+let imageData38 = new ImageData(184, 44);
+try {
+externalTexture30.label = '\ubeb3\uc274\u{1f67f}\u{1f7eb}';
+} catch {}
+let bindGroup172 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 227, resource: textureView100}]});
+let textureView260 = texture122.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'linear'} });
+let buffer164 = device0.createBuffer({
+  size: 6610,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler181 = device0.createSampler({
+  label: '\u495c\u{1f6b6}\u07e1\u{1f9ab}\u08e5\u24a5\u0971\u0ceb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.07,
+  lodMaxClamp: 93.54,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder145.setBindGroup(3, bindGroup140, new Uint32Array(160), 19, 0);
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup57);
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  label: '\u5f2c\uacb5\ufe45\uce11\u1351',
+  entries: [
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 487, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+  ],
+});
+let buffer165 = device0.createBuffer({
+  size: 14632,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture267 = device0.createTexture({
+  size: [258, 1, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture268 = gpuCanvasContext6.getCurrentTexture();
+let textureView261 = texture174.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3});
+let sampler182 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.58,
+  lodMaxClamp: 80.87,
+  compare: 'not-equal',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(0, bindGroup140, new Uint32Array(749), 55, 0);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: -35.82, g: 896.2, b: -722.1, a: -360.8, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer37, 'uint16', 1_354, 1_197);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline7);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let bindGroup173 = device0.createBindGroup({
+  layout: bindGroupLayout37,
+  entries: [{binding: 105, resource: textureView218}, {binding: 636, resource: textureView256}],
+});
+let pipelineLayout20 = device0.createPipelineLayout({label: '\ub848\u90dd', bindGroupLayouts: [bindGroupLayout18]});
+let textureView262 = texture267.createView({dimension: '2d-array', mipLevelCount: 1});
+let texture269 = device0.createTexture({
+  label: '\uf52b\u{1fe2c}\udbd8\u0a06\u6f69',
+  size: {width: 516, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup143, new Uint32Array(2605), 278, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup105);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise29;
+} catch {}
+let buffer166 = device0.createBuffer({
+  size: 2148,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture270 = gpuCanvasContext8.getCurrentTexture();
+let sampler183 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.81,
+  lodMaxClamp: 84.17,
+  maxAnisotropy: 13,
+});
+let externalTexture34 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup166, []);
+} catch {}
+try {
+computePassEncoder111.setBindGroup(2, bindGroup150, new Uint32Array(1055), 15, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture223,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 112},
+  aspect: 'all',
+}, new Uint8Array(750_870).fill(99), /* required buffer size: 750_870 */
+{offset: 258, bytesPerRow: 1096, rowsPerImage: 120}, {width: 237, height: 85, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise30;
+} catch {}
+let bindGroup174 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 61, resource: textureView196}]});
+let texture271 = device0.createTexture({
+  size: [516, 1, 67],
+  mipLevelCount: 9,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup140);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let querySet20 = device0.createQuerySet({label: '\u09a1\ud227\u512a\u0c3a\u3c19\ua2c8\u0816\uf34b\u6ab9\u5734', type: 'occlusion', count: 892});
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup112, []);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer61, 'uint32', 1_972, 7_606);
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  label: '\u0448\u{1f9e3}\u00cc\u{1f9aa}\u9543',
+  layout: bindGroupLayout19,
+  entries: [{binding: 326, resource: textureView42}],
+});
+let textureView263 = texture267.createView({
+  label: '\u4e95\u0cfb\u{1fcf8}\u{1feb6}\uc83c\u{1f8c5}\u{1fad0}\u9934',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let texture272 = device0.createTexture({size: [165, 24, 111], dimension: '3d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder199 = commandEncoder142.beginComputePass({label: '\u0126\u6a84\u{1ff3e}\u09f5\u3218\u{1f9e4}\u0955\u08fe\u{1f61a}'});
+let sampler184 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.13,
+  lodMaxClamp: 89.34,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder199.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 28, new DataView(new ArrayBuffer(16207)), 4855, 128);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 660, height: 96, depthOrArrayLayers: 446}
+*/
+{
+  source: canvas9,
+  origin: { x: 17, y: 19 },
+  flipY: true,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 195, y: 19, z: 68},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 120, height: 55, depthOrArrayLayers: 0});
+} catch {}
+let texture273 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 28},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 82, height: 12, depthOrArrayLayers: 8}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 158 },
+  flipY: true,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 20, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture274 = device0.createTexture({
+  size: [330, 48, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler185 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.857,
+  compare: 'never',
+});
+try {
+computePassEncoder137.setBindGroup(1, bindGroup16, new Uint32Array(585), 162, 0);
+} catch {}
+try {
+renderPassEncoder66.insertDebugMarker('\ue4f0');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 1412, new BigUint64Array(22892), 7892, 316);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer167 = device0.createBuffer({
+  size: 2508,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let texture275 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup124, new Uint32Array(3435), 227, 0);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline4);
+} catch {}
+let textureView264 = texture178.createView({label: '\u{1fc26}\u1eda\u06e2\u009f', dimension: '2d-array'});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 292});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup14, new Uint32Array(1259), 449, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer105, 'uint32', 160, 1_950);
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 90, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture276 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder89.setBindGroup(1, bindGroup27, new Uint32Array(261), 61, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup165, new Uint32Array(2548), 592, 0);
+} catch {}
+try {
+renderPassEncoder76.beginOcclusionQuery(5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u0b8a\u{1fad2}\u414b\ubc7a\u71a5\u41fc\u08d8\u5213\u853e\u838a\u0c5d',
+  entries: [
+    {
+      binding: 266,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer168 = device0.createBuffer({
+  size: 11345,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup1, new Uint32Array(2080), 410, 0);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup144, new Uint32Array(3307), 261, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer70, 'uint32', 2_792, 2_156);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(0, buffer105, 696, 992);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(0, bindGroup24, new Uint32Array(737), 128, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 140, new Float32Array(15742), 1416, 8);
+} catch {}
+let textureView265 = texture39.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup86, new Uint32Array(750), 34, 0);
+} catch {}
+try {
+renderPassEncoder76.endOcclusionQuery();
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'unspecified', transfer: 'gamma22curve'} });
+let textureView266 = texture43.createView({
+  label: '\u01e5\uc369\uac0d\u098d\u3d9c\u419f\u78dd',
+  format: 'rg8sint',
+  baseArrayLayer: 1,
+  arrayLayerCount: 1,
+});
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer169 = device0.createBuffer({
+  size: 7155,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder76.setBlendConstant({ r: -44.55, g: -20.01, b: 663.8, a: -785.2, });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 165, height: 24, depthOrArrayLayers: 111}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 2, y: 73 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 10, y: 2, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView267 = texture229.createView({arrayLayerCount: 2});
+let sampler186 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 27.05,
+  lodMaxClamp: 69.58,
+});
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup39, new Uint32Array(7), 0, 0);
+} catch {}
+try {
+renderPassEncoder61.beginOcclusionQuery(244);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline7);
+} catch {}
+let querySet22 = device0.createQuerySet({
+  label: '\u01ab\u9cb3\u03ef\u{1f750}\u0530\u3c48\u{1f93e}\u1bf0\u7ab0\u0f4f\ud57f',
+  type: 'occlusion',
+  count: 472,
+});
+let textureView268 = texture183.createView({baseMipLevel: 1, mipLevelCount: 1});
+let sampler187 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.37,
+  lodMaxClamp: 91.30,
+});
+try {
+computePassEncoder181.setBindGroup(0, bindGroup117, new Uint32Array(1905), 897, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup31, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'smpte240m'} });
+try {
+computePassEncoder167.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(1, bindGroup116, new Uint32Array(168), 4, 0);
+} catch {}
+try {
+renderPassEncoder61.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+let textureView269 = texture131.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup23, new Uint32Array(829), 262, 0);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer140, 'uint32', 220, 76);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline4);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 24, new DataView(new ArrayBuffer(18126)), 424, 28);
+} catch {}
+document.body.append(img2);
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'bt1361ExtendedColourGamut'} });
+let textureView270 = texture274.createView({label: '\u04eb\u04bc\ue087\u{1f95b}\u{1fc5e}\u09f4\u1d58', dimension: '2d-array'});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup123, new Uint32Array(827), 156, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(56);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer29, 'uint32', 160, 402);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+let buffer170 = device0.createBuffer({size: 14950, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup140, new Uint32Array(1848), 634, 0);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -474.2, g: 506.2, b: 100.2, a: 205.1, });
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(1, buffer41, 0, 885);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+let querySet23 = device0.createQuerySet({label: '\u99bf\u00cd\u0e92\u{1f937}\u0a26', type: 'occlusion', count: 408});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], sampleCount: 1});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(1, buffer136, 56, 41);
+} catch {}
+let buffer171 = device0.createBuffer({size: 2722, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let texture277 = device0.createTexture({
+  size: [129, 1, 31],
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler188 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.41,
+  lodMaxClamp: 84.91,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder177.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup128);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+await gc();
+let buffer172 = device0.createBuffer({
+  size: 3555,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView271 = texture86.createView({});
+try {
+computePassEncoder189.setBindGroup(0, bindGroup87);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup44, new Uint32Array(369), 34, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(7, buffer57, 1_868, 249);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 4084, new Int16Array(3506), 136, 1096);
+} catch {}
+let buffer173 = device0.createBuffer({label: '\u0b83\u0ef3', size: 17835, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext10.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'opaque'});
+} catch {}
+let videoFrame40 = new VideoFrame(videoFrame37, {timestamp: 0});
+let buffer174 = device0.createBuffer({
+  size: 30935,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture278 = device0.createTexture({
+  size: [1032, 1, 43],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame18, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup71, new Uint32Array(1350), 226, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer166, 'uint16', 200, 549);
+} catch {}
+document.body.prepend(img7);
+let textureView272 = texture150.createView({aspect: 'all', mipLevelCount: 1});
+let sampler189 = device0.createSampler({
+  label: '\u0d8e\u3789\u0b19\u0ec7\ua389\u025e\u63db\ud145\u0174\u24d3',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.04,
+  lodMaxClamp: 94.40,
+  compare: 'less',
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame12});
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup109, new Uint32Array(1370), 80, 0);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(0, buffer15, 80);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture268,
+  mipLevel: 0,
+  origin: {x: 20, y: 120, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroup176 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView120}]});
+let texture279 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView273 = texture36.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let sampler190 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.63,
+  lodMaxClamp: 89.34,
+});
+try {
+computePassEncoder162.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup24, new Uint32Array(1921), 304, 0);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle25, renderBundle25]);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup68, new Uint32Array(132), 28, 0);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(4, buffer69);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'unspecified', transfer: 'smpte240m'} });
+let texture280 = device0.createTexture({
+  size: [516, 1, 50],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView274 = texture150.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder156.setBindGroup(1, bindGroup169, new Uint32Array(132), 16, 0);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+let textureView275 = texture106.createView({});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], stencilReadOnly: true});
+try {
+renderPassEncoder13.setViewport(30.055957615722573, 16.481099496882706, 19.9879447814384, 22.970921890459273, 0.5381586935535055, 0.9917132156882402);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer109, 0, 2_798);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup130, new Uint32Array(368), 89, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer2, 'uint16', 146, 126);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 516, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData25,
+  origin: { x: 8, y: 8 },
+  flipY: true,
+}, {
+  texture: texture278,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  multisample: {},
+  fragment: {module: shaderModule13, constants: {override23: 0}, targets: [{format: 'r8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule12,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x2', offset: 156, shaderLocation: 15},
+          {format: 'uint16x2', offset: 1580, shaderLocation: 1},
+          {format: 'sint8x2', offset: 98, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 120, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture281 = device0.createTexture({
+  size: {width: 1032, height: 1, depthOrArrayLayers: 136},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroupsIndirect(buffer76, 116); };
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup148);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer25, 'uint32', 388, 823);
+} catch {}
+let bindGroup177 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [{binding: 101, resource: textureView81}, {binding: 145, resource: textureView95}],
+});
+let querySet24 = device0.createQuerySet({label: '\u6144\ub87a\u2294\u6513\u0ea7\u44b7\u{1fbac}\u07a1\u40bc', type: 'occlusion', count: 519});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55); };
+} catch {}
+let bindGroup178 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 332, resource: sampler158},
+    {binding: 116, resource: {buffer: buffer14, offset: 2816}},
+    {binding: 428, resource: {buffer: buffer12, offset: 1792, size: 1256}},
+    {binding: 57, resource: textureView187},
+  ],
+});
+let texture282 = device0.createTexture({size: [516], dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder49.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture232,
+  mipLevel: 3,
+  origin: {x: 17, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(1_693).fill(210), /* required buffer size: 1_693 */
+{offset: 45, bytesPerRow: 103, rowsPerImage: 8}, {width: 23, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let texture283 = device0.createTexture({
+  label: '\ubd3d\u8e33\u{1fe53}\u0e1f\u01c8\u003f',
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler191 = device0.createSampler({
+  label: '\uca9b\u{1fc7f}\u5080\u0bc0\u72d9\u0cd5\u2484\u{1fab4}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 34.27,
+  lodMaxClamp: 42.42,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup42, new Uint32Array(3770), 182, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup125, new Uint32Array(51), 8, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle8, renderBundle8, renderBundle8, renderBundle11, renderBundle8, renderBundle8]);
+} catch {}
+let arrayBuffer24 = buffer68.getMappedRange(5104, 2040);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 129, height: 1, depthOrArrayLayers: 158}
+*/
+{
+  source: imageData24,
+  origin: { x: 19, y: 5 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 119},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer175 = device0.createBuffer({
+  size: 3300,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let sampler192 = device0.createSampler({
+  label: '\u{1fb27}\ub036\u91a6\ub6e8\u92c8\u8607\u131e\u065d\u3f75\u05c4\u4b28',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 13.91,
+  lodMaxClamp: 76.27,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder177.end();
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+  await buffer127.mapAsync(GPUMapMode.READ, 0, 944);
+} catch {}
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1404 */
+  offset: 1404,
+  bytesPerRow: 29952,
+  buffer: buffer12,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder231.copyTextureToBuffer({
+  texture: texture245,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3372 */
+  offset: 3372,
+  buffer: buffer72,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture268,
+  mipLevel: 0,
+  origin: {x: 7, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(98).fill(81), /* required buffer size: 98 */
+{offset: 98, bytesPerRow: 178, rowsPerImage: 33}, {width: 35, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let buffer176 = device0.createBuffer({
+  size: 16356,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let renderPassEncoder81 = commandEncoder231.beginRenderPass({
+  label: '\u0327\u3599\u0fcc\u{1fac8}\u0025',
+  colorAttachments: [{
+  view: textureView180,
+  depthSlice: 365,
+  clearValue: { r: -904.6, g: -604.6, b: 393.8, a: 905.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder21.beginOcclusionQuery(126);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle26, renderBundle12, renderBundle12, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture226,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'all',
+}, new Uint8Array(6_243).fill(141), /* required buffer size: 6_243 */
+{offset: 56, bytesPerRow: 25, rowsPerImage: 24}, {width: 3, height: 8, depthOrArrayLayers: 11});
+} catch {}
+let sampler193 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.58,
+  lodMaxClamp: 54.75,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup85, new Uint32Array(234), 66, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup74);
+} catch {}
+let buffer177 = device0.createBuffer({
+  size: 2138,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView276 = texture261.createView({});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint']});
+let renderBundle32 = renderBundleEncoder32.finish({});
+let sampler194 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 44.99,
+  lodMaxClamp: 78.75,
+});
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer40);
+} catch {}
+let texture284 = device0.createTexture({size: [165], dimension: '1d', format: 'r32uint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+computePassEncoder124.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle1, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder8.setViewport(48.15519201665276, 0.2688256304946035, 3.425743253654169, 0.6932667901124692, 0.10998747292380917, 0.9715467122548814);
+} catch {}
+let bindGroup179 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 131, resource: {buffer: buffer96, offset: 3072, size: 332}},
+    {binding: 80, resource: {buffer: buffer171, offset: 0, size: 542}},
+    {binding: 50, resource: textureView45},
+  ],
+});
+let buffer178 = device0.createBuffer({label: '\u{1f843}\u{1fc0a}', size: 23026, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 1761});
+try {
+renderPassEncoder15.setIndexBuffer(buffer103, 'uint32', 80, 602);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer60, 796, 1_703);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(50).fill(53), /* required buffer size: 50 */
+{offset: 50}, {width: 109, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer179 = device0.createBuffer({size: 17805, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture285 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler195 = device0.createSampler({
+  label: '\u{1fb08}\ud2d9\ucedf\u00f5\u0a08\u{1fcba}\u{1fedf}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 88.38,
+});
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup98, new Uint32Array(6), 0, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer159, 1_300, 1_309);
+} catch {}
+try {
+buffer133.unmap();
+} catch {}
+let bindGroup180 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 271, resource: {buffer: buffer97, offset: 0, size: 112}},
+    {binding: 23, resource: textureView111},
+  ],
+});
+let texture286 = device0.createTexture({
+  size: [516, 1, 4],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+renderPassEncoder21.executeBundles([renderBundle12, renderBundle12, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer164, 3_032, 719);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let buffer180 = device0.createBuffer({
+  size: 17313,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture287 = device0.createTexture({
+  size: [129, 1, 248],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+computePassEncoder195.setBindGroup(2, bindGroup109, []);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup95, new Uint32Array(364), 44, 0);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline4);
+} catch {}
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer181 = device0.createBuffer({size: 27863, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let textureView277 = texture58.createView({dimension: '2d', baseArrayLayer: 3});
+try {
+renderPassEncoder76.setIndexBuffer(buffer20, 'uint32', 2_844, 6_298);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(3, buffer95);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let arrayBuffer25 = buffer10.getMappedRange(352, 12);
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(111).fill(149), /* required buffer size: 111 */
+{offset: 111, bytesPerRow: 38}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer182 = device0.createBuffer({size: 13172, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let texture288 = device0.createTexture({
+  size: [129, 1, 1],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView278 = texture156.createView({});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], stencilReadOnly: true});
+let renderBundle33 = renderBundleEncoder33.finish({});
+let sampler196 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.22,
+  lodMaxClamp: 83.49,
+  compare: 'equal',
+});
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'smpteSt4281'} });
+let bindGroup181 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 208, resource: {buffer: buffer16, offset: 256, size: 1112}}],
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup54, new Uint32Array(409), 30, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup14, new Uint32Array(80), 8, 0);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer90, 'uint32', 1_088, 948);
+} catch {}
+let texture289 = device0.createTexture({
+  size: [82, 12, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView279 = texture183.createView({
+  label: '\u59c6\u{1fb1f}\ue66c\uc567\u{1ff41}\u4a5f\u5b52\u000a\u324f',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup172);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer26 = buffer127.getMappedRange(120, 112);
+let promise31 = device0.queue.onSubmittedWorkDone();
+let imageData39 = new ImageData(108, 28);
+try {
+computePassEncoder140.setBindGroup(0, bindGroup111, new Uint32Array(1569), 404, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup94);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(127);
+} catch {}
+try {
+renderPassEncoder75.setStencilReference(251);
+} catch {}
+let buffer183 = device0.createBuffer({size: 11550, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let sampler197 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 79.46,
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup105);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer180, 'uint16', 982, 891);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer57, 0, 838);
+} catch {}
+try {
+computePassEncoder117.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder132.setBindGroup(3, bindGroup101, new Uint32Array(230), 3, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer31, 'uint16', 726, 12);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+let texture290 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup105);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(5, buffer27, 0);
+} catch {}
+let arrayBuffer27 = buffer127.getMappedRange(400, 8);
+try {
+device0.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 190, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(131), /* required buffer size: 63 */
+{offset: 63}, {width: 164, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder11.label;
+} catch {}
+let bindGroup182 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 482, resource: sampler147}]});
+let texture291 = device0.createTexture({
+  size: {width: 330},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup79, new Uint32Array(761), 23, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer18, 'uint32', 288, 192);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer4, 112, 409);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 252, new Float32Array(2074), 1057, 48);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(6, 186);
+let bindGroup183 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 326, resource: textureView42}]});
+let buffer184 = device0.createBuffer({size: 2272, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup130);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer77, 0, 2_273);
+} catch {}
+let arrayBuffer28 = buffer28.getMappedRange(152, 104);
+try {
+buffer151.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer105, 1320, new Int16Array(7340), 1177, 256);
+} catch {}
+try {
+  await promise31;
+} catch {}
+await gc();
+let bindGroup184 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 14, resource: {buffer: buffer164, offset: 512, size: 116}}],
+});
+let texture292 = device0.createTexture({
+  label: '\u0278\uce44\u4d2d\u{1f624}\u0f40\u{1f8d4}\u6873',
+  size: [660],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture37 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder151.setBindGroup(2, bindGroup10, new Uint32Array(817), 234, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer29 = buffer34.getMappedRange(0, 0);
+let offscreenCanvas8 = new OffscreenCanvas(190, 1);
+let pipelineLayout21 = device0.createPipelineLayout({label: '\u07cf\u2380\u0ec7\u75b0\ucbfe\u8f7c\ua802\ue419\ufe1d\u{1ffe4}', bindGroupLayouts: []});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 216});
+let texture293 = gpuCanvasContext10.getCurrentTexture();
+let textureView280 = texture161.createView({label: '\u0657\u02ae\u5574\u768d', mipLevelCount: 1});
+try {
+computePassEncoder108.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup144, new Uint32Array(1091), 13, 0);
+} catch {}
+try {
+renderPassEncoder42.pushDebugGroup('\u9eb4');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture264,
+  mipLevel: 1,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup185 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 208, resource: {buffer: buffer0, offset: 256, size: 591}}],
+});
+let buffer185 = device0.createBuffer({size: 13039, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let sampler198 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 38.24,
+  lodMaxClamp: 40.83,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroupsIndirect(buffer183, 156); };
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup171, []);
+} catch {}
+let bindGroup186 = device0.createBindGroup({
+  label: '\u{1f69d}\uf005',
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 19, resource: textureView55},
+    {binding: 78, resource: textureView95},
+    {binding: 52, resource: textureView191},
+    {binding: 288, resource: {buffer: buffer17, offset: 3072, size: 2688}},
+    {binding: 191, resource: textureView200},
+  ],
+});
+try {
+computePassEncoder193.setBindGroup(0, bindGroup137, [2048]);
+} catch {}
+try {
+buffer117.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 500, new Float32Array(9020), 2101, 32);
+} catch {}
+let texture294 = device0.createTexture({
+  size: [165, 24, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler199 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 47.70,
+});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup171);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(1, bindGroup122, new Uint32Array(1808), 573, 0);
+} catch {}
+try {
+renderPassEncoder72.beginOcclusionQuery(202);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer130, 'uint32', 268, 46);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder95.setBindGroup(0, bindGroup20, new Uint32Array(2040), 159, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup74, new Uint32Array(1088), 1_048, 0);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer17, 'uint32', 1_588, 3_361);
+} catch {}
+try {
+computePassEncoder154.insertDebugMarker('\u038a');
+} catch {}
+let buffer186 = device0.createBuffer({
+  size: 30787,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer85, 'uint16', 4_894, 1_789);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer111, 1_888, 1_622);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 41, y: 15, z: 61},
+  aspect: 'all',
+}, new Uint8Array(246_695).fill(230), /* required buffer size: 246_695 */
+{offset: 531, bytesPerRow: 312, rowsPerImage: 8}, {width: 77, height: 5, depthOrArrayLayers: 99});
+} catch {}
+let sampler200 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 37.75,
+  lodMaxClamp: 48.15,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder143.setBindGroup(0, bindGroup97);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer15, 112, 54);
+} catch {}
+let imageData40 = new ImageData(16, 56);
+let bindGroup187 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 326, resource: textureView13}]});
+let texture295 = device0.createTexture({
+  label: '\u079f\u{1fad8}\ua1cd\u0f8c\u{1f682}\udb4e\u{1fde6}\u{1f7f0}',
+  size: {width: 258, height: 1, depthOrArrayLayers: 169},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView281 = texture180.createView({label: '\u{1f8b1}\u5e9e\u5f65\ua9d7', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder200 = commandEncoder89.beginComputePass({});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(4, buffer129);
+} catch {}
+let arrayBuffer30 = buffer28.getMappedRange(0, 4);
+try {
+buffer156.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 660, height: 96, depthOrArrayLayers: 446}
+*/
+{
+  source: videoFrame36,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 226, y: 29, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView282 = texture217.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder200.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder81.setBindGroup(3, bindGroup166);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup37, new Uint32Array(1343), 51, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData24,
+  origin: { x: 1, y: 9 },
+  flipY: true,
+}, {
+  texture: texture268,
+  mipLevel: 0,
+  origin: {x: 13, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture296 = device0.createTexture({
+  size: [1032],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let buffer187 = device0.createBuffer({
+  size: 4282,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView283 = texture138.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup159);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup90, new Uint32Array(2250), 96, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer73, 'uint32', 2_148, 5_349);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let bindGroup188 = device0.createBindGroup({
+  layout: bindGroupLayout32,
+  entries: [
+    {binding: 113, resource: textureView13},
+    {binding: 14, resource: sampler18},
+    {binding: 64, resource: {buffer: buffer102, offset: 0, size: 110}},
+  ],
+});
+let buffer188 = device0.createBuffer({
+  label: '\u5dcb\u0d35\u0435\uc7f7\u{1fdad}\u0ae3\u0519\u7576\u0921\uc9e5',
+  size: 11382,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture297 = device0.createTexture({
+  size: [1032, 1, 1],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler201 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.44,
+  lodMaxClamp: 44.96,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer78, 'uint32', 72, 918);
+} catch {}
+try {
+computePassEncoder101.insertDebugMarker('\u0de4');
+} catch {}
+let pipeline13 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule9, constants: {2_312: 0}}});
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 986,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer189 = device0.createBuffer({size: 11597, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView284 = texture250.createView({format: 'r32float', baseMipLevel: 0, baseArrayLayer: 7, arrayLayerCount: 2});
+let textureView285 = texture58.createView({label: '\u08cd\u0716', dimension: '2d'});
+try {
+globalThis.someLabel = externalTexture8.label;
+} catch {}
+let texture298 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 23},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView286 = texture241.createView({label: '\u036b\u02ba\u054b\uacf2\u{1fc9b}\u660d\uc513\u08ff\ubd53\u09d0\u0503', mipLevelCount: 1});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup132);
+} catch {}
+try {
+buffer184.unmap();
+} catch {}
+try {
+renderPassEncoder42.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: canvas3,
+  origin: { x: 53, y: 17 },
+  flipY: false,
+}, {
+  texture: texture290,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder167.setBindGroup(2, bindGroup172);
+} catch {}
+try {
+renderPassEncoder72.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer125, 'uint32', 1_720, 10_576);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer19, 5_540, 1_868);
+} catch {}
+let bindGroup189 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 97, resource: {buffer: buffer60, offset: 512, size: 952}},
+    {binding: 61, resource: {buffer: buffer129, offset: 768, size: 912}},
+  ],
+});
+let buffer190 = device0.createBuffer({
+  size: 26820,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup23, new Uint32Array(771), 338, 0);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+computePassEncoder133.pushDebugGroup('\u5f2f');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let texture299 = device0.createTexture({
+  label: '\u04a6\u04e5\u581a\u{1f9d8}\u{1ff5f}\u{1f73d}\u{1f80a}\u72d7\u511b\u0fe6',
+  size: [660, 96, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView287 = texture90.createView({});
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_212).fill(184), /* required buffer size: 1_212 */
+{offset: 192, bytesPerRow: 85, rowsPerImage: 2}, {width: 30, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let imageBitmap7 = await createImageBitmap(videoFrame2);
+let textureView288 = texture250.createView({mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 9});
+let sampler202 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.63,
+  lodMaxClamp: 29.62,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup179, [0]);
+} catch {}
+try {
+renderPassEncoder76.executeBundles([renderBundle6, renderBundle22, renderBundle6, renderBundle5, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(3, buffer97, 64, 5);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 60});
+try {
+renderPassEncoder73.executeBundles([renderBundle26, renderBundle26, renderBundle12, renderBundle12, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(311.082388033124, 0.39492956316379757, 605.1055734001967, 0.5051504126712817, 0.9571336831052539, 0.9728517441603364);
+} catch {}
+try {
+buffer133.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer156, 1312, new DataView(new ArrayBuffer(20445)), 4178, 156);
+} catch {}
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 150, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup190 = device0.createBindGroup({
+  label: '\u0804\u83c1\u02ce\u9d8f\u0b4d\u273d\u92b1\u{1f933}',
+  layout: bindGroupLayout7,
+  entries: [{binding: 358, resource: textureView64}],
+});
+let texture300 = device0.createTexture({
+  size: {width: 516, height: 1, depthOrArrayLayers: 233},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler203 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.51,
+  lodMaxClamp: 28.24,
+  compare: 'not-equal',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer118, 0, 117);
+} catch {}
+try {
+computePassEncoder142.pushDebugGroup('\u{1f6ab}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer29.detached) { new Uint8Array(arrayBuffer29).fill(0x55); };
+} catch {}
+let buffer191 = device0.createBuffer({
+  size: 3988,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture301 = device0.createTexture({
+  label: '\uf533\u8d69\u{1ff5c}\u755e\u09a1\u9c03\u{1f89d}\ud017\ub250\u8c15',
+  size: {width: 8, height: 8, depthOrArrayLayers: 101},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup162);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup74, new Uint32Array(2611), 554, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer25, 0, 3_554);
+} catch {}
+let texture302 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture303 = gpuCanvasContext5.getCurrentTexture();
+let textureView289 = texture166.createView({label: '\u334d\u{1feae}\u{1faf8}\u71e0\u0343\u{1f630}', mipLevelCount: 1});
+try {
+renderPassEncoder47.executeBundles([renderBundle6, renderBundle19, renderBundle19]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7_724).fill(129), /* required buffer size: 7_724 */
+{offset: 240, bytesPerRow: 10, rowsPerImage: 34}, {width: 1, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let texture304 = device0.createTexture({
+  label: '\u{1fcaa}\u0184\uf570\u{1f9cf}\ud79c\u0298\ua976\u{1ff29}\u{1f6c4}\u{1ff3e}\u{1fd66}',
+  size: {width: 1032, height: 1, depthOrArrayLayers: 11},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup128, []);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 726.7, g: -967.4, b: 420.2, a: -808.1, });
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer103, 'uint16', 296, 547);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+let sampler204 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.40,
+  compare: 'equal',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder56.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(2, buffer26, 2_044, 1_775);
+} catch {}
+let buffer192 = device0.createBuffer({size: 7482, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle2, renderBundle4, renderBundle4]);
+} catch {}
+let img9 = await imageWithData(72, 29, '#10101010', '#20202020');
+try {
+computePassEncoder105.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder118.setBindGroup(2, bindGroup188, new Uint32Array(153), 0, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup104, new Uint32Array(1556), 191, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer134, 'uint32', 2_280, 319);
+} catch {}
+try {
+renderPassEncoder10.pushDebugGroup('\u0b05');
+} catch {}
+await gc();
+let buffer193 = device0.createBuffer({
+  label: '\u079b\u0a90\u0748\u{1fae0}\u{1f97b}\u{1fa92}',
+  size: 31583,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder125.setBindGroup(3, bindGroup148);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline12);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let textureView290 = texture234.createView({});
+let texture305 = device0.createTexture({
+  size: [258, 1, 2],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture38 = device0.importExternalTexture({source: videoFrame42, colorSpace: 'display-p3'});
+try {
+renderPassEncoder66.setScissorRect(73, 0, 32, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer20);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(170, 84);
+let textureView291 = texture95.createView({
+  label: '\u76ce\u9972\u{1f7b3}\uf226\u{1f664}\u0ca9',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 26,
+});
+try {
+computePassEncoder100.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup70, new Uint32Array(4459), 87, 0);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(4, buffer139);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let textureView292 = texture48.createView({label: '\u{1ff02}\uc78f', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer74);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer169.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture306 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 68},
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler205 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 48.68,
+  lodMaxClamp: 79.48,
+});
+try {
+computePassEncoder158.setBindGroup(0, bindGroup130, new Uint32Array(3302), 20, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup168);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer73, 'uint32', 1_568, 151);
+} catch {}
+try {
+computePassEncoder133.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer159, 9816, new DataView(new ArrayBuffer(2946)), 766);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup191 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 32, resource: {buffer: buffer123, offset: 16640, size: 5396}}],
+});
+let textureView293 = texture21.createView({aspect: 'all'});
+let sampler206 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.59,
+  lodMaxClamp: 46.20,
+  compare: 'less',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6, new Uint32Array(277), 68, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup149, new Uint32Array(1102), 315, 0);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(4, buffer17, 0, 862);
+} catch {}
+let promise34 = shaderModule4.getCompilationInfo();
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 129, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture218,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture307 = device0.createTexture({
+  size: [165, 24, 24],
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup27, new Uint32Array(74), 1, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer152, 88, new DataView(new ArrayBuffer(15551)), 3137, 28);
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 24, resource: textureView20}, {binding: 127, resource: textureView273}],
+});
+let textureView294 = texture6.createView({dimension: '2d-array'});
+let sampler207 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.60,
+  lodMaxClamp: 99.14,
+});
+try {
+computePassEncoder126.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer103, 'uint32', 100, 1_093);
+} catch {}
+let arrayBuffer31 = buffer51.getMappedRange(10872, 364);
+try {
+computePassEncoder88.insertDebugMarker('\u081e');
+} catch {}
+let textureView295 = texture245.createView({label: '\u1e05\uba12\u{1fc8c}', mipLevelCount: 1});
+let sampler208 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 57.11,
+  compare: 'equal',
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+computePassEncoder178.setBindGroup(0, bindGroup146, new Uint32Array(1073), 407, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup153);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer170, 'uint32', 4_176, 2_227);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, new Uint8Array(357_360).fill(97), /* required buffer size: 357_360 */
+{offset: 150, bytesPerRow: 63, rowsPerImage: 42}, {width: 0, height: 1, depthOrArrayLayers: 136});
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+adapter0.label = '\u{1f77a}\u09d5\u0bb7\u000e';
+} catch {}
+try {
+offscreenCanvas7.getContext('webgl');
+} catch {}
+let texture308 = device0.createTexture({
+  size: [1032, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup127);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup19, new Uint32Array(1629), 440, 0);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(473);
+} catch {}
+try {
+renderPassEncoder30.draw(1, 46, 3, 1_069_460_643);
+} catch {}
+try {
+renderPassEncoder30.drawIndexed(10, 84, 162, 178_747_302, 207_124_883);
+} catch {}
+try {
+externalTexture25.label = '\u{1fdf3}\u1895\ud4a5\u0096\ufa7f\u0c9f\u{1ffe3}\u33ba';
+} catch {}
+let bindGroup193 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView29}]});
+let buffer194 = device0.createBuffer({size: 8642, usage: GPUBufferUsage.VERTEX});
+let texture309 = device0.createTexture({
+  label: '\u0606\uf102\u{1f9b7}\ufbbf\u0583\u0710\u{1ff71}',
+  size: [258, 1, 9],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView296 = texture309.createView({format: 'rg16uint', mipLevelCount: 1});
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(452, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder30.drawIndexed(4, 104, 36, 202_328_572, 409_177_376);
+} catch {}
+try {
+renderPassEncoder30.drawIndexedIndirect(buffer18, 1_120);
+} catch {}
+try {
+renderPassEncoder30.drawIndirect(buffer35, 336);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 784, new BigUint64Array(3403), 264, 720);
+} catch {}
+let buffer195 = device0.createBuffer({
+  label: '\ubb14\ub925\ufd6e\u4865\ub542\uf9f2\ua137\u0e2b\u86d3\udc53',
+  size: 1072,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup190);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(623);
+} catch {}
+try {
+renderPassEncoder30.draw(4, 36, 0, 1_527_004_793);
+} catch {}
+try {
+renderPassEncoder30.drawIndirect(buffer138, 4_636);
+} catch {}
+await gc();
+let shaderModule15 = device0.createShaderModule({
+  label: '\ub9a6\ud921\u8ff4',
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+@group(0) @binding(227) var tex19: texture_2d_array<f32>;
+
+struct FragmentOutput9 {
+  @location(0) f0: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn0() -> i32 {
+  var out: i32;
+  out = override28;
+  let vf256: vec2i = insertBits(vec2i(unconst_i32(44), unconst_i32(586)), vec2i(unconst_i32(20), unconst_i32(30)), u32(unconst_u32(71)), u32(unconst_u32(63)));
+  out &= insertBits(vec2i(unconst_i32(20), unconst_i32(26)), vec2i(i32(override27)), u32(unconst_u32(283)), u32(unconst_u32(128)))[1];
+  out *= override28;
+  var vf257: i32 = override28;
+  let vf258: vec2i = insertBits(vec2i(unconst_i32(356), unconst_i32(-430)), vec2i(override28), u32(unconst_u32(109)), u32(unconst_u32(479)));
+  let vf259: bool = override27;
+  var vf260: i32 = override28;
+  out &= i32(pow(f16(unconst_f16(25831.8)), f16(unconst_f16(3593.4))));
+  out = vf260;
+  out = vec3i(fma(vec3h(unconst_f16(11946.7), unconst_f16(5811.0), unconst_f16(23916.5)), vec3h(unconst_f16(19012.8), unconst_f16(27182.6), unconst_f16(5944.9)), vec3h(f16(vf258[u32(unconst_u32(68))])))).r;
+  let vf261: i32 = insertBits(i32(unconst_i32(117)), vf256[1], u32(unconst_u32(299)), u32(unconst_u32(98)));
+  vf260 -= i32(degrees(f32(unconst_f32(0.4418))));
+  var vf262: bool = vf259;
+  let vf263: vec2i = vf258;
+  let ptr95: ptr<function, i32> = &vf257;
+  var vf264: vec2i = insertBits(vec2i(unconst_i32(-488), unconst_i32(153)), vec2i(unconst_i32(34), unconst_i32(323)), u32(unconst_u32(73)), u32(unconst_u32(398)));
+  let vf265: vec2i = vf256;
+  vf264 = vec2i(i32(degrees(f32(unconst_f32(-0.04357)))));
+  vf264 = vec2i(fma(vec3h(unconst_f16(1135.0), unconst_f16(4433.4), unconst_f16(6148.0)), vec3h(unconst_f16(-922.4), unconst_f16(1957.2), unconst_f16(13070.6)), vec3h(unconst_f16(3441.3), unconst_f16(-5130.7), unconst_f16(2010.0))).yy);
+  vf257 ^= vec3i(atan2(vec3f(tanh(vec2h(unconst_f16(1016.8), unconst_f16(6227.9))).xyy), vec3f(unconst_f32(0.01237), unconst_f32(0.1133), unconst_f32(0.05625)))).z;
+  let vf266: i32 = vf261;
+  vf260 = vf265[u32(unconst_u32(147))];
+  return out;
+  _ = override28;
+  _ = override27;
+}
+
+struct FragmentOutput8 {
+  @location(1) @interpolate(flat, sample) f0: vec2u,
+  @location(0) @interpolate(flat, sample) f1: vec2u,
+  @location(6) f2: f32,
+  @location(4) @interpolate(perspective) f3: vec2f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @align(2) @size(12) f0: array<u32>,
+}
+
+@id(34962) override override27: bool;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> VertexOutput8 {
+  var out: VertexOutput8;
+  let vf267: vec2u = countOneBits(vec2u(unconst_u32(277), unconst_u32(384)));
+  out.f35 = unpack2x16snorm(u32(unconst_u32(588))).yxyx;
+  out.f36 = vec4f(bitcast<f32>(dot4I8Packed(u32(unconst_u32(120)), u32(unconst_u32(255)))));
+  var vf268 = fn0();
+  var vf269: vec2u = countOneBits(vec2u(unconst_u32(1), unconst_u32(18)));
+  vf268 *= select(i32(unconst_i32(118)), i32(unconst_i32(46)), bool(unconst_bool(false)));
+  var vf270: vec2u = vf267;
+  out.f35 -= log(vec2f(f32(acosh(f16(unconst_f16(11346.3)))))).ggrg;
+  out.f35 = vec4f(f32(acosh(f16(unconst_f16(2695.0)))));
+  vf269 = bitcast<vec2u>(atan(vec4h(unconst_f16(30930.4), unconst_f16(8326.9), unconst_f16(-13301.7), unconst_f16(7536.5))));
+  vf270 -= vec2u(vf269[u32(unconst_u32(13))]);
+  var vf271: f16 = acosh(f16(unconst_f16(1689.2)));
+  out.f36 = vec4f(fract(vec3h(unconst_f16(14276.6), unconst_f16(16222.3), unconst_f16(-21565.9))).xzyx);
+  vf268 = i32(override27);
+  fn0();
+  return out;
+  _ = override28;
+  _ = override27;
+}
+
+var<workgroup> vw57: vec2f;
+
+struct VertexOutput8 {
+  @location(11) @interpolate(perspective, sample) f35: vec4f,
+  @builtin(position) f36: vec4f,
+}
+
+override override28: i32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex12(@location(10) @interpolate(flat, centroid) a0: vec2u, @location(1) a1: vec2h, @location(0) a2: u32, @location(11) @interpolate(linear, center) a3: vec2f) -> VertexOutput8 {
+  var out: VertexOutput8;
+  out.f35 = a3.rrrg;
+  var vf272: vec4h = trunc(vec4h(unconst_f16(10017.7), unconst_f16(4040.0), unconst_f16(13958.8), unconst_f16(13623.6)));
+  out.f35 = unpack4x8snorm(a2);
+  return out;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out.f1 = vec2u(u32(max(i32(unconst_i32(18)), vec2i(normalize(vec2f(unconst_f32(0.1305), unconst_f32(-0.08204))))[0])));
+  return out;
+}
+
+@fragment
+fn fragment14() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  fn0();
+  let vf273: vec2u = min(vec2u(unconst_u32(18), unconst_u32(148)), vec2u(unconst_u32(208), unconst_u32(217)));
+  out = FragmentOutput9(bitcast<vec4f>(min(vec2u(unconst_u32(14), unconst_u32(34)), vec2u(unconst_u32(329), unconst_u32(273))).rrrg));
+  let vf274: i32 = override28;
+  fn0();
+  var vf275 = fn0();
+  out.f0 = vec4f(f32(saturate(f16(unconst_f16(18609.8)))));
+  out.f0 *= vec4f(trunc(vec4h(unconst_f16(7220.5), unconst_f16(26280.7), unconst_f16(24844.2), unconst_f16(1354.9))));
+  vf275 = i32(trunc(vec4h(unconst_f16(23263.8), unconst_f16(22322.9), unconst_f16(10648.0), unconst_f16(2206.7)))[1]);
+  var vf276 = fn0();
+  var vf277 = fn0();
+  vf275 = vec4i(exp(vec4h(unconst_f16(822.7), unconst_f16(6631.6), unconst_f16(9273.4), unconst_f16(27742.3))))[3];
+  out.f0 = unpack2x16float(u32(unconst_u32(707))).yxyx;
+  vf275 = override28;
+  var vf278 = fn0();
+  var vf279 = fn0();
+  var vf280 = fn1();
+  fn0();
+  vf278 += bitcast<i32>(vf273[1]);
+  vf275 &= vf274;
+  vf277 *= bitcast<i32>(unpack2x16float(u32(unconst_u32(30)))[1]);
+  vf280.f35 = vec4f(trunc(vec4h(unconst_f16(2288.2), unconst_f16(16195.3), unconst_f16(11644.4), unconst_f16(8173.1))));
+  out.f0 += vf280.f35;
+  var vf281 = fn0();
+  return out;
+  _ = override27;
+  _ = override28;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute11() {
+  vw57 = bitcast<vec2f>(textureDimensions(tex19, i32(unconst_i32(-22))));
+  vw57 = vec2f(f32(override27));
+  vw57 += textureLoad(tex19, vec2i(unconst_i32(19), unconst_i32(93)), i32(unconst_i32(43)), i32(determinant(mat2x2f(unconst_f32(0.3928), unconst_f32(0.1006), unconst_f32(0.01419), unconst_f32(0.1226))))).rg;
+  let vf282: vec3i = clamp(vec3i(unconst_i32(329), unconst_i32(43), unconst_i32(105)), vec3i(unconst_i32(59), unconst_i32(84), unconst_i32(42)), vec3i(unconst_i32(246), unconst_i32(108), unconst_i32(272)));
+  vw57 = vec2f(determinant(mat2x2f()));
+  let vf283: i32 = vf282[u32(unconst_u32(56))];
+  let vf284: vec4h = cos(vec4h(unconst_f16(4576.8), unconst_f16(4640.2), unconst_f16(15155.7), unconst_f16(11866.4)));
+  vw57 = vec2f(textureDimensions(tex19, i32(unconst_i32(204))));
+  vw57 -= bitcast<vec2f>(clamp(vec3i(unconst_i32(438), unconst_i32(194), unconst_i32(32)), vec3i(unconst_i32(-351), unconst_i32(-35), unconst_i32(-137)), vec3i(unconst_i32(-332), unconst_i32(8), unconst_i32(493))).zz);
+  var vf285: vec2f = unpack2x16float(u32(unconst_u32(0)));
+  let vf286: vec3i = vf282;
+  storageBarrier();
+  vw57 *= vw57;
+  let vf287: vec3f = log2(vec3f(unconst_f32(0.07321), unconst_f32(0.00107), unconst_f32(0.4841)));
+  vw57 = vec2f(bitcast<f32>(vf286[u32(unconst_u32(36))]));
+  var vf288: i32 = vf283;
+  var vf289: vec3h = ldexp(vec3h(unconst_f16(1674.2), unconst_f16(3398.1), unconst_f16(2401.3)), vec3i(unconst_i32(426), unconst_i32(195), unconst_i32(-86)));
+  vf285 = vw57;
+  vf289 = ldexp(vec3h(unconst_f16(2366.6), unconst_f16(13882.0), unconst_f16(17324.2)), vec3i(unconst_i32(11), unconst_i32(-52), unconst_i32(134)));
+  _ = override27;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer196 = device0.createBuffer({size: 13620, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder57.setScissorRect(27, 9, 92, 2);
+} catch {}
+try {
+renderPassEncoder30.drawIndexed(77, 167, 88, 829_599_236, 175_505_063);
+} catch {}
+try {
+renderPassEncoder30.drawIndirect(buffer94, 604);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(5, buffer69);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 158}
+*/
+{
+  source: img6,
+  origin: { x: 1, y: 16 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas8.getContext('webgpu');
+await gc();
+let bindGroupLayout44 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup194 = device0.createBindGroup({
+  label: '\u{1fd12}\ue557\u1b1b\ufe0b\uf967',
+  layout: bindGroupLayout42,
+  entries: [{binding: 986, resource: textureView1}, {binding: 279, resource: textureView284}],
+});
+let textureView297 = texture180.createView({mipLevelCount: 1});
+let texture310 = device0.createTexture({
+  size: [516, 1, 1],
+  mipLevelCount: 7,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.draw(1, 9, 0, 1_291_008_969);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+let sampler209 = device0.createSampler({
+  label: '\u{1f6df}\u201f\u{1fd6b}\u332d\u59ca',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 27.22,
+});
+try {
+computePassEncoder194.setBindGroup(1, bindGroup9, new Uint32Array(6988), 1_489, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup29);
+} catch {}
+let sampler210 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 72.11,
+  lodMaxClamp: 95.24,
+  compare: 'always',
+});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder196.setBindGroup(1, bindGroup158, new Uint32Array(1386), 184, 0);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder75.executeBundles([renderBundle19, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder30.drawIndexedIndirect(buffer92, 112);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(1, undefined, 561_243_135, 923_817_022);
+} catch {}
+document.body.append(img3);
+let bindGroup195 = device0.createBindGroup({
+  label: '\u03c2\u125e\u03d0\u{1f9cb}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 127, resource: textureView277}],
+});
+let buffer197 = device0.createBuffer({
+  label: '\uae75\u5bc4',
+  size: 1911,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler211 = device0.createSampler({
+  label: '\u5f24\ud6d5\u{1ff37}\u{1fad6}\ufac4\u09cc\u75db\u32e2\u0155',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 60.79,
+  lodMaxClamp: 72.83,
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup5, new Uint32Array(1314), 117, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle32, renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder30.drawIndexed(133, 90, 18, -1_541_365_161, 235_536_625);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer197, 'uint32', 12, 182);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(6, undefined, 272_769_214, 9_835_412);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas9.getContext('webgpu');
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+computePassEncoder136.setBindGroup(0, bindGroup28, new Uint32Array(260), 21, 0);
+} catch {}
+try {
+renderPassEncoder30.draw(4, 8, 1, 255_419_791);
+} catch {}
+let texture311 = device0.createTexture({size: [165], dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle33, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder30.draw(0, 267, 0, 2_782_591_073);
+} catch {}
+try {
+renderPassEncoder30.drawIndexed(19, 260, 39, 359_115_865, 424_378_225);
+} catch {}
+try {
+renderPassEncoder30.drawIndexedIndirect(buffer170, 14_080);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer156, 'uint16', 4_430, 864);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 157, y: 0, z: 27},
+  aspect: 'all',
+}, new Uint8Array(844_997).fill(184), /* required buffer size: 844_997 */
+{offset: 97, bytesPerRow: 85, rowsPerImage: 140}, {width: 42, height: 0, depthOrArrayLayers: 72});
+} catch {}
+document.body.prepend(img1);
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup100);
+} catch {}
+try {
+renderPassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder80.executeBundles([renderBundle22, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(5, buffer144, 192, 278);
+} catch {}
+let buffer198 = device0.createBuffer({
+  label: '\u{1fefe}\ue5cd\u0c00\u0bb8\u30ec\uc62b\u{1fc02}\u00b0\u46e5',
+  size: 281,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture312 = device0.createTexture({
+  size: [165, 24, 24],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder82 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{view: textureView271, depthSlice: 46, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 48708648,
+});
+try {
+computePassEncoder134.setBindGroup(1, bindGroup94, []);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(1, bindGroup79, new Uint32Array(958), 55, 0);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 282, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17).fill(198), /* required buffer size: 17 */
+{offset: 17, bytesPerRow: 898, rowsPerImage: 19}, {width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData41 = new ImageData(12, 12);
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup87);
+} catch {}
+let texture313 = device0.createTexture({
+  size: [660, 96, 446],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture39 = device0.importExternalTexture({source: videoFrame31});
+try {
+computePassEncoder169.setBindGroup(3, bindGroup83);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(0, bindGroup181, new Uint32Array(5216), 352, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer109);
+} catch {}
+try {
+buffer133.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer152, 8, new Float32Array(6795), 478, 0);
+} catch {}
+let texture314 = gpuCanvasContext7.getCurrentTexture();
+let textureView298 = texture48.createView({mipLevelCount: 1});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup55, new Uint32Array(1952), 269, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup14, new Uint32Array(807), 51, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer17, 'uint16', 1_382, 2_193);
+} catch {}
+try {
+computePassEncoder142.popDebugGroup();
+} catch {}
+let imageData42 = new ImageData(16, 8);
+let textureView299 = texture0.createView({label: '\u{1fdaf}\u{1f70d}\uf464\u8a4d', mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 1});
+let sampler212 = device0.createSampler({
+  label: '\u43bc\u76bc\u98c6\u{1fd33}\u7482\u1231\u007d\u680b',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.92,
+  lodMaxClamp: 48.51,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder154.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer36, 80); };
+} catch {}
+try {
+renderPassEncoder77.beginOcclusionQuery(707);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder74.setBlendConstant({ r: 382.1, g: -848.0, b: 587.6, a: 99.80, });
+} catch {}
+try {
+renderPassEncoder79.setViewport(0.6447053471749591, 1.0569794337655782, 2.340040545604479, 2.619867479138487, 0.34308989184837957, 0.6551712592211376);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer157, 'uint32', 92, 126);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet28 = device0.createQuerySet({
+  label: '\u{1f8a2}\u0548\u{1f90d}\u0bab\u08f6\u{1fec9}\u0835\u9727\u604b\u{1fb8c}\u0e2f',
+  type: 'occlusion',
+  count: 63,
+});
+let sampler213 = device0.createSampler({
+  label: '\u4e15\u5a95\u{1f710}\u{1f662}\u{1f702}\u{1f96f}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.01,
+  lodMaxClamp: 92.37,
+  maxAnisotropy: 1,
+});
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer159, 2092, new BigUint64Array(562), 44);
+} catch {}
+let pipeline14 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule15, constants: {34_962: 0}}});
+try {
+bindGroupLayout24.label = '\u609e\udf1a\u8985\u04fa';
+} catch {}
+let sampler214 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.84,
+  lodMaxClamp: 58.35,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 76},
+  aspect: 'all',
+}, new Uint8Array(50_719).fill(148), /* required buffer size: 50_719 */
+{offset: 67, bytesPerRow: 469, rowsPerImage: 6}, {width: 100, height: 0, depthOrArrayLayers: 19});
+} catch {}
+let texture315 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 111},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView300 = texture272.createView({dimension: '3d'});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup174, new Uint32Array(4682), 1_751, 0);
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(160);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let texture316 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 45},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup136, new Uint32Array(2262), 145, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle5]);
+} catch {}
+let buffer199 = device0.createBuffer({size: 8500, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView301 = texture193.createView({label: '\ud18d\u0e45\u69b9\uf6b1\u{1fe14}\uc04c\u0370\u2d8d\u{1f908}', arrayLayerCount: 1});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup22, new Uint32Array(1433), 39, 0);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline4);
+} catch {}
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture317 = device0.createTexture({
+  size: [82, 12, 19],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder174.setBindGroup(0, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup121);
+} catch {}
+try {
+buffer169.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture307,
+  mipLevel: 1,
+  origin: {x: 34, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(3_020).fill(240), /* required buffer size: 3_020 */
+{offset: 130, bytesPerRow: 134, rowsPerImage: 21}, {width: 19, height: 1, depthOrArrayLayers: 2});
+} catch {}
+await gc();
+let buffer200 = device0.createBuffer({size: 55617, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let sampler215 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.19,
+  lodMaxClamp: 60.13,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder35.end();
+} catch {}
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'jedecP22Phosphors', transfer: 'smpteSt4281'} });
+let texture318 = device0.createTexture({
+  label: '\u2c6e\u3307\uc868\u8686\u0748\u{1fadf}\ue765\ue8d5\u7ea1',
+  size: {width: 1032, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder201 = commandEncoder19.beginComputePass();
+try {
+computePassEncoder125.setBindGroup(1, bindGroup92, new Uint32Array(31), 1, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer180, 'uint32', 3_132, 3_072);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer81, 0, 1_783);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+document.body.append(img7);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({label: '\u{1f808}\u462b\u0f40\uc3ee\ueda8\u886e', colorFormats: ['r8uint'], depthReadOnly: true});
+let externalTexture40 = device0.importExternalTexture({
+  label: '\u2a24\u{1f743}\ua9d8\u6f42\u{1fe8f}\u0532\u0607\u0858\u843a\u28c0',
+  source: videoFrame18,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup179, [0]);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(3, bindGroup167, new Uint32Array(1356), 62, 0);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer54, 'uint16', 2_068, 7_622);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup172);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(6, buffer92, 1_984, 1_851);
+} catch {}
+try {
+buffer113.unmap();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup196 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [{binding: 100, resource: textureView159}, {binding: 26, resource: {buffer: buffer81, offset: 256}}],
+});
+let buffer201 = device0.createBuffer({size: 8552, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView302 = texture176.createView({label: '\u441c\u{1f7ae}\u0b9e\u{1ffd3}\u0447\u0335\u0733\u9fe8'});
+let sampler216 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.50,
+  lodMaxClamp: 59.44,
+});
+try {
+computePassEncoder136.setBindGroup(1, bindGroup191);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(7, buffer152, 0, 57);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 292, new DataView(new ArrayBuffer(22702)), 7216, 2448);
+} catch {}
+let bindGroup197 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 23, resource: textureView26},
+    {binding: 271, resource: {buffer: buffer172, offset: 0, size: 1132}},
+  ],
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 1470});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup64, new Uint32Array(764), 156, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer91, 'uint32', 32, 20);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup51);
+} catch {}
+let buffer202 = device0.createBuffer({
+  label: '\u525e\u6859\ucf60\u0fee\u7fad\ue6d0\ub00b\u{1f901}\u074f',
+  size: 20795,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let sampler217 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.78,
+  lodMaxClamp: 94.62,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(2, buffer177, 32, 576);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer156, 1192, new Float32Array(11330), 2676, 4);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(1, bindGroup48, new Uint32Array(1081), 116, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup159);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt709', transfer: 'bt2020_10bit'} });
+let querySet30 = device0.createQuerySet({label: '\u{1f840}\u{1fa92}\u{1f744}\u505b\u087b\u4997\u7014', type: 'occlusion', count: 1077});
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+let textureView303 = texture33.createView({
+  label: '\u594e\u02a2\u{1fe7d}\u0248\u066f\u044d\u096e\u082f\u4e15\u0042',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 1,
+});
+try {
+device0.queue.writeBuffer(buffer156, 8312, new Float32Array(1181));
+} catch {}
+let bindGroup198 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 10, resource: sampler75}]});
+let buffer203 = device0.createBuffer({
+  size: 2114,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 304});
+let textureView304 = texture80.createView({label: '\u2fe8\u01f6\u398b\ucc41\u0cd4\u37eb\u0fcc\u{1f92e}\u{1fcc4}'});
+let arrayBuffer32 = buffer167.getMappedRange(0, 700);
+let renderBundle34 = renderBundleEncoder34.finish({label: '\u{1fd83}\ubfde'});
+try {
+renderPassEncoder67.setPipeline(pipeline4);
+} catch {}
+let querySet32 = device0.createQuerySet({label: '\uea69\u755a\u{1f9bf}', type: 'occlusion', count: 64});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup103, new Uint32Array(1683), 272, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer6, 'uint32', 88, 40);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { });
+} catch {}
+try {
+buffer200.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 25, y: 14, z: 0},
+  aspect: 'all',
+}, new Uint8Array(68).fill(200), /* required buffer size: 68 */
+{offset: 68, bytesPerRow: 28}, {width: 12, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  label: '\u{1fee9}\u6312\u0520\uc140\u0220',
+  layout: bindGroupLayout24,
+  entries: [
+    {binding: 288, resource: {buffer: buffer164, offset: 0, size: 1828}},
+    {binding: 52, resource: textureView163},
+    {binding: 19, resource: textureView59},
+    {binding: 78, resource: textureView273},
+    {binding: 191, resource: textureView168},
+  ],
+});
+try {
+renderPassEncoder47.setIndexBuffer(buffer16, 'uint16', 802, 196);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer204 = device0.createBuffer({
+  label: '\u{1f893}\u6752\u06b7\u09da\u{1f614}\u1e46',
+  size: 16557,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture319 = device0.createTexture({size: [8, 8, 23], format: 'rgba32float', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+renderPassEncoder67.setIndexBuffer(buffer155, 'uint16', 52, 3_248);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(0, buffer144);
+} catch {}
+let buffer205 = device0.createBuffer({size: 9002, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder175.setBindGroup(1, bindGroup198);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup170, new Uint32Array(710), 21, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder44.setStencilReference(1023);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(34, 176, 36, 277_364_155, 1_293_417_202);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer115, 464);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint16', 104, 51);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer138, 5_052, 1_440);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+let texture320 = device0.createTexture({
+  size: [330, 48, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture321 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder146.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup96, []);
+} catch {}
+try {
+renderPassEncoder17.draw(0, 155, 0, 100_172_193);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(48, 86, 25, -1_963_571_934, 29_801_261);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer186, 'uint16', 1_042, 3_661);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 173}
+*/
+{
+  source: canvas3,
+  origin: { x: 12, y: 53 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 24},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture322 = device0.createTexture({
+  size: {width: 258, height: 1, depthOrArrayLayers: 12},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u0a27\u0d7d\u6027\u4eac\u02fa\ud3ce\u1679\ud366\u{1fc02}',
+  colorFormats: ['rg8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder80.setBlendConstant({ r: 561.0, g: -147.2, b: 594.9, a: -82.65, });
+} catch {}
+try {
+renderPassEncoder17.draw(0, 246, 0, 966_124_577);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer65, 192);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer25, 3_116);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 5216, new Float32Array(70), 31, 0);
+} catch {}
+let bindGroup200 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 136, resource: {buffer: buffer99, offset: 0}}, {binding: 606, resource: textureView110}],
+});
+let renderBundle35 = renderBundleEncoder35.finish({});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup182);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup165, new Uint32Array(2285), 233, 0);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer96, 488, 460);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(2_717).fill(156), /* required buffer size: 2_717 */
+{offset: 77, bytesPerRow: 30, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let renderPassEncoder83 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{
+  view: textureView291,
+  clearValue: { r: -880.4, g: -414.7, b: -518.3, a: 37.89, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup153);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(2, buffer100);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+globalThis.someLabel = externalTexture25.label;
+} catch {}
+let textureView305 = texture306.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 27});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+let renderBundle36 = renderBundleEncoder36.finish();
+try {
+renderPassEncoder69.setPipeline(pipeline12);
+} catch {}
+let bindGroup201 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 301, resource: {buffer: buffer123, offset: 1024, size: 1094}},
+    {binding: 84, resource: textureView224},
+    {binding: 207, resource: textureView225},
+    {binding: 172, resource: textureView13},
+    {binding: 0, resource: textureView177},
+  ],
+});
+let texture323 = device0.createTexture({size: [129, 1, 44], mipLevelCount: 3, format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder146.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer85, 'uint16', 158, 3_930);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline7);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+gpuCanvasContext8.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+let buffer206 = device0.createBuffer({size: 8629, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture324 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler218 = device0.createSampler({
+  label: '\ue83a\u{1ff5d}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.056,
+  lodMaxClamp: 18.40,
+});
+try {
+renderPassEncoder21.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer52, 'uint32', 516, 107);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder44.insertDebugMarker('\u0013');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 1140, new DataView(new ArrayBuffer(245)), 46, 8);
+} catch {}
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte240m', transfer: 'logSqrt'} });
+let texture325 = device0.createTexture({
+  size: {width: 129, height: 1, depthOrArrayLayers: 25},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView306 = texture168.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+renderPassEncoder77.setBindGroup(3, bindGroup179, [256]);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(4_294_967_294, undefined, 0, 137_270_009);
+} catch {}
+let textureView307 = texture276.createView({
+  label: '\u{1fcd1}\u0c52\u{1fbeb}\u069b\u{1f9e6}\uf445\u{1f8c8}\u002e\u053c',
+  dimension: '2d',
+  baseArrayLayer: 2,
+});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup91, []);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(0, bindGroup182, new Uint32Array(301), 100, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer16, 'uint32', 1_168, 18);
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(110, 65);
+let buffer207 = device0.createBuffer({
+  label: '\u4aa3\u{1f969}\u{1f751}\u0df1\u9b75',
+  size: 23008,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture326 = gpuCanvasContext8.getCurrentTexture();
+let sampler219 = device0.createSampler({
+  label: '\uc3e2\uf914\uf02a\ud984',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 74.29,
+  lodMaxClamp: 89.00,
+});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup55, new Uint32Array(350), 48, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer31, 'uint16', 80, 180);
+} catch {}
+let texture327 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 223},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView308 = texture79.createView({aspect: 'all'});
+try {
+computePassEncoder197.setBindGroup(3, bindGroup200);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle3, renderBundle1, renderBundle2, renderBundle0, renderBundle2, renderBundle0]);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let sampler220 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.98,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer36, 824); };
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer4, 'uint16', 16, 2_114);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture247,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(44).fill(56), /* required buffer size: 44 */
+{offset: 44}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout45 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 504,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 143,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 112,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 278,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 20, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let buffer208 = device0.createBuffer({
+  size: 17934,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture328 = device0.createTexture({
+  size: [8, 8, 36],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup181, new Uint32Array(750), 35, 0);
+} catch {}
+try {
+renderPassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder59.setViewport(327.59524728072387, 0.3164677847982543, 56.08485493496498, 0.35319296165847425, 0.6214597658759992, 0.7702429401808372);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 119, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(218).fill(136), /* required buffer size: 218 */
+{offset: 218, bytesPerRow: 1012, rowsPerImage: 25}, {width: 219, height: 17, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise33;
+} catch {}
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 211});
+let texture329 = device0.createTexture({
+  size: [258, 1, 69],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder84 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: 363.8, g: 637.9, b: -835.6, a: -751.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder199.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer78, 'uint16', 3_268, 430);
+} catch {}
+try {
+buffer111.unmap();
+} catch {}
+let textureView309 = texture329.createView({aspect: 'all', format: 'rg32uint'});
+let textureView310 = texture194.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup105);
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle11, renderBundle11, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 29 */
+  offset: 29,
+  buffer: buffer197,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer179, 2112, 8196);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise34;
+} catch {}
+let bindGroup202 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 97, resource: {buffer: buffer21, offset: 2048, size: 432}},
+    {binding: 61, resource: {buffer: buffer88, offset: 768, size: 1284}},
+  ],
+});
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView311 = texture328.createView({label: '\uaff5\u{1fe7b}\ua03f\u884d\u{1f6fc}\uec7f\u0754\u{1f955}\u7bcc\u050f', aspect: 'all'});
+let texture330 = device0.createTexture({
+  size: {width: 82, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder85 = commandEncoder29.beginRenderPass({
+  colorAttachments: [{
+  view: textureView177,
+  clearValue: { r: 844.6, g: -164.0, b: -829.9, a: 926.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler221 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.61,
+  lodMaxClamp: 97.59,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup88);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup194, new Uint32Array(2368), 103, 0);
+} catch {}
+try {
+renderPassEncoder73.setStencilReference(146);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer92, 1_704, 1_018);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+await gc();
+let texture331 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 28},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler222 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.60,
+  lodMaxClamp: 84.45,
+  compare: 'greater',
+});
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+let buffer209 = device0.createBuffer({
+  size: 17969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder171.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle33]);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(8, 6, 3, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+let bindGroup203 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 14, resource: {buffer: buffer96, offset: 2560, size: 632}}],
+});
+let textureView312 = texture217.createView({aspect: 'all', mipLevelCount: 1});
+let sampler223 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.352,
+  lodMaxClamp: 65.79,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder37.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise32;
+} catch {}
+let textureView313 = texture28.createView({label: '\u8bd1\u0282\u270b\u{1f7b5}\ub49e\u0c73\u3015', dimension: '2d', baseArrayLayer: 3});
+try {
+computePassEncoder145.setBindGroup(1, bindGroup173);
+} catch {}
+try {
+renderPassEncoder72.beginOcclusionQuery(285);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer40);
+} catch {}
+offscreenCanvas2.height = 353;
+let bindGroup204 = device0.createBindGroup({
+  layout: bindGroupLayout34,
+  entries: [{binding: 101, resource: textureView27}, {binding: 145, resource: textureView27}],
+});
+let textureView314 = texture286.createView({arrayLayerCount: 1});
+let sampler224 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 89.95,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup189);
+} catch {}
+try {
+buffer146.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer156, 44, new DataView(new ArrayBuffer(7262)), 818);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+try {
+computePassEncoder194.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas10.getContext('webgpu');
+document.body.append(img7);
+let videoFrame48 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt709', transfer: 'iec61966-2-1'} });
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 832});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+computePassEncoder78.setBindGroup(1, bindGroup148, new Uint32Array(1805), 16, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer197, 'uint32', 8, 1_170);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 129, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture218,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let textureView315 = texture186.createView({});
+let sampler225 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 74.95,
+  lodMaxClamp: 87.90,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder72.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder75.setScissorRect(3, 0, 5, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer176, 'uint32', 120, 1_166);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+offscreenCanvas1.width = 1370;
+let bindGroup205 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 167, resource: {buffer: buffer204, offset: 1536, size: 5713}},
+    {binding: 419, resource: {buffer: buffer31, offset: 0, size: 120}},
+    {binding: 569, resource: sampler12},
+    {binding: 445, resource: textureView59},
+  ],
+});
+document.body.prepend(img9);
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler226 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.57,
+  lodMaxClamp: 78.70,
+});
+try {
+renderPassEncoder41.executeBundles([renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer175, 'uint32', 692, 564);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup206 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 71, resource: sampler72}]});
+let sampler227 = device0.createSampler({
+  label: '\u774e\u69bf\u73d2\u086c\u96c4\u7443\u{1f824}\u{1fef1}\ucb48\ucdaa',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.52,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder75.setBindGroup(1, bindGroup182);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle8, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer89, 'uint32', 72, 0);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer33 = buffer42.getMappedRange(1120, 72);
+try {
+buffer109.unmap();
+} catch {}
+try {
+computePassEncoder48.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+computePassEncoder138.setBindGroup(0, bindGroup7, new Uint32Array(533), 102, 0);
+} catch {}
+try {
+renderPassEncoder61.beginOcclusionQuery(1629);
+} catch {}
+let arrayBuffer34 = buffer34.getMappedRange(16, 0);
+let imageBitmap8 = await createImageBitmap(imageData29);
+let sampler228 = device0.createSampler({
+  label: '\u0ee3\uf39d\u9f33',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.55,
+  lodMaxClamp: 96.38,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder88.setBindGroup(3, bindGroup33, new Uint32Array(2353), 1_000, 0);
+} catch {}
+try {
+renderPassEncoder61.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(4, buffer172, 0, 236);
+} catch {}
+document.body.prepend(img6);
+let buffer210 = device0.createBuffer({
+  label: '\udf70\u0286\u{1fbfe}\u0d71\udbdc\u0142\uf214\u8b71\u6522\ub602',
+  size: 8664,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let sampler229 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.51,
+  lodMaxClamp: 96.01,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder192.setBindGroup(3, bindGroup123);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(1, bindGroup109);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, undefined);
+} catch {}
+let imageData43 = new ImageData(48, 80);
+let bindGroup207 = device0.createBindGroup({
+  label: '\ude28\u5e53',
+  layout: bindGroupLayout43,
+  entries: [
+    {binding: 93, resource: {buffer: buffer162, offset: 7424, size: 4601}},
+    {binding: 150, resource: sampler89},
+  ],
+});
+let buffer211 = device0.createBuffer({
+  size: 29428,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder111.setBindGroup(2, bindGroup207);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(2, bindGroup8, new Uint32Array(622), 108, 0);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer105, 'uint16', 112, 40);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(5, undefined);
+} catch {}
+let buffer212 = device0.createBuffer({size: 3324, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup38, new Uint32Array(6292), 792, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup176, new Uint32Array(877), 84, 0);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer114, 'uint32', 352, 330);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+let bindGroup208 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 358, resource: textureView29}]});
+let buffer213 = device0.createBuffer({
+  size: 21907,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture332 = device0.createTexture({
+  size: [8, 8, 23],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler230 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.372,
+  lodMaxClamp: 50.10,
+});
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle15, renderBundle15, renderBundle0, renderBundle15, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 82, height: 12, depthOrArrayLayers: 8}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(19, 54);
+let buffer214 = device0.createBuffer({
+  label: '\u{1f9f4}\uea80\u0f4b\u{1ff0f}\u0f69\ue099\u5626\u07b0\uc11a',
+  size: 1668,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let textureView316 = texture328.createView({label: '\udf1d\u637b\u0153\ua403'});
+let sampler231 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.79,
+  lodMaxClamp: 96.71,
+});
+try {
+renderPassEncoder83.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(5, buffer59, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame42,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture264,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext16 = offscreenCanvas11.getContext('webgpu');
+try {
+renderPassEncoder76.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup160, new Uint32Array(6212), 751, 0);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle32]);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer136, 'uint16', 662, 271);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer180, 428, new Int16Array(914), 205, 512);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder175.setBindGroup(0, bindGroup132);
+} catch {}
+try {
+computePassEncoder126.setBindGroup(1, bindGroup176, new Uint32Array(687), 218, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(1, buffer69, 0, 6_757);
+} catch {}
+try {
+buffer152.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(114).fill(6), /* required buffer size: 114 */
+{offset: 114}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1032, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 20, y: 7 },
+  flipY: false,
+}, {
+  texture: texture278,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer215 = device0.createBuffer({
+  label: '\ue752\udf47\u{1ff48}\u2305\u549a\uc851\u{1fd50}\u74e4\u{1fce9}\u0a5d\u0a0f',
+  size: 18131,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup70, new Uint32Array(1943), 1_577, 0);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer103, 'uint16', 254, 265);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(6, buffer121, 64, 11);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u{1f65b}\u0e06\u{1f616}',
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @size(16) f0: T0,
+}
+
+fn fn0() -> T0 {
+  var out: T0;
+  out.f0[u32(unconst_u32(177))] *= degrees(vec3h(unconst_f16(22121.5), unconst_f16(1725.7), unconst_f16(20136.2)))[1];
+  var vf290: f32 = fract(f32(unconst_f32(0.3270)));
+  out.f0[u32(unconst_u32(31))] = f16(sqrt(vec3f(unconst_f32(0.1051), unconst_f32(0.01060), unconst_f32(0.02316))).r);
+  let vf291: vec3u = abs(vec3u(unconst_u32(93), unconst_u32(58), unconst_u32(73)));
+  let vf292: vec4h = reflect(vec4h(unconst_f16(633.7), unconst_f16(2802.6), unconst_f16(16494.5), unconst_f16(7028.7)), vec4h(unconst_f16(11752.8), unconst_f16(8231.6), unconst_f16(30567.2), unconst_f16(1869.0)));
+  var vf293: f32 = fract(f32(unconst_f32(0.05284)));
+  let vf294: u32 = pack4x8snorm(vec4f(unconst_f32(0.05432), unconst_f32(0.1979), unconst_f32(0.03561), unconst_f32(0.01538)));
+  var vf295: vec2f = unpack2x16float(vec3u(degrees(vec3h(unconst_f16(1350.0), unconst_f16(7932.4), unconst_f16(655.6)))).b);
+  vf293 -= bitcast<f32>(vf294);
+  return out;
+}
+
+var<workgroup> vw58: atomic<u32>;
+
+@group(0) @binding(482) var sam5: sampler;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @size(4) f0: array<f16, 1>,
+}
+
+@compute @workgroup_size(3, 1, 2)
+fn compute12(@builtin(num_workgroups) a0: vec3u) {
+  fn0();
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer216 = device0.createBuffer({
+  size: 10630,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView317 = texture219.createView({dimension: '2d-array'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup197, new Uint32Array(768), 162, 0);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(2, bindGroup194, new Uint32Array(3274), 440, 0);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer89, 'uint16', 234, 167);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer138, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture268,
+  mipLevel: 0,
+  origin: {x: 2, y: 55, z: 0},
+  aspect: 'all',
+}, new Uint8Array(150).fill(198), /* required buffer size: 150 */
+{offset: 150, rowsPerImage: 18}, {width: 41, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['r8uint'], depthReadOnly: true});
+try {
+renderPassEncoder66.setVertexBuffer(5, buffer211, 18_748);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup72, new Uint32Array(113), 7, 0);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(1, buffer77);
+} catch {}
+let texture333 = device0.createTexture({
+  size: {width: 129, height: 1, depthOrArrayLayers: 16},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle37 = renderBundleEncoder37.finish({});
+let shaderModule17 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+var<workgroup> vw69: mat2x2h;
+
+var<workgroup> vw67: array<u32, 9>;
+
+var<workgroup> vw70: VertexOutput9;
+
+@group(0) @binding(99) var tex20: texture_multisampled_2d<f32>;
+
+struct VertexOutput9 {
+  @location(12) f37: i32,
+  @builtin(position) f38: vec4f,
+  @location(5) @interpolate(flat) f39: f16,
+}
+
+@group(0) @binding(135) var tex21: texture_2d<f32>;
+
+var<workgroup> vw63: VertexOutput9;
+
+fn fn1() -> array<array<f16, 1>, 43> {
+  var out: array<array<f16, 1>, 43>;
+  let ptr102: ptr<uniform, f16> = &buffer217[0][u32(unconst_u32(123))];
+  out[u32(unconst_u32(317))][u32(unconst_u32(120))] += (*ptr102);
+  let ptr103: ptr<uniform, f16> = &buffer217[u32(unconst_u32(409))][1];
+  fn0(array<f32, 2>(vec4f(normalize(vec4h(unconst_f16(36071.1), unconst_f16(47565.5), unconst_f16(7366.5), unconst_f16(12095.6))))[3], f32(normalize(vec4h(unconst_f16(36071.1), unconst_f16(47565.5), unconst_f16(7366.5), unconst_f16(12095.6))).g)));
+  var vf301 = fn0(array<f32, 2>(f32(unconst_f32(0.5086)), f32(unconst_f32(0.03177))));
+  fn0(array<f32, 2>(f32((*&buffer217)[u32(buffer217[u32(unconst_u32(87))][1])][1]), f32((*&buffer217)[u32(buffer217[u32(unconst_u32(87))][1])][1])));
+  vf301[u32(unconst_u32(649))] -= bitcast<f32>(vp13.f1);
+  out[u32(unconst_u32(202))][u32(unconst_u32(121))] = buffer217[0][1];
+  var vf302 = fn0(array<f32, 2>(f32((*&buffer217)[0][u32(unconst_u32(26))]), f32((*&buffer217)[0][u32(unconst_u32(26))])));
+  vp13 = FragmentOutput10(vec4u(bitcast<u32>(vf301[3])), i32(vf301[3]));
+  vp13 = FragmentOutput10(vp13.f0, i32(vp13.f0[2]));
+  vp13 = FragmentOutput10(unpack4xU8(u32((*&buffer217)[0][1])), i32((*&buffer217)[0][1]));
+  vf301[u32(unconst_u32(203))] = f32((*&buffer217)[0][1]);
+  fn0(array<f32, 2>(f32(buffer217[0][1]), f32(buffer217[0][1])));
+  var vf303: vec4h = normalize(vec4h(unconst_f16(70.26), unconst_f16(7787.8), unconst_f16(5982.6), unconst_f16(4756.7)));
+  var vf304: vec3f = quantizeToF16(vec3f(unconst_f32(0.1067), unconst_f32(0.00851), unconst_f32(0.2372)));
+  var vf305 = fn0(array<f32, 2>(f32(pack4xU8Clamp(vp13.f0)), vec4f(vp13.f0)[0]));
+  let ptr104: ptr<function, f32> = &vf305[textureDimensions(tex21, i32(unconst_i32(62)))[1]];
+  let ptr105: ptr<function, array<f32, 4>> = &vf302;
+  vf305[u32(unconst_u32(73))] = (*ptr105)[3];
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw61: mat4x4h;
+
+var<workgroup> vw65: atomic<u32>;
+
+@group(1) @binding(42) var<uniform> buffer217: array<array<f16, 2>, 1>;
+
+fn fn0(a0: array<f32, 2>) -> array<f32, 4> {
+  var out: array<f32, 4>;
+  let vf296: vec4h = asin(vec4h(unconst_f16(5519.4), unconst_f16(19138.6), unconst_f16(815.7), unconst_f16(56413.9)));
+  let vf297: f32 = a0[1];
+  var vf298: vec2u = textureDimensions(tex21, i32(unconst_i32(124)));
+  let ptr96: ptr<uniform, array<f16, 2>> = &buffer217[0];
+  let vf299: f32 = a0[u32(unconst_u32(91))];
+  let ptr97: ptr<uniform, array<f16, 2>> = &(*&buffer217)[u32(unconst_u32(226))];
+  var vf300: f32 = a0[u32(unconst_u32(125))];
+  let ptr98: ptr<function, f32> = &vf300;
+  vf298 *= vec2u(u32((*ptr97)[1]));
+  let ptr99: ptr<function, vec2u> = &vf298;
+  out[u32(unconst_u32(144))] *= f32((*ptr99).x);
+  out[u32(unconst_u32(39))] = f32(buffer217[pack4xI8Clamp(vec4i(unconst_i32(285), unconst_i32(124), unconst_i32(234), unconst_i32(127)))][1]);
+  let ptr100: ptr<uniform, f16> = &(*ptr97)[u32(unconst_u32(30))];
+  let ptr101: ptr<uniform, f16> = &(*ptr97)[u32(unconst_u32(179))];
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw66: array<VertexOutput9, 2>;
+
+var<workgroup> vw59: VertexOutput9;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput10 {
+  @location(0) f0: vec4u,
+  @location(5) @interpolate(flat) f1: i32,
+}
+
+var<workgroup> vw60: array<array<vec2h, 1>, 21>;
+
+var<workgroup> vw64: VertexOutput9;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @align(2) f0: array<u32>,
+}
+
+var<workgroup> vw62: VertexOutput9;
+
+var<workgroup> vw68: atomic<u32>;
+
+var<private> vp13: FragmentOutput10 = FragmentOutput10();
+
+@vertex
+fn vertex13() -> VertexOutput9 {
+  var out: VertexOutput9;
+  let ptr106: ptr<uniform, f16> = &buffer217[u32(buffer217[0][1])][1];
+  fn0(array<f32, 2>(f32((*&buffer217)[0][1]), f32((*&buffer217)[0][1])));
+  let ptr107: ptr<uniform, f16> = &(*&buffer217)[0][1];
+  vp13 = FragmentOutput10(vec4u(u32(buffer217[0][1])), i32(buffer217[0][1]));
+  fn1();
+  out.f39 = f16(vp13.f0.r);
+  let vf306: bool = all(bool(unconst_bool(false)));
+  fn0(array<f32, 2>(bitcast<f32>(vp13.f1), bitcast<f32>(vp13.f1)));
+  fn0(array<f32, 2>(textureLoad(tex21, vec2i(unconst_i32(248), unconst_i32(99)), i32(unconst_i32(64))).w, textureLoad(tex21, vec2i(unconst_i32(248), unconst_i32(99)), i32(unconst_i32(64)))[1]));
+  out = VertexOutput9(bitcast<i32>(textureNumLevels(tex21)), vec4f(bitcast<f32>(textureNumLevels(tex21))), f16(textureNumLevels(tex21)));
+  out.f39 = (*ptr107);
+  var vf307 = fn0(array<f32, 2>(f32(unconst_f32(-0.2711)), f32(unconst_f32(0.5154))));
+  var vf308 = fn0(array<f32, 2>(f32(buffer217[0][1]), f32(buffer217[0][1])));
+  fn1();
+  out.f39 *= f16(vf306);
+  let ptr108: ptr<uniform, f16> = &(*&buffer217)[0][u32(unconst_u32(84))];
+  out.f37 = i32(buffer217[u32(unconst_u32(7))][1]);
+  var vf309 = fn1();
+  let ptr109: ptr<uniform, f16> = &buffer217[u32(unconst_u32(70))][1];
+  fn0(array<f32, 2>(f32(buffer217[0][u32(unconst_u32(318))]), f32(buffer217[0][u32(unconst_u32(318))])));
+  vf309[u32(unconst_u32(17))][u32(vf309[u32(unconst_u32(28))][0])] += f16(vf307[3]);
+  fn0(array<f32, 2>(vf308[3], vf308[3]));
+  return out;
+}
+
+@fragment
+fn fragment15(@location(3) a0: vec2h, @location(5) a1: vec2i) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let vf310: u32 = vp13.f0[vp13.f0.z];
+  out.f0 <<= vec4u(pack4x8snorm(vec4f(vp13.f0)));
+  var vf311: i32 = a1[pack4x8snorm(vec4f(unconst_f32(0.1546), unconst_f32(0.4806), unconst_f32(0.00741), unconst_f32(0.1329)))];
+  vf311 += vec2i(unpack2x16snorm(u32(unconst_u32(236))))[1];
+  let vf312: u32 = pack4x8snorm(vec4f(unconst_f32(0.1013), unconst_f32(0.00600), unconst_f32(-0.1173), unconst_f32(-0.03797)));
+  let vf313: vec2f = unpack2x16snorm(u32(unconst_u32(302)));
+  let vf314: f16 = a0[u32(unconst_u32(10))];
+  vf311 = vp13.f1;
+  out.f0 &= unpack4xU8(bitcast<u32>(vf313[u32(unconst_u32(221))]));
+  vf311 = i32(textureNumSamples(tex20));
+  let ptr110: ptr<private, FragmentOutput10> = &vp13;
+  let ptr111: ptr<private, i32> = &(*ptr110).f1;
+  var vf315: u32 = (*ptr110).f0[u32(unconst_u32(25))];
+  out.f0 = bitcast<vec4u>(insertBits(vec4i(unconst_i32(93), unconst_i32(121), unconst_i32(40), unconst_i32(23)), vec4i(unconst_i32(59), unconst_i32(47), unconst_i32(-139), unconst_i32(56)), u32(unconst_u32(347)), u32(unconst_u32(22))));
+  var vf316: f16 = a0[(*ptr110).f0[u32(unconst_u32(307))]];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute13(@builtin(num_workgroups) a0: vec3u, @builtin(local_invocation_id) a1: vec3u, @builtin(global_invocation_id) a2: vec3u) {
+  var vf317: f32 = vw62.f38[u32(unconst_u32(110))];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder65.executeBundles([renderBundle35]);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+let texture334 = device0.createTexture({
+  label: '\u{1ffa0}\u00a5\u010c\ue051\u9956',
+  size: [516, 1, 39],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder183.setBindGroup(1, bindGroup27, new Uint32Array(679), 111, 0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup182);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 108, new BigUint64Array(140), 44, 4);
+} catch {}
+let sampler232 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.56,
+});
+let externalTexture41 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup130, new Uint32Array(491), 19, 0);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer35 = buffer34.getMappedRange(80, 72);
+try {
+computePassEncoder84.pushDebugGroup('\u088f');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires pointer_composite_access;
+
+@id(35233) override override31: f16;
+
+@group(0) @binding(227) var tex22: texture_2d_array<f32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(23884) override override29: i32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw71: atomic<i32>;
+
+struct VertexOutput10 {
+  @builtin(position) f40: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override30: f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct S6 {
+  @builtin(vertex_index) f0: u32,
+  @location(5) @interpolate(flat, centroid) f1: i32,
+  @location(15) f2: i32,
+  @builtin(instance_index) f3: u32,
+  @location(9) @interpolate(flat, sample) f4: vec2u,
+}
+
+struct S7 {
+  @location(12) @interpolate(flat) f0: f16,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+@vertex
+fn vertex14(@location(11) @interpolate(flat, sample) a0: vec2f, @location(10) a1: u32, @location(8) @interpolate(flat) a2: vec2u, a3: S6, @location(0) a4: vec4i, @location(14) a5: f16, @location(6) a6: vec2i, @location(4) a7: u32, a8: S7, @location(1) @interpolate(flat) a9: vec4i, @location(2) @interpolate(perspective, center) a10: vec2f, @location(3) @interpolate(flat, sample) a11: u32, @location(7) a12: vec4f) -> VertexOutput10 {
+  var out: VertexOutput10;
+  out.f40 *= vec4f(smoothstep(degrees(vec3f(unconst_f32(-0.3114), unconst_f32(0.02605), unconst_f32(0.00035))).y, f32(unconst_f32(-0.08910)), bitcast<vec4f>(a4).r));
+  let vf318: i32 = a3.f1;
+  let vf319: u32 = pack4xU8Clamp(vec4u(unconst_u32(3), unconst_u32(18), unconst_u32(140), unconst_u32(21)));
+  var vf320: i32 = a3.f2;
+  out.f40 -= unpack4x8snorm(a3.f0);
+  var vf321: f16 = override30;
+  let vf322: u32 = pack4xU8Clamp(vec4u(unconst_u32(213), unconst_u32(131), unconst_u32(2), unconst_u32(191)));
+  let vf323: u32 = vf319;
+  vf320 &= bitcast<i32>(degrees(vec3f(unconst_f32(0.1009), unconst_f32(0.01874), unconst_f32(0.07557)))[2]);
+  var vf324: i32 = a4[u32(unconst_u32(309))];
+  let vf325: S7 = a8;
+  vf321 = a5;
+  let vf326: f16 = a8.f0;
+  let vf327: vec2f = cosh(unpack2x16snorm(a7));
+  vf320 += vec4i(refract(vec4f(unconst_f32(0.2224), unconst_f32(0.1525), unconst_f32(0.5203), unconst_f32(0.2147)), vec4f(unconst_f32(0.1222), unconst_f32(0.09939), unconst_f32(0.01430), unconst_f32(0.4379)), f32(unconst_f32(0.04239))))[0];
+  var vf328: u32 = vf322;
+  vf321 = override31;
+  vf320 += i32(override31);
+  return out;
+  _ = override31;
+  _ = override30;
+}`,
+  sourceMap: {},
+});
+let textureView318 = texture220.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn1(a0: ptr<uniform, array<array<vec2u, 14>, 1>>, a1: VertexOutput11, a2: ptr<workgroup, T3>, a3: T4, a4: array<i32, 7>, a5: u32, a6: ptr<private, T4>, a7: array<i32, 54>, a8: VertexOutput11, a9: i32, a10: ptr<function, bool>, a11: mat4x4f, a12: ptr<uniform, vec4h>, a13: ptr<workgroup, array<array<T4, 6>, 2>>, a14: ptr<uniform, vec4<bool>>, a15: T4, a16: ptr<storage, T4, read>, a17: vec4h, a18: ptr<uniform, mat4x3f>, a19: array<array<mat2x3h, 3>, 1>, a20: ptr<workgroup, vec4i>, a21: T4, a22: ptr<uniform, u32>, a23: vec2u, a24: ptr<storage, array<u32>, read_write>, a25: ptr<storage, mat3x3f, read_write>, a26: ptr<private, array<T4, 3>>, a27: vec2u, a28: ptr<uniform, vec4h>, a29: mat3x2f, a30: ptr<storage, array<u32>, read>, a31: ptr<storage, array<u32>, read_write>, a32: VertexOutput11, a33: ptr<uniform, T4>, a34: array<T4, 9>, a35: ptr<function, array<T4, 13>>, a36: ptr<workgroup, vec4<bool>>, a37: ptr<workgroup, atomic<u32>>, a38: mat4x2f, a39: ptr<uniform, bool>, a40: ptr<storage, array<u32>, read>, a41: ptr<private, mat3x3h>, a42: ptr<storage, atomic<i32>, read_write>, a43: ptr<private, vec4f>, a44: array<array<f16, 1>, 1>, a45: ptr<function, mat4x4h>, a46: array<mat3x4h, 1>, a47: ptr<storage, array<u32>, read>, a48: ptr<workgroup, vec4i>, a49: ptr<function, T4>, a50: ptr<workgroup, T4>, a51: T4, a52: ptr<workgroup, array<array<T3, 1>, 3>>, a53: ptr<uniform, T4>, a54: ptr<storage, array<u32>, read>, a55: T4, a56: array<VertexOutput11, 1>, a57: T4, a58: vec2h, a59: array<array<f16, 1>, 8>, a60: ptr<storage, u32, read_write>, a61: ptr<uniform, T4>, a62: ptr<private, array<array<array<T4, 1>, 1>, 28>>, a63: ptr<storage, array<u32>, read>, a64: ptr<workgroup, atomic<i32>>, a65: T4, a66: ptr<uniform, u32>, a67: ptr<uniform, array<array<T4, 1>, 24>>, a68: ptr<storage, u32, read>, a69: ptr<storage, T2, read>, a70: ptr<storage, array<u32>, read>, a71: array<T4, 62>, a72: ptr<storage, mat2x3f, read>, a73: array<array<T4, 3>, 3>, a74: ptr<function, array<T4, 5>>, a75: ptr<storage, array<u32>, read>, a76: ptr<private, array<VertexOutput11, 1>>, a77: ptr<private, i32>, a78: ptr<storage, array<u32>, read_write>, a79: mat4x4h, a80: VertexOutput11, a81: array<T4, 16>, a82: T4, a83: ptr<storage, array<vec2u>, read_write>, a84: T4, a85: array<T4, 1>, a86: T4, a87: T4, a88: ptr<uniform, array<array<array<i32, 2>, 1>, 18>>, a89: ptr<private, mat2x3h>, a90: ptr<private, T4>, a91: VertexOutput11, a92: ptr<storage, array<u32>, read>, a93: ptr<storage, array<u32>, read_write>, a94: mat2x3f, a95: T4, a96: VertexOutput11, a97: VertexOutput11, a98: VertexOutput11, a99: array<T4, 15>, a100: VertexOutput11, a101: ptr<storage, array<u32>, read_write>, a102: T4, a103: ptr<workgroup, array<vec4i, 4>>, a104: ptr<uniform, array<T4, 19>>, a105: ptr<function, VertexOutput11>, a106: array<array<array<T4, 1>, 23>, 1>, a107: VertexOutput11, a108: ptr<uniform, array<T4, 14>>, a109: ptr<function, array<array<array<T4, 1>, 1>, 4>>, a110: ptr<workgroup, atomic<i32>>) -> array<array<T4, 1>, 28> {
+  var out: array<array<T4, 1>, 28>;
+  let ptr112: ptr<workgroup, T4> = &(*a50);
+  (*a90) = T4(a51.f0);
+  (*a89) = mat2x3h(f16(a34[8].f0), f16(a34[8].f0), f16(a34[8].f0), f16(a34[8].f0), f16(a34[8].f0), f16(a34[8].f0));
+  (*a103)[bitcast<u32>((*a6).f0)] -= vec4i(i32(a44[0][0]));
+  (*a36) = vec4<bool>(bool((*a16).f0));
+  (*a49) = T4(vec3i(a19[0][2][0])[0]);
+  let ptr113: ptr<storage, T4, read> = &(*a16);
+  let vf340: T4 = a73[2][u32(unconst_u32(437))];
+  (*a60) <<= (*a69).f0[u32(unconst_u32(179))];
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput11 {
+  @builtin(position) f41: vec4f,
+}
+
+var<workgroup> vw72: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(135) var tex24: texture_2d<f32>;
+
+struct T2 {
+  f0: array<u32>,
+}
+
+struct T4 {
+  f0: i32,
+}
+
+struct T3 {
+  f0: atomic<u32>,
+}
+
+@group(0) @binding(99) var tex23: texture_multisampled_2d<f32>;
+
+@group(1) @binding(42) var<uniform> buffer218: T4;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn fn0() -> mat3x4h {
+  var out: mat3x4h;
+  out = mat3x4h(vec4h(textureLoad(tex23, vec2i(unconst_i32(109), unconst_i32(560)), i32(radians(f32(unconst_f32(0.00877)))))), vec4h(textureLoad(tex23, vec2i(unconst_i32(109), unconst_i32(560)), i32(radians(f32(unconst_f32(0.00877)))))), vec4h(textureLoad(tex23, vec2i(unconst_i32(109), unconst_i32(560)), i32(radians(f32(unconst_f32(0.00877)))))));
+  let vf329: vec4h = faceForward(vec4h(unconst_f16(15908.0), unconst_f16(12886.2), unconst_f16(14162.7), unconst_f16(18630.2)), vec4h(unconst_f16(193.2), unconst_f16(6860.3), unconst_f16(1788.5), unconst_f16(29.71)), vec4h(unconst_f16(36363.4), unconst_f16(33074.6), unconst_f16(7795.0), unconst_f16(383.1)));
+  out = mat3x4h(f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))), f16(radians(f32(unconst_f32(0.1427)))));
+  let vf330: vec2h = mix(vec2h(unconst_f16(15442.7), unconst_f16(18043.0)), vec2h(unconst_f16(-164.8), unconst_f16(4919.3)), f16(unconst_f16(8756.9)));
+  var vf331: u32 = dot4U8Packed(u32(unconst_u32(83)), u32(unconst_u32(235)));
+  let vf332: vec2u = textureDimensions(tex23);
+  let vf333: vec4h = vf329;
+  let vf334: f16 = vf329[u32(normalize(vec3h(unconst_f16(17645.8), unconst_f16(7358.3), unconst_f16(13750.4)))[2])];
+  var vf335: vec4h = inverseSqrt(vec4h(unconst_f16(37608.6), unconst_f16(260.5), unconst_f16(34.56), unconst_f16(1030.3)));
+  var vf336: u32 = vf332[u32(unconst_u32(257))];
+  vf336 <<= abs(u32(faceForward(vec4h(unconst_f16(10237.2), unconst_f16(-4515.2), unconst_f16(20517.5), unconst_f16(-8098.9)), vec4h(unconst_f16(34553.8), unconst_f16(5993.7), unconst_f16(9253.9), unconst_f16(7046.1)), vec4h(unconst_f16(14644.8), unconst_f16(-3781.8), unconst_f16(6670.6), unconst_f16(14980.0)))[2]));
+  let vf337: vec2u = textureDimensions(tex23);
+  let vf338: f16 = vf334;
+  vf331 ^= bitcast<u32>(log2(vec3f(unconst_f32(0.1159), unconst_f32(0.06203), unconst_f32(0.06570))).b);
+  vf336 >>= u32(vf335[u32(unconst_u32(44))]);
+  var vf339: f32 = radians(f32(unconst_f32(0.4800)));
+  vf339 = bitcast<f32>(vf330);
+  return out;
+}
+
+struct T1 {
+  f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@vertex
+fn vertex15() -> VertexOutput11 {
+  var out: VertexOutput11;
+  let vf341: vec4h = abs(vec4h(unconst_f16(966.8), unconst_f16(5574.6), unconst_f16(1297.6), unconst_f16(1011.0)));
+  out.f41 = vec4f(unpack4xU8(u32(unconst_u32(171))));
+  out.f41 += quantizeToF16(vec2f(bitcast<f32>((*&buffer218).f0))).yyyy;
+  out.f41 *= vec4f(unpack4xU8(pack4xU8Clamp(vec4u(fma(vec4f(unconst_f32(0.05888), unconst_f32(0.3091), unconst_f32(0.3630), unconst_f32(0.01208)), vec4f(unconst_f32(0.4563), unconst_f32(-0.1382), unconst_f32(0.2117), unconst_f32(0.02799)), vec4f(unconst_f32(0.08488), unconst_f32(0.05733), unconst_f32(0.3714), unconst_f32(0.04141)))))));
+  out = VertexOutput11(vec4f(log2(vec2h(unconst_f16(4183.8), unconst_f16(1296.0))).rrgg));
+  return out;
+}
+
+@fragment
+fn fragment16(@location(11) a0: vec4u) -> @location(200) @interpolate(linear) vec4u {
+  var out: vec4u;
+  out += vec4u(u32(exp(f16(unconst_f16(53160.1)))));
+  let vf342: u32 = textureNumSamples(tex23);
+  out ^= unpack4xU8(a0[textureDimensions(tex23).r]);
+  out &= vec4u(faceForward(vec3h(unconst_f16(4890.8), unconst_f16(937.5), unconst_f16(779.5)), vec3h(f16(fma(f32(unconst_f32(0.2006)), f32(unconst_f32(0.1212)), f32(unconst_f32(0.3603))))), vec3h(unconst_f16(2221.6), unconst_f16(10375.8), unconst_f16(15624.0))).gggb);
+  out <<= unpack4xU8(u32(unconst_u32(89)));
+  out = unpack4xU8(pack4x8snorm(vec4f(unconst_f32(0.03093), unconst_f32(0.1963), unconst_f32(0.1012), unconst_f32(0.2080))));
+  let vf343: mat2x2h = transpose(mat2x2h(unconst_f16(6833.4), unconst_f16(14736.3), unconst_f16(1121.7), unconst_f16(13988.1)));
+  let vf344: u32 = textureNumSamples(tex23);
+  fn0();
+  let vf345: u32 = vf344;
+  out <<= bitcast<vec4u>(textureLoad(tex23, vec2i(unconst_i32(48), unconst_i32(126)), i32(unconst_i32(338))));
+  var vf346: u32 = a0[u32(unconst_u32(554))];
+  fn0();
+  var vf347: f32 = fma(f32(unconst_f32(0.1239)), f32(unconst_f32(0.04260)), f32(unconst_f32(0.06036)));
+  var vf348 = fn0();
+  fn0();
+  out *= vec4u(u32(length(vec4h(unconst_f16(15429.0), unconst_f16(-6024.5), unconst_f16(10389.3), unconst_f16(7656.5)))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute14(@builtin(local_invocation_index) a0: u32) {
+  atomicCompareExchangeWeak(&vw72, unconst_i32(223), unconst_i32(215));
+  fn0();
+  atomicStore(&vw72, i32(unconst_i32(213)));
+  atomicMax(&vw72, i32(unconst_i32(-188)));
+  fn0();
+  var vf349 = fn0();
+  vf349 = mat3x4h(f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)), f16(textureNumSamples(tex23)));
+  vf349 = mat3x4h(bitcast<vec4h>(textureDimensions(tex23)), bitcast<vec4h>(textureDimensions(tex23)), bitcast<vec4h>(textureDimensions(tex23)));
+  var vf350: f32 = atan2(f32(unconst_f32(0.2487)), f32(unconst_f32(0.1350)));
+  var vf351 = fn0();
+  var vf352 = fn0();
+  var vf353 = fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView319 = texture105.createView({label: '\u4163\ub3b3\u0284\u5a58\u287a', mipLevelCount: 1});
+let sampler233 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.17,
+  lodMaxClamp: 94.09,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup145);
+} catch {}
+try {
+buffer193.unmap();
+} catch {}
+let imageData44 = new ImageData(20, 60);
+let texture335 = device0.createTexture({
+  size: [330, 48, 30],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler234 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 92.09,
+  lodMaxClamp: 99.63,
+});
+try {
+computePassEncoder131.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder183.setBindGroup(3, bindGroup104, new Uint32Array(1183), 261, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup154);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline4);
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+let buffer219 = device0.createBuffer({size: 829, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(0, bindGroup53, new Uint32Array(3316), 390, 0);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer8, 'uint32', 244, 349);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer144);
+} catch {}
+try {
+computePassEncoder84.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer220 = device0.createBuffer({size: 12170, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup48, []);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup46, new Uint32Array(1991), 421, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer176, 'uint32', 1_008, 3_221);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(3, buffer113, 0, 1_013);
+} catch {}
+document.body.prepend(img6);
+let sampler235 = device0.createSampler({
+  label: '\ub370\u6947\u0023\u3e13\uc76f\u0614\u134d\ud637\u{1fbe0}',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 78.94,
+  lodMaxClamp: 85.28,
+});
+try {
+computePassEncoder183.setBindGroup(3, bindGroup57, new Uint32Array(815), 146, 0);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: -425.1, g: 342.2, b: -142.1, a: 979.9, });
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let sampler236 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.18,
+});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup193);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer36 = buffer51.getMappedRange(8368, 100);
+let buffer221 = device0.createBuffer({
+  label: '\u391f\ue626\u5ded\u1e98\u14ca\u09b1\u{1fcd9}\u04c5',
+  size: 6881,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView320 = texture9.createView({format: 'rgb10a2uint', baseArrayLayer: 0});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup109, []);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer26, 'uint32', 484, 1_754);
+} catch {}
+let arrayBuffer37 = buffer42.getMappedRange(624, 192);
+try {
+renderPassEncoder83.insertDebugMarker('\u7d6a');
+} catch {}
+let textureView321 = texture297.createView({});
+try {
+computePassEncoder181.setBindGroup(2, bindGroup112);
+} catch {}
+try {
+computePassEncoder172.setBindGroup(2, bindGroup18, new Uint32Array(1147), 32, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup55, new Uint32Array(114), 58, 0);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(105, 14, 12, 3);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder82.setVertexBuffer(4, buffer77);
+} catch {}
+let textureView322 = texture294.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler237 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 93.75,
+  lodMaxClamp: 97.58,
+});
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule9, constants: {2_312: 0}}});
+try {
+externalTexture35.label = '\u0a49\uc7a6\u{1fb63}\uae7d\u074b\u0baa\uf762\u{1f8e0}';
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+struct S8 {
+  @location(1) @interpolate(flat, center) f0: vec4f,
+  @location(5) f1: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput11 {
+  @location(0) @interpolate(flat, sample) f0: vec4i,
+}
+
+fn fn1() -> S8 {
+  var out: S8;
+  var vf360: vec2f = unpack2x16unorm(u32(unconst_u32(381)));
+  vf360 *= vec2f(bitcast<f32>(dot4I8Packed(u32(unconst_u32(95)), u32(unconst_u32(243)))));
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw73: atomic<i32>;
+
+var<workgroup> vw76: S8;
+
+override override32: u32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw74: i32;
+
+fn fn0() -> u32 {
+  var out: u32;
+  let vf354: bool = all(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false), unconst_bool(false)));
+  let ptr114: ptr<private, vec4f> = &vp14.whole;
+  let vf355: u32 = override32;
+  var vf356: u32 = vf355;
+  let vf357: f32 = (*ptr114)[u32(unconst_u32(4))];
+  var vf358: f32 = (*ptr114)[u32(unconst_u32(223))];
+  let vf359: vec3f = acosh(vec3f(unconst_f32(0.07287), unconst_f32(0.3594), unconst_f32(-0.2453)));
+  return out;
+  _ = override32;
+}
+
+var<private> vp14 = modf(vec4f(0.07069, 0.5886, 0.2758, 0.1693));
+
+var<workgroup> vw75: atomic<u32>;
+
+struct T0 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(227) var tex25: texture_2d_array<f32>;
+
+@vertex
+fn vertex16(@location(6) @interpolate(flat) a0: i32, @location(8) @interpolate(flat, center) a1: vec4i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf361: f16 = pow(f16(unconst_f16(12814.0)), f16(unconst_f16(11388.7)));
+  var vf362: f16 = saturate(f16(unconst_f16(8122.5)));
+  let vf363: u32 = textureNumLayers(tex25);
+  var vf364: u32 = textureNumLayers(tex25);
+  vp14.whole += vec4f(f32(vf362));
+  let vf365: f16 = pow(f16(unconst_f16(27700.5)), f16(unconst_f16(17768.8)));
+  return out;
+}
+
+@fragment
+fn fragment17(a0: S8, @location(6) a1: vec4h) -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  fn1();
+  vp14 = modf(vec4f(bitcast<f32>(firstTrailingBit(i32(unconst_i32(15))))));
+  out.f0 = vec4i(i32(any(vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))));
+  var vf366: f32 = length(vec3f(unconst_f32(0.1760), unconst_f32(0.1779), unconst_f32(0.3173)));
+  var vf367: f16 = a1[u32(unconst_u32(91))];
+  out.f0 = bitcast<vec4i>(vp14.fract);
+  var vf368: f16 = a1[u32(unconst_u32(117))];
+  out = FragmentOutput11(vec4i(bitcast<i32>(vf366)));
+  var vf369 = fn1();
+  let ptr115: ptr<function, f32> = &vf369.f1;
+  out.f0 *= bitcast<vec4i>(vp14.fract);
+  var vf370: vec4u = reverseBits(vec4u(unconst_u32(4), unconst_u32(3), unconst_u32(81), unconst_u32(381)));
+  let ptr116: ptr<function, f32> = &(*ptr115);
+  var vf371: f32 = a0.f1;
+  var vf372 = fn0();
+  var vf373 = fn1();
+  fn1();
+  var vf374: S8 = a0;
+  return out;
+  _ = override32;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute15(@builtin(local_invocation_index) a0: u32, @builtin(global_invocation_id) a1: vec3u) {
+  atomicOr(&vw75, u32(unconst_u32(16)));
+  let ptr117: ptr<workgroup, i32> = &vw74;
+  var vf375: u32 = textureNumLayers(tex25);
+  let ptr118: ptr<workgroup, atomic<u32>> = &(*&vw75);
+  let ptr119: ptr<workgroup, i32> = &(*ptr117);
+  vf375 = pack4x8snorm(vw76.f0);
+  vw74 = vec3i(asin(vec3f(unconst_f32(0.01320), unconst_f32(0.03353), unconst_f32(0.1536))))[1];
+  let ptr120 = &vp14;
+  let vf376: vec2u = textureDimensions(tex25, i32(unconst_i32(133)));
+  vw74 = vec4i((*ptr120).whole)[0];
+  let ptr121: ptr<workgroup, vec4f> = &(*&vw76).f0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture336 = device0.createTexture({
+  size: {width: 330, height: 48, depthOrArrayLayers: 223},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup84, new Uint32Array(330), 57, 0);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(4, buffer104, 336);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 316, new DataView(new ArrayBuffer(5948)), 1942, 344);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup102, new Uint32Array(2513), 116, 0);
+} catch {}
+try {
+renderPassEncoder43.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer148);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let sampler238 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 93.43,
+});
+try {
+computePassEncoder132.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(4, buffer146, 772, 742);
+} catch {}
+canvas5.width = 1078;
+let buffer222 = device0.createBuffer({
+  size: 286,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture337 = device0.createTexture({
+  size: {width: 165, height: 24, depthOrArrayLayers: 30},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder163.setBindGroup(0, bindGroup191);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup87);
+} catch {}
+try {
+buffer85.unmap();
+} catch {}
+try {
+  await promise36;
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle35, renderBundle26]);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture338 = device0.createTexture({
+  size: [258, 1, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder45.setVertexBuffer(1, buffer140, 472, 238);
+} catch {}
+try {
+buffer205.unmap();
+} catch {}
+await gc();
+let buffer223 = device0.createBuffer({
+  label: '\u06c0\u4989\ufab5\u0b12\u{1fabf}\u0a17\ucb01\ud531\uf78f',
+  size: 3221,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView323 = texture306.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+computePassEncoder90.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(3, bindGroup112, new Uint32Array(3143), 27, 0);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup53, []);
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(27, 0, 12, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer73, 'uint16', 2_726, 1_504);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer27, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+globalThis.someLabel = externalTexture11.label;
+} catch {}
+let buffer224 = device0.createBuffer({
+  label: '\u2254\u0a17\ua6d4\u911a\ue12b\u0fad\u07f1\u9eb1\ub732\u241c\u6596',
+  size: 21372,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup68, new Uint32Array(1035), 279, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup168);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer44, 'uint32', 2_020, 453);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup209 = device0.createBindGroup({
+  layout: bindGroupLayout28,
+  entries: [
+    {binding: 380, resource: textureView247},
+    {binding: 136, resource: sampler203},
+    {binding: 999, resource: textureView27},
+  ],
+});
+let buffer225 = device0.createBuffer({size: 9298, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let texture339 = device0.createTexture({
+  size: [129, 1, 2],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder68.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+renderPassEncoder43.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer131, 0, 7_801);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let bindGroup210 = device0.createBindGroup({
+  layout: bindGroupLayout43,
+  entries: [
+    {binding: 150, resource: sampler2},
+    {binding: 93, resource: {buffer: buffer168, offset: 256, size: 4137}},
+  ],
+});
+let buffer226 = device0.createBuffer({
+  size: 1344,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 1040});
+let textureView324 = texture250.createView({baseArrayLayer: 2, arrayLayerCount: 3});
+let texture340 = device0.createTexture({
+  size: {width: 660, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler239 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.70,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(2, bindGroup5, new Uint32Array(953), 50, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer126, 'uint32', 2_252, 291);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer38 = buffer34.getMappedRange(384, 40);
+try {
+device0.queue.writeTexture({
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(144).fill(101), /* required buffer size: 144 */
+{offset: 144}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView325 = texture171.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+let texture341 = device0.createTexture({
+  size: [258, 1, 82],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup166, new Uint32Array(539), 174, 0);
+} catch {}
+let bindGroup211 = device0.createBindGroup({layout: bindGroupLayout16, entries: [{binding: 208, resource: {buffer: buffer138, offset: 512}}]});
+let texture342 = gpuCanvasContext9.getCurrentTexture();
+try {
+computePassEncoder149.setBindGroup(1, bindGroup188, new Uint32Array(280), 12, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer177, 0);
+} catch {}
+let buffer227 = device0.createBuffer({size: 6467, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder115.setBindGroup(1, bindGroup119);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(3, bindGroup132, new Uint32Array(774), 6, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup212 = device0.createBindGroup({
+  label: '\u9e21\uf034\u2a7d',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 80, resource: {buffer: buffer88, offset: 1280, size: 115}},
+    {binding: 50, resource: textureView123},
+    {binding: 131, resource: {buffer: buffer164, offset: 256, size: 248}},
+  ],
+});
+let texture343 = device0.createTexture({
+  size: {width: 330},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup210, new Uint32Array(147), 17, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(6, buffer191);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2}});
+document.body.prepend(canvas8);
+let textureView326 = texture213.createView({aspect: 'all'});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true});
+try {
+renderPassEncoder52.setScissorRect(315, 0, 55, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer186, 0, 15_602);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup160);
+} catch {}
+try {
+if (!arrayBuffer32.detached) { new Uint8Array(arrayBuffer32).fill(0x55); };
+} catch {}
+try {
+  await promise35;
+} catch {}
+let textureView327 = texture66.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(0, buffer20, 0, 10_533);
+} catch {}
+let buffer228 = device0.createBuffer({size: 4229, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView328 = texture343.createView({});
+let renderBundle38 = renderBundleEncoder38.finish({});
+let externalTexture42 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup43, new Uint32Array(375), 13, 0);
+} catch {}
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame38.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -965,7 +965,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400771-copyfrombuffer?language=objc
         // "When you copy to a 2D texture, depth must be 1."
         auto sourceSize = MTLSizeMake(widthForMetal, heightForMetal, 1);
-        if (!widthForMetal || !heightForMetal || bytesPerRow < Texture::bytesPerRow(textureFormat, widthForMetal, texture->sampleCount()))
+        if (!widthForMetal || !heightForMetal || (bytesPerRow && bytesPerRow < Texture::bytesPerRow(textureFormat, widthForMetal, texture->sampleCount())))
             return;
 
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, 0);
@@ -997,7 +997,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
     case WGPUTextureDimension_3D: {
         auto sourceSize = MTLSizeMake(widthForMetal, heightForMetal, depthForMetal);
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, destination.origin.z);
-        if (!widthForMetal || !heightForMetal || !depthForMetal || bytesPerRow < Texture::bytesPerRow(textureFormat, widthForMetal, texture->sampleCount()))
+        if (!widthForMetal || !heightForMetal || !depthForMetal || (bytesPerRow && bytesPerRow < Texture::bytesPerRow(textureFormat, widthForMetal, texture->sampleCount())))
             return;
 
         [m_blitCommandEncoder

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2150,13 +2150,13 @@ NSUInteger Texture::bytesPerRow(WGPUTextureFormat format, uint32_t textureWidth,
     NSUInteger blockWidth = Texture::texelBlockWidth(format);
     if (!blockWidth) {
         ASSERT_NOT_REACHED();
-        return 0;
+        return NSUIntegerMax;
     }
-    if (textureWidth % blockWidth) {
-        ASSERT_NOT_REACHED();
-        return 0;
-    }
-    NSUInteger blocksInWidth = textureWidth / blockWidth;
+    NSUInteger add = 0;
+    if (textureWidth % blockWidth)
+        add = 1;
+
+    NSUInteger blocksInWidth = textureWidth / blockWidth + add;
     auto product = checkedProduct<NSUInteger>(Texture::texelBlockSize(format), blocksInWidth, sampleCount);
     return product.hasOverflowed() ? NSUIntegerMax : product.value();
 }


### PR DESCRIPTION
#### df86c2df8b080d365a046dc24ebf06093d069a9d
<pre>
[WebGPU] Texture::bytesPerRow does not handle textureWidth which are not divisible by the blockWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=282499">https://bugs.webkit.org/show_bug.cgi?id=282499</a>
<a href="https://rdar.apple.com/138789129">rdar://138789129</a>

Reviewed by Tadeu Zagallo.

Instead of returning zero, add one to the required bytesPerRow when it is
not a multiple of the block size, as Metal expects this.

* LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.html: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-282499-expected.txt: Added.
Add regression test.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::bytesPerRow):

Canonical link: <a href="https://commits.webkit.org/286096@main">https://commits.webkit.org/286096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa34646ff4fd4a5d32128e349267e670e8917da3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58678 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80619 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8327 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1989 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->