### PR TITLE
[WPE][GTK][WTF] Add support for tracing counters with Sysprof

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -370,6 +370,8 @@ enum WTFOSSignpostType {
 #define WTFEmitSignpostIndirectlyWithType(type, pointer, name, timeDelta, format, ...) \
     SUPPRESS_UNCOUNTED_LOCAL os_log(WTFSignpostLogHandle(), "type=%d name=%d p=%" PRIuPTR " ts=%llu " format, type, WTFOSSignpostName ## name, reinterpret_cast<uintptr_t>(pointer), WTFCurrentContinuousTime(timeDelta), ##__VA_ARGS__)
 
+#define WTFSetCounter(name, value) do { } while (0)
+
 #elif USE(SYSPROF_CAPTURE)
 
 #define WTFEmitSignpost(pointer, name, ...) \
@@ -415,6 +417,12 @@ enum WTFOSSignpostType {
 #define WTFBeginSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) WTFBeginSignpostWithTimeDelta((pointer), name, (timeDelta), ##__VA_ARGS__)
 #define WTFEndSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) WTFEndSignpostWithTimeDelta((pointer), name, (timeDelta), ##__VA_ARGS__)
 
+#define WTFSetCounter(name, value) \
+    do { \
+        if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
+            annotator->setCounter(std::span(_STRINGIFY(name)), value); \
+    } while (0)
+
 #else
 
 #define WTFEmitSignpost(pointer, name, ...) do { } while (0)
@@ -432,5 +440,7 @@ enum WTFOSSignpostType {
 #define WTFEmitSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
 #define WTFBeginSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
 #define WTFEndSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
+
+#define WTFSetCounter(name, value) do { } while (0)
 
 #endif

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <glib.h>
 #include <sysprof-capture.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -241,6 +242,31 @@ public:
         case GPUProcessRange:
         case GTKWPEPortRange:
             break;
+        }
+    }
+
+    void setCounter(std::span<const char> name, int64_t value)
+    {
+        Locker locker { m_countersLock };
+
+        if (auto id = m_counters.getOptional(static_cast<const void*>(name.data()))) {
+            SysprofCaptureCounterValue counterValue;
+            counterValue.v64 = value;
+            sysprof_collector_set_counters(&id.value(), &counterValue, 1);
+        } else {
+            unsigned newId = sysprof_collector_request_counters(1);
+
+            m_counters.add(static_cast<const void*>(name.data()), newId);
+
+            SysprofCaptureCounter counter = { };
+            counter.id = newId;
+            counter.type = SYSPROF_CAPTURE_COUNTER_INT64;
+            counter.value.v64 = value;
+            strlcpy(counter.category, m_processName.characters(), sizeof counter.category);
+            strlcpy(counter.name, name.data(), sizeof counter.name);
+            strlcpy(counter.description, "", sizeof counter.description);
+
+            sysprof_collector_define_counters(&counter, 1);
         }
     }
 
@@ -480,6 +506,8 @@ private:
     ASCIILiteral m_processName;
     Lock m_lock;
     UncheckedKeyHashMap<RawPointerPair, TimestampAndString> m_ongoingMarks WTF_GUARDED_BY_LOCK(m_lock);
+    Lock m_countersLock;
+    UncheckedKeyHashMap<const void*, unsigned> m_counters WTF_GUARDED_BY_LOCK(m_countersLock);
     static SysprofAnnotator* s_annotator;
 };
 


### PR DESCRIPTION
#### e812b451c525841463ca33c35c160cbb2d23f894
<pre>
[WPE][GTK][WTF] Add support for tracing counters with Sysprof
<a href="https://bugs.webkit.org/show_bug.cgi?id=282535">https://bugs.webkit.org/show_bug.cgi?id=282535</a>

Reviewed by Adrian Perez de Castro.

Add a new tracing macro `WTFSetCounter(name, value)` which, on systems
with Sysprof enabled, translates to sysprof_collector_define_counters().
If the mark isn&apos;t yet registered on Sysprof, register it on demand on
first use.

This macro is a stub on Apple platforms.

As a proof of concept, implement the FPS counter tracing using the pre-
existing FPS accounting code.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperFPSCounter.cpp:
(WebCore::TextureMapperFPSCounter::updateFPSAndDisplay):

Canonical link: <a href="https://commits.webkit.org/293020@main">https://commits.webkit.org/293020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49290c041145598b994eb34f1bd6a1d5ae96b6d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74372 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13283 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88276 "Found 2 new API test failures: TestWebKitAPI.WKUserContentController.ScriptMessageHandlerBasicPostIsolatedWorld, TestWebKitAPI.WKWebExtensionAPITabs.ExecuteScriptJSONTypes (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47595 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90300 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83077 "Found 1 new API test failure: TestWebKitAPI.ApplePay.ApplePayAvailableInFrame (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104731 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96246 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18014 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82848 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18299 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29834 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119872 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24487 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33649 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->