### PR TITLE
Replace more use of MallocPtr with MallocSpan

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -39,6 +39,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/FileSystem.h>
 #include <wtf/FixedVector.h>
 #include <wtf/IterationStatus.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/PageReservation.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RedBlackTree.h>
@@ -1430,8 +1431,9 @@ ExecutableMemoryHandle::~ExecutableMemoryHandle()
     allocator->handleWillBeReleased(*this, sizeInBytes());
     if (UNLIKELY(Options::zeroExecutableMemoryOnFree())) {
         // We don't have a performJITMemset so just use a zeroed buffer.
-        auto zeros = MallocPtr<uint8_t>::zeroedMalloc(sizeInBytes());
-        performJITMemcpy(start().untaggedPtr(), zeros.get(), sizeInBytes());
+        auto zeros = MallocSpan<uint8_t>::zeroedMalloc(sizeInBytes());
+        auto span = zeros.span();
+        performJITMemcpy(start().untaggedPtr(), span.data(), span.size());
     }
     jit_heap_deallocate(key());
 }

--- a/Source/JavaScriptCore/runtime/CachePayload.h
+++ b/Source/JavaScriptCore/runtime/CachePayload.h
@@ -28,14 +28,14 @@
 #include "VM.h"
 #include <variant>
 #include <wtf/FileSystem.h>
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 
 namespace JSC {
 
 class CachePayload {
 public:
     JS_EXPORT_PRIVATE static CachePayload makeMappedPayload(FileSystem::MappedFileData&&);
-    JS_EXPORT_PRIVATE static CachePayload makeMallocPayload(MallocPtr<uint8_t, VMMalloc>&&, size_t);
+    JS_EXPORT_PRIVATE static CachePayload makeMallocPayload(MallocSpan<uint8_t, VMMalloc>&&);
     JS_EXPORT_PRIVATE static CachePayload makeEmptyPayload();
 
     JS_EXPORT_PRIVATE CachePayload(CachePayload&&);
@@ -45,9 +45,10 @@ public:
     JS_EXPORT_PRIVATE std::span<const uint8_t> span() const;
 
 private:
-    CachePayload(std::variant<FileSystem::MappedFileData, std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>>&&);
+    using DataType = std::variant<MallocSpan<uint8_t, VMMalloc>, FileSystem::MappedFileData>;
+    explicit CachePayload(DataType&&);
 
-    std::variant<FileSystem::MappedFileData, std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>> m_data;
+    DataType m_data;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/CachedBytecode.h
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.h
@@ -28,7 +28,7 @@
 #include "CacheUpdate.h"
 #include "LeafExecutable.h"
 #include "ParserModes.h"
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
@@ -51,9 +51,9 @@ public:
         return adoptRef(*new CachedBytecode(CachePayload::makeMappedPayload(WTFMove(data)), WTFMove(leafExecutables)));
     }
 
-    static Ref<CachedBytecode> create(MallocPtr<uint8_t, VMMalloc>&& data, size_t size, LeafExecutableMap&& leafExecutables)
+    static Ref<CachedBytecode> create(MallocSpan<uint8_t, VMMalloc>&& data, LeafExecutableMap&& leafExecutables)
     {
-        return adoptRef(*new CachedBytecode(CachePayload::makeMallocPayload(WTFMove(data), size), WTFMove(leafExecutables)));
+        return adoptRef(*new CachedBytecode(CachePayload::makeMallocPayload(WTFMove(data)), WTFMove(leafExecutables)));
     }
 
     LeafExecutableMap& leafExecutables() { return m_leafExecutables; }

--- a/Source/JavaScriptCore/runtime/CachedTypes.h
+++ b/Source/JavaScriptCore/runtime/CachedTypes.h
@@ -30,7 +30,6 @@
 #include "VariableEnvironment.h"
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
-#include <wtf/MallocPtr.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
@@ -32,7 +32,6 @@
 #include "WasmLimits.h"
 #include "WebAssemblyFunction.h"
 #include "WebAssemblyWrapperFunction.h"
-#include <wtf/MallocPtr.h>
 #include <wtf/Ref.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -32,7 +32,6 @@
 #include "JSWebAssemblyInstance.h"
 #include "WasmFormat.h"
 #include "WasmModuleInformation.h"
-#include <wtf/MallocPtr.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -32,7 +32,6 @@
 #include "WasmTable.h"
 #include "WebAssemblyWrapperFunction.h"
 #include "WebAssemblyFunction.h"
-#include <wtf/MallocPtr.h>
 #include <wtf/Ref.h>
 
 namespace JSC {

--- a/Source/WTF/wtf/win/MemoryFootprintWin.cpp
+++ b/Source/WTF/wtf/win/MemoryFootprintWin.cpp
@@ -30,7 +30,7 @@
 #include <type_traits>
 #include <windows.h>
 #include <psapi.h>
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/win/Win32Handle.h>
 
 namespace WTF {
@@ -76,13 +76,14 @@ size_t memoryFootprint()
 
     for (size_t numberOfEntries = updateNumberOfEntries(workingSetsOnStack->NumberOfEntries);;) {
         size_t workingSetSizeInBytes = sizeof(PSAPI_WORKING_SET_INFORMATION) + sizeof(PSAPI_WORKING_SET_BLOCK) * numberOfEntries;
-        auto workingSets = MallocPtr<PSAPI_WORKING_SET_INFORMATION>::malloc(workingSetSizeInBytes);
-        if (QueryWorkingSet(process.get(), workingSets.get(), workingSetSizeInBytes))
-            return countSizeOfPrivateWorkingSet(*workingSets);
+        auto workingSets = MallocSpan<PSAPI_WORKING_SET_INFORMATION>::malloc(workingSetSizeInBytes);
+        auto workingSetsSpan = workingSets.mutableSpan();
+        if (QueryWorkingSet(process.get(), workingSetsSpan.data(), workingSetsSpan.size_bytes()))
+            return countSizeOfPrivateWorkingSet(workingSetsSpan[0]);
 
         if (GetLastError() != ERROR_BAD_LENGTH)
             return 0;
-        numberOfEntries = updateNumberOfEntries(workingSets->NumberOfEntries);
+        numberOfEntries = updateNumberOfEntries(workingSetsSpan[0].NumberOfEntries);
     }
 }
 

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -31,7 +31,6 @@
 #include "CalculationValue.h"
 #include <wtf/ASCIICType.h>
 #include <wtf/HashMap.h>
-#include <wtf/MallocPtr.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -96,7 +96,7 @@ CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer(const Int
     , m_size(size)
 {
     const auto checkedArea = size.area() * 4;
-    m_data = MallocPtr<unsigned char>::tryZeroedMalloc(checkedArea);
+    m_data = MallocSpan<unsigned char>::tryZeroedMalloc(checkedArea);
 
     {
         Locker locker { s_layersMemoryUsageLock };
@@ -135,7 +135,7 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
     auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
-    m_surface = SkSurfaces::WrapPixels(imageInfo, m_data.get(), imageInfo.minRowBytes64(), &properties);
+    m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
     return true;
 }
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -33,7 +33,7 @@
 #include "IntSize.h"
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -99,7 +99,9 @@ public:
     WEBCORE_EXPORT virtual ~CoordinatedUnacceleratedTileBuffer();
 
     int stride() const { return m_size.width() * 4; }
-    unsigned char* data() const { return m_data.get(); }
+
+    const unsigned char* data() const { return m_data.span().data(); }
+    unsigned char* data() { return m_data.mutableSpan().data(); }
 
     PixelFormat pixelFormat() const;
 
@@ -116,7 +118,7 @@ private:
     void completePainting() final;
     void waitUntilPaintingComplete() final;
 
-    MallocPtr<unsigned char> m_data;
+    MallocSpan<unsigned char> m_data;
     IntSize m_size;
 
     enum class PaintingState {

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/MallocPtr.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -37,7 +37,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <wtf/Assertions.h>
-#include <wtf/MallocPtr.h>
+#include <wtf/MallocSpan.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -260,10 +260,10 @@ static ssize_t readBytesFromSocket(int socketDescriptor, Vector<uint8_t>& buffer
     struct iovec iov[1];
     memset(&iov, 0, sizeof(iov));
 
-    message.msg_controllen = CMSG_SPACE(sizeof(int) * attachmentMaxAmount);
-    MallocPtr<char> attachmentDescriptorBuffer = MallocPtr<char>::malloc(sizeof(char) * message.msg_controllen);
-    memset(attachmentDescriptorBuffer.get(), 0, sizeof(char) * message.msg_controllen);
-    message.msg_control = attachmentDescriptorBuffer.get();
+    auto attachmentDescriptorBuffer = MallocSpan<char>::zeroedMalloc(CMSG_SPACE(sizeof(int) * attachmentMaxAmount));
+    auto attachmentDescriptorSpan = attachmentDescriptorBuffer.mutableSpan();
+    message.msg_control = attachmentDescriptorSpan.data();
+    message.msg_controllen = attachmentDescriptorSpan.size();
 
     size_t previousBufferSize = buffer.size();
     buffer.grow(buffer.capacity());
@@ -463,7 +463,7 @@ bool Connection::sendOutputMessage(UnixMessage& outputMessage)
     iov[0].iov_len = sizeof(messageInfo);
 
     Vector<AttachmentInfo> attachmentInfo;
-    MallocPtr<char> attachmentFDBuffer;
+    MallocSpan<char> attachmentFDBuffer;
 
     auto& attachments = outputMessage.attachments();
     if (!attachments.isEmpty()) {
@@ -475,11 +475,10 @@ bool Connection::sendOutputMessage(UnixMessage& outputMessage)
             });
 
         if (attachmentFDBufferLength) {
-            attachmentFDBuffer = MallocPtr<char>::malloc(sizeof(char) * CMSG_SPACE(sizeof(int) * attachmentFDBufferLength));
-
-            message.msg_control = attachmentFDBuffer.get();
-            message.msg_controllen = CMSG_SPACE(sizeof(int) * attachmentFDBufferLength);
-            memset(message.msg_control, 0, message.msg_controllen);
+            attachmentFDBuffer = MallocSpan<char>::zeroedMalloc(CMSG_SPACE(sizeof(int) * attachmentFDBufferLength));
+            auto span = attachmentFDBuffer.mutableSpan();
+            message.msg_control = span.data();
+            message.msg_controllen = span.size();
 
             struct cmsghdr* cmsg = CMSG_FIRSTHDR(&message);
             cmsg->cmsg_level = SOL_SOCKET;


### PR DESCRIPTION
#### 419636cf5d236be22ae30d2e4a9b62360b9a2848
<pre>
Replace more use of MallocPtr with MallocSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=282521">https://bugs.webkit.org/show_bug.cgi?id=282521</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableMemoryHandle::~ExecutableMemoryHandle):
* Source/JavaScriptCore/runtime/CachePayload.cpp:
(JSC::CachePayload::makeMallocPayload):
(JSC::CachePayload::makeEmptyPayload):
(JSC::CachePayload::CachePayload):
(JSC::CachePayload::span const):
* Source/JavaScriptCore/runtime/CachePayload.h:
* Source/JavaScriptCore/runtime/CachedBytecode.h:
(JSC::CachedBytecode::create):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::release):
(JSC::Encoder::Page::Page):
(JSC::Encoder::Page::malloc):
(JSC::Encoder::Page::buffer const):
(JSC::Encoder::Page::buffer):
(JSC::Encoder::Page::mutableSpan):
(JSC::Encoder::Page::span const):
(JSC::Encoder::Page::getOffset const):
(JSC::Encoder::Page::alignEnd):
(JSC::Encoder::Page::capacity const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/WTF/wtf/win/MemoryFootprintWin.cpp:
(WTF::memoryFootprint):
* Source/WebCore/platform/Length.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer):
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::readBytesFromSocket):
(IPC::Connection::sendOutputMessage):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeLegacySessionState):

Canonical link: <a href="https://commits.webkit.org/286085@main">https://commits.webkit.org/286085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c2b5f19628fe7996aae7690445f5498a71fee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46119 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21739 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24332 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/67898 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80674 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74019 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66985 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66276 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8366 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96290 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4831 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21054 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->