### PR TITLE
Build fix for some Apple internal bots

### DIFF
--- a/Source/WTF/wtf/IndexedRange.h
+++ b/Source/WTF/wtf/IndexedRange.h
@@ -71,12 +71,12 @@ private:
     Iterator m_end;
 };
 
-template<typename Collection> auto begin(const Collection& collection)
+template<typename Collection> auto boundsCheckedBegin(const Collection& collection)
 {
     return BoundsCheckedIterator<Collection, decltype(collection.begin())>::begin(collection);
 }
 
-template<typename Collection> auto end(const Collection& collection)
+template<typename Collection> auto boundsCheckedEnd(const Collection& collection)
 {
     return BoundsCheckedIterator<Collection, decltype(collection.end())>::end(collection);
 }
@@ -113,17 +113,17 @@ private:
 // Usage: for (auto [ index, value ] : IndexedRange(collection)) { ... }
 template<typename Collection>
 class IndexedRange {
-    using Iterator = IndexedRangeIterator<decltype(WTF::begin(std::declval<Collection>()))>;
+    using Iterator = IndexedRangeIterator<decltype(boundsCheckedBegin(std::declval<Collection>()))>;
 public:
     IndexedRange(const Collection& collection)
-        : m_begin(WTF::begin(collection))
-        , m_end(WTF::end(collection))
+        : m_begin(boundsCheckedBegin(collection))
+        , m_end(boundsCheckedEnd(collection))
     {
     }
 
     IndexedRange(Collection&& collection)
-        : m_begin(WTF::begin(collection))
-        , m_end(WTF::end(collection))
+        : m_begin(boundsCheckedBegin(collection))
+        , m_end(boundsCheckedEnd(collection))
     {
         // Prevent use after destruction of a returned temporary.
         static_assert(std::ranges::borrowed_range<Collection>);


### PR DESCRIPTION
#### f5478d9ee0c44575582ea6cb20319ef98c734a2c
<pre>
Build fix for some Apple internal bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=282513">https://bugs.webkit.org/show_bug.cgi?id=282513</a>
<a href="https://rdar.apple.com/139160864">rdar://139160864</a>

Unreviewed, build fix.

Some versions of libc++ use an unqualified call to &apos;begin()&apos; when e.g.
instantiating a span.

In some contexts that creates a name conflict with WTF::begin because of
argument-dependent lookup.

Rename begin/end to boundsCheckedBegin/boundsCheckedEnd to fix this.

* Source/WTF/wtf/IndexedRange.h:
(WTF::boundsCheckedBegin):
(WTF::boundsCheckedEnd):
(WTF::IndexedRange::IndexedRange):
(WTF::begin): Deleted.
(WTF::end): Deleted.

Canonical link: <a href="https://commits.webkit.org/286062@main">https://commits.webkit.org/286062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97d394af1f26062a8562ac2b0d732afa29012fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24294 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67860 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80636 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/73981 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66954 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 42 flakes 286 failures; Uploaded test results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2189 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66245 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96252 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11529 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2006 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->