### PR TITLE
IndexedRange is unsafe to use with temporaries

### DIFF
--- a/Source/WTF/wtf/IndexedRange.h
+++ b/Source/WTF/wtf/IndexedRange.h
@@ -111,18 +111,30 @@ private:
 };
 
 // Usage: for (auto [ index, value ] : IndexedRange(collection)) { ... }
-template<typename Collection> class IndexedRange {
+template<typename Collection>
+class IndexedRange {
+    using Iterator = IndexedRangeIterator<decltype(WTF::begin(std::declval<Collection>()))>;
 public:
     IndexedRange(const Collection& collection)
-        : m_collection(collection)
+        : m_begin(WTF::begin(collection))
+        , m_end(WTF::end(collection))
     {
     }
 
-    auto begin() { return IndexedRangeIterator(WTF::begin(m_collection)); }
-    auto end() { return IndexedRangeIterator(WTF::end(m_collection)); }
+    IndexedRange(Collection&& collection)
+        : m_begin(WTF::begin(collection))
+        , m_end(WTF::end(collection))
+    {
+        // Prevent use after destruction of a returned temporary.
+        static_assert(std::ranges::borrowed_range<Collection>);
+    }
+
+    auto begin() { return m_begin; }
+    auto end() { return m_end; }
 
 private:
-    const Collection& m_collection;
+    Iterator m_begin;
+    Iterator m_end;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 460abf576622806c66767e3ac5c9f01ee912070e
<pre>
IndexedRange is unsafe to use with temporaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=282503">https://bugs.webkit.org/show_bug.cgi?id=282503</a>
<a href="https://rdar.apple.com/139127354">rdar://139127354</a>

Reviewed by Mike Wyrzykowski and Chris Dumez.

This was technically undef:

    for (auto [ index, value ] : IndexedRange(std::span(collection))) { ... }

because IndexedRange kept a reference to its constructor argument, which was
a destroyed temporary.

The solution has three parts:

1. Use an IndexedRange(Collection&amp;&amp;) overload to detect construction with a
temporary.

2. Store begin() / end() iterators instead of a reference to the collection.
This eliminates the reference to a destroyed temporary -- but adds use of
an iterator after invalidation. Yayboo.

3. static_assert that the temporary supports std::ranges::borrowed_range,
which makes use of an iterator after invalidation well-defined. Yay.

* Source/WTF/wtf/IndexedRange.h:
(WTF::IndexedRange::IndexedRange):
(WTF::IndexedRange::begin):
(WTF::IndexedRange::end):

Canonical link: <a href="https://commits.webkit.org/286060@main">https://commits.webkit.org/286060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b12b84b62898ae66678b2cf8b56df9a70337fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58679 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24278 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80620 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73965 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66231 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8326 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96236 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11527 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1990 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21023 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->