### PR TITLE
Dynamically changing scrollbar-width causes horizontal scrollbars to be painted strangely

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001-expected.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001-expected.html
@@ -1,0 +1,66 @@
+<!doctype html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+  }
+
+  .container.auto {
+    scrollbar-width: auto;
+  }
+
+  .container.thin {
+    scrollbar-width: thin;
+  }
+
+  .container.none {
+    scrollbar-width: none;
+  }
+
+  .content.plain {
+    background: red;
+  }
+
+  .content.gradient {
+    background: linear-gradient(135deg, red, blue);
+  }
+</style>
+<div id="one" class="container thin">
+  <div class="content plain"></div>
+</div>
+<div id="two" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="three" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="four" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="five" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="six" class="container thin">
+  <div class="content gradient"></div>
+</div>
+<script>
+    if (internals)
+        internals.setUsesOverlayScrollbars(false);
+</script>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001.html
@@ -1,0 +1,77 @@
+<!doctype html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+  }
+
+  .container.auto {
+    scrollbar-width: auto;
+  }
+
+  .container.thin {
+    scrollbar-width: thin;
+  }
+
+  .container.none {
+    scrollbar-width: none;
+  }
+
+  .content.plain {
+    background: red;
+  }
+
+  .content.gradient {
+    background: linear-gradient(135deg, red, blue);
+  }
+</style>
+<div id="one" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="two" class="container thin">
+  <div class="content plain"></div>
+</div>
+<div id="three" class="container none">
+  <div class="content plain"></div>
+</div>
+<div id="four" class="container auto">
+  <div class="content gradient"></div>
+</div>
+<div id="five" class="container thin">
+  <div class="content gradient"></div>
+</div>
+<div id="six" class="container none">
+  <div class="content gradient"></div>
+</div>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    if (internals)
+        internals.setUsesOverlayScrollbars(false);
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.getElementById('one').style.scrollbarWidth = 'thin';
+    document.getElementById('two').style.scrollbarWidth = 'auto';
+    document.getElementById('three').style.scrollbarWidth = 'auto';
+    document.getElementById('four').style.scrollbarWidth = 'none';
+    document.getElementById('five').style.scrollbarWidth = 'none';
+    document.getElementById('six').style.scrollbarWidth = 'thin';
+    testRunner.notifyDone();
+  }));
+</script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1633,6 +1633,7 @@ webkit.org/b/264266 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/css/filt
 
 webkit.org/b/264306 fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html [ Pass ImageOnlyFailure Timeout ]
 [ Ventura ] fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto.html [ ImageOnlyFailure ]
+[ Ventura ] fast/scrolling/mac/scrollbars/scrollbar-width-paint-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/265599 [ Sonoma+ Debug x86_64 ] imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html [ Pass Crash ]
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -380,8 +380,13 @@ void ScrollerMac::updateValues()
 
 void ScrollerMac::updateScrollbarStyle()
 {
-    setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()]);
+    setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil]);
+    [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
+
+    [m_scrollerImp setLayer:m_hostLayer.get()];
+
     updatePairScrollerImps();
+    updateValues();
 }
 
 void ScrollerMac::updatePairScrollerImps()


### PR DESCRIPTION
#### 191811467c4395e1f87046e4fe5d3f34f5e7281d
<pre>
Dynamically changing scrollbar-width causes horizontal scrollbars to be painted strangely
<a href="https://bugs.webkit.org/show_bug.cgi?id=282520">https://bugs.webkit.org/show_bug.cgi?id=282520</a>
<a href="https://rdar.apple.com/139172581">rdar://139172581</a>

Reviewed by Simon Fraser.

When changing scrollbar width dynamically between auto and thin, horizontal scrollbars would
occasionally be painted with the track and thumb in the wrong location. This appears to be the
result of an AppKit bug around calling scrollerImpWithStyle with replacingScrollerImp being non
null. What would happen is when updating the double value and presentation value, they wouldn&apos;t update
the new scroller imp&apos;s layer geometry because of checks in the AppKit code that would ensure that
the provided values are different than the current values of the scroller imp (which presumably were
carried over from the previous scroller imp). This can be worked around by simply not providing a previous
scroller imp, and ensuring we update the new scroller imp with the appropriate data.

* LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001-expected.html: Added.
* LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-paint-001.html: Added.
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::updateScrollbarStyle):

Canonical link: <a href="https://commits.webkit.org/286112@main">https://commits.webkit.org/286112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4bc42edc85f0e9f5408bbd931d6c19cf1af1ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58793 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17072 "2 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1313 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66344 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8443 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2139 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->