### PR TITLE
[JSC] Butterfly needs to initialize vector range

### DIFF
--- a/JSTests/stress/vector-values-need-to-be-initialized-for-regexp-atom-fast-path.js
+++ b/JSTests/stress/vector-values-need-to-be-initialized-for-regexp-atom-fast-path.js
@@ -1,0 +1,48 @@
+var var_1_ = 'var_4_';
+var_1_ = var_1_ + var_1_;
+var var_2_ = /var_4_/g[Symbol.match](var_1_);
+const var_3_ = [
+  ,
+  (() => {
+    try {
+      var_2_.length += var_2_.length;
+      const var_10_ = `
+for (let var_7_ = (function func_1_() {return func_1_.arguments[0]})(0);
+var_7_ < 100;
+var_7_++) {
+try
+{
+try
+{
+var var_11_ = ArrayBuffer.prototype.slice.call(var_5_,4005839658, 35318-4005839658);
+} finally {
+var_13_ = 1 / var_2_.length;
+var_13_ = 1 / var_2_.length;
+var_5_ = new SharedArrayBuffer(4);
+}
+}
+catch(var_9_) {
+while (var_1_.length < 200000)
+}
+}
+`;
+      const var_8_ = eval?.(var_10_);
+      for (let var_6_ = 0; var_6_ < 1000000; ++var_6_) {
+        String.prototype.blink.__proto__ = Intl.PluralRules.prototype;
+      }
+    } catch {
+      const z50138 = [0.4, 1145324612];
+      const z86027 = [0.4, 1145324612];
+      const z692631 = [0.4, 1145324612];
+      const z306626 = [0.4, 1145324612];
+      edenGC({'g': 5});
+      const z24352 = [0.4, 1145324612];
+      const z594993 = [0.4, 1145324612];
+      const z170652 = [0.4, 1145324612];
+      const z356061 = [0.4, 1145324612];
+      const z96659 = [0.4, 1145324612];
+      const z413229 = [0.4, 1145324612];
+    }
+    var var_12_ = var_2_[1].padStart(-2974.820125862534 && 2 ** 31 - 1, 'aa');
+  })()
+];

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -342,9 +342,13 @@ ALWAYS_INLINE JSArray* tryCreateContiguousArrayWithPattern(JSGlobalObject* globa
 
 #if OS(DARWIN)
     memset_pattern8(static_cast<void*>(butterfly->contiguous().data()), &pattern, sizeof(EncodedJSValue) * initialLength);
+    if (vectorLength > initialLength)
+        memset(static_cast<void*>(butterfly->contiguous().data() + initialLength), 0, sizeof(EncodedJSValue) * (vectorLength - initialLength));
 #else
     for (unsigned i = 0; i < initialLength; ++i)
         butterfly->contiguous().atUnsafe(i).setWithoutWriteBarrier(pattern);
+    for (unsigned i = initialLength; i < vectorLength; ++i)
+        butterfly->contiguous().atUnsafe(i).clear();
 #endif
     return JSArray::createWithButterfly(vm, nullptr, structure, butterfly);
 }


### PR DESCRIPTION
#### 101cf7bb5c9cef1a754bc87439247bb39ea7838f
<pre>
[JSC] Butterfly needs to initialize vector range
<a href="https://bugs.webkit.org/show_bug.cgi?id=282551">https://bugs.webkit.org/show_bug.cgi?id=282551</a>
<a href="https://rdar.apple.com/138178624">rdar://138178624</a>

Reviewed by Yijia Huang.

We must initialize vector length range in the butterfly when creating a
fast butterfly for RegExp atom path.

* JSTests/stress/vector-values-need-to-be-initialized-for-regexp-atom-fast-path.js: Added.
(try.const.var_10_.let.var_7_):
(try.var_7_.catch):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::tryCreateContiguousArrayWithPattern):

Canonical link: <a href="https://commits.webkit.org/286118@main">https://commits.webkit.org/286118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a0aedb932faef469588036f1cebcb5830d0940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27685 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79296 "Hash c4a0aedb for PR 36138 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2083 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/79296 "Hash c4a0aedb for PR 36138 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17078 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64337 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/79296 "Hash c4a0aedb for PR 36138 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21835 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68005 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80782 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74126 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1320 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66358 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8452 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96397 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11555 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2151 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->