### PR TITLE
CoreAudioCaptureSourceFactoryIOS does not need to register itself as an AudioSession observer

### DIFF
--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
 
-#include "AudioSession.h"
 #include "CoreAudioCaptureSource.h"
 #include <wtf/WeakHashSet.h>
 

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
@@ -87,12 +87,10 @@ namespace WebCore {
 CoreAudioCaptureSourceFactoryIOS::CoreAudioCaptureSourceFactoryIOS()
     : m_listener(adoptNS([[WebCoreAudioCaptureSourceIOSListener alloc] initWithCallback:this]))
 {
-    AudioSession::sharedSession().addInterruptionObserver(*this);
 }
 
 CoreAudioCaptureSourceFactoryIOS::~CoreAudioCaptureSourceFactoryIOS()
 {
-    AudioSession::sharedSession().removeInterruptionObserver(*this);
     [m_listener invalidate];
     m_listener = nullptr;
 }


### PR DESCRIPTION
#### 5e09d740b66d445af88b61841b3d8a92ac9518f1
<pre>
CoreAudioCaptureSourceFactoryIOS does not need to register itself as an AudioSession observer
<a href="https://rdar.apple.com/139198634">rdar://139198634</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282537">https://bugs.webkit.org/show_bug.cgi?id=282537</a>

Reviewed by Jean-Yves Avenard.

We no longer need to have CoreAudioCaptureSourceFactoryIOS register to AudioSession since CoreAudioCaptureSourceFactory is already doing it.

* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(WebCore::CoreAudioCaptureSourceFactoryIOS::CoreAudioCaptureSourceFactoryIOS):
(WebCore::CoreAudioCaptureSourceFactoryIOS::~CoreAudioCaptureSourceFactoryIOS):

Canonical link: <a href="https://commits.webkit.org/286144@main">https://commits.webkit.org/286144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53cad38936f976bb35cbbbedff8cd118999c1315

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17036 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21774 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8401 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4870 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->