### PR TITLE
Make ReadOperation and WriteOperation thread-safe

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -431,16 +431,15 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, std::optional<Glob
     m_storage->retrieve(storageKey, priority, [this, protectedThis = Ref { *this }, request, completionHandler = WTFMove(completionHandler), info = WTFMove(info), storageKey, networkProcess = Ref { networkProcess() }, sessionID = m_sessionID, frameID, isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections](auto record, auto timings) mutable {
         info.storageTimings = timings;
 
-        if (!record) {
+        if (record.isNull()) {
             LOG(NetworkCache, "(NetworkProcess) not found in storage");
             completeRetrieve(WTFMove(completionHandler), nullptr, info);
             return false;
         }
 
-        ASSERT(record->key == storageKey);
+        ASSERT(record.key == storageKey);
 
-        auto entry = Entry::decodeStorageRecord(*record);
-
+        auto entry = Entry::decodeStorageRecord(record);
         auto useDecision = entry ? makeUseDecision(networkProcess, sessionID, *entry, request) : UseDecision::NoDueToDecodeFailure;
         switch (useDecision) {
         case UseDecision::AsyncRevalidate: {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
@@ -44,42 +44,28 @@ namespace NetworkCache {
 class IOChannel : public ThreadSafeRefCounted<IOChannel> {
 public:
     enum class Type { Read, Write, Create };
-    static Ref<IOChannel> open(String&& file, Type type, std::optional<WorkQueue::QOS> qos = { }) { return adoptRef(*new IOChannel(WTFMove(file).isolatedCopy(), type, qos)); }
+    static Ref<IOChannel> open(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos = { }) { return adoptRef(*new IOChannel(filePath, type, qos)); }
 
-    // Using nullptr as queue submits the result to the main queue.
-    // FIXME: We should add WorkQueue::main() instead.
-    // Can be used with either a concurrent WorkQueue or a serial one.
-    void read(size_t offset, size_t, WTF::WorkQueueBase&, Function<void(Data&, int error)>&&);
-    void write(size_t offset, const Data&, WTF::WorkQueueBase&, Function<void(int error)>&&);
-
-    const String& path() const { return m_path; }
-    Type type() const { return m_type; }
-
-#if !USE(GLIB)
-    bool isOpened() const { return FileSystem::isHandleValid(m_fileDescriptor); }
-#else
-    bool isOpened() const { return m_inputStream || m_outputStream; }
-#endif
+    void read(size_t offset, size_t, Ref<WTF::WorkQueueBase>&&, Function<void(Data&&, int error)>&&);
+    void write(size_t offset, const Data&, Ref<WTF::WorkQueueBase>&&, Function<void(int error)>&&);
 
     ~IOChannel();
 
 private:
-    IOChannel(String&& filePath, IOChannel::Type, std::optional<WorkQueue::QOS>);
+    IOChannel(const String& filePath, IOChannel::Type, std::optional<WorkQueue::QOS>);
 
-    String m_path;
-    Type m_type;
-
-#if !USE(GLIB)
-    FileSystem::PlatformFileHandle m_fileDescriptor { FileSystem::invalidPlatformFileHandle };
+    Lock m_lock;
+#if !PLATFORM(COCOA) && !USE(GLIB)
+    FileSystem::PlatformFileHandle m_fileDescriptor WTF_GUARDED_BY_LOCK(m_lock) { FileSystem::invalidPlatformFileHandle };
 #endif
     std::atomic<bool> m_wasDeleted { false }; // Try to narrow down a crash, https://bugs.webkit.org/show_bug.cgi?id=165659
 #if PLATFORM(COCOA)
-    OSObjectPtr<dispatch_io_t> m_dispatchIO;
+    OSObjectPtr<dispatch_io_t> m_dispatchIO WTF_GUARDED_BY_LOCK(m_lock);
 #endif
 #if USE(GLIB)
-    GRefPtr<GInputStream> m_inputStream;
-    GRefPtr<GOutputStream> m_outputStream;
-    WorkQueue::QOS m_qos;
+    GRefPtr<GInputStream> m_inputStream WTF_GUARDED_BY_LOCK(m_lock);
+    GRefPtr<GOutputStream> m_outputStream WTF_GUARDED_BY_LOCK(m_lock);
+    WorkQueue::QOS m_qos WTF_GUARDED_BY_LOCK(m_lock);
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "NetworkCacheIOChannel.h"
 
+#import "Logging.h"
 #import "NetworkCacheFileSystem.h"
 #import <dispatch/dispatch.h>
 #import <mach/vm_param.h>
@@ -51,16 +52,16 @@ static long dispatchQueueIdentifier(WorkQueue::QOS qos)
     }
 }
 
-IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS> qos)
-    : m_path(WTFMove(filePath))
-    , m_type(type)
+IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos)
 {
-    auto path = FileSystem::fileSystemRepresentation(m_path);
+    RELEASE_ASSERT(!filePath.impl()->isAtom());
+
+    auto path = FileSystem::fileSystemRepresentation(filePath);
     int oflag;
     mode_t mode;
     WorkQueue::QOS dispatchQOS;
 
-    switch (m_type) {
+    switch (type) {
     case Type::Create:
         // We don't want to truncate any existing file (with O_TRUNC) as another thread might be mapping it.
         unlink(path.data());
@@ -80,8 +81,8 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
     }
 
     int fd = ::open(path.data(), oflag, mode);
-    m_fileDescriptor = fd;
 
+    Locker locker { m_lock };
     m_dispatchIO = adoptOSObject(dispatch_io_create(DISPATCH_IO_RANDOM, fd, dispatch_get_global_queue(dispatchQueueIdentifier(dispatchQOS), 0), [fd](int) {
         close(fd);
     }));
@@ -96,29 +97,34 @@ IOChannel::~IOChannel()
     RELEASE_ASSERT(!m_wasDeleted.exchange(true));
 }
 
-void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
+void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> channel(this);
+    Locker locker { m_lock };
+
     bool didCallCompletionHandler = false;
-    dispatch_io_read(m_dispatchIO.get(), offset, size, queue.dispatchQueue(), makeBlockPtr([channel, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
+    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
+
         Data data { OSObjectPtr<dispatch_data_t> { fileData } };
-        auto callback = WTFMove(completionHandler);
-        callback(data, error);
+        completionHandler(WTFMove(data), error);
         didCallCompletionHandler = true;
     }).get());
 }
 
-void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue, Function<void(int error)>&& completionHandler)
+void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> channel(this);
+    Locker locker { m_lock };
+
     auto dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData, queue.dispatchQueue(), makeBlockPtr([channel, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t fileData, int error) mutable {
-        ASSERT_UNUSED(done, done);
-        auto callback = WTFMove(completionHandler);
-        callback(error);
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+        if (!done) {
+            RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
+            return;
+        }
+
+        completionHandler(error);
     }).get());
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
@@ -31,9 +31,7 @@
 namespace WebKit {
 namespace NetworkCache {
 
-IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>)
-    : m_path(WTFMove(filePath))
-    , m_type(type)
+IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue::QOS>)
 {
     FileSystem::FileOpenMode mode { };
     switch (type) {
@@ -47,7 +45,7 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
         mode = FileSystem::FileOpenMode::ReadWrite;
         break;
     }
-    m_fileDescriptor = FileSystem::openFile(m_path, mode);
+    m_fileDescriptor = FileSystem::openFile(filePath, mode);
 }
 
 IOChannel::~IOChannel()
@@ -55,13 +53,13 @@ IOChannel::~IOChannel()
     FileSystem::closeFile(m_fileDescriptor);
 }
 
-void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
+void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
-    queue.dispatch([this, protectedThis = Ref { *this }, offset, size, completionHandler = WTFMove(completionHandler)] {
+    queue->dispatch([this, protectedThis = Ref { *this }, offset, size, completionHandler = WTFMove(completionHandler)] {
         auto fileSize = FileSystem::fileSize(m_fileDescriptor);
         if (!fileSize || *fileSize > std::numeric_limits<size_t>::max()) {
             Data data;
-            completionHandler(data, -1);
+            completionHandler(WTFMove(data), -1);
             return;
         }
         size_t readSize = *fileSize;
@@ -71,13 +69,13 @@ void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Func
         int err = FileSystem::readFromFile(m_fileDescriptor, buffer.mutableSpan());
         err = err < 0 ? err : 0;
         auto data = Data(WTFMove(buffer));
-        completionHandler(data, err);
+        completionHandler(WTFMove(data), err);
     });
 }
 
-void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue, Function<void(int error)>&& completionHandler)
+void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    queue.dispatch([this, protectedThis = Ref { *this }, offset, data, completionHandler = WTFMove(completionHandler)] {
+    queue->dispatch([this, protectedThis = Ref { *this }, offset, data, completionHandler = WTFMove(completionHandler)] {
         FileSystem::seekFile(m_fileDescriptor, offset, FileSystem::FileSeekOrigin::Beginning);
         int err = FileSystem::writeToFile(m_fileDescriptor, data.span());
         err = err < 0 ? err : 0;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -97,6 +97,15 @@ public:
         m_partitionHash
     }; }
 
+    Key isolatedCopy() const & { return {
+        crossThreadCopy(m_partition),
+        crossThreadCopy(m_type),
+        crossThreadCopy(m_identifier),
+        crossThreadCopy(m_range),
+        m_hash,
+        m_partitionHash
+    }; }
+
 private:
     friend struct WTF::Persistence::Coder<Key>;
     static String hashAsString(const HashType&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -428,11 +428,11 @@ void SpeculativeLoadManager::addPreloadedEntry(std::unique_ptr<Entry> entry, con
 void SpeculativeLoadManager::retrieveEntryFromStorage(const SubresourceInfo& info, RetrieveCompletionHandler&& completionHandler)
 {
     protectedStorage()->retrieve(info.key(), static_cast<unsigned>(info.priority()), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
-        if (!record) {
+        if (record.isNull()) {
             completionHandler(nullptr);
             return false;
         }
-        auto entry = Entry::decodeStorageRecord(*record);
+        auto entry = Entry::decodeStorageRecord(record);
         if (!entry) {
             completionHandler(nullptr);
             return false;
@@ -628,12 +628,12 @@ void SpeculativeLoadManager::retrieveSubresourcesEntry(const Key& storageKey, WT
     RefPtr storage = m_storage.get();
     auto subresourcesStorageKey = makeSubresourcesKey(storageKey, storage->salt());
     storage->retrieve(subresourcesStorageKey, static_cast<unsigned>(ResourceLoadPriority::Medium), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
-        if (!record) {
+        if (record.isNull()) {
             completionHandler(nullptr);
             return false;
         }
 
-        auto subresourcesEntry = SubresourcesEntry::decodeStorageRecord(*record);
+        auto subresourcesEntry = SubresourcesEntry::decodeStorageRecord(record);
         if (!subresourcesEntry) {
             completionHandler(nullptr);
             return false;


### PR DESCRIPTION
#### 6aa2a15a3955ac4f4107074b06b661493ff0aced
<pre>
Make ReadOperation and WriteOperation thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=282519">https://bugs.webkit.org/show_bug.cgi?id=282519</a>
<a href="https://rdar.apple.com/139207292">rdar://139207292</a>

Reviewed by NOBODY (OOPS!).

In NetworkCache::Storage, ReadOperation and WriteOperation can be accessed from different threads, and some of their
data members are read and written on different threads, which could lead to data race. To fix this, this patch makes a
few changes:
1. Add threading annotation to data members of ReadOperation and WriteOperation.
2. Make ReadOperation and WriteOperation class instead of struct, and their data members can only be accessed via public
functions which acquires lock or performs threading check as needed.
3. For data members that could contain AtomString, like NetworkCache::Key and NetworkCache::Storage::Record, make
ReadOperation and WriteOperation either store isolated copy of them, or ensure they are only accessed from main thread
and make isolated copy of them when passing them across thread.
4. Make ReadOperation directly stores Storage::Record like WriteOperation does, instead of storing a pointer to it.

This patch also makes some improvments, including removing unnecessary data members, on NetworkCache::IOChannel to make
it more safe, as it is also designed to be accessed from multiple threads (ConcurrentWorkQueue).

* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::retrieve):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h:
(WebKit::NetworkCache::IOChannel::open):
(WebKit::NetworkCache::IOChannel::WTF_GUARDED_BY_LOCK):
(WebKit::NetworkCache::IOChannel::path const): Deleted.
(WebKit::NetworkCache::IOChannel::type const): Deleted.
(WebKit::NetworkCache::IOChannel::isOpened const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::Key::isolatedCopy const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveEntryFromStorage):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveSubresourcesEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::ReadOperation::ReadOperation):
(WebKit::NetworkCache::Storage::ReadOperation::WTF_GUARDED_BY_CAPABILITY):
(WebKit::NetworkCache::Storage::isHigherPriority):
(WebKit::NetworkCache::Storage::ReadOperation::cancel):
(WebKit::NetworkCache::Storage::ReadOperation::finish):
(WebKit::NetworkCache::Storage::ReadOperation::key const):
(WebKit::NetworkCache::Storage::ReadOperation::ordinal const):
(WebKit::NetworkCache::Storage::ReadOperation::priority const):
(WebKit::NetworkCache::Storage::ReadOperation::isCanceled const):
(WebKit::NetworkCache::Storage::ReadOperation::timings):
(WebKit::NetworkCache::Storage::ReadOperation::setTimings):
(WebKit::NetworkCache::Storage::ReadOperation::setBlob):
(WebKit::NetworkCache::Storage::ReadOperation::setResultRecord):
(WebKit::NetworkCache::Storage::WriteOperation::WriteOperation):
(WebKit::NetworkCache::Storage::WriteOperation::callMappedBodyHandler):
(WebKit::NetworkCache::Storage::WriteOperation::callCompletionHandler):
(WebKit::NetworkCache::Storage::WriteOperation::record const):
(WebKit::NetworkCache::Storage::readRecord):
(WebKit::NetworkCache::Storage::storeBodyAsBlob):
(WebKit::NetworkCache::Storage::removeFromPendingWriteOperations):
(WebKit::NetworkCache::Storage::dispatchReadOperation):
(WebKit::NetworkCache::Storage::finishReadOperation):
(WebKit::NetworkCache::retrieveFromMemory):
(WebKit::NetworkCache::Storage::dispatchWriteOperation):
(WebKit::NetworkCache::Storage::finishWriteOperation):
(WebKit::NetworkCache::Storage::retrieve):
(WebKit::NetworkCache::Storage::traverseWithinRootPath):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
(WebKit::NetworkCache::Storage::Record::Record):
(WebKit::NetworkCache::Storage::Record::isolatedCopy const):
(WebKit::NetworkCache::Storage::Record::isNull const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa2a15a3955ac4f4107074b06b661493ff0aced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58776 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17058 "21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46207 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80740 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67032 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66325 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8423 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4896 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->