### PR TITLE
Remove templating from TextBoxPainter

### DIFF
--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -93,7 +93,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
         if (!hasVisibleDamage)
             return;
 
-        ModernTextBoxPainter { m_inlineContent, box, m_paintInfo, m_paintOffset }.paint();
+        TextBoxPainter { m_inlineContent, box, m_paintInfo, m_paintOffset }.paint();
         return;
     }
 

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -276,10 +276,6 @@ inline void LegacyInlineFlowBox::addTextBoxVisualOverflow(LegacyInlineTextBox& t
     
     logicalVisualOverflow = LayoutRect(logicalLeftVisualOverflow, logicalTopVisualOverflow, logicalRightVisualOverflow - logicalLeftVisualOverflow, logicalBottomVisualOverflow - logicalTopVisualOverflow);
 
-    auto documentMarkerBounds = LegacyTextBoxPainter::calculateUnionOfAllDocumentMarkerBounds(textBox);
-    documentMarkerBounds.move(textBox.logicalLeft(), textBox.logicalTop());
-    logicalVisualOverflow = unionRect(logicalVisualOverflow, LayoutRect(documentMarkerBounds));
-
     textBox.setLogicalOverflowRect(logicalVisualOverflow);
 }
 

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -250,27 +250,9 @@ bool LegacyInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResu
     return false;
 }
 
-void LegacyInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset, LayoutUnit /*lineTop*/, LayoutUnit /*lineBottom*/)
+void LegacyInlineTextBox::paint(PaintInfo&, const LayoutPoint&, LayoutUnit /*lineTop*/, LayoutUnit /*lineBottom*/)
 {
-    if (isLineBreak() || !paintInfo.shouldPaintWithinRoot(renderer()) || renderer().style().usedVisibility() != Visibility::Visible
-        || paintInfo.phase == PaintPhase::Outline || !hasTextContent())
-        return;
-
-    ASSERT(paintInfo.phase != PaintPhase::SelfOutline && paintInfo.phase != PaintPhase::ChildOutlines);
-
-    LayoutUnit logicalLeftSide = logicalLeftVisualOverflow();
-    LayoutUnit logicalRightSide = logicalRightVisualOverflow();
-    LayoutUnit logicalStart = logicalLeftSide + (isHorizontal() ? paintOffset.x() : paintOffset.y());
-    LayoutUnit logicalExtent = logicalRightSide - logicalLeftSide;
-    
-    LayoutUnit paintEnd = isHorizontal() ? paintInfo.rect.maxX() : paintInfo.rect.maxY();
-    LayoutUnit paintStart = isHorizontal() ? paintInfo.rect.x() : paintInfo.rect.y();
-
-    if (logicalStart >= paintEnd || logicalStart + logicalExtent <= paintStart)
-        return;
-
-    LegacyTextBoxPainter textBoxPainter(*this, paintInfo, paintOffset);
-    textBoxPainter.paint();
+    ASSERT_NOT_REACHED();
 }
 
 TextBoxSelectableRange LegacyInlineTextBox::selectableRange() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -717,12 +717,7 @@ void RenderBoxModelObject::paintMaskForTextFillBox(GraphicsContext& context, con
         for (auto box = inlineBox->firstLeafBox(), end = inlineBox->endLeafBox(); box != end; box.traverseNextOnLine()) {
             if (!box->isText())
                 continue;
-            if (auto* legacyTextBox = downcast<LegacyInlineTextBox>(box->legacyInlineBox())) {
-                LegacyTextBoxPainter textBoxPainter(*legacyTextBox, maskInfo, paintOffset);
-                textBoxPainter.paint();
-                continue;
-            }
-            ModernTextBoxPainter textBoxPainter(box->modernPath().inlineContent(), box->modernPath().box(), maskInfo, paintOffset);
+            TextBoxPainter textBoxPainter(box->modernPath().inlineContent(), box->modernPath().box(), maskInfo, paintOffset);
             textBoxPainter.paint();
         }
         return;

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -37,7 +37,6 @@ namespace WebCore {
 
 class Color;
 class Document;
-class LegacyInlineTextBox;
 class RenderCombineText;
 class RenderStyle;
 class RenderText;
@@ -47,10 +46,9 @@ struct MarkedText;
 struct PaintInfo;
 struct StyledMarkedText;
 
-template<typename TextBoxPath>
 class TextBoxPainter {
 public:
-    TextBoxPainter(TextBoxPath&&, PaintInfo&, const LayoutPoint& paintOffset);
+    TextBoxPainter(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&, PaintInfo&, const LayoutPoint& paintOffset);
     ~TextBoxPainter();
 
     void paint();
@@ -94,9 +92,8 @@ protected:
     using DecoratingBoxList = Vector<DecoratingBox>;
     void collectDecoratingBoxesForTextBox(DecoratingBoxList&, const InlineIterator::TextBoxIterator&, FloatPoint textBoxLocation, const TextDecorationPainter::Styles&);
 
-    const ShadowData* debugTextShadow() const;
-
-    const TextBoxPath m_textBox;
+    // FIXME: We could just talk to the display box directly.
+    const InlineIterator::BoxModernPath m_textBox;
     const RenderText& m_renderer;
     const Document& m_document;
     const RenderStyle& m_style;
@@ -113,18 +110,6 @@ protected:
     const bool m_containsComposition;
     const bool m_useCustomUnderlines;
     std::optional<bool> m_emphasisMarkExistsAndIsAbove { };
-};
-
-class LegacyTextBoxPainter : public TextBoxPainter<InlineIterator::BoxLegacyPath> {
-public:
-    LegacyTextBoxPainter(const LegacyInlineTextBox&, PaintInfo&, const LayoutPoint& paintOffset);
-
-    static FloatRect calculateUnionOfAllDocumentMarkerBounds(const LegacyInlineTextBox&);
-};
-
-class ModernTextBoxPainter : public TextBoxPainter<InlineIterator::BoxModernPath> {
-public:
-    ModernTextBoxPainter(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&, PaintInfo&, const LayoutPoint& paintOffset);
 };
 
 }

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
@@ -38,7 +38,7 @@ class SVGPaintServerHandling;
 struct SVGTextFragment;
 
 template<typename TextBoxPath>
-class SVGTextBoxPainter : public TextBoxPainter<TextBoxPath> {
+class SVGTextBoxPainter {
 public:
     SVGTextBoxPainter(TextBoxPath&&, PaintInfo&, const LayoutPoint& paintOffset);
     ~SVGTextBoxPainter() = default;
@@ -47,17 +47,9 @@ public:
     void paintSelectionBackground();
 
 private:
-    using TextBoxPainter<TextBoxPath>::textBox;
-    using TextBoxPainter<TextBoxPath>::m_selectableRange;
-    using TextBoxPainter<TextBoxPath>::m_paintInfo;
-    using TextBoxPainter<TextBoxPath>::m_paintOffset;
-    using TextBoxPainter<TextBoxPath>::m_renderer;
-    using TextBoxPainter<TextBoxPath>::m_haveSelection;
-    using TextBoxPainter<TextBoxPath>::selectionStartEnd;
-
     InlineIterator::SVGTextBoxIterator textBoxIterator() const;
 
-    const RenderSVGInlineText& renderer() const; // { return downcast<RenderSVGInlineText>(m_renderer); }
+    const RenderSVGInlineText& renderer() const { return m_renderer; }
     const RenderBoxModelObject& parentRenderer() const;
     OptionSet<RenderSVGResourceMode> paintingResourceMode() const { return m_paintingResourceMode; }
 
@@ -76,6 +68,14 @@ private:
     bool mapStartEndPositionsIntoFragmentCoordinates(const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
 
     TextRun constructTextRun(const RenderStyle&, const SVGTextFragment&) const;
+    std::pair<unsigned, unsigned> selectionStartEnd() const;
+
+    const TextBoxPath m_textBox;
+    const RenderSVGInlineText& m_renderer;
+    PaintInfo& m_paintInfo;
+    const TextBoxSelectableRange m_selectableRange;
+    const LayoutPoint m_paintOffset;
+    const bool m_haveSelection;
 
     OptionSet<RenderSVGResourceMode> m_paintingResourceMode;
     LegacyRenderSVGResource* m_legacyPaintingResource { nullptr };


### PR DESCRIPTION
#### 491ccb3337ce2d1fefdbe9e71e8dbec8735b6850
<pre>
Remove templating from TextBoxPainter
<a href="https://bugs.webkit.org/show_bug.cgi?id=282548">https://bugs.webkit.org/show_bug.cgi?id=282548</a>
<a href="https://rdar.apple.com/139215702">rdar://139215702</a>

Reviewed by Alan Baradlay.

It is only used for painting IFC text boxes so does not need path templating anymore.

This patch still acceses the boxes somewhat unnecessarily via InlineIterator::BoxModernPath
to limit the scope. Direct access to display boxes can be factored in later.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addTextBoxVisualOverflow):
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::paint):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::paintMaskForTextFillBox):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::TextBoxPainter):
(WebCore::TextBoxPainter::~TextBoxPainter):
(WebCore::TextBoxPainter::makeIterator const):
(WebCore::TextBoxPainter::paint):
(WebCore::TextBoxPainter::selectionStartEnd const):
(WebCore::TextBoxPainter::createMarkedTextFromSelectionInBox):
(WebCore::TextBoxPainter::paintBackground):
(WebCore::TextBoxPainter::paintCompositionForeground):
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
(WebCore::TextBoxPainter::paintCompositionBackground):
(WebCore::TextBoxPainter::paintForeground):
(WebCore::TextBoxPainter::createDecorationPainter):
(WebCore::TextBoxPainter::collectDecoratingBoxesForTextBox):
(WebCore::TextBoxPainter::paintBackgroundDecorations):
(WebCore::TextBoxPainter::paintForegroundDecorations):
(WebCore::layoutBoxSequenceLocation):
(WebCore::TextBoxPainter::fillCompositionUnderline const):
(WebCore::TextBoxPainter::paintCompositionUnderlines):
(WebCore::TextBoxPainter::textPosition):
(WebCore::TextBoxPainter::paintCompositionUnderline):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):
(WebCore::TextBoxPainter::paintPlatformDocumentMarker):
(WebCore::TextBoxPainter::computePaintRect):
(WebCore::TextBoxPainter::computeHaveSelection const):
(WebCore::TextBoxPainter::fontCascade const):
(WebCore::TextBoxPainter::textOriginFromPaintRect const):
(WebCore::LegacyTextBoxPainter::LegacyTextBoxPainter): Deleted.
(): Deleted.
(WebCore::ModernTextBoxPainter::ModernTextBoxPainter): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::TextBoxPainter): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::~TextBoxPainter): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::makeIterator const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paint): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::selectionStartEnd const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::createMarkedTextFromSelectionInBox): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintBackground): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionForeground): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundAndDecorations): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionBackground): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForeground): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::createDecorationPainter): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::collectDecoratingBoxesForTextBox): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintBackgroundDecorations): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundDecorations): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fillCompositionUnderline const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionUnderlines): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::textPosition): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionUnderline): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarkers): Deleted.
(WebCore::LegacyTextBoxPainter::calculateUnionOfAllDocumentMarkerBounds): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::computePaintRect): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::computeHaveSelection const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fontCascade const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::textOriginFromPaintRect const): Deleted.
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::debugTextShadow const): Deleted.
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::SVGTextBoxPainter):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::textBoxIterator const):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::mapStartEndPositionsIntoFragmentCoordinates const):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::constructTextRun const):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::selectionStartEnd const):
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::renderer const): Deleted.
* Source/WebCore/rendering/svg/SVGTextBoxPainter.h:

Don&apos;t inherit SVGTextBoxPainter from TextBoxPainter. It was hardly used in any case.

(WebCore::SVGTextBoxPainter::renderer const):

Canonical link: <a href="https://commits.webkit.org/286107@main">https://commits.webkit.org/286107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19cd8a9e1f56f79b4d7544c59a9871d4c556096a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79281 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46230 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/21823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80768 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1314 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67049 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16477 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8441 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/4924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->