### PR TITLE
compositingStatusChanged can set invalid repaint rects while backing sharing state is in-flight.

### DIFF
--- a/LayoutTests/compositing/update-compositing-rects-with-sharing-descendants-expected.html
+++ b/LayoutTests/compositing/update-compositing-rects-with-sharing-descendants-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html>
+<p>This test should not crash.</p>
+
+<div style="width: 200px; height: 200px; isolation: isolate">
+  <div style="width: 200px; height: 200px; overflow: scroll">
+    <div style="width: 200px; height: 400px; background: green; position: relative"></div>
+
+  </div>
+  <div style="mix-blend-mode: screen; width: 100px; height: 120px; background: blue"></div>
+</div>
+</html>

--- a/LayoutTests/compositing/update-compositing-rects-with-sharing-descendants.html
+++ b/LayoutTests/compositing/update-compositing-rects-with-sharing-descendants.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+
+<p>This test should not crash.</p>
+
+<div style="width: 200px; height: 200px; isolation: isolate">
+  <div style="width: 200px; height: 200px; overflow: scroll">
+    <div style="width: 200px; height: 400px; background: green; position: relative"></div>
+
+  </div>
+  <div id=composited style="mix-blend-mode: screen; width: 100px; height: 100px; background: blue"></div>
+</div>
+
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function runTest() {
+    // Make 'composited' actually composited, which should also make the outer div
+    // to composite too.
+    document.getElementById("composited").style.transform = "translateZ(0px)";
+
+    // Let a rendering update happen for the outer compositing change to take effect, and
+    // repaint rects for the scroller and scrolled to be recomputed.
+    await new Promise(requestAnimationFrame);
+
+    // Trigger a layout change to run updateLayerPositions and verify that the scroller
+    // was left in a valid state.
+    document.getElementById("composited").style.height = "120px";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+</html>


### PR DESCRIPTION
#### 6d0d68f4fda386b6b9db349f8f2f97625ef69455
<pre>
compositingStatusChanged can set invalid repaint rects while backing sharing state is in-flight.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282518">https://bugs.webkit.org/show_bug.cgi?id=282518</a>
&lt;<a href="https://rdar.apple.com/139172121">rdar://139172121</a>&gt;

Reviewed by Simon Fraser.

When RenderLayerCompositor::computeCompositingRequirements makes a layer
composited, it calls compositingStatusChanged to recompute the repaint rects on
descendants.

This happens before updateBackingSharingAfterDescendantTraversal, so any backing
sharing happening on descendants hasn&apos;t yet been resolved.

Backing sharing always clears the state on layers, and then re-sets it once
completed, even if there aren&apos;t any changes.

This means we recompute the repaint rects using the &apos;repaint container&apos; as if
backing sharing wasn&apos;t happening, which is incorrect. Once backing sharing is
finalised, we would recompute again if there had been changes, but if not this
invalid state remains.

The fix is to defer compositingStatusChanged until after backing sharing is
finalized.

* LayoutTests/compositing/update-compositing-rects-with-sharing-descendants-expected.html: Added.
* LayoutTests/compositing/update-compositing-rects-with-sharing-descendants.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::layerGainedCompositedScrollableOverflow):
(WebCore::RenderLayerCompositor::layerStyleChanged):
(WebCore::RenderLayerCompositor::updateBacking):
(WebCore::RenderLayerCompositor::updateLayerCompositingState):

Canonical link: <a href="https://commits.webkit.org/286181@main">https://commits.webkit.org/286181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4874f579598d7d21a30621c38228c5ffdb80045c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58880 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17122 "Found 4 new test failures: webgl/2.0.y/conformance/context/context-release-with-workers.html webgl/2.0.y/conformance/rendering/canvas-alpha-bug.html webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-sync.html webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24530 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66415 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8504 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->