### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebKit

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -802,6 +802,12 @@ std::span<uint8_t, Extent == std::dynamic_extent ? std::dynamic_extent: Extent *
 }
 
 template<typename T>
+std::span<const T> singleElementSpan(const T& object)
+{
+    return unsafeMakeSpan(std::addressof(object), 1);
+}
+
+template<typename T>
 std::span<const uint8_t> asByteSpan(const T& input)
 {
     return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(&input), sizeof(input));
@@ -825,6 +831,18 @@ std::span<uint8_t> asMutableByteSpan(std::span<T, Extent> input)
 {
     static_assert(!std::is_const_v<T>);
     return unsafeMakeSpan(reinterpret_cast<uint8_t*>(input.data()), input.size_bytes());
+}
+
+template<typename T, std::size_t Extent>
+const T& reinterpretCastSpanStartTo(std::span<const uint8_t, Extent> span)
+{
+    return spanReinterpretCast<const T>(span.first(sizeof(T)))[0];
+}
+
+template<typename T, std::size_t Extent>
+T& reinterpretCastSpanStartTo(std::span<uint8_t, Extent> span)
+{
+    return spanReinterpretCast<T>(span.first(sizeof(T)))[0];
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1113,10 +1131,12 @@ using WTF::makeUniqueWithoutRefCountedCheck;
 using WTF::memcpySpan;
 using WTF::memsetSpan;
 using WTF::mergeDeduplicatedSorted;
+using WTF::reinterpretCastSpanStartTo;
 using WTF::roundUpToMultipleOf;
 using WTF::roundUpToMultipleOfNonPowerOfTwo;
 using WTF::roundDownToMultipleOf;
 using WTF::safeCast;
+using WTF::singleElementSpan;
 using WTF::spanConstCast;
 using WTF::spanReinterpretCast;
 using WTF::tryBinarySearch;

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -30,8 +30,6 @@
 #import "WKBase.h"
 #import "XPCServiceEntryPoint.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if ENABLE(GPU_PROCESS)
 
 namespace WebKit {
@@ -52,9 +50,11 @@ extern "C" WK_EXPORT void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, x
 
 void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     g_jscConfig.vmCreationDisallowed = true;
     g_jscConfig.vmEntryDisallowed = true;
     g_wtfConfig.useSpecialAbortForExtraSecurityImplications = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     WTF::initializeMainThread();
     {
@@ -72,5 +72,3 @@ void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializ
 
     JSC::Config::finalize();
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
@@ -27,8 +27,7 @@
 #import "NetworkTransportReceiveStream.h"
 
 #import "NetworkTransportSession.h"
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {
 
@@ -48,9 +47,9 @@ void NetworkTransportReceiveStream::receiveLoop()
         // FIXME: Not only is this an unnecessary string copy, but it's also something that should probably be in WTF or FragmentedSharedBuffer.
         auto vectorFromData = [](dispatch_data_t content) {
             ASSERT(content);
-            __block Vector<uint8_t> request;
-            dispatch_data_apply(content, ^bool(dispatch_data_t, size_t, const void* buffer, size_t size) {
-                request.append(std::span { static_cast<const uint8_t*>(buffer), size });
+            Vector<uint8_t> request;
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> buffer) {
+                request.append(buffer);
                 return true;
             });
             return request;
@@ -67,5 +66,3 @@ void NetworkTransportReceiveStream::receiveLoop()
     }).get());
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -39,6 +39,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/OptionSet.h>
 #include <wtf/SHA1.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Unexpected.h>
 #include <wtf/WallTime.h>
 
@@ -51,8 +52,6 @@
 #if USE(UNIX_DOMAIN_SOCKETS)
 #include "ArgumentCodersUnix.h"
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace IPC {
 
@@ -94,7 +93,7 @@ template<typename T, size_t Extent> struct ArgumentCoder<std::span<T, Extent>> {
         if constexpr (Extent == std::dynamic_extent)
             return data;
         else
-            return std::span<T, Extent> { data.data(), Extent };
+            return data.template subspan<0, Extent>();
     }
 };
 
@@ -114,7 +113,7 @@ struct ArgumentCoder<ArrayReferenceTuple<Types...>> {
         if (UNLIKELY(!size))
             return;
 
-        (..., encoder.encodeSpan(std::span(arrayReference.template data<Indices>(), size)));
+        (..., encoder.encodeSpan(arrayReference.template span<Indices>()));
     }
 
     template<typename Decoder>
@@ -856,5 +855,3 @@ template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Trai
 };
 
 } // namespace IPC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -35,10 +35,9 @@
 
 #if PLATFORM(COCOA)
 #include <CoreFoundation/CoreFoundation.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit::Daemon {
 
@@ -59,7 +58,7 @@ std::optional<WTF::WallTime> Coder<WTF::WallTime>::decode(Decoder& decoder)
 void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& instance)
 {
 #if PLATFORM(COCOA)
-    auto data = adoptCF(SecTrustSerialize(instance.trust().get(), nullptr));
+    RetainPtr data = adoptCF(SecTrustSerialize(instance.trust().get(), nullptr));
     if (!data) {
         encoder << false;
         return;
@@ -67,7 +66,7 @@ void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::Ce
     encoder << true;
     uint64_t length = CFDataGetLength(data.get());
     encoder << length;
-    encoder.encodeFixedLengthData({ CFDataGetBytePtr(data.get()), static_cast<size_t>(length) });
+    encoder.encodeFixedLengthData(span(data.get()));
 #endif
 }
 
@@ -312,5 +311,3 @@ std::optional<WebCore::RegistrableDomain> Coder<WebCore::RegistrableDomain, void
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -33,8 +33,6 @@
 #include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 struct ExceptionData;
 class CertificateInfo;
@@ -59,8 +57,9 @@ template<typename T, typename = void> struct Coder;
 template<typename T> struct Coder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> {
     template<typename Encoder> static void encode(Encoder& encoder, T value)
     {
-        encoder.encodeFixedLengthData({ reinterpret_cast<const uint8_t*>(&value), sizeof(T) });
+        encoder.encodeFixedLengthData(asByteSpan(value));
     }
+
     template<typename Decoder> static std::optional<T> decode(Decoder& decoder)
     {
         if (T result; decoder.decodeFixedLengthData(asMutableByteSpan(result)))
@@ -193,5 +192,3 @@ template<> struct Coder<WTF::String> {
 
 } // namespace Daemon
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
@@ -28,8 +28,6 @@
 
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 namespace Daemon {
@@ -65,5 +63,3 @@ std::span<const uint8_t> Decoder::decodeFixedLengthReference(size_t size)
 } // namespace Daemon
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -30,14 +30,13 @@
 #include "MessageFlags.h"
 #include <algorithm>
 #include <wtf/OptionSet.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
 #if OS(DARWIN)
 #include <sys/mman.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace IPC {
 
@@ -48,10 +47,10 @@ static inline std::span<uint8_t> allocBuffer(size_t size)
 #if OS(DARWIN)
     auto* buffer = static_cast<uint8_t*>(mmap(0, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0));
     RELEASE_ASSERT(buffer != MAP_FAILED);
-    return std::span { buffer, size };
+    return unsafeMakeSpan(buffer, size);
 #else
     auto* buffer = static_cast<uint8_t*>(fastMalloc(size));
-    return std::span { buffer, size };
+    return unsafeMakeSpan(buffer, size);
 #endif
 }
 
@@ -201,5 +200,3 @@ bool Encoder::hasAttachments() const
 }
 
 } // namespace IPC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -35,8 +35,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace IPC {
 
 enum class MessageFlags : uint8_t;
@@ -87,6 +85,7 @@ public:
         return *this;
     }
 
+    std::span<uint8_t> mutableSpan() { return m_capacityBuffer.first(m_bufferSize); }
     std::span<const uint8_t> span() const { return m_capacityBuffer.first(m_bufferSize); }
 
     void addAttachment(Attachment&&);
@@ -132,9 +131,7 @@ template<typename T>
 inline void Encoder::encodeObject(const T& object)
 {
     static_assert(std::is_trivially_copyable_v<T>);
-    encodeSpan(std::span(std::addressof(object), 1));
+    encodeSpan(unsafeMakeSpan(std::addressof(object), 1));
 }
 
 } // namespace IPC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -30,8 +30,7 @@
 #include <span>
 #include <wtf/Atomics.h>
 #include <wtf/Ref.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace IPC {
 class Decoder;
@@ -138,7 +137,7 @@ protected:
 
 #undef HEADER_POINTER_ALIGNMENT
 
-    Header& header() const { return *reinterpret_cast<Header*>(m_sharedMemory->mutableSpan().data()); }
+    Header& header() const { return reinterpretCastSpanStartTo<Header>(m_sharedMemory->mutableSpan()); }
     static constexpr size_t headerSize() { return roundUpToMultipleOf<alignof(std::max_align_t)>(sizeof(Header)); }
 
     size_t m_dataSize { 0 };
@@ -146,5 +145,3 @@ protected:
 };
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -160,11 +160,11 @@ void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequest
         if (m_isProcessingStreamMessage) {
             auto span = m_buffer.acquireAll();
             {
-                StreamConnectionEncoder messageEncoder { MessageName::SyncMessageReply, span.data(), span.size() };
+                StreamConnectionEncoder messageEncoder { MessageName::SyncMessageReply, span };
                 if ((messageEncoder << ... << arguments))
                     return;
             }
-            StreamConnectionEncoder outOfStreamEncoder { MessageName::ProcessOutOfStreamMessage, span.data(), span.size() };
+            StreamConnectionEncoder outOfStreamEncoder { MessageName::ProcessOutOfStreamMessage, span };
         }
     }
     auto encoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -32,8 +32,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 namespace Daemon {
@@ -124,5 +122,3 @@ template class ConnectionToMachService<WebPushD::ConnectionTraits>;
 } // namespace Daemon
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/cocoa/MachMessage.h
+++ b/Source/WebKit/Platform/IPC/cocoa/MachMessage.h
@@ -31,6 +31,7 @@
 #include <mach/message.h>
 #include <memory>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 
 namespace IPC {
@@ -45,6 +46,8 @@ public:
 
     size_t size() const { return m_size; }
     mach_msg_header_t* header() { return m_messageHeader; }
+
+    std::span<uint8_t> span() { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(m_messageHeader), m_size); }
 
     void leakDescriptors();
 

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -106,7 +106,7 @@ private:
 
         Impl()
             : buffer(1024, static_cast<uint8_t>(0))
-            , encoder(EncoderDecoderTest::name(), buffer.data(), buffer.size())
+            , encoder(EncoderDecoderTest::name(), buffer.mutableSpan())
         { }
 
         Vector<uint8_t> buffer;

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionEncoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionEncoderTests.cpp
@@ -50,7 +50,7 @@ TEST(StreamConnectionEncoderTest, MinimumMessageSizeCanEncodeExpectedMessageAtAn
 
     size_t minimumMessageSize = IPC::StreamConnectionEncoder::minimumMessageSize;
     for (size_t i = 0; i < maxAlignment; i += IPC::StreamConnectionEncoder::messageAlignment) {
-        IPC::StreamConnectionEncoder encoder { IPC::MessageName::SetStreamDestinationID, buffer + i,  minimumMessageSize };
+        IPC::StreamConnectionEncoder encoder { IPC::MessageName::SetStreamDestinationID, unsafeMakeSpan(buffer + i, minimumMessageSize) };
         encoder << static_cast<int64_t>(0);
         EXPECT_TRUE(encoder.isValid()) << i;
     }


### PR DESCRIPTION
#### 6c78d5f3b973b90e15c86c0704655b36c18a9c9a
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=282524">https://bugs.webkit.org/show_bug.cgi?id=282524</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(GPU_SERVICE_INITIALIZER):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm:
(WebKit::NetworkTransportReceiveStream::receiveLoop):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::CertificateInfo&gt;::encode):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
* Source/WebKit/Platform/IPC/DaemonDecoder.cpp:
* Source/WebKit/Platform/IPC/Decoder.cpp:
* Source/WebKit/Platform/IPC/Encoder.cpp:
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeObject):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
(IPC::StreamClientConnection::sendProcessOutOfStreamMessage):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
(IPC::StreamConnectionBuffer::header const):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::getDescriptorAndAdvance):
(IPC::Connection::sendOutgoingMessage):
(IPC::createMessageDecoder):
(IPC::Connection::receiveSourceEventHandler):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
* Source/WebKit/Platform/IPC/cocoa/MachMessage.h:
(IPC::MachMessage::span):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::StreamConnectionEncoder&gt;::Impl::Impl):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionEncoderTests.cpp:
(TestWebKitAPI::TEST(StreamConnectionEncoderTest, MinimumMessageSizeCanEncodeExpectedMessageAtAnyOffset)):

Canonical link: <a href="https://commits.webkit.org/286137@main">https://commits.webkit.org/286137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ccbdddad3ecf5ba111d67106749f51e542f6524

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74951 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17121 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24522 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68088 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80867 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67110 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66410 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8505 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96480 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11563 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2234 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21085 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->