### PR TITLE
[JHBuild] Replace download.gnome.org for GitHub mirror or gitlab.gnome.org

### DIFF
--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -53,11 +53,11 @@
       href="https://chromium.googlesource.com"/>
   <repository type="git" name="git.freedesktop.org"
       href="https://gitlab.freedesktop.org"/>
+  <repository type="git" name="gitlab.gnome.org"
+      href="https://gitlab.gnome.org"/>
   <repository type="git" name="github.com"
       href="https://github.com"/>
   <!-- Tarball repositories. -->
-  <repository type="tarball" name="download.gnome.org"
-      href="https://download.gnome.org"/>
   <repository type="tarball" name="github-tarball"
       href="https://github.com"/>
   <repository type="tarball" name="ftp.gnome.org"
@@ -173,10 +173,11 @@
       <dep package="glib-networking"/>
       <dep package="libpsl"/>
     </dependencies>
-    <branch module="/sources/libsoup/3.6/libsoup-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="GNOME/libsoup.git"
+            repo="github.com"
+            tag="3.6.0"
             version="3.6.0"
-            hash="sha256:62959f791e8e8442f8c13cedac8c4919d78f9120d5bb5301be67a5e53318b4a3"/>
+            checkoutdir="libsoup-${version}"/>
   </meson>
 
   <autotools id="libpsl" autogenargs="--enable-runtime=libicu --enable-builtin=libicu">
@@ -223,32 +224,32 @@
 
   <meson id="glib" mesonargs="-Dlibmount=disabled -Dselinux=disabled -Dgtk_doc=false -Dtests=false">
     <pkg-config>glib-2.0.pc</pkg-config>
-    <branch module="/sources/glib/2.72/glib-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="GNOME/glib"
+            repo="github.com"
+            tag="2.72.4"
             version="2.72.4"
-            checkoutdir="glib-${version}"
-            hash="sha256:8848aba518ba2f4217d144307a1d6cb9afcc92b54e5c13ac1f8c4d4608e96f0e">
-    </branch>
+            checkoutdir="glib-${version}"/>
   </meson>
 
   <meson id="glib-networking">
     <dependencies>
       <dep package="glib"/>
     </dependencies>
-    <branch module="/sources/glib-networking/2.70/glib-networking-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="GNOME/glib-networking"
+            repo="github.com"
+            tag="2.70.0"
             version="2.70.0"
-            checkoutdir="glib-networking-${version}"
-            hash="sha256:66b408e7afa86c582fe38963db56133869ab4b57d34e48ec56aba621940d6f35"/>
+            checkoutdir="glib-networking-${version}"/>
   </meson>
 
   <!-- atk needed to build with A11y support -->
   <meson id="atk" mesonargs="-Dintrospection=false">
     <pkg-config>atk.pc</pkg-config>
-    <branch module="/sources/atk/2.38/atk-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="Archive/atk.git"
+            repo="gitlab.gnome.org"
+            tag="2.38.0"
             version="2.38.0"
-            hash="sha256:ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36"/>
+            checkoutdir="atk-${version}"/>
     <dependencies>
       <dep package="glib"/>
     </dependencies>
@@ -257,11 +258,11 @@
   <!-- at-spi2-core needed to build with A11y support -->
   <meson id="at-spi2-core" mesonargs="-Dintrospection=no -Dx11=no">
     <pkg-config>atspi-2.pc</pkg-config>
-    <branch module="/sources/at-spi2-core/2.44/at-spi2-core-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="GNOME/at-spi2-core"
+            repo="github.com"
+            tag="AT_SPI2_CORE_2_44_1"
             version="2.44.1"
-            hash="sha256:4beb23270ba6cf7caf20b597354d75194d89afb69d2efcf15f4271688ba6f746">
-    </branch>
+            checkoutdir="at-spi2-core-${version}"/>
     <dependencies>
       <dep package="glib"/>
     </dependencies>
@@ -270,11 +271,11 @@
   <!-- at-spi2-atk needed to build with A11y support -->
   <meson id="at-spi2-atk" mesonargs="">
     <pkg-config>atk-bridge-2.0.pc</pkg-config>
-    <branch module="/sources/at-spi2-atk/2.38/at-spi2-atk-${version}.tar.xz"
-            repo="download.gnome.org"
+    <branch module="Archive/at-spi2-atk.git"
+            repo="gitlab.gnome.org"
+            tag="AT_SPI2_ATK_2_38_0"
             version="2.38.0"
-            hash="sha256:cfa008a5af822b36ae6287f18182c40c91dd699c55faa38605881ed175ca464f">
-    </branch>
+            checkoutdir="at-spi2-atk-${version}"/>
     <dependencies>
       <dep package="glib"/>
       <dep package="atk"/>


### PR DESCRIPTION
#### 09963421693e1d72cd5a9732a183138984894a28
<pre>
[JHBuild] Replace download.gnome.org for GitHub mirror or gitlab.gnome.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=282528">https://bugs.webkit.org/show_bug.cgi?id=282528</a>

Reviewed by Carlos Alberto Lopez Perez.

Many times downloads of &apos;libsoup&apos;, &apos;glib&apos; or &apos;glib-networking&apos; fail
unexpectedly. This might be due to a problem on server side. Apparently,
GitHub mirrors are more reliably. Thus, it would be better to rely on
github mirrors in those modules where it&apos;s possible.

Also, for the ATK/ASPI modules use a git repository, instead of a
tarball.

* Tools/jhbuild/jhbuild-minimal.modules:

Canonical link: <a href="https://commits.webkit.org/286145@main">https://commits.webkit.org/286145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baae18ea75c60ad470504051194f2d3faeafe0b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58733 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17015 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21754 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66993 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66286 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8381 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11567 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2061 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->