### PR TITLE
Regression(280901@main)? [WPE][TextureMapper] Incorrect extra hole punches with fixed body position

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -52,6 +52,7 @@ public:
     TextureMapperLayer* replicaLayer { nullptr };
     bool preserves3D { false };
     Vector<IntRect> holePunchRects;
+    bool isPreserves3DFirstTile { false };
 };
 
 struct TextureMapperLayer::ComputeTransformData {
@@ -441,33 +442,42 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         options.textureMapper.beginClip(transform, m_state.contentsClippingRect);
     }
 
-    bool isHolePunchInPreserve3D = options.preserves3D && contentsLayer->isHolePunchBuffer();
-    if (isHolePunchInPreserve3D) {
-        // If we're in preserve3D mode, then we're painting into an intermediate surface. This means that the
-        // elements are not painted into their final position, as it depends on the offset applied when painting the
-        // intermediate surface. But holepunch buffers need to know the final position in order to position the video
-        // sink and draw the transparent rectangle in the main framebuffer. Options.offset was applied to remove the
-        // offset from the elements that is instead applied to the intermediate surface, so we undo that. That way the
-        // transform shows the final position, and paintToTextureMapper can properly notify the video sink.
-        transform.translate(-options.offset.width(), -options.offset.height());
-    }
-
-    contentsLayer->paintToTextureMapper(options.textureMapper, m_state.contentsRect, transform, options.opacity);
-
-    if (isHolePunchInPreserve3D) {
-        // Once the video sink was notified of the position, store the rect in the list of rects that need to be
-        // painted into the main framebuffer and reapply options.offset.
-        // The holepunch rects stored will be painted transparent into the main framebuffer before blending the
-        // intermediate surface.
-        options.holePunchRects.append(enclosingIntRect(transform.mapRect(m_state.contentsRect)));
-        transform.translate(options.offset.width(), options.offset.height());
-    }
+    if (options.preserves3D && contentsLayer->isHolePunchBuffer())
+        paintPreserves3DHolePunch(contentsLayer, transform, options);
+    else
+        contentsLayer->paintToTextureMapper(options.textureMapper, m_state.contentsRect, transform, options.opacity);
 
     if (shouldClip)
         options.textureMapper.endClip();
 
     if (m_state.showDebugBorders)
         contentsLayer->drawBorder(options.textureMapper, m_state.debugBorderColor, m_state.debugBorderWidth, m_state.contentsRect, transform);
+}
+
+void TextureMapperLayer::paintPreserves3DHolePunch(TextureMapperPlatformLayer* contentsLayer, const TransformationMatrix& transform, TextureMapperPaintOptions& options)
+{
+    // In preserve3D mode we're painting into an intermediate surface. To make holepunch work we need to
+    // paint the transparent rectangle in this layer, but also in the background layer.
+    // The rendering to the intermediate surface is also tiled, which means that this layer can be painted
+    // several times in different tiles. We need to notify the video position and queue the paint of the
+    // background hole only once, while the transparent rectangle to this layer needs to be painted
+    // for each tile.
+
+    if (options.isPreserves3DFirstTile) {
+        // We can't use the passed transform here cause it was created with a modified offset to paint
+        // into the intermediate surface. We need to calculate the real position of the video sink
+        // here by using a transform that doesn't have the intermediate surface offset.
+        TransformationMatrix videoSinkTransform;
+        videoSinkTransform.multiply(options.transform);
+        videoSinkTransform.multiply(m_layerTransforms.combined);
+
+        // Enqueue the holepunch rect to be painted in the background and notify the position to the
+        // video sink.
+        options.holePunchRects.append(enclosingIntRect(videoSinkTransform.mapRect(m_state.contentsRect)));
+        contentsLayer->notifyVideoPosition(m_state.contentsRect, videoSinkTransform);
+    }
+    // Paint the transparent rectangle in the intermediate surface with the original transform.
+    contentsLayer->paintTransparentRectangle(options.textureMapper, m_state.contentsRect, transform);
 }
 
 void TextureMapperLayer::sortByZOrder(Vector<TextureMapperLayer* >& array)
@@ -1073,6 +1083,7 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
                     SetForScope scopedSurface(options.surface, surface.ptr());
                     SetForScope scopedOffset(options.offset, -toIntSize(tileRect.location()));
                     SetForScope scopedOpacity(options.opacity, 1);
+                    SetForScope scopedFirstPass(options.isPreserves3DFirstTile, x == rect.x() && y == rect.y());
 
                     options.textureMapper.bindSurface(options.surface.get());
                     paintSelfAndChildrenWithReplica(options);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -156,6 +156,8 @@ private:
     void removeFromParent();
     void removeAllChildren();
 
+    void paintPreserves3DHolePunch(TextureMapperPlatformLayer*, const TransformationMatrix&, TextureMapperPaintOptions&);
+
     enum class ComputeOverlapRegionMode : uint8_t {
         Intersection,
         Union,

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
@@ -46,6 +46,8 @@ public:
     void setClient(TextureMapperPlatformLayer::Client* client) { m_client = client; }
 
     virtual bool isHolePunchBuffer() const { return false; }
+    virtual void notifyVideoPosition(const FloatRect&, const TransformationMatrix&) { };
+    virtual void paintTransparentRectangle(TextureMapper&, const FloatRect&, const TransformationMatrix&) { };
 
 protected:
     TextureMapperPlatformLayer::Client* client() { return m_client; }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
@@ -72,6 +72,19 @@ void CoordinatedPlatformLayerBufferHolePunch::paintToTextureMapper(TextureMapper
     textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
 }
 
+void CoordinatedPlatformLayerBufferHolePunch::notifyVideoPosition(const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix)
+{
+#if USE(GSTREAMER)
+    if (m_videoSink && m_quirksManager)
+        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), enclosingIntRect(modelViewMatrix.mapRect(targetRect)));
+#endif
+}
+
+void CoordinatedPlatformLayerBufferHolePunch::paintTransparentRectangle(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix)
+{
+    textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
@@ -49,6 +49,9 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+    void notifyVideoPosition(const FloatRect&, const TransformationMatrix&) override;
+    void paintTransparentRectangle(TextureMapper&, const FloatRect&, const TransformationMatrix&) override;
+
 #if USE(GSTREAMER)
     GRefPtr<GstElement> m_videoSink;
     RefPtr<GStreamerQuirksManager> m_quirksManager;


### PR DESCRIPTION
#### 4df9391bfafa06f4869c34e701cc1ee6c94caf14
<pre>
Regression(280901@main)? [WPE][TextureMapper] Incorrect extra hole punches with fixed body position
<a href="https://bugs.webkit.org/show_bug.cgi?id=281309">https://bugs.webkit.org/show_bug.cgi?id=281309</a>

Reviewed by Carlos Garcia Campos.

When rendering into a preserves3D subtree, we&apos;re rendering into an intermediate surface
that, once ready, is blended into the main framebuffer.
To make holepunching work in this situation we need to render the transparent rectangle
in the intermediate surface, but also in the main framebuffer. To achieve this, when
rendering into the intermediate surface we keep a vector of rects that need to be painted
to the main framebuffer just before blending the intermediate surface.
There are a couple of points that need to be taken into account though: the intermediate
surface rendering is tiled, so the same TextureMapperLayer can be rendered several times,
and it will receive an offset to compensate the rendering into the intermediate surface.

In order to notify the video sink and render the transparent rectange in the main
framebuffer, we need to use a transform that doesn&apos;t include the intermediate surface
offset. But to paint into the intermediate surface we need to use the offsetted transform.
To achieve this, we calculate the non offsetted transform in the first tile, and use it
to notify the real video position to the video sink and the main framebuffer. Then
we use the normal transform to paint the transparent rectangle into the intermediate
surface.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintSelf):
(WebCore::TextureMapperLayer::paintPreserves3DHolePunch):
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h:
(WebCore::TextureMapperPlatformLayer::notifyVideoPosition):
(WebCore::TextureMapperPlatformLayer::paintTransparentRectangle):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp:
(WebCore::CoordinatedPlatformLayerBufferHolePunch::notifyVideoPosition):
(WebCore::CoordinatedPlatformLayerBufferHolePunch::paintTransparentRectangle):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h:

Canonical link: <a href="https://commits.webkit.org/286146@main">https://commits.webkit.org/286146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/076331c40ab1af184ec9c836dc2a731603707c06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58739 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17020 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80697 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66295 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8389 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4854 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->