### PR TITLE
PBKDF2 & HKDF derive bits returns an empty array when length is zero

### DIFF
--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits-expected.txt
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits-expected.txt
@@ -3,16 +3,16 @@ Test HKDF deriveBits operation for corner-case length values
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS deriveBits("sha-1", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS Bit derivations with zero length returned an empty string
 PASS Bit derivations for SHA-1 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-1", 256 * 20 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits("sha-256", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS Bit derivations with zero length returned an empty string
 PASS Bit derivations for SHA-256 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-256", 256 * 32 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits("sha-384", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS Bit derivations with zero length returned an empty string
 PASS Bit derivations for SHA-384 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-384", 256 * 48 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits("sha-512", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS Bit derivations with zero length returned an empty string
 PASS Bit derivations for SHA-512 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-512", 256 * 64 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS successfullyParsed is true

--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits.html
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits.html
@@ -32,7 +32,9 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
 
     return Promise.resolve().then(function(result) {
         // SHA-1, hash output length is 20 bytes
-        return shouldReject('deriveBits("sha-1", 0)').then(function(result) {
+        return deriveBits("sha-1", 0).then(function(result) {
+            if (result.byteLength == 0)
+                testPassed("Bit derivations with zero length returned an empty string");
             return Promise.all([
                 deriveBits("sha-1", 8),
                 deriveBits("sha-1", 20 * 8),
@@ -44,7 +46,9 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
         });
     }).then(function(result) {
         // SHA-256, hash output length is 32 bytes
-        return shouldReject('deriveBits("sha-256", 0)').then(function(result) {
+        return deriveBits("sha-256", 0).then(function(result) {
+            if (result.byteLength == 0)
+                testPassed("Bit derivations with zero length returned an empty string");
             return Promise.all([
                 deriveBits("sha-256", 8),
                 deriveBits("sha-256", 32 * 8),
@@ -56,7 +60,9 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
         });
     }).then(function(result) {
         // SHA-384, hash output length is 48 bytes
-        return shouldReject('deriveBits("sha-384", 0)').then(function(result) {
+        return deriveBits("sha-384", 0).then(function(result) {
+            if (result.byteLength == 0)
+                testPassed("Bit derivations with zero length returned an empty string");
             return Promise.all([
                 deriveBits("sha-384", 8),
                 deriveBits("sha-384", 48 * 8),
@@ -68,7 +74,9 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
         });
     }).then(function(result) {
         // SHA-512, hash output length is 64 bytes
-        return shouldReject('deriveBits("sha-512", 0)').then(function(result) {
+        return deriveBits("sha-512", 0).then(function(result) {
+            if (result.byteLength == 0)
+                testPassed("Bit derivations with zero length returned an empty string");
             return Promise.all([
                 deriveBits("sha-512", 8),
                 deriveBits("sha-512", 64 * 8),

--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs-expected.txt
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs-expected.txt
@@ -18,7 +18,6 @@ PASS crypto.subtle.deriveBits({name: "HKDF", info: Symbol(), salt: salt, hash: "
 PASS crypto.subtle.deriveBits({name: "HKDF", info: { }, salt: salt, hash: "sha-1"}, baseKey, 128) rejected promise  with TypeError: Type error.
 PASS crypto.subtle.deriveBits({name: "HKDF", info: 1, salt: salt, hash: "sha-1"}, baseKey, 128) rejected promise  with TypeError: Type error.
 PASS crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, null) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 5) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 100000) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS successfullyParsed is true

--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs.html
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs.html
@@ -38,7 +38,6 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
     shouldReject('crypto.subtle.deriveBits({name: "HKDF", info: 1, salt: salt, hash: "sha-1"}, baseKey, 128)');
     // Wrong length
     shouldReject('crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, null)');
-    shouldReject('crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 0)');
     shouldReject('crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 5)');
     // Large length
     return shouldReject('crypto.subtle.deriveBits({name: "HKDF", salt: salt, info: info, hash: "sha-1"}, baseKey, 100000)');

--- a/LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs-expected.txt
+++ b/LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs-expected.txt
@@ -14,7 +14,6 @@ PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: 1, iterations: 100000, hash
 PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: undefined, hash: "sha-1"}, baseKey, 128) rejected promise  with TypeError: Member Pbkdf2Params.iterations is required and must be an instance of unsigned long.
 PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: Symbol(), hash: "sha-1"}, baseKey, 128) rejected promise  with TypeError: Cannot convert a symbol to a number.
 PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, null) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, 5) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 0, hash: "sha-1"}, baseKey, 128) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS successfullyParsed is true

--- a/LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs.html
+++ b/LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs.html
@@ -33,7 +33,6 @@ crypto.subtle.importKey("raw", rawKey, "PBKDF2", nonExtractable, ["deriveBits"])
     shouldReject('crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: Symbol(), hash: "sha-1"}, baseKey, 128)');
     // Wrong length
     shouldReject('crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, null)');
-    shouldReject('crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, 0)');
     shouldReject('crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 100000, hash: "sha-1"}, baseKey, 5)');
     // Operation Error
     return shouldReject('crypto.subtle.deriveBits({name: "PBKDF2", salt: salt, iterations: 0, hash: "sha-1"}, baseKey, 128)');

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
@@ -3,14 +3,14 @@ PASS setup - define tests
 PASS HKDF derivation with 256 as 'length' parameter
 PASS HKDF derivation with 384 as 'length' parameter
 PASS HKDF derivation with 230 as 'length' parameter
-FAIL HKDF derivation with 0 as 'length' parameter promise_test: Unhandled rejection with value: object "OperationError: The operation failed for an operation-specific reason"
+PASS HKDF derivation with 0 as 'length' parameter
 PASS HKDF derivation with null as 'length' parameter
 PASS HKDF derivation with undefined as 'length' parameter
 PASS HKDF derivation with omitted as 'length' parameter
 PASS PBKDF2 derivation with 256 as 'length' parameter
 PASS PBKDF2 derivation with 384 as 'length' parameter
 PASS PBKDF2 derivation with 230 as 'length' parameter
-FAIL PBKDF2 derivation with 0 as 'length' parameter promise_test: Unhandled rejection with value: object "OperationError: The operation failed for an operation-specific reason"
+PASS PBKDF2 derivation with 0 as 'length' parameter
 PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
 PASS PBKDF2 derivation with omitted as 'length' parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
@@ -3,14 +3,14 @@ PASS setup - define tests
 PASS HKDF derivation with 256 as 'length' parameter
 PASS HKDF derivation with 384 as 'length' parameter
 PASS HKDF derivation with 230 as 'length' parameter
-FAIL HKDF derivation with 0 as 'length' parameter promise_test: Unhandled rejection with value: object "OperationError: The operation failed for an operation-specific reason"
+PASS HKDF derivation with 0 as 'length' parameter
 PASS HKDF derivation with null as 'length' parameter
 PASS HKDF derivation with undefined as 'length' parameter
 PASS HKDF derivation with omitted as 'length' parameter
 PASS PBKDF2 derivation with 256 as 'length' parameter
 PASS PBKDF2 derivation with 384 as 'length' parameter
 PASS PBKDF2 derivation with 230 as 'length' parameter
-FAIL PBKDF2 derivation with 0 as 'length' parameter promise_test: Unhandled rejection with value: object "OperationError: The operation failed for an operation-specific reason"
+PASS PBKDF2 derivation with 0 as 'length' parameter
 PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
 PASS PBKDF2 derivation with omitted as 'length' parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1-1000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1-1000-expected.txt
@@ -1,7 +1,7 @@
 
 PASS setup - define tests
 PASS short derivedKey, normal salt, SHA-384, with normal info
-FAIL short derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -73,7 +73,7 @@ PASS short derivedKey, normal salt, SHA-384, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-384, with empty info
-FAIL short derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -145,7 +145,7 @@ PASS short derivedKey, normal salt, SHA-384, with empty info with bad hash name 
 PASS short derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-512, with normal info
-FAIL short derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -217,7 +217,7 @@ PASS short derivedKey, normal salt, SHA-512, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-512, with empty info
-FAIL short derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -289,7 +289,7 @@ PASS short derivedKey, normal salt, SHA-512, with empty info with bad hash name 
 PASS short derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-1, with normal info
-FAIL short derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS short derivedKey, normal salt, SHA-1, with normal info with bad hash name S
 PASS short derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-1, with empty info
-FAIL short derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -433,7 +433,7 @@ PASS short derivedKey, normal salt, SHA-1, with empty info with bad hash name SH
 PASS short derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-256, with normal info
-FAIL short derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -505,7 +505,7 @@ PASS short derivedKey, normal salt, SHA-256, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-256, with empty info
-FAIL short derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage
@@ -611,7 +611,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info
 PASS short derivedKey, empty salt, SHA-384, with normal info
-FAIL short derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -683,7 +683,7 @@ PASS short derivedKey, empty salt, SHA-384, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-384, with empty info
-FAIL short derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS short derivedKey, empty salt, SHA-384, with empty info with bad hash name S
 PASS short derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-512, with normal info
-FAIL short derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage
@@ -827,7 +827,7 @@ PASS short derivedKey, empty salt, SHA-512, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-512, with empty info
-FAIL short derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -899,7 +899,7 @@ PASS short derivedKey, empty salt, SHA-512, with empty info with bad hash name S
 PASS short derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-1, with normal info
-FAIL short derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -971,7 +971,7 @@ PASS short derivedKey, empty salt, SHA-1, with normal info with bad hash name SH
 PASS short derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-1, with empty info
-FAIL short derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1001-2000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1001-2000-expected.txt
@@ -43,7 +43,7 @@ PASS short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA
 PASS short derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-256, with normal info
-FAIL short derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -115,7 +115,7 @@ PASS short derivedKey, empty salt, SHA-256, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-256, with empty info
-FAIL short derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage
@@ -221,7 +221,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info
 PASS long derivedKey, normal salt, SHA-384, with normal info
-FAIL long derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -293,7 +293,7 @@ PASS long derivedKey, normal salt, SHA-384, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-384, with empty info
-FAIL long derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -365,7 +365,7 @@ PASS long derivedKey, normal salt, SHA-384, with empty info with bad hash name S
 PASS long derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-512, with normal info
-FAIL long derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -437,7 +437,7 @@ PASS long derivedKey, normal salt, SHA-512, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-512, with empty info
-FAIL long derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -509,7 +509,7 @@ PASS long derivedKey, normal salt, SHA-512, with empty info with bad hash name S
 PASS long derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-1, with normal info
-FAIL long derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -581,7 +581,7 @@ PASS long derivedKey, normal salt, SHA-1, with normal info with bad hash name SH
 PASS long derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-1, with empty info
-FAIL long derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -653,7 +653,7 @@ PASS long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA
 PASS long derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-256, with normal info
-FAIL long derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -725,7 +725,7 @@ PASS long derivedKey, normal salt, SHA-256, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-256, with empty info
-FAIL long derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage
@@ -831,7 +831,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long derive
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info
 PASS long derivedKey, empty salt, SHA-384, with normal info
-FAIL long derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -903,7 +903,7 @@ PASS long derivedKey, empty salt, SHA-384, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-384, with empty info
-FAIL long derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -975,7 +975,7 @@ PASS long derivedKey, empty salt, SHA-384, with empty info with bad hash name SH
 PASS long derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-512, with normal info
-FAIL long derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_2001-3000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_2001-3000-expected.txt
@@ -47,7 +47,7 @@ PASS long derivedKey, empty salt, SHA-512, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-512, with empty info
-FAIL long derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -119,7 +119,7 @@ PASS long derivedKey, empty salt, SHA-512, with empty info with bad hash name SH
 PASS long derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-1, with normal info
-FAIL long derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -191,7 +191,7 @@ PASS long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA
 PASS long derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-1, with empty info
-FAIL long derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage
@@ -263,7 +263,7 @@ PASS long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS long derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-256, with normal info
-FAIL long derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -335,7 +335,7 @@ PASS long derivedKey, empty salt, SHA-256, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-256, with empty info
-FAIL long derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage
@@ -441,7 +441,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long derive
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info
 PASS empty derivedKey, normal salt, SHA-384, with normal info
-FAIL empty derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS empty derivedKey, normal salt, SHA-384, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-384, with empty info
-FAIL empty derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -585,7 +585,7 @@ PASS empty derivedKey, normal salt, SHA-384, with empty info with bad hash name 
 PASS empty derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-512, with normal info
-FAIL empty derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -657,7 +657,7 @@ PASS empty derivedKey, normal salt, SHA-512, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-512, with empty info
-FAIL empty derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -729,7 +729,7 @@ PASS empty derivedKey, normal salt, SHA-512, with empty info with bad hash name 
 PASS empty derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-1, with normal info
-FAIL empty derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -801,7 +801,7 @@ PASS empty derivedKey, normal salt, SHA-1, with normal info with bad hash name S
 PASS empty derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-1, with empty info
-FAIL empty derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -873,7 +873,7 @@ PASS empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SH
 PASS empty derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-256, with normal info
-FAIL empty derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -945,7 +945,7 @@ PASS empty derivedKey, normal salt, SHA-256, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-256, with empty info
-FAIL empty derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_3001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_3001-last-expected.txt
@@ -51,7 +51,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info
 PASS empty derivedKey, empty salt, SHA-384, with normal info
-FAIL empty derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -123,7 +123,7 @@ PASS empty derivedKey, empty salt, SHA-384, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-384, with empty info
-FAIL empty derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -195,7 +195,7 @@ PASS empty derivedKey, empty salt, SHA-384, with empty info with bad hash name S
 PASS empty derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-512, with normal info
-FAIL empty derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty derivedKey, empty salt, SHA-512, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-512, with empty info
-FAIL empty derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -339,7 +339,7 @@ PASS empty derivedKey, empty salt, SHA-512, with empty info with bad hash name S
 PASS empty derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-1, with normal info
-FAIL empty derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -411,7 +411,7 @@ PASS empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SH
 PASS empty derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-1, with empty info
-FAIL empty derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage
@@ -483,7 +483,7 @@ PASS empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA
 PASS empty derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-256, with normal info
-FAIL empty derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -555,7 +555,7 @@ PASS empty derivedKey, empty salt, SHA-256, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-256, with empty info
-FAIL empty derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1-1000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1-1000-expected.txt
@@ -1,7 +1,7 @@
 
 PASS setup - define tests
 PASS short derivedKey, normal salt, SHA-384, with normal info
-FAIL short derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -73,7 +73,7 @@ PASS short derivedKey, normal salt, SHA-384, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-384, with empty info
-FAIL short derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -145,7 +145,7 @@ PASS short derivedKey, normal salt, SHA-384, with empty info with bad hash name 
 PASS short derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-512, with normal info
-FAIL short derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -217,7 +217,7 @@ PASS short derivedKey, normal salt, SHA-512, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-512, with empty info
-FAIL short derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -289,7 +289,7 @@ PASS short derivedKey, normal salt, SHA-512, with empty info with bad hash name 
 PASS short derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-1, with normal info
-FAIL short derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS short derivedKey, normal salt, SHA-1, with normal info with bad hash name S
 PASS short derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-1, with empty info
-FAIL short derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -433,7 +433,7 @@ PASS short derivedKey, normal salt, SHA-1, with empty info with bad hash name SH
 PASS short derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-256, with normal info
-FAIL short derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -505,7 +505,7 @@ PASS short derivedKey, normal salt, SHA-256, with normal info with bad hash name
 PASS short derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS short derivedKey, normal salt, SHA-256, with empty info
-FAIL short derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage
@@ -611,7 +611,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info
 PASS short derivedKey, empty salt, SHA-384, with normal info
-FAIL short derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -683,7 +683,7 @@ PASS short derivedKey, empty salt, SHA-384, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-384, with empty info
-FAIL short derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS short derivedKey, empty salt, SHA-384, with empty info with bad hash name S
 PASS short derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-512, with normal info
-FAIL short derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage
@@ -827,7 +827,7 @@ PASS short derivedKey, empty salt, SHA-512, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-512, with empty info
-FAIL short derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -899,7 +899,7 @@ PASS short derivedKey, empty salt, SHA-512, with empty info with bad hash name S
 PASS short derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-1, with normal info
-FAIL short derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -971,7 +971,7 @@ PASS short derivedKey, empty salt, SHA-1, with normal info with bad hash name SH
 PASS short derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-1, with empty info
-FAIL short derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1001-2000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1001-2000-expected.txt
@@ -43,7 +43,7 @@ PASS short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA
 PASS short derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-256, with normal info
-FAIL short derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -115,7 +115,7 @@ PASS short derivedKey, empty salt, SHA-256, with normal info with bad hash name 
 PASS short derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS short derivedKey, empty salt, SHA-256, with empty info
-FAIL short derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage
@@ -221,7 +221,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info
 PASS long derivedKey, normal salt, SHA-384, with normal info
-FAIL long derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -293,7 +293,7 @@ PASS long derivedKey, normal salt, SHA-384, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-384, with empty info
-FAIL long derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -365,7 +365,7 @@ PASS long derivedKey, normal salt, SHA-384, with empty info with bad hash name S
 PASS long derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-512, with normal info
-FAIL long derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -437,7 +437,7 @@ PASS long derivedKey, normal salt, SHA-512, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-512, with empty info
-FAIL long derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -509,7 +509,7 @@ PASS long derivedKey, normal salt, SHA-512, with empty info with bad hash name S
 PASS long derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-1, with normal info
-FAIL long derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -581,7 +581,7 @@ PASS long derivedKey, normal salt, SHA-1, with normal info with bad hash name SH
 PASS long derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-1, with empty info
-FAIL long derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -653,7 +653,7 @@ PASS long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA
 PASS long derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-256, with normal info
-FAIL long derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -725,7 +725,7 @@ PASS long derivedKey, normal salt, SHA-256, with normal info with bad hash name 
 PASS long derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS long derivedKey, normal salt, SHA-256, with empty info
-FAIL long derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage
@@ -831,7 +831,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long derive
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info
 PASS long derivedKey, empty salt, SHA-384, with normal info
-FAIL long derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -903,7 +903,7 @@ PASS long derivedKey, empty salt, SHA-384, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-384, with empty info
-FAIL long derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -975,7 +975,7 @@ PASS long derivedKey, empty salt, SHA-384, with empty info with bad hash name SH
 PASS long derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-512, with normal info
-FAIL long derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_2001-3000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_2001-3000-expected.txt
@@ -47,7 +47,7 @@ PASS long derivedKey, empty salt, SHA-512, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-512, with empty info
-FAIL long derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -119,7 +119,7 @@ PASS long derivedKey, empty salt, SHA-512, with empty info with bad hash name SH
 PASS long derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-1, with normal info
-FAIL long derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -191,7 +191,7 @@ PASS long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA
 PASS long derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-1, with empty info
-FAIL long derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage
@@ -263,7 +263,7 @@ PASS long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS long derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-256, with normal info
-FAIL long derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -335,7 +335,7 @@ PASS long derivedKey, empty salt, SHA-256, with normal info with bad hash name S
 PASS long derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS long derivedKey, empty salt, SHA-256, with empty info
-FAIL long derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage
@@ -441,7 +441,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long derive
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info
 PASS empty derivedKey, normal salt, SHA-384, with normal info
-FAIL empty derivedKey, normal salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS empty derivedKey, normal salt, SHA-384, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-384, with empty info
-FAIL empty derivedKey, normal salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage
@@ -585,7 +585,7 @@ PASS empty derivedKey, normal salt, SHA-384, with empty info with bad hash name 
 PASS empty derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-512, with normal info
-FAIL empty derivedKey, normal salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage
@@ -657,7 +657,7 @@ PASS empty derivedKey, normal salt, SHA-512, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-512, with empty info
-FAIL empty derivedKey, normal salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage
@@ -729,7 +729,7 @@ PASS empty derivedKey, normal salt, SHA-512, with empty info with bad hash name 
 PASS empty derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-1, with normal info
-FAIL empty derivedKey, normal salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage
@@ -801,7 +801,7 @@ PASS empty derivedKey, normal salt, SHA-1, with normal info with bad hash name S
 PASS empty derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-1, with empty info
-FAIL empty derivedKey, normal salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage
@@ -873,7 +873,7 @@ PASS empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SH
 PASS empty derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-256, with normal info
-FAIL empty derivedKey, normal salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage
@@ -945,7 +945,7 @@ PASS empty derivedKey, normal salt, SHA-256, with normal info with bad hash name
 PASS empty derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage
 PASS empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key
 PASS empty derivedKey, normal salt, SHA-256, with empty info
-FAIL empty derivedKey, normal salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, normal salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_3001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_3001-last-expected.txt
@@ -51,7 +51,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty deriv
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info
 PASS empty derivedKey, empty salt, SHA-384, with normal info
-FAIL empty derivedKey, empty salt, SHA-384, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-384, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage
@@ -123,7 +123,7 @@ PASS empty derivedKey, empty salt, SHA-384, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-384, with empty info
-FAIL empty derivedKey, empty salt, SHA-384, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-384, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage
@@ -195,7 +195,7 @@ PASS empty derivedKey, empty salt, SHA-384, with empty info with bad hash name S
 PASS empty derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-512, with normal info
-FAIL empty derivedKey, empty salt, SHA-512, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-512, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty derivedKey, empty salt, SHA-512, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-512, with empty info
-FAIL empty derivedKey, empty salt, SHA-512, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-512, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage
@@ -339,7 +339,7 @@ PASS empty derivedKey, empty salt, SHA-512, with empty info with bad hash name S
 PASS empty derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-1, with normal info
-FAIL empty derivedKey, empty salt, SHA-1, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-1, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage
@@ -411,7 +411,7 @@ PASS empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SH
 PASS empty derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-1, with empty info
-FAIL empty derivedKey, empty salt, SHA-1, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-1, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage
@@ -483,7 +483,7 @@ PASS empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA
 PASS empty derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-256, with normal info
-FAIL empty derivedKey, empty salt, SHA-256, with normal info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-256, with normal info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage
@@ -555,7 +555,7 @@ PASS empty derivedKey, empty salt, SHA-256, with normal info with bad hash name 
 PASS empty derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage
 PASS empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key
 PASS empty derivedKey, empty salt, SHA-256, with empty info
-FAIL empty derivedKey, empty salt, SHA-256, with empty info with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty derivedKey, empty salt, SHA-256, with empty info with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1-1000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1-1000-expected.txt
@@ -1,7 +1,7 @@
 
 PASS setup - define tests
 PASS short password, short salt, SHA-384, with 1 iterations
-FAIL short password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -71,7 +71,7 @@ PASS short password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-384, with 1000 iterations
-FAIL short password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -141,7 +141,7 @@ PASS short password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-384, with 100000 iterations
-FAIL short password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -228,7 +228,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations
 PASS short password, short salt, SHA-512, with 1 iterations
-FAIL short password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -298,7 +298,7 @@ PASS short password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-512, with 1000 iterations
-FAIL short password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -368,7 +368,7 @@ PASS short password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-512, with 100000 iterations
-FAIL short password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -455,7 +455,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations
 PASS short password, short salt, SHA-1, with 1 iterations
-FAIL short password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -525,7 +525,7 @@ PASS short password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-1, with 1000 iterations
-FAIL short password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -595,7 +595,7 @@ PASS short password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-1, with 100000 iterations
-FAIL short password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -682,7 +682,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations
 PASS short password, short salt, SHA-256, with 1 iterations
-FAIL short password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -752,7 +752,7 @@ PASS short password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-256, with 1000 iterations
-FAIL short password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -822,7 +822,7 @@ PASS short password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-256, with 100000 iterations
-FAIL short password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -960,7 +960,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, PBKDF2, with 100000 iterations
 PASS short password, long salt, SHA-384, with 1 iterations
-FAIL short password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt
@@ -30,7 +30,7 @@ PASS short password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 1000 iterations
-FAIL short password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -100,7 +100,7 @@ PASS short password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 100000 iterations
-FAIL short password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -187,7 +187,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS short password, long salt, SHA-512, with 1 iterations
-FAIL short password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -257,7 +257,7 @@ PASS short password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 1000 iterations
-FAIL short password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -327,7 +327,7 @@ PASS short password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 100000 iterations
-FAIL short password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -414,7 +414,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS short password, long salt, SHA-1, with 1 iterations
-FAIL short password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -484,7 +484,7 @@ PASS short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS short password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 1000 iterations
-FAIL short password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -554,7 +554,7 @@ PASS short password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS short password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 100000 iterations
-FAIL short password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -641,7 +641,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS short password, long salt, SHA-256, with 1 iterations
-FAIL short password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -711,7 +711,7 @@ PASS short password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 1000 iterations
-FAIL short password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -781,7 +781,7 @@ PASS short password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 100000 iterations
-FAIL short password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -919,7 +919,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS short password, empty salt, SHA-384, with 1 iterations
-FAIL short password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -989,7 +989,7 @@ PASS short password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-384, with 1000 iterations
-FAIL short password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt
@@ -59,7 +59,7 @@ PASS short password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-384, with 100000 iterations
-FAIL short password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -146,7 +146,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS short password, empty salt, SHA-512, with 1 iterations
-FAIL short password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -216,7 +216,7 @@ PASS short password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-512, with 1000 iterations
-FAIL short password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -286,7 +286,7 @@ PASS short password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-512, with 100000 iterations
-FAIL short password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -373,7 +373,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS short password, empty salt, SHA-1, with 1 iterations
-FAIL short password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -443,7 +443,7 @@ PASS short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-1, with 1000 iterations
-FAIL short password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS short password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-1, with 100000 iterations
-FAIL short password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -600,7 +600,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS short password, empty salt, SHA-256, with 1 iterations
-FAIL short password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -670,7 +670,7 @@ PASS short password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-256, with 1000 iterations
-FAIL short password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -740,7 +740,7 @@ PASS short password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-256, with 100000 iterations
-FAIL short password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -878,7 +878,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS long password, short salt, SHA-384, with 1 iterations
-FAIL long password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -948,7 +948,7 @@ PASS long password, short salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 1000 iterations
-FAIL long password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_3001-4000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_3001-4000-expected.txt
@@ -18,7 +18,7 @@ PASS long password, short salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 100000 iterations
-FAIL long password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -105,7 +105,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations
 PASS long password, short salt, SHA-512, with 1 iterations
-FAIL long password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -175,7 +175,7 @@ PASS long password, short salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-512, with 1000 iterations
-FAIL long password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -245,7 +245,7 @@ PASS long password, short salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-512, with 100000 iterations
-FAIL long password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -332,7 +332,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations
 PASS long password, short salt, SHA-1, with 1 iterations
-FAIL long password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -402,7 +402,7 @@ PASS long password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-1, with 1000 iterations
-FAIL long password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -472,7 +472,7 @@ PASS long password, short salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-1, with 100000 iterations
-FAIL long password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -559,7 +559,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations
 PASS long password, short salt, SHA-256, with 1 iterations
-FAIL long password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -629,7 +629,7 @@ PASS long password, short salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-256, with 1000 iterations
-FAIL long password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -699,7 +699,7 @@ PASS long password, short salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-256, with 100000 iterations
-FAIL long password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -837,7 +837,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, PBKDF2, with 100000 iterations
 PASS long password, long salt, SHA-384, with 1 iterations
-FAIL long password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -907,7 +907,7 @@ PASS long password, long salt, SHA-384, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-384, with 1000 iterations
-FAIL long password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -977,7 +977,7 @@ PASS long password, long salt, SHA-384, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-384, with 100000 iterations
-FAIL long password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt
@@ -64,7 +64,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS long password, long salt, SHA-512, with 1 iterations
-FAIL long password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -134,7 +134,7 @@ PASS long password, long salt, SHA-512, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 1000 iterations
-FAIL long password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -204,7 +204,7 @@ PASS long password, long salt, SHA-512, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 100000 iterations
-FAIL long password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -291,7 +291,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS long password, long salt, SHA-1, with 1 iterations
-FAIL long password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 1000 iterations
-FAIL long password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -431,7 +431,7 @@ PASS long password, long salt, SHA-1, with 1000 iterations with bad hash name SH
 PASS long password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 100000 iterations
-FAIL long password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -518,7 +518,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS long password, long salt, SHA-256, with 1 iterations
-FAIL long password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -588,7 +588,7 @@ PASS long password, long salt, SHA-256, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 1000 iterations
-FAIL long password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -658,7 +658,7 @@ PASS long password, long salt, SHA-256, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 100000 iterations
-FAIL long password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -796,7 +796,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS long password, empty salt, SHA-384, with 1 iterations
-FAIL long password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -866,7 +866,7 @@ PASS long password, empty salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-384, with 1000 iterations
-FAIL long password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -936,7 +936,7 @@ PASS long password, empty salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-384, with 100000 iterations
-FAIL long password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt
@@ -23,7 +23,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS long password, empty salt, SHA-512, with 1 iterations
-FAIL long password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -93,7 +93,7 @@ PASS long password, empty salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-512, with 1000 iterations
-FAIL long password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -163,7 +163,7 @@ PASS long password, empty salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-512, with 100000 iterations
-FAIL long password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -250,7 +250,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS long password, empty salt, SHA-1, with 1 iterations
-FAIL long password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -320,7 +320,7 @@ PASS long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-1, with 1000 iterations
-FAIL long password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -390,7 +390,7 @@ PASS long password, empty salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-1, with 100000 iterations
-FAIL long password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -477,7 +477,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS long password, empty salt, SHA-256, with 1 iterations
-FAIL long password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -547,7 +547,7 @@ PASS long password, empty salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-256, with 1000 iterations
-FAIL long password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -617,7 +617,7 @@ PASS long password, empty salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-256, with 100000 iterations
-FAIL long password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS empty password, short salt, SHA-384, with 1 iterations
-FAIL empty password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -825,7 +825,7 @@ PASS empty password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-384, with 1000 iterations
-FAIL empty password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -895,7 +895,7 @@ PASS empty password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-384, with 100000 iterations
-FAIL empty password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -982,7 +982,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS empty password, short salt, SHA-512, with 1 iterations
-FAIL empty password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt
@@ -52,7 +52,7 @@ PASS empty password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-512, with 1000 iterations
-FAIL empty password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -122,7 +122,7 @@ PASS empty password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-512, with 100000 iterations
-FAIL empty password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -209,7 +209,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS empty password, short salt, SHA-1, with 1 iterations
-FAIL empty password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -279,7 +279,7 @@ PASS empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-1, with 1000 iterations
-FAIL empty password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -349,7 +349,7 @@ PASS empty password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-1, with 100000 iterations
-FAIL empty password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -436,7 +436,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS empty password, short salt, SHA-256, with 1 iterations
-FAIL empty password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -506,7 +506,7 @@ PASS empty password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-256, with 1000 iterations
-FAIL empty password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -576,7 +576,7 @@ PASS empty password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-256, with 100000 iterations
-FAIL empty password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -714,7 +714,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS empty password, long salt, SHA-384, with 1 iterations
-FAIL empty password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -784,7 +784,7 @@ PASS empty password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-384, with 1000 iterations
-FAIL empty password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -854,7 +854,7 @@ PASS empty password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-384, with 100000 iterations
-FAIL empty password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -941,7 +941,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS empty password, long salt, SHA-512, with 1 iterations
-FAIL empty password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt
@@ -11,7 +11,7 @@ PASS empty password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-512, with 1000 iterations
-FAIL empty password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -81,7 +81,7 @@ PASS empty password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-512, with 100000 iterations
-FAIL empty password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -168,7 +168,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS empty password, long salt, SHA-1, with 1 iterations
-FAIL empty password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -238,7 +238,7 @@ PASS empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS empty password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-1, with 1000 iterations
-FAIL empty password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -308,7 +308,7 @@ PASS empty password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS empty password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-1, with 100000 iterations
-FAIL empty password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -395,7 +395,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS empty password, long salt, SHA-256, with 1 iterations
-FAIL empty password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -465,7 +465,7 @@ PASS empty password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-256, with 1000 iterations
-FAIL empty password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -535,7 +535,7 @@ PASS empty password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-256, with 100000 iterations
-FAIL empty password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -673,7 +673,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS empty password, empty salt, SHA-384, with 1 iterations
-FAIL empty password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -743,7 +743,7 @@ PASS empty password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-384, with 1000 iterations
-FAIL empty password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -813,7 +813,7 @@ PASS empty password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-384, with 100000 iterations
-FAIL empty password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -900,7 +900,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS empty password, empty salt, SHA-512, with 1 iterations
-FAIL empty password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -970,7 +970,7 @@ PASS empty password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-512, with 1000 iterations
-FAIL empty password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt
@@ -40,7 +40,7 @@ PASS empty password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-512, with 100000 iterations
-FAIL empty password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -127,7 +127,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS empty password, empty salt, SHA-1, with 1 iterations
-FAIL empty password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -197,7 +197,7 @@ PASS empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-1, with 1000 iterations
-FAIL empty password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-1, with 100000 iterations
-FAIL empty password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -354,7 +354,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS empty password, empty salt, SHA-256, with 1 iterations
-FAIL empty password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -424,7 +424,7 @@ PASS empty password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-256, with 1000 iterations
-FAIL empty password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -494,7 +494,7 @@ PASS empty password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-256, with 100000 iterations
-FAIL empty password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1-1000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1-1000-expected.txt
@@ -1,7 +1,7 @@
 
 PASS setup - define tests
 PASS short password, short salt, SHA-384, with 1 iterations
-FAIL short password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -71,7 +71,7 @@ PASS short password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-384, with 1000 iterations
-FAIL short password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -141,7 +141,7 @@ PASS short password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-384, with 100000 iterations
-FAIL short password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -228,7 +228,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations
 PASS short password, short salt, SHA-512, with 1 iterations
-FAIL short password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -298,7 +298,7 @@ PASS short password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-512, with 1000 iterations
-FAIL short password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -368,7 +368,7 @@ PASS short password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-512, with 100000 iterations
-FAIL short password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -455,7 +455,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations
 PASS short password, short salt, SHA-1, with 1 iterations
-FAIL short password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -525,7 +525,7 @@ PASS short password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-1, with 1000 iterations
-FAIL short password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -595,7 +595,7 @@ PASS short password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-1, with 100000 iterations
-FAIL short password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -682,7 +682,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations
 PASS short password, short salt, SHA-256, with 1 iterations
-FAIL short password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -752,7 +752,7 @@ PASS short password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-256, with 1000 iterations
-FAIL short password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -822,7 +822,7 @@ PASS short password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, short salt, SHA-256, with 100000 iterations
-FAIL short password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -960,7 +960,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, PBKDF2, with 100000 iterations
 PASS short password, long salt, SHA-384, with 1 iterations
-FAIL short password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt
@@ -30,7 +30,7 @@ PASS short password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 1000 iterations
-FAIL short password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -100,7 +100,7 @@ PASS short password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 100000 iterations
-FAIL short password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -187,7 +187,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS short password, long salt, SHA-512, with 1 iterations
-FAIL short password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -257,7 +257,7 @@ PASS short password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 1000 iterations
-FAIL short password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -327,7 +327,7 @@ PASS short password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 100000 iterations
-FAIL short password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -414,7 +414,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS short password, long salt, SHA-1, with 1 iterations
-FAIL short password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -484,7 +484,7 @@ PASS short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS short password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 1000 iterations
-FAIL short password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -554,7 +554,7 @@ PASS short password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS short password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 100000 iterations
-FAIL short password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -641,7 +641,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS short password, long salt, SHA-256, with 1 iterations
-FAIL short password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -711,7 +711,7 @@ PASS short password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 1000 iterations
-FAIL short password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -781,7 +781,7 @@ PASS short password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 100000 iterations
-FAIL short password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -919,7 +919,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS short password, empty salt, SHA-384, with 1 iterations
-FAIL short password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -989,7 +989,7 @@ PASS short password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-384, with 1000 iterations
-FAIL short password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt
@@ -59,7 +59,7 @@ PASS short password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-384, with 100000 iterations
-FAIL short password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -146,7 +146,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS short password, empty salt, SHA-512, with 1 iterations
-FAIL short password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -216,7 +216,7 @@ PASS short password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-512, with 1000 iterations
-FAIL short password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -286,7 +286,7 @@ PASS short password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-512, with 100000 iterations
-FAIL short password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -373,7 +373,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS short password, empty salt, SHA-1, with 1 iterations
-FAIL short password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -443,7 +443,7 @@ PASS short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-1, with 1000 iterations
-FAIL short password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS short password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-1, with 100000 iterations
-FAIL short password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -600,7 +600,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS short password, empty salt, SHA-256, with 1 iterations
-FAIL short password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -670,7 +670,7 @@ PASS short password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-256, with 1000 iterations
-FAIL short password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -740,7 +740,7 @@ PASS short password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, empty salt, SHA-256, with 100000 iterations
-FAIL short password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -878,7 +878,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS long password, short salt, SHA-384, with 1 iterations
-FAIL long password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -948,7 +948,7 @@ PASS long password, short salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 1000 iterations
-FAIL long password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_3001-4000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_3001-4000-expected.txt
@@ -18,7 +18,7 @@ PASS long password, short salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 100000 iterations
-FAIL long password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -105,7 +105,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations
 PASS long password, short salt, SHA-512, with 1 iterations
-FAIL long password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -175,7 +175,7 @@ PASS long password, short salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-512, with 1000 iterations
-FAIL long password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -245,7 +245,7 @@ PASS long password, short salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-512, with 100000 iterations
-FAIL long password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -332,7 +332,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations
 PASS long password, short salt, SHA-1, with 1 iterations
-FAIL long password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -402,7 +402,7 @@ PASS long password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-1, with 1000 iterations
-FAIL long password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -472,7 +472,7 @@ PASS long password, short salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-1, with 100000 iterations
-FAIL long password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -559,7 +559,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations
 PASS long password, short salt, SHA-256, with 1 iterations
-FAIL long password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -629,7 +629,7 @@ PASS long password, short salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-256, with 1000 iterations
-FAIL long password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -699,7 +699,7 @@ PASS long password, short salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-256, with 100000 iterations
-FAIL long password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -837,7 +837,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, PBKDF2, with 100000 iterations
 PASS long password, long salt, SHA-384, with 1 iterations
-FAIL long password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -907,7 +907,7 @@ PASS long password, long salt, SHA-384, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-384, with 1000 iterations
-FAIL long password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -977,7 +977,7 @@ PASS long password, long salt, SHA-384, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-384, with 100000 iterations
-FAIL long password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt
@@ -64,7 +64,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS long password, long salt, SHA-512, with 1 iterations
-FAIL long password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -134,7 +134,7 @@ PASS long password, long salt, SHA-512, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 1000 iterations
-FAIL long password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -204,7 +204,7 @@ PASS long password, long salt, SHA-512, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 100000 iterations
-FAIL long password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -291,7 +291,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS long password, long salt, SHA-1, with 1 iterations
-FAIL long password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 1000 iterations
-FAIL long password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -431,7 +431,7 @@ PASS long password, long salt, SHA-1, with 1000 iterations with bad hash name SH
 PASS long password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 100000 iterations
-FAIL long password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -518,7 +518,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS long password, long salt, SHA-256, with 1 iterations
-FAIL long password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -588,7 +588,7 @@ PASS long password, long salt, SHA-256, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 1000 iterations
-FAIL long password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -658,7 +658,7 @@ PASS long password, long salt, SHA-256, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 100000 iterations
-FAIL long password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -796,7 +796,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS long password, empty salt, SHA-384, with 1 iterations
-FAIL long password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -866,7 +866,7 @@ PASS long password, empty salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-384, with 1000 iterations
-FAIL long password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -936,7 +936,7 @@ PASS long password, empty salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-384, with 100000 iterations
-FAIL long password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt
@@ -23,7 +23,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS long password, empty salt, SHA-512, with 1 iterations
-FAIL long password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -93,7 +93,7 @@ PASS long password, empty salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-512, with 1000 iterations
-FAIL long password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -163,7 +163,7 @@ PASS long password, empty salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-512, with 100000 iterations
-FAIL long password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -250,7 +250,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS long password, empty salt, SHA-1, with 1 iterations
-FAIL long password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -320,7 +320,7 @@ PASS long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-1, with 1000 iterations
-FAIL long password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -390,7 +390,7 @@ PASS long password, empty salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-1, with 100000 iterations
-FAIL long password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -477,7 +477,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS long password, empty salt, SHA-256, with 1 iterations
-FAIL long password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -547,7 +547,7 @@ PASS long password, empty salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-256, with 1000 iterations
-FAIL long password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -617,7 +617,7 @@ PASS long password, empty salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, empty salt, SHA-256, with 100000 iterations
-FAIL long password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS empty password, short salt, SHA-384, with 1 iterations
-FAIL empty password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -825,7 +825,7 @@ PASS empty password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-384, with 1000 iterations
-FAIL empty password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -895,7 +895,7 @@ PASS empty password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-384, with 100000 iterations
-FAIL empty password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -982,7 +982,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS empty password, short salt, SHA-512, with 1 iterations
-FAIL empty password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt
@@ -52,7 +52,7 @@ PASS empty password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-512, with 1000 iterations
-FAIL empty password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -122,7 +122,7 @@ PASS empty password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-512, with 100000 iterations
-FAIL empty password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -209,7 +209,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS empty password, short salt, SHA-1, with 1 iterations
-FAIL empty password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -279,7 +279,7 @@ PASS empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-1, with 1000 iterations
-FAIL empty password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -349,7 +349,7 @@ PASS empty password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-1, with 100000 iterations
-FAIL empty password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -436,7 +436,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS empty password, short salt, SHA-256, with 1 iterations
-FAIL empty password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -506,7 +506,7 @@ PASS empty password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-256, with 1000 iterations
-FAIL empty password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -576,7 +576,7 @@ PASS empty password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, short salt, SHA-256, with 100000 iterations
-FAIL empty password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -714,7 +714,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS empty password, long salt, SHA-384, with 1 iterations
-FAIL empty password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -784,7 +784,7 @@ PASS empty password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-384, with 1000 iterations
-FAIL empty password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -854,7 +854,7 @@ PASS empty password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-384, with 100000 iterations
-FAIL empty password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -941,7 +941,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS empty password, long salt, SHA-512, with 1 iterations
-FAIL empty password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt
@@ -11,7 +11,7 @@ PASS empty password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-512, with 1000 iterations
-FAIL empty password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -81,7 +81,7 @@ PASS empty password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-512, with 100000 iterations
-FAIL empty password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -168,7 +168,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS empty password, long salt, SHA-1, with 1 iterations
-FAIL empty password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -238,7 +238,7 @@ PASS empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS empty password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-1, with 1000 iterations
-FAIL empty password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -308,7 +308,7 @@ PASS empty password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS empty password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-1, with 100000 iterations
-FAIL empty password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -395,7 +395,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS empty password, long salt, SHA-256, with 1 iterations
-FAIL empty password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -465,7 +465,7 @@ PASS empty password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-256, with 1000 iterations
-FAIL empty password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -535,7 +535,7 @@ PASS empty password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, long salt, SHA-256, with 100000 iterations
-FAIL empty password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -673,7 +673,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS empty password, empty salt, SHA-384, with 1 iterations
-FAIL empty password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -743,7 +743,7 @@ PASS empty password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-384, with 1000 iterations
-FAIL empty password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -813,7 +813,7 @@ PASS empty password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-384, with 100000 iterations
-FAIL empty password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -900,7 +900,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS empty password, empty salt, SHA-512, with 1 iterations
-FAIL empty password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -970,7 +970,7 @@ PASS empty password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-512, with 1000 iterations
-FAIL empty password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt
@@ -40,7 +40,7 @@ PASS empty password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-512, with 100000 iterations
-FAIL empty password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -127,7 +127,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS empty password, empty salt, SHA-1, with 1 iterations
-FAIL empty password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -197,7 +197,7 @@ PASS empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-1, with 1000 iterations
-FAIL empty password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-1, with 100000 iterations
-FAIL empty password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -354,7 +354,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS empty password, empty salt, SHA-256, with 1 iterations
-FAIL empty password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -424,7 +424,7 @@ PASS empty password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-256, with 1000 iterations
-FAIL empty password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -494,7 +494,7 @@ PASS empty password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS empty password, empty salt, SHA-256, with 100000 iterations
-FAIL empty password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt
@@ -30,7 +30,7 @@ PASS short password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 1000 iterations
-FAIL short password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -100,7 +100,7 @@ PASS short password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 100000 iterations
-FAIL short password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -187,7 +187,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS short password, long salt, SHA-512, with 1 iterations
-FAIL short password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -257,7 +257,7 @@ PASS short password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 1000 iterations
-FAIL short password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -327,7 +327,7 @@ PASS short password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 100000 iterations
-FAIL short password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -414,7 +414,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS short password, long salt, SHA-1, with 1 iterations
-FAIL short password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -484,7 +484,7 @@ PASS short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS short password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 1000 iterations
-FAIL short password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -554,7 +554,7 @@ PASS short password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS short password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 100000 iterations
-FAIL short password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -641,7 +641,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS short password, long salt, SHA-256, with 1 iterations
-FAIL short password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -711,7 +711,7 @@ PASS short password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 1000 iterations
-FAIL short password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -781,7 +781,7 @@ PASS short password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 100000 iterations
-FAIL short password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -919,7 +919,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 FAIL short password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -989,7 +989,7 @@ PASS short password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt
@@ -59,7 +59,7 @@ PASS short password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -146,7 +146,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 FAIL short password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -216,7 +216,7 @@ PASS short password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -286,7 +286,7 @@ PASS short password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -373,7 +373,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 FAIL short password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -443,7 +443,7 @@ PASS short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS short password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -600,7 +600,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 FAIL short password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -670,7 +670,7 @@ PASS short password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -740,7 +740,7 @@ PASS short password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -878,7 +878,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS long password, short salt, SHA-384, with 1 iterations
-FAIL long password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -948,7 +948,7 @@ PASS long password, short salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 1000 iterations
-FAIL long password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt
@@ -64,7 +64,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS long password, long salt, SHA-512, with 1 iterations
-FAIL long password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -134,7 +134,7 @@ PASS long password, long salt, SHA-512, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 1000 iterations
-FAIL long password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -204,7 +204,7 @@ PASS long password, long salt, SHA-512, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 100000 iterations
-FAIL long password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -291,7 +291,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS long password, long salt, SHA-1, with 1 iterations
-FAIL long password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 1000 iterations
-FAIL long password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -431,7 +431,7 @@ PASS long password, long salt, SHA-1, with 1000 iterations with bad hash name SH
 PASS long password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 100000 iterations
-FAIL long password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -518,7 +518,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS long password, long salt, SHA-256, with 1 iterations
-FAIL long password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -588,7 +588,7 @@ PASS long password, long salt, SHA-256, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 1000 iterations
-FAIL long password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -658,7 +658,7 @@ PASS long password, long salt, SHA-256, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 100000 iterations
-FAIL long password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -796,7 +796,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 FAIL long password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -866,7 +866,7 @@ PASS long password, empty salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -936,7 +936,7 @@ PASS long password, empty salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt
@@ -23,7 +23,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 FAIL long password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -93,7 +93,7 @@ PASS long password, empty salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -163,7 +163,7 @@ PASS long password, empty salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -250,7 +250,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 FAIL long password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -320,7 +320,7 @@ PASS long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -390,7 +390,7 @@ PASS long password, empty salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -477,7 +477,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 FAIL long password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -547,7 +547,7 @@ PASS long password, empty salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -617,7 +617,7 @@ PASS long password, empty salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 FAIL empty password, short salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -825,7 +825,7 @@ PASS empty password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -895,7 +895,7 @@ PASS empty password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -982,7 +982,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 FAIL empty password, short salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt
@@ -52,7 +52,7 @@ PASS empty password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -122,7 +122,7 @@ PASS empty password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -209,7 +209,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 FAIL empty password, short salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -279,7 +279,7 @@ PASS empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -349,7 +349,7 @@ PASS empty password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -436,7 +436,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 FAIL empty password, short salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -506,7 +506,7 @@ PASS empty password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -576,7 +576,7 @@ PASS empty password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -714,7 +714,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 FAIL empty password, long salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -784,7 +784,7 @@ PASS empty password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -854,7 +854,7 @@ PASS empty password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -941,7 +941,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 FAIL empty password, long salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt
@@ -11,7 +11,7 @@ PASS empty password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -81,7 +81,7 @@ PASS empty password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -168,7 +168,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 FAIL empty password, long salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -238,7 +238,7 @@ PASS empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS empty password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -308,7 +308,7 @@ PASS empty password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS empty password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -395,7 +395,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 FAIL empty password, long salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -465,7 +465,7 @@ PASS empty password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -535,7 +535,7 @@ PASS empty password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -673,7 +673,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 FAIL empty password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -743,7 +743,7 @@ PASS empty password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -813,7 +813,7 @@ PASS empty password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -900,7 +900,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 FAIL empty password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -970,7 +970,7 @@ PASS empty password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt
@@ -40,7 +40,7 @@ PASS empty password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -127,7 +127,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 FAIL empty password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -197,7 +197,7 @@ PASS empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -354,7 +354,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 FAIL empty password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -424,7 +424,7 @@ PASS empty password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -494,7 +494,7 @@ PASS empty password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt
@@ -30,7 +30,7 @@ PASS short password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 1000 iterations
-FAIL short password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -100,7 +100,7 @@ PASS short password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-384, with 100000 iterations
-FAIL short password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-384, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -187,7 +187,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations
 PASS short password, long salt, SHA-512, with 1 iterations
-FAIL short password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -257,7 +257,7 @@ PASS short password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 1000 iterations
-FAIL short password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -327,7 +327,7 @@ PASS short password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-512, with 100000 iterations
-FAIL short password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -414,7 +414,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations
 PASS short password, long salt, SHA-1, with 1 iterations
-FAIL short password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -484,7 +484,7 @@ PASS short password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS short password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 1000 iterations
-FAIL short password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -554,7 +554,7 @@ PASS short password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS short password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-1, with 100000 iterations
-FAIL short password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -641,7 +641,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations
 PASS short password, long salt, SHA-256, with 1 iterations
-FAIL short password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -711,7 +711,7 @@ PASS short password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS short password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 1000 iterations
-FAIL short password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -781,7 +781,7 @@ PASS short password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS short password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS short password, long salt, SHA-256, with 100000 iterations
-FAIL short password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -919,7 +919,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, PBKDF2, with 100000 iterations
 FAIL short password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -989,7 +989,7 @@ PASS short password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt
@@ -59,7 +59,7 @@ PASS short password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -146,7 +146,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations
 FAIL short password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -216,7 +216,7 @@ PASS short password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -286,7 +286,7 @@ PASS short password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -373,7 +373,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations
 FAIL short password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -443,7 +443,7 @@ PASS short password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS short password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -513,7 +513,7 @@ PASS short password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS short password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -600,7 +600,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations
 FAIL short password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -670,7 +670,7 @@ PASS short password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS short password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -740,7 +740,7 @@ PASS short password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS short password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL short password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL short password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS short password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -878,7 +878,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using short passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, PBKDF2, with 100000 iterations
 PASS long password, short salt, SHA-384, with 1 iterations
-FAIL long password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -948,7 +948,7 @@ PASS long password, short salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 PASS long password, short salt, SHA-384, with 1000 iterations
-FAIL long password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, short salt, SHA-384, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt
@@ -64,7 +64,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations
 PASS long password, long salt, SHA-512, with 1 iterations
-FAIL long password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -134,7 +134,7 @@ PASS long password, long salt, SHA-512, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 1000 iterations
-FAIL long password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -204,7 +204,7 @@ PASS long password, long salt, SHA-512, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-512, with 100000 iterations
-FAIL long password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-512, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -291,7 +291,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations
 PASS long password, long salt, SHA-1, with 1 iterations
-FAIL long password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -361,7 +361,7 @@ PASS long password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 1000 iterations
-FAIL long password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -431,7 +431,7 @@ PASS long password, long salt, SHA-1, with 1000 iterations with bad hash name SH
 PASS long password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-1, with 100000 iterations
-FAIL long password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-1, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -518,7 +518,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations
 PASS long password, long salt, SHA-256, with 1 iterations
-FAIL long password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -588,7 +588,7 @@ PASS long password, long salt, SHA-256, with 1 iterations with bad hash name SHA
 PASS long password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 1000 iterations
-FAIL long password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 1000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -658,7 +658,7 @@ PASS long password, long salt, SHA-256, with 1000 iterations with bad hash name 
 PASS long password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 PASS long password, long salt, SHA-256, with 100000 iterations
-FAIL long password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, long salt, SHA-256, with 100000 iterations with 0 length
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -796,7 +796,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, PBKDF2, with 100000 iterations
 FAIL long password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -866,7 +866,7 @@ PASS long password, empty salt, SHA-384, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -936,7 +936,7 @@ PASS long password, empty salt, SHA-384, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt
@@ -23,7 +23,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations
 FAIL long password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -93,7 +93,7 @@ PASS long password, empty salt, SHA-512, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -163,7 +163,7 @@ PASS long password, empty salt, SHA-512, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -250,7 +250,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations
 FAIL long password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -320,7 +320,7 @@ PASS long password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS long password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -390,7 +390,7 @@ PASS long password, empty salt, SHA-1, with 1000 iterations with bad hash name S
 PASS long password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -477,7 +477,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations
 FAIL long password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -547,7 +547,7 @@ PASS long password, empty salt, SHA-256, with 1 iterations with bad hash name SH
 PASS long password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -617,7 +617,7 @@ PASS long password, empty salt, SHA-256, with 1000 iterations with bad hash name
 PASS long password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL long password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL long password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS long password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -755,7 +755,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using long passwo
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, PBKDF2, with 100000 iterations
 FAIL empty password, short salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -825,7 +825,7 @@ PASS empty password, short salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -895,7 +895,7 @@ PASS empty password, short salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -982,7 +982,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations
 FAIL empty password, short salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt
@@ -52,7 +52,7 @@ PASS empty password, short salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -122,7 +122,7 @@ PASS empty password, short salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -209,7 +209,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations
 FAIL empty password, short salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -279,7 +279,7 @@ PASS empty password, short salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, short salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -349,7 +349,7 @@ PASS empty password, short salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, short salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -436,7 +436,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations
 FAIL empty password, short salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -506,7 +506,7 @@ PASS empty password, short salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, short salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -576,7 +576,7 @@ PASS empty password, short salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, short salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, short salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, short salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, short salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -714,7 +714,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, PBKDF2, with 100000 iterations
 FAIL empty password, long salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -784,7 +784,7 @@ PASS empty password, long salt, SHA-384, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -854,7 +854,7 @@ PASS empty password, long salt, SHA-384, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -941,7 +941,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations
 FAIL empty password, long salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt
@@ -11,7 +11,7 @@ PASS empty password, long salt, SHA-512, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage
@@ -81,7 +81,7 @@ PASS empty password, long salt, SHA-512, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -168,7 +168,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations
 FAIL empty password, long salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -238,7 +238,7 @@ PASS empty password, long salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS empty password, long salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -308,7 +308,7 @@ PASS empty password, long salt, SHA-1, with 1000 iterations with bad hash name S
 PASS empty password, long salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -395,7 +395,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations
 FAIL empty password, long salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -465,7 +465,7 @@ PASS empty password, long salt, SHA-256, with 1 iterations with bad hash name SH
 PASS empty password, long salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -535,7 +535,7 @@ PASS empty password, long salt, SHA-256, with 1000 iterations with bad hash name
 PASS empty password, long salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, long salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, long salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, long salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage
@@ -673,7 +673,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, PBKDF2, with 100000 iterations
 FAIL empty password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage
@@ -743,7 +743,7 @@ PASS empty password, empty salt, SHA-384, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-384, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage
@@ -813,7 +813,7 @@ PASS empty password, empty salt, SHA-384, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-384, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-384, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-384, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with bad hash name SHA384
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage
@@ -900,7 +900,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations
 FAIL empty password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage
@@ -970,7 +970,7 @@ PASS empty password, empty salt, SHA-512, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-512, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt
@@ -40,7 +40,7 @@ PASS empty password, empty salt, SHA-512, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-512, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-512, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-512, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with bad hash name SHA512
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage
@@ -127,7 +127,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations
 FAIL empty password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage
@@ -197,7 +197,7 @@ PASS empty password, empty salt, SHA-1, with 1 iterations with bad hash name SHA
 PASS empty password, empty salt, SHA-1, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage
@@ -267,7 +267,7 @@ PASS empty password, empty salt, SHA-1, with 1000 iterations with bad hash name 
 PASS empty password, empty salt, SHA-1, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-1, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-1, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with bad hash name SHA1
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage
@@ -354,7 +354,7 @@ PASS Derived key of type name: HMAC hash: SHA-256 length: 256  using empty passw
 PASS Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 PASS Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations
 FAIL empty password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 1 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage
@@ -424,7 +424,7 @@ PASS empty password, empty salt, SHA-256, with 1 iterations with bad hash name S
 PASS empty password, empty salt, SHA-256, with 1 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 1000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 1000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage
@@ -494,7 +494,7 @@ PASS empty password, empty salt, SHA-256, with 1000 iterations with bad hash nam
 PASS empty password, empty salt, SHA-256, with 1000 iterations with missing deriveBits usage
 PASS empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key
 FAIL empty password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
-FAIL empty password, empty salt, SHA-256, with 100000 iterations with 0 length assert_unreached: deriveBits failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
+PASS empty password, empty salt, SHA-256, with 100000 iterations with 0 length
 FAIL Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations assert_unreached: deriveKey failed with error OperationError: The operation failed for an operation-specific reason Reached unreachable code
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with bad hash name SHA256
 PASS Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -46,14 +46,14 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHKDF::identifier() const
 
 void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || !(*length) || *length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(ExceptionCode::OperationError);
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
         [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length);
+            return *length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length) : Vector<uint8_t>();
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -45,14 +45,14 @@ CryptoAlgorithmIdentifier CryptoAlgorithmPBKDF2::identifier() const
 
 void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || !(*length) || *length % 8) {
+    if (!length || *length % 8) {
         exceptionCallback(ExceptionCode::OperationError);
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
         [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTFMove(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length);
+            return *length ? platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length) : Vector<uint8_t>();
         });
 }
 


### PR DESCRIPTION
#### cf84c972cf09376c7840489b2632f9b7098fbf97
<pre>
PBKDF2 &amp; HKDF derive bits returns an empty array when length is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=282531">https://bugs.webkit.org/show_bug.cgi?id=282531</a>

Reviewed by Sihui Liu.

This change removes the code that thrown an OperationError exception
when the &apos;length&apos; parameter got zero as value. Instead, it&apos;s been
added an early return of an empty array, avoiding the unneedded
computation of the derived bits.

The related tests has also been modified in this patch, updating their
expectations and removing the test cases that thrown an exception when
length is zero.

* LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits-expected.txt:
* LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits.html:
* LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs-expected.txt:
* LayoutTests/crypto/subtle/hkdf-derive-bits-malformed-parametrs.html:
* LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs-expected.txt:
* LayoutTests/crypto/subtle/pbkdf2-derive-bits-malformed-parametrs.html:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1-1000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_1001-2000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_2001-3000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any.worker_3001-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1-1000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_1001-2000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_2001-3000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/hkdf.https.any_3001-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1-1000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_3001-4000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1-1000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_3001-4000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_1001-2000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_2001-3000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_4001-5000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_5001-6000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_6001-7000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_7001-8000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker_8001-last-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_1001-2000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_2001-3000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_4001-5000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_5001-6000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_6001-7000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_7001-8000-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any_8001-last-expected.txt:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp:
(WebCore::CryptoAlgorithmPBKDF2::deriveBits):

Canonical link: <a href="https://commits.webkit.org/287750@main">https://commits.webkit.org/287750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/122dea0b763511571680329a835080b8d147a678

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18843 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17581 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10455 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7812 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->