### PR TITLE
Update API::Data::createWithoutCopying() to stop promoting manual memory management

### DIFF
--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -127,20 +127,11 @@ API::Array* WebArchive::subframeArchives()
     return m_cachedSubframeArchives.get();
 }
 
-static void releaseWebArchiveData(uint8_t*, const void* data)
-{
-    // Balanced by CFRetain in WebArchive::data().
-    CFRelease(data);
-}
-
 Ref<API::Data> WebArchive::data()
 {
-    RetainPtr<CFDataRef> rawDataRepresentation = m_legacyWebArchive->rawDataRepresentation();
-
-    // Balanced by CFRelease in releaseWebArchiveData.
-    CFRetain(rawDataRepresentation.get());
-
-    return API::Data::createWithoutCopying(span(rawDataRepresentation.get()), releaseWebArchiveData, rawDataRepresentation.get());
+    RetainPtr rawDataRepresentation = m_legacyWebArchive->rawDataRepresentation();
+    auto rawDataSpan = span(rawDataRepresentation.get());
+    return API::Data::createWithoutCopying(rawDataSpan, [rawDataRepresentation = WTFMove(rawDataRepresentation)] { });
 }
 
 LegacyWebArchive* WebArchive::coreLegacyWebArchive()

--- a/Source/WebKit/Shared/APIWebArchiveResource.mm
+++ b/Source/WebKit/Shared/APIWebArchiveResource.mm
@@ -57,24 +57,13 @@ WebArchiveResource::WebArchiveResource(RefPtr<ArchiveResource>&& archiveResource
 {
 }
 
-WebArchiveResource::~WebArchiveResource()
-{
-}
-
-static void releaseWebArchiveResourceData(uint8_t*, const void* data)
-{
-    // Balanced by CFRetain in WebArchiveResource::data().
-    CFRelease(data);
-}
+WebArchiveResource::~WebArchiveResource() = default;
 
 Ref<API::Data> WebArchiveResource::data()
 {
-    RetainPtr<CFDataRef> cfData = m_archiveResource->data().makeContiguous()->createCFData();
-
-    // Balanced by CFRelease in releaseWebArchiveResourceData.
-    CFRetain(cfData.get());
-
-    return API::Data::createWithoutCopying(span(cfData.get()), releaseWebArchiveResourceData, cfData.get());
+    RetainPtr cfData = m_archiveResource->data().makeContiguous()->createCFData();
+    auto cfDataSpan = span(cfData.get());
+    return API::Data::createWithoutCopying(cfDataSpan, [cfData = WTFMove(cfData)] { });
 }
 
 String WebArchiveResource::URL()

--- a/Source/WebKit/Shared/Cocoa/APIDataCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/APIDataCocoa.mm
@@ -32,11 +32,8 @@ namespace API {
 
 Ref<Data> Data::createWithoutCopying(RetainPtr<NSData> data)
 {
-    return createWithoutCopying(WTF::span(data.get()), [](uint8_t*, const void* data) {
-        if (!data)
-            return;
-        CFRelease(data);
-    }, static_cast<void*>(data.leakRef()));
+    auto dataSpan = WTF::span(data.get());
+    return createWithoutCopying(dataSpan, [data = WTFMove(data)] { });
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
@@ -49,11 +49,9 @@ WebAuthenticationAssertionResponse::~WebAuthenticationAssertionResponse() = defa
 RefPtr<Data> WebAuthenticationAssertionResponse::userHandle() const
 {
     RefPtr<API::Data> data;
-    if (auto* userHandle = m_response->userHandle()) {
-        userHandle->ref();
-        data = API::Data::createWithoutCopying(userHandle->span(), [] (uint8_t*, const void* data) {
-            static_cast<ArrayBuffer*>(const_cast<void*>(data))->deref();
-        }, userHandle);
+    if (RefPtr userHandle = m_response->userHandle()) {
+        auto userHandleSpan = userHandle->span();
+        data = API::Data::createWithoutCopying(userHandleSpan, [userHandle = WTFMove(userHandle)] { });
     }
     return data;
 }
@@ -61,11 +59,9 @@ RefPtr<Data> WebAuthenticationAssertionResponse::userHandle() const
 RefPtr<Data> WebAuthenticationAssertionResponse::credentialID() const
 {
     RefPtr<API::Data> data;
-    if (auto* rawId = m_response->rawId()) {
-        rawId->ref();
-        data = API::Data::createWithoutCopying(rawId->span(), [] (uint8_t*, const void* data) {
-            static_cast<ArrayBuffer*>(const_cast<void*>(data))->deref();
-        }, rawId);
+    if (RefPtr rawId = m_response->rawId()) {
+        auto rawIdSpan = rawId->span();
+        data = API::Data::createWithoutCopying(rawIdSpan, [rawId = WTFMove(rawId)] { });
     }
     return data;
 }

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -529,7 +529,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
     // Copy in the actual session state data
     CFDataGetBytes(data.get(), CFRangeMake(0, length), buffer.subspan(sizeof(uint32_t)).data());
 
-    return API::Data::createWithoutCopying(buffer, [mallocBuffer = WTFMove(mallocBuffer)] (uint8_t*, const void*) { }, nullptr);
+    return API::Data::createWithoutCopying(buffer, [mallocBuffer = WTFMove(mallocBuffer)] { });
 }
 
 class HistoryEntryDataDecoder {


### PR DESCRIPTION
#### 74c0856594bcee0f044935783cc1e77b2bbd8c8d
<pre>
Update API::Data::createWithoutCopying() to stop promoting manual memory management
<a href="https://bugs.webkit.org/show_bug.cgi?id=282545">https://bugs.webkit.org/show_bug.cgi?id=282545</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Shared/API/APIData.h:
(API::Data::createWithoutCopying):
(API::Data::create):
(API::Data::~Data):
(API::Data::Data):
(): Deleted.
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::data):
(API::releaseWebArchiveData): Deleted.
* Source/WebKit/Shared/APIWebArchiveResource.mm:
(API::WebArchiveResource::data):
(API::WebArchiveResource::~WebArchiveResource): Deleted.
(API::releaseWebArchiveResourceData): Deleted.
* Source/WebKit/Shared/Cocoa/APIDataCocoa.mm:
(API::Data::createWithoutCopying):
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.cpp:
(API::WebAuthenticationAssertionResponse::userHandle const):
(API::WebAuthenticationAssertionResponse::credentialID const):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeLegacySessionState):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp:
(WebKit::InjectedBundlePageLoaderClient::willLoadDataRequest):
(WebKit::releaseSharedBuffer): Deleted.

Canonical link: <a href="https://commits.webkit.org/286117@main">https://commits.webkit.org/286117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82ade6c864a7f04021c853a43eb704a98bde5d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26090 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46225 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67048 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66341 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8442 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4922 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3084 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->