### PR TITLE
Replace autoFill with autofill for spelling consistency

### DIFF
--- a/LayoutTests/accessibility/auto-fill-crash.html
+++ b/LayoutTests/accessibility/auto-fill-crash.html
@@ -18,7 +18,7 @@
         var axTextField = accessibilityController.accessibleElementById("textfield");
         var domTextField = document.getElementById("textfield");
 
-        window.internals.setShowAutoFillButton(domTextField, "Contacts");
+        window.internals.setAutofillButtonType(domTextField, "Contacts");
         var expectedChildrenCount = platformName == "atspi" ? "1" : "2";
         setTimeout(async function() {
             await expectAsyncExpression("axTextField.childrenCount", expectedChildrenCount);
@@ -26,7 +26,7 @@
             await expectAsyncExpression("axTextField.childAtIndex(expectedChildrenCount - 1).description", "'AXDescription: contact info AutoFill'");
 
             // Don't crash!
-            window.internals.setShowAutoFillButton(domTextField, "None");
+            window.internals.setAutofillButtonType(domTextField, "None");
             await expectAsyncExpression("axTextField.childrenCount", platformName == "atspi" ? "0" : "1");
 
             finishJSTest();

--- a/LayoutTests/accessibility/auto-fill-types.html
+++ b/LayoutTests/accessibility/auto-fill-types.html
@@ -19,7 +19,7 @@
         output += `Initial auto-fill available: ${axTextField.boolAttributeValue("AXValueAutofillAvailable")}\n`;
         output += `Auto-fill type: ${axTextField.stringAttributeValue("AXValueAutofillType")}\n`;
 
-        window.internals.setShowAutoFillButton(document.getElementById("textfield"), "Contacts");
+        window.internals.setAutofillButtonType(document.getElementById("textfield"), "Contacts");
         setTimeout(async function() {
             let contactsButton = null;
             // Wait for contacts autofill button to render.
@@ -31,7 +31,7 @@
             output += `Contact button label: ${contactsButton.description}\n`;
             output += `Auto-fill type: ${axTextField.stringAttributeValue("AXValueAutofillType")}\n`;
 
-            window.internals.setShowAutoFillButton(document.getElementById("textfield"), "Credentials");
+            window.internals.setAutofillButtonType(document.getElementById("textfield"), "Credentials");
             // Wait for credentials autofill button to render.
             let credentialsButton = null;
             await waitFor(() => {

--- a/LayoutTests/accessibility/ios-simulator/strong-password-field.html
+++ b/LayoutTests/accessibility/ios-simulator/strong-password-field.html
@@ -23,7 +23,7 @@
 
     if (window.internals) {
         window.internals.setAutofilled(pw2, true);
-        window.internals.setShowAutoFillButton(pw2, "StrongPassword");
+        window.internals.setAutofillButtonType(pw2, "StrongPassword");
     }
 
     if (window.accessibilityController) {

--- a/LayoutTests/accessibility/secure-field-value.html
+++ b/LayoutTests/accessibility/secure-field-value.html
@@ -21,15 +21,15 @@ if (window.accessibilityController) {
     output += `#autofill-input value before being obscured: ${lastAutofillValue}\n`;
 
     output += "Making #autofill-input obscured.\n";
-    window.internals.setAutoFilledAndObscured(document.getElementById("autofill-input"), true);
+    window.internals.setAutofilledAndObscured(document.getElementById("autofill-input"), true);
     setTimeout(async function() {
         await waitFor(() => lastAutofillValue !== autofillInput.stringValue);
         lastAutofillValue = autofillInput.stringValue;
         output += `#autofill-input value after being obscured: ${autofillInput.stringValue}\n`;
 
         output += "Making #autofill-input viewable.\n";
-        window.internals.setAutoFilledAndObscured(document.getElementById("autofill-input"), false);
-        window.internals.setAutoFilledAndViewable(document.getElementById("autofill-input"), true);
+        window.internals.setAutofilledAndObscured(document.getElementById("autofill-input"), false);
+        window.internals.setAutofilledAndViewable(document.getElementById("autofill-input"), true);
         await waitFor(() => lastAutofillValue !== autofillInput.stringValue);
         output += `#autofill-input value after being made viewable: ${autofillInput.stringValue}\n`;
 

--- a/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html
@@ -22,7 +22,7 @@ function handleCapsLockEnabled(event)
     console.assert(event.key === "CapsLock");
     let input = document.querySelector("input");
     internals.setAutofilled(input, false);
-    internals.setShowAutoFillButton(input, "None");
+    internals.setAutofillButtonType(input, "None");
 
     // Move the caret to the beginning of the field to ensure consistent test results.
     input.setSelectionRange(0, 0);
@@ -38,7 +38,7 @@ async function runTest()
 
     let input = document.querySelector("input");
     internals.setAutofilled(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofillButtonType(input, "StrongPassword");
 
     function handleFocus(event) {
         console.assert(event.target === input);

--- a/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible-expected.html
@@ -25,7 +25,7 @@ async function runTest()
 
     let input = document.querySelector("input");
     internals.setAutofilled(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofillButtonType(input, "StrongPassword");
 
     input.addEventListener("focus", () => testRunner.notifyDone(), { once: true });
     await UIHelper.activateElement(input);

--- a/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html
+++ b/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html
@@ -31,7 +31,7 @@ async function runTest()
 
     let input = document.querySelector("input");
     internals.setAutofilled(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofillButtonType(input, "StrongPassword");
 
     function handleFocus(event) {
         console.assert(event.target === input);

--- a/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-disabled.html
+++ b/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-disabled.html
@@ -10,7 +10,7 @@ if (window.testRunner)
 var password = document.getElementById("password");
 
 if (window.internals)
-    internals.setShowAutoFillButton(password, "Credentials");
+    internals.setAutofillButtonType(password, "Credentials");
 
 function makeFieldDisabledAndNotifyDone()
 {

--- a/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html
+++ b/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html
@@ -10,7 +10,7 @@ if (window.testRunner)
 var password = document.getElementById("password");
 
 if (window.internals)
-    internals.setShowAutoFillButton(password, "Credentials");
+    internals.setAutofillButtonType(password, "Credentials");
 
 function makeFieldReadOnlyAndNotifyDone()
 {

--- a/LayoutTests/fast/forms/auto-fill-button/input-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-auto-fill-button.html
@@ -8,14 +8,14 @@
 if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i)
-        window.internals.setShowAutoFillButton(inputs[i], "Credentials");
+        window.internals.setAutofillButtonType(inputs[i], "Credentials");
 
     var dynamicInput = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput, "Credentials");
+    window.internals.setAutofillButtonType(dynamicInput, "Credentials");
     document.querySelector("#container").appendChild(dynamicInput);
 
     var dynamicInput2 = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput2, "Credentials");
+    window.internals.setAutofillButtonType(dynamicInput2, "Credentials");
     document.querySelector("#container").appendChild(dynamicInput2);
     dynamicInput2.setAttribute("type", "password");
 }

--- a/LayoutTests/fast/forms/auto-fill-button/input-auto-filled-and-obscured.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-auto-filled-and-obscured.html
@@ -14,11 +14,11 @@
 if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i) {
-        window.internals.setAutoFilledAndObscured(inputs[i], true);
+        window.internals.setAutofilledAndObscured(inputs[i], true);
     }
 
     var dynamicInput = document.createElement("input");
-    window.internals.setAutoFilledAndObscured(dynamicInput, true);
+    window.internals.setAutofilledAndObscured(dynamicInput, true);
     document.querySelector("#container").appendChild(dynamicInput);
 }
 </script>

--- a/LayoutTests/fast/forms/auto-fill-button/input-contacts-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-contacts-auto-fill-button.html
@@ -11,19 +11,19 @@
 if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i)
-        window.internals.setShowAutoFillButton(inputs[i], "Contacts");
+        window.internals.setAutofillButtonType(inputs[i], "Contacts");
 
     var dynamicInput = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput, "Contacts");
+    window.internals.setAutofillButtonType(dynamicInput, "Contacts");
     document.querySelector("#container").appendChild(dynamicInput);
 
     var dynamicInput2 = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput2, "Contacts");
+    window.internals.setAutofillButtonType(dynamicInput2, "Contacts");
     document.querySelector("#container").appendChild(dynamicInput2);
     dynamicInput2.setAttribute("name", "address");
 
     var dynamicInput3 = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput3, "Contacts");
+    window.internals.setAutofillButtonType(dynamicInput3, "Contacts");
     document.querySelector("#container").appendChild(dynamicInput3);
     dynamicInput3.setAttribute("name", "phone_number");
 }

--- a/LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button.html
@@ -12,10 +12,10 @@
 if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i)
-        window.internals.setShowAutoFillButton(inputs[i], "CreditCard");
+        window.internals.setAutofillButtonType(inputs[i], "CreditCard");
 
     var dynamicInput = document.createElement("input");
-    window.internals.setShowAutoFillButton(dynamicInput, "CreditCard");
+    window.internals.setAutofillButtonType(dynamicInput, "CreditCard");
     document.querySelector("#container").appendChild(dynamicInput);
 }
 </script>

--- a/LayoutTests/fast/forms/auto-fill-button/input-disabled-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-disabled-auto-fill-button.html
@@ -5,7 +5,7 @@
 <input type="password" id="password" placeholder="disabled" disabled autofocus>
 <script>
 if (window.internals)
-    internals.setShowAutoFillButton(document.getElementById("password"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("password"), "Credentials");
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-loading-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-loading-auto-fill-button.html
@@ -7,7 +7,7 @@
 
 if (window.internals) {
     const input = document.querySelector("input");
-    window.internals?.setShowAutoFillButton(input, "Loading");
+    window.internals?.setAutofillButtonType(input, "Loading");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/input-readonly-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-readonly-auto-fill-button.html
@@ -5,7 +5,7 @@
 <input type="password" id="password" placeholder="read only" readonly autofocus>
 <script>
 if (window.internals)
-    internals.setShowAutoFillButton(document.getElementById("password"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("password"), "Credentials");
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-readonly-non-empty-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-readonly-non-empty-auto-fill-button.html
@@ -5,7 +5,7 @@
 <input type="password" id="password" value="read only" readonly autofocus>
 <script>
 if (window.internals)
-    internals.setShowAutoFillButton(document.getElementById("password"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("password"), "Credentials");
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html
@@ -15,12 +15,12 @@ if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i) {
         window.internals.setAutofilled(inputs[i], true);
-        window.internals.setShowAutoFillButton(inputs[i], "StrongPassword");
+        window.internals.setAutofillButtonType(inputs[i], "StrongPassword");
     }
 
     var dynamicInput = document.createElement("input");
     window.internals.setAutofilled(dynamicInput, true);
-    window.internals.setShowAutoFillButton(dynamicInput, "StrongPassword");
+    window.internals.setAutofillButtonType(dynamicInput, "StrongPassword");
     document.querySelector("#container").appendChild(dynamicInput);
 }
 </script>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html
@@ -20,8 +20,8 @@ input {
 <script>
 if (window.internals) {
     var input = document.querySelector("input");
-    internals.setAutoFilledAndViewable(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofilledAndViewable(input, true);
+    internals.setAutofillButtonType(input, "StrongPassword");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html
@@ -33,8 +33,8 @@ input {
 <script>
 if (window.internals) {
     var input = document.querySelector("input");
-    internals.setAutoFilledAndViewable(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofilledAndViewable(input, true);
+    internals.setAutofillButtonType(input, "StrongPassword");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html
@@ -34,8 +34,8 @@ input {
 <script>
 if (window.internals) {
     var input = document.querySelector("input");
-    internals.setAutoFilledAndViewable(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofilledAndViewable(input, true);
+    internals.setAutofillButtonType(input, "StrongPassword");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html
@@ -24,8 +24,8 @@ input::-webkit-strong-password-auto-fill-button {
 <script>
 if (window.internals) {
     var input = document.querySelector("input");
-    internals.setAutoFilledAndViewable(input, true);
-    internals.setShowAutoFillButton(input, "StrongPassword");
+    internals.setAutofilledAndViewable(input, true);
+    internals.setAutofillButtonType(input, "StrongPassword");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable.html
@@ -14,11 +14,11 @@
 if (window.internals) {
     var inputs = document.querySelectorAll("input");
     for (var i = 0; i < inputs.length; ++i) {
-        window.internals.setAutoFilledAndViewable(inputs[i], true);
+        window.internals.setAutofilledAndViewable(inputs[i], true);
     }
 
     var dynamicInput = document.createElement("input");
-    window.internals.setAutoFilledAndViewable(dynamicInput, true);
+    window.internals.setAutofilledAndViewable(dynamicInput, true);
     document.querySelector("#container").appendChild(dynamicInput);
 }
 </script>

--- a/LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type-expected.txt
+++ b/LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type-expected.txt
@@ -3,25 +3,25 @@ This tests that querying for the last auto fill button type works. This test mus
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS internals.autoFillButtonType(inputElement) is "None"
-internals.setShowAutoFillButton(inputElement, 'Credentials')
-PASS internals.autoFillButtonType(inputElement) is "Credentials"
-PASS internals.lastAutoFillButtonType(inputElement) is "None"
-internals.setShowAutoFillButton(inputElement, 'Contacts')
-PASS internals.autoFillButtonType(inputElement) is "Contacts"
-PASS internals.lastAutoFillButtonType(inputElement) is "Credentials"
-internals.setShowAutoFillButton(inputElement, 'StrongPassword')
-PASS internals.autoFillButtonType(inputElement) is "StrongPassword"
-PASS internals.lastAutoFillButtonType(inputElement) is "Contacts"
-internals.setShowAutoFillButton(inputElement, 'Credentials')
-PASS internals.autoFillButtonType(inputElement) is "Credentials"
-PASS internals.lastAutoFillButtonType(inputElement) is "StrongPassword"
-internals.setShowAutoFillButton(inputElement, 'CreditCard')
-PASS internals.autoFillButtonType(inputElement) is "CreditCard"
-PASS internals.lastAutoFillButtonType(inputElement) is "Credentials"
-internals.setShowAutoFillButton(inputElement, 'None')
-PASS internals.autoFillButtonType(inputElement) is "None"
-PASS internals.lastAutoFillButtonType(inputElement) is "CreditCard"
+PASS internals.autofillButtonType(inputElement) is "None"
+internals.setAutofillButtonType(inputElement, 'Credentials')
+PASS internals.autofillButtonType(inputElement) is "Credentials"
+PASS internals.lastAutofillButtonType(inputElement) is "None"
+internals.setAutofillButtonType(inputElement, 'Contacts')
+PASS internals.autofillButtonType(inputElement) is "Contacts"
+PASS internals.lastAutofillButtonType(inputElement) is "Credentials"
+internals.setAutofillButtonType(inputElement, 'StrongPassword')
+PASS internals.autofillButtonType(inputElement) is "StrongPassword"
+PASS internals.lastAutofillButtonType(inputElement) is "Contacts"
+internals.setAutofillButtonType(inputElement, 'Credentials')
+PASS internals.autofillButtonType(inputElement) is "Credentials"
+PASS internals.lastAutofillButtonType(inputElement) is "StrongPassword"
+internals.setAutofillButtonType(inputElement, 'CreditCard')
+PASS internals.autofillButtonType(inputElement) is "CreditCard"
+PASS internals.lastAutofillButtonType(inputElement) is "Credentials"
+internals.setAutofillButtonType(inputElement, 'None')
+PASS internals.autofillButtonType(inputElement) is "None"
+PASS internals.lastAutofillButtonType(inputElement) is "CreditCard"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type.html
+++ b/LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type.html
@@ -12,25 +12,25 @@ if (!window.internals)
     testFailed("Must be run in WebKitTestRunner or DumpRenderTree");
 else {
     var inputElement = document.getElementById("input");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "None");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'Credentials')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "Credentials");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "None");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'Contacts')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "Contacts");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "Credentials");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'StrongPassword')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "StrongPassword");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "Contacts");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'Credentials')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "Credentials");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "StrongPassword");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'CreditCard')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "CreditCard");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "Credentials");
-    evalAndLog("internals.setShowAutoFillButton(inputElement, 'None')");
-    shouldBeEqualToString("internals.autoFillButtonType(inputElement)", "None");
-    shouldBeEqualToString("internals.lastAutoFillButtonType(inputElement)", "CreditCard");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "None");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'Credentials')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "Credentials");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "None");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'Contacts')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "Contacts");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "Credentials");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'StrongPassword')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "StrongPassword");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "Contacts");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'Credentials')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "Credentials");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "StrongPassword");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'CreditCard')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "CreditCard");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "Credentials");
+    evalAndLog("internals.setAutofillButtonType(inputElement, 'None')");
+    shouldBeEqualToString("internals.autofillButtonType(inputElement)", "None");
+    shouldBeEqualToString("internals.lastAutofillButtonType(inputElement)", "CreditCard");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html
@@ -22,7 +22,7 @@ function runTest()
     if (!window.internals || !window.eventSender)
         return;
 
-    internals.setShowAutoFillButton(password, "Credentials");
+    internals.setAutofillButtonType(password, "Credentials");
 
     var autoFillButton = getElementByPseudoId(internals.shadowRoot(password), "-webkit-credentials-auto-fill-button");
     autoFillButton.onclick = checkEventAndDone;

--- a/LayoutTests/fast/forms/auto-fill-button/resources/process-auto-fill-button-type-and-invoke-runTest.js
+++ b/LayoutTests/fast/forms/auto-fill-button/resources/process-auto-fill-button-type-and-invoke-runTest.js
@@ -7,8 +7,8 @@ window.onload = function ()
     let inputElements = document.getElementsByTagName("input");
     for (let inputElement of inputElements) {
         internals.setAutofilled(inputElement, inputElement.dataset.autofilled == "true");
-	internals.setAutoFilledAndViewable(inputElement, inputElement.dataset.autoFilledAndViewable == "true");
-        internals.setShowAutoFillButton(inputElement, inputElement.dataset.autoFillButtonType);
+	internals.setAutofilledAndViewable(inputElement, inputElement.dataset.autoFilledAndViewable == "true");
+        internals.setAutofillButtonType(inputElement, inputElement.dataset.autoFillButtonType);
     }
     if (window.runTest)
         window.runTest();

--- a/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html
+++ b/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html
@@ -18,7 +18,7 @@ async function runTest() {
 
     await UIHelper.activateElement(input);
 
-    internals.setShowAutoFillButton(input, "Credentials");
+    internals.setAutofillButtonType(input, "Credentials");
 
     await UIHelper.renderingUpdate();
 

--- a/LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes-expected.html
@@ -6,8 +6,8 @@
 <input id="contacts">
 <script>
 if (window.internals) {
-    internals.setShowAutoFillButton(document.getElementById("credentials"), "Contacts");
-    internals.setShowAutoFillButton(document.getElementById("contacts"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("credentials"), "Contacts");
+    internals.setAutofillButtonType(document.getElementById("contacts"), "Credentials");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes.html
+++ b/LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes.html
@@ -6,11 +6,11 @@
 <input id="contacts">
 <script>
 if (window.internals) {
-    internals.setShowAutoFillButton(document.getElementById("credentials"), "Credentials");
-    internals.setShowAutoFillButton(document.getElementById("credentials"), "Contacts");
+    internals.setAutofillButtonType(document.getElementById("credentials"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("credentials"), "Contacts");
 
-    internals.setShowAutoFillButton(document.getElementById("contacts"), "Contacts");
-    internals.setShowAutoFillButton(document.getElementById("contacts"), "Credentials");
+    internals.setAutofillButtonType(document.getElementById("contacts"), "Contacts");
+    internals.setAutofillButtonType(document.getElementById("contacts"), "Credentials");
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/input-autofilled-and-obscured-clear-field-programatically.html
+++ b/LayoutTests/fast/forms/input-autofilled-and-obscured-clear-field-programatically.html
@@ -13,7 +13,7 @@
         var originalBackground = computedStyle.backgroundColor;
 
         if (window.internals) {
-            window.internals.setAutoFilledAndObscured(tf, true);
+            window.internals.setAutofilledAndObscured(tf, true);
         }
 
         // Both the foreground and background colors should change.

--- a/LayoutTests/fast/forms/input-autofilled-and-obscured-clear-form-programatically.html
+++ b/LayoutTests/fast/forms/input-autofilled-and-obscured-clear-form-programatically.html
@@ -13,7 +13,7 @@
         var originalBackground = computedStyle.backgroundColor;
 
         if (window.internals) {
-            window.internals.setAutoFilledAndObscured(tf, true);
+            window.internals.setAutofilledAndObscured(tf, true);
         }
 
         // Both the foreground and background colors should change.

--- a/LayoutTests/fast/forms/input-autofilled-and-obscured.html
+++ b/LayoutTests/fast/forms/input-autofilled-and-obscured.html
@@ -13,7 +13,7 @@
         var originalBackground = computedStyle.backgroundColor;
 
         if (window.internals) {
-            window.internals.setAutoFilledAndObscured(tf, true);
+            window.internals.setAutofilledAndObscured(tf, true);
         }
 
         // Both the foreground and background colors should change.

--- a/LayoutTests/fast/forms/input-autofilled-and-viewable.html
+++ b/LayoutTests/fast/forms/input-autofilled-and-viewable.html
@@ -13,7 +13,7 @@
         var originalBackground = computedStyle.backgroundColor;
 
         if (window.internals) {
-            window.internals.setAutoFilledAndViewable(tf, true);
+            window.internals.setAutofilledAndViewable(tf, true);
         }
 
         // Both the foreground and background colors should change.

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3064,7 +3064,7 @@ bool AccessibilityObject::isValueAutofillAvailable() const
         return false;
 
     RefPtr input = dynamicDowncast<HTMLInputElement>(node());
-    return input && (input->isAutoFillAvailable() || input->autoFillButtonType() != AutoFillButtonType::None);
+    return input && (input->autofillAvailable() || input->autofillButtonType() != AutoFillButtonType::None);
 }
 
 AutoFillButtonType AccessibilityObject::valueAutofillButtonType() const
@@ -3072,7 +3072,7 @@ AutoFillButtonType AccessibilityObject::valueAutofillButtonType() const
     if (!isValueAutofillAvailable())
         return AutoFillButtonType::None;
     
-    return downcast<HTMLInputElement>(*this->node()).autoFillButtonType();
+    return downcast<HTMLInputElement>(*this->node()).autofillButtonType();
 }
 
 bool AccessibilityObject::isSelected() const

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -66,25 +66,25 @@ namespace WebCore {
 ALWAYS_INLINE bool isAutofilled(const Element& element)
 {
     auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
-    return inputElement && inputElement->isAutoFilled();
+    return inputElement && inputElement->autofilled();
 }
 
 ALWAYS_INLINE bool isAutofilledStrongPassword(const Element& element)
 {
     auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
-    return inputElement && inputElement->isAutoFilled() && inputElement->hasAutoFillStrongPasswordButton();
+    return inputElement && inputElement->autofilled() && inputElement->hasAutofillStrongPasswordButton();
 }
 
 ALWAYS_INLINE bool isAutofilledStrongPasswordViewable(const Element& element)
 {
     auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
-    return inputElement && inputElement->isAutoFilledAndViewable();
+    return inputElement && inputElement->autofilledAndViewable();
 }
 
 ALWAYS_INLINE bool isAutofilledAndObscured(const Element& element)
 {
     auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
-    return inputElement && inputElement->isAutoFilledAndObscured();
+    return inputElement && inputElement->autofilledAndObscured();
 }
 
 ALWAYS_INLINE bool matchesDefaultPseudoClass(const Element& element)

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -371,7 +371,7 @@ static bool shouldIgnoreNodeInTextField(const Node& node)
     if (!input)
         return false;
 
-    return input->lastChangeWasUserEdit() || input->isAutoFilled();
+    return input->lastChangeWasUserEdit() || input->autofilled();
 }
 
 TextManipulationController::ManipulationUnit TextManipulationController::createUnit(const Vector<String>& text, Node& textNode)

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -716,7 +716,7 @@ bool VisibleSelection::canEnableWritingSuggestions() const
 bool VisibleSelection::isInAutoFilledAndViewableField() const
 {
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(enclosingTextFormControl(start())))
-        return input->isAutoFilledAndViewable();
+        return input->autofilledAndViewable();
     return false;
 }
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -508,11 +508,11 @@ void HTMLInputElement::setType(const AtomString& type)
 
 void HTMLInputElement::resignStrongPasswordAppearance()
 {
-    if (!hasAutoFillStrongPasswordButton())
+    if (!hasAutofillStrongPasswordButton())
         return;
-    setAutoFilled(false);
-    setAutoFilledAndViewable(false);
-    setShowAutoFillButton(AutoFillButtonType::None);
+    setAutofilled(false);
+    setAutofilledAndViewable(false);
+    setAutofillButtonType(AutoFillButtonType::None);
     if (auto* page = document().page())
         page->chrome().client().inputElementDidResignStrongPasswordAppearance(*this);
 }
@@ -1037,10 +1037,10 @@ void HTMLInputElement::reset()
     }
 
     setInteractedWithSinceLastFormSubmitEvent(false);
-    setAutoFilled(false);
-    setAutoFilledAndViewable(false);
-    setAutoFilledAndObscured(false);
-    setShowAutoFillButton(AutoFillButtonType::None);
+    setAutofilled(false);
+    setAutofilledAndViewable(false);
+    setAutofilledAndObscured(false);
+    setAutofillButtonType(AutoFillButtonType::None);
     setChecked(hasAttributeWithoutSynchronization(checkedAttr));
     m_dirtyCheckednessFlag = false;
 }
@@ -1199,7 +1199,7 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
         resignStrongPasswordAppearance();
 
         if (m_isAutoFilledAndObscured)
-            setAutoFilledAndObscured(false);
+            setAutofilledAndObscured(false);
     }
 
     return { };
@@ -1266,16 +1266,16 @@ void HTMLInputElement::setValueFromRenderer(const String& value)
     updateValidity();
 
     // We clear certain AutoFill flags here because this catches user edits.
-    setAutoFilled(false);
+    setAutofilled(false);
 
     if (!value.isEmpty())
         return;
 
     if (m_isAutoFilledAndViewable)
-        setAutoFilledAndViewable(false);
+        setAutofilledAndViewable(false);
 
     if (m_isAutoFilledAndObscured)
-        setAutoFilledAndObscured(false);
+        setAutofilledAndObscured(false);
 }
 
 void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& state)
@@ -1530,7 +1530,7 @@ URL HTMLInputElement::src() const
     return document().completeURL(attributeWithoutSynchronization(srcAttr));
 }
 
-void HTMLInputElement::setAutoFilled(bool autoFilled)
+void HTMLInputElement::setAutofilled(bool autoFilled)
 {
     if (autoFilled == m_isAutoFilled)
         return;
@@ -1539,7 +1539,7 @@ void HTMLInputElement::setAutoFilled(bool autoFilled)
     m_isAutoFilled = autoFilled;
 }
 
-void HTMLInputElement::setAutoFilledAndViewable(bool autoFilledAndViewable)
+void HTMLInputElement::setAutofilledAndViewable(bool autoFilledAndViewable)
 {
     if (autoFilledAndViewable == m_isAutoFilledAndViewable)
         return;
@@ -1548,7 +1548,7 @@ void HTMLInputElement::setAutoFilledAndViewable(bool autoFilledAndViewable)
     m_isAutoFilledAndViewable = autoFilledAndViewable;
 }
 
-void HTMLInputElement::setAutoFilledAndObscured(bool autoFilledAndObscured)
+void HTMLInputElement::setAutofilledAndObscured(bool autoFilledAndObscured)
 {
     if (autoFilledAndObscured == m_isAutoFilledAndObscured)
         return;
@@ -1560,9 +1560,9 @@ void HTMLInputElement::setAutoFilledAndObscured(bool autoFilledAndObscured)
         cache->onTextSecurityChanged(*this);
 }
 
-void HTMLInputElement::setShowAutoFillButton(AutoFillButtonType autoFillButtonType)
+void HTMLInputElement::setAutofillButtonType(AutoFillButtonType autoFillButtonType)
 {
-    if (autoFillButtonType == this->autoFillButtonType())
+    if (autoFillButtonType == this->autofillButtonType())
         return;
 
     m_lastAutoFillButtonType = m_autoFillButtonType;
@@ -2335,7 +2335,7 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
 
     textBlockStyle.setDisplay(DisplayType::Block);
 
-    if (hasAutoFillStrongPasswordButton() && isMutable()) {
+    if (hasAutofillStrongPasswordButton() && isMutable()) {
         textBlockStyle.setDisplay(DisplayType::InlineBlock);
         textBlockStyle.setLogicalMaxWidth(Length { 100, LengthType::Percent });
         textBlockStyle.setColor(Color::black.colorWithAlphaByte(153));
@@ -2350,7 +2350,7 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
         // Do not allow line-height to be smaller than our default.
         if (textBlockStyle.metricsOfPrimaryFont().intLineSpacing() > style.computedLineHeight())
             return true;
-        return isText() && !style.logicalHeight().isAuto() && !hasAutoFillStrongPasswordButton();
+        return isText() && !style.logicalHeight().isAuto() && !hasAutofillStrongPasswordButton();
     };
     if (shouldUseInitialLineHeight())
         textBlockStyle.setLineHeight(RenderStyle::initialLineHeight());

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -153,7 +153,7 @@ public:
     WEBCORE_EXPORT bool isSearchField() const;
     bool isInputTypeHidden() const;
     WEBCORE_EXPORT bool isPasswordField() const;
-    bool isSecureField() const { return isPasswordField() || isAutoFilledAndObscured(); }
+    bool isSecureField() const { return isPasswordField() || autofilledAndObscured(); }
     bool isCheckbox() const;
     bool isSwitch() const;
     bool isRangeControl() const;
@@ -257,18 +257,18 @@ public:
     WEBCORE_EXPORT bool multiple() const;
 
     // AutoFill.
-    bool isAutoFilled() const { return m_isAutoFilled; }
-    WEBCORE_EXPORT void setAutoFilled(bool = true);
-    bool isAutoFilledAndViewable() const { return m_isAutoFilledAndViewable; }
-    WEBCORE_EXPORT void setAutoFilledAndViewable(bool = true);
-    bool isAutoFilledAndObscured() const { return m_isAutoFilledAndObscured; }
-    WEBCORE_EXPORT void setAutoFilledAndObscured(bool = true);
-    AutoFillButtonType lastAutoFillButtonType() const { return static_cast<AutoFillButtonType>(m_lastAutoFillButtonType); }
-    AutoFillButtonType autoFillButtonType() const { return static_cast<AutoFillButtonType>(m_autoFillButtonType); }
-    WEBCORE_EXPORT void setShowAutoFillButton(AutoFillButtonType);
-    bool hasAutoFillStrongPasswordButton() const  { return autoFillButtonType() == AutoFillButtonType::StrongPassword; }
-    bool isAutoFillAvailable() const { return m_isAutoFillAvailable; }
-    void setAutoFillAvailable(bool autoFillAvailable) { m_isAutoFillAvailable = autoFillAvailable; }
+    bool autofilled() const { return m_isAutoFilled; }
+    WEBCORE_EXPORT void setAutofilled(bool = true);
+    bool autofilledAndViewable() const { return m_isAutoFilledAndViewable; }
+    WEBCORE_EXPORT void setAutofilledAndViewable(bool = true);
+    bool autofilledAndObscured() const { return m_isAutoFilledAndObscured; }
+    WEBCORE_EXPORT void setAutofilledAndObscured(bool = true);
+    AutoFillButtonType lastAutofillButtonType() const { return static_cast<AutoFillButtonType>(m_lastAutoFillButtonType); }
+    AutoFillButtonType autofillButtonType() const { return static_cast<AutoFillButtonType>(m_autoFillButtonType); }
+    WEBCORE_EXPORT void setAutofillButtonType(AutoFillButtonType);
+    bool hasAutofillStrongPasswordButton() const  { return autofillButtonType() == AutoFillButtonType::StrongPassword; }
+    bool autofillAvailable() const { return m_isAutoFillAvailable; }
+    void setAutofillAvailable(bool autoFillAvailable) { m_isAutoFillAvailable = autoFillAvailable; }
 
 #if ENABLE(DRAG_SUPPORT)
     // Returns true if the given DragData has more than one dropped file.
@@ -344,7 +344,7 @@ public:
 
     String resultForDialogSubmit() const final;
 
-    bool isInnerTextElementEditable() const final { return !hasAutoFillStrongPasswordButton() && HTMLTextFormControlElement::isInnerTextElementEditable(); }
+    bool isInnerTextElementEditable() const final { return !hasAutofillStrongPasswordButton() && HTMLTextFormControlElement::isInnerTextElementEditable(); }
     void finishParsingChildren() final;
 
     bool hasEverBeenPasswordField() const { return m_hasEverBeenPasswordField; }

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -785,7 +785,7 @@ bool TextFieldInputType::shouldDrawCapsLockIndicator() const
     if (!element()->isMutable())
         return false;
 
-    if (element()->hasAutoFillStrongPasswordButton())
+    if (element()->hasAutofillStrongPasswordButton())
         return false;
 
     RefPtr frame { element()->document().frame() };
@@ -810,7 +810,7 @@ void TextFieldInputType::capsLockStateMayHaveChanged()
 bool TextFieldInputType::shouldDrawAutoFillButton() const
 {
     ASSERT(element());
-    return element()->isMutable() && element()->autoFillButtonType() != AutoFillButtonType::None;
+    return element()->isMutable() && element()->autofillButtonType() != AutoFillButtonType::None;
 }
 
 void TextFieldInputType::autoFillButtonElementWasClicked()
@@ -894,7 +894,7 @@ void TextFieldInputType::updateAutoFillButton()
         if (!m_container)
             createContainer();
 
-        AutoFillButtonType autoFillButtonType = element()->autoFillButtonType();
+        AutoFillButtonType autoFillButtonType = element()->autofillButtonType();
         if (!m_autoFillButton)
             createAutoFillButton(autoFillButtonType);
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -85,7 +85,7 @@ RenderPtr<RenderElement> TextControlInnerContainer::createElementRenderer(Render
 static inline bool isStrongPasswordTextField(const Element* element)
 {
     RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
-    return inputElement && inputElement->hasAutoFillStrongPasswordButton();
+    return inputElement && inputElement->hasAutofillStrongPasswordButton();
 }
 
 std::optional<Style::ResolvedStyle> TextControlInnerContainer::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle*)

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -156,7 +156,7 @@ void RenderTextControlSingleLine::layout()
         LayoutUnit containerLogicalHeight = containerRenderer->logicalHeight();
 
         CheckedPtr autoFillStrongPasswordButtonRenderer = [&]() -> RenderBox* {
-            if (!inputElement().hasAutoFillStrongPasswordButton())
+            if (!inputElement().hasAutofillStrongPasswordButton())
                 return nullptr;
 
             RefPtr autoFillButtonElement = inputElement().autoFillButtonElement();
@@ -191,7 +191,7 @@ void RenderTextControlSingleLine::layout()
 
     // Fix up the y-position of the container as it may have been flexed when the strong password or strong
     // confirmation password button wraps to the next line.
-    if (inputElement().hasAutoFillStrongPasswordButton() && containerRenderer)
+    if (inputElement().hasAutofillStrongPasswordButton() && containerRenderer)
         containerRenderer->setLogicalTop(oldContainerLogicalTop);
 
     // Center the child block in the block progression direction (vertical centering for horizontal text fields).

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -96,7 +96,7 @@ private:
     bool canBeProgramaticallyScrolled() const override
     {
         if (auto* shadowHost = dynamicDowncast<HTMLInputElement>(element()->shadowHost()))
-            return !shadowHost->hasAutoFillStrongPasswordButton();
+            return !shadowHost->hasAutofillStrongPasswordButton();
         return true;
     }
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2373,20 +2373,20 @@ bool Internals::elementShouldAutoComplete(HTMLInputElement& element)
 
 void Internals::setAutofilled(HTMLInputElement& element, bool enabled)
 {
-    element.setAutoFilled(enabled);
+    element.setAutofilled(enabled);
 }
 
-void Internals::setAutoFilledAndViewable(HTMLInputElement& element, bool enabled)
+void Internals::setAutofilledAndViewable(HTMLInputElement& element, bool enabled)
 {
-    element.setAutoFilledAndViewable(enabled);
+    element.setAutofilledAndViewable(enabled);
 }
 
-void Internals::setAutoFilledAndObscured(HTMLInputElement& element, bool enabled)
+void Internals::setAutofilledAndObscured(HTMLInputElement& element, bool enabled)
 {
-    element.setAutoFilledAndObscured(enabled);
+    element.setAutofilledAndObscured(enabled);
 }
 
-static AutoFillButtonType toAutoFillButtonType(Internals::AutoFillButtonType type)
+static AutoFillButtonType toAutofillButtonType(Internals::AutoFillButtonType type)
 {
     switch (type) {
     case Internals::AutoFillButtonType::None:
@@ -2406,7 +2406,7 @@ static AutoFillButtonType toAutoFillButtonType(Internals::AutoFillButtonType typ
     return AutoFillButtonType::None;
 }
 
-static Internals::AutoFillButtonType toInternalsAutoFillButtonType(AutoFillButtonType type)
+static Internals::AutoFillButtonType toInternalsAutofillButtonType(AutoFillButtonType type)
 {
     switch (type) {
     case AutoFillButtonType::None:
@@ -2426,19 +2426,19 @@ static Internals::AutoFillButtonType toInternalsAutoFillButtonType(AutoFillButto
     return Internals::AutoFillButtonType::None;
 }
 
-void Internals::setShowAutoFillButton(HTMLInputElement& element, AutoFillButtonType type)
+void Internals::setAutofillButtonType(HTMLInputElement& element, AutoFillButtonType type)
 {
-    element.setShowAutoFillButton(toAutoFillButtonType(type));
+    element.setAutofillButtonType(toAutofillButtonType(type));
 }
 
-auto Internals::autoFillButtonType(const HTMLInputElement& element) -> AutoFillButtonType
+auto Internals::autofillButtonType(const HTMLInputElement& element) -> AutoFillButtonType
 {
-    return toInternalsAutoFillButtonType(element.autoFillButtonType());
+    return toInternalsAutofillButtonType(element.autofillButtonType());
 }
 
-auto Internals::lastAutoFillButtonType(const HTMLInputElement& element) -> AutoFillButtonType
+auto Internals::lastAutofillButtonType(const HTMLInputElement& element) -> AutoFillButtonType
 {
-    return toInternalsAutoFillButtonType(element.lastAutoFillButtonType());
+    return toInternalsAutofillButtonType(element.lastAutofillButtonType());
 }
 
 Vector<String> Internals::recentSearches(const HTMLInputElement& element)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -388,12 +388,12 @@ public:
     ExceptionOr<bool> wasLastChangeUserEdit(Element& textField);
     bool elementShouldAutoComplete(HTMLInputElement&);
     void setAutofilled(HTMLInputElement&, bool enabled);
-    void setAutoFilledAndViewable(HTMLInputElement&, bool enabled);
-    void setAutoFilledAndObscured(HTMLInputElement&, bool enabled);
+    void setAutofilledAndViewable(HTMLInputElement&, bool enabled);
+    void setAutofilledAndObscured(HTMLInputElement&, bool enabled);
     enum class AutoFillButtonType { None, Contacts, Credentials, StrongPassword, CreditCard, Loading };
-    void setShowAutoFillButton(HTMLInputElement&, AutoFillButtonType);
-    AutoFillButtonType autoFillButtonType(const HTMLInputElement&);
-    AutoFillButtonType lastAutoFillButtonType(const HTMLInputElement&);
+    void setAutofillButtonType(HTMLInputElement&, AutoFillButtonType);
+    AutoFillButtonType autofillButtonType(const HTMLInputElement&);
+    AutoFillButtonType lastAutofillButtonType(const HTMLInputElement&);
     Vector<String> recentSearches(const HTMLInputElement&);
     ExceptionOr<void> scrollElementToRect(Element&, int x, int y, int w, int h);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -602,11 +602,11 @@ enum RenderingMode {
     boolean wasLastChangeUserEdit(Element textField);
     boolean elementShouldAutoComplete(HTMLInputElement inputElement);
     undefined setAutofilled(HTMLInputElement inputElement, boolean enabled);
-    undefined setAutoFilledAndViewable(HTMLInputElement inputElement, boolean enabled);
-    undefined setAutoFilledAndObscured(HTMLInputElement inputElement, boolean enabled);
-    undefined setShowAutoFillButton(HTMLInputElement inputElement, AutoFillButtonType autoFillButtonType);
-    AutoFillButtonType autoFillButtonType(HTMLInputElement inputElement);
-    AutoFillButtonType lastAutoFillButtonType(HTMLInputElement inputElement);
+    undefined setAutofilledAndViewable(HTMLInputElement inputElement, boolean enabled);
+    undefined setAutofilledAndObscured(HTMLInputElement inputElement, boolean enabled);
+    undefined setAutofillButtonType(HTMLInputElement inputElement, AutoFillButtonType autoFillButtonType);
+    AutoFillButtonType autofillButtonType(HTMLInputElement inputElement);
+    AutoFillButtonType lastAutofillButtonType(HTMLInputElement inputElement);
     sequence<DOMString> recentSearches(HTMLInputElement inputElement);
 
     undefined setCanShowPlaceholder(Element element, boolean canShowPlaceholder);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
@@ -223,7 +223,7 @@ void webkit_web_form_manager_input_element_auto_fill(JSCValue* element, const ch
     if (!input)
         return;
 
-    input->setAutoFilled(true);
+    input->setAutofilled(true);
     input->setValueForUser(String::fromUTF8(value));
 }
 
@@ -245,5 +245,5 @@ gboolean webkit_web_form_manager_input_element_is_auto_filled(JSCValue* element)
 
     RefPtr node = nodeForJSCValue(element);
     RefPtr input = dynamicDowncast<HTMLInputElement>(node);
-    return input && input->isAutoFilled();
+    return input && input->autofilled();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -266,7 +266,7 @@ bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilled() const
     if (!input)
         return false;
     
-    return input->isAutoFilled();
+    return input->autofilled();
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndViewable() const
@@ -275,7 +275,7 @@ bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndViewable() const
     if (!input)
         return false;
 
-    return input->isAutoFilledAndViewable();
+    return input->autofilledAndViewable();
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndObscured() const
@@ -284,7 +284,7 @@ bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndObscured() const
     if (!input)
         return false;
 
-    return input->isAutoFilledAndObscured();
+    return input->autofilledAndObscured();
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilled(bool filled)
@@ -293,7 +293,7 @@ void InjectedBundleNodeHandle::setHTMLInputElementAutoFilled(bool filled)
     if (!input)
         return;
 
-    input->setAutoFilled(filled);
+    input->setAutofilled(filled);
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndViewable(bool autoFilledAndViewable)
@@ -302,7 +302,7 @@ void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndViewable(bool aut
     if (!input)
         return;
 
-    input->setAutoFilledAndViewable(autoFilledAndViewable);
+    input->setAutofilledAndViewable(autoFilledAndViewable);
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndObscured(bool autoFilledAndObscured)
@@ -311,7 +311,7 @@ void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndObscured(bool aut
     if (!input)
         return;
 
-    input->setAutoFilledAndObscured(autoFilledAndObscured);
+    input->setAutofilledAndObscured(autoFilledAndObscured);
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFillButtonEnabled() const
@@ -320,7 +320,7 @@ bool InjectedBundleNodeHandle::isHTMLInputElementAutoFillButtonEnabled() const
     if (!input)
         return false;
     
-    return input->autoFillButtonType() != AutoFillButtonType::None;
+    return input->autofillButtonType() != AutoFillButtonType::None;
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFillButtonEnabled(AutoFillButtonType autoFillButtonType)
@@ -329,7 +329,7 @@ void InjectedBundleNodeHandle::setHTMLInputElementAutoFillButtonEnabled(AutoFill
     if (!input)
         return;
 
-    input->setShowAutoFillButton(autoFillButtonType);
+    input->setAutofillButtonType(autoFillButtonType);
 }
 
 AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementAutoFillButtonType() const
@@ -338,7 +338,7 @@ AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementAutoFillButtonType(
     if (!input)
         return AutoFillButtonType::None;
 
-    return input->autoFillButtonType();
+    return input->autofillButtonType();
 }
 
 AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementLastAutoFillButtonType() const
@@ -347,7 +347,7 @@ AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementLastAutoFillButtonT
     if (!input)
         return AutoFillButtonType::None;
 
-    return input->lastAutoFillButtonType();
+    return input->lastAutofillButtonType();
 }
 
 bool InjectedBundleNodeHandle::isAutoFillAvailable() const
@@ -356,7 +356,7 @@ bool InjectedBundleNodeHandle::isAutoFillAvailable() const
     if (!input)
         return false;
 
-    return input->isAutoFillAvailable();
+    return input->autofillAvailable();
 }
 
 void InjectedBundleNodeHandle::setAutoFillAvailable(bool autoFillAvailable)
@@ -365,7 +365,7 @@ void InjectedBundleNodeHandle::setAutoFillAvailable(bool autoFillAvailable)
     if (!input)
         return;
 
-    input->setAutoFillAvailable(autoFillAvailable);
+    input->setAutofillAvailable(autoFillAvailable);
 }
 
 IntRect InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5248,7 +5248,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
     auto isTextObscured = [] (const VisiblePosition& visiblePosition) {
         if (RefPtr textControl = enclosingTextFormControl(visiblePosition.deepEquivalent())) {
             if (auto* input = dynamicDowncast<HTMLInputElement>(textControl.get())) {
-                if (input->isAutoFilledAndObscured())
+                if (input->autofilledAndObscured())
                     return true;
             }
         }

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -220,22 +220,22 @@ using namespace JSC;
 
 - (BOOL)_isAutofilled
 {
-    return downcast<HTMLInputElement>(core((DOMElement *)self))->isAutoFilled();
+    return downcast<HTMLInputElement>(core((DOMElement *)self))->autofilled();
 }
 
 - (BOOL)_isAutoFilledAndViewable
 {
-    return downcast<HTMLInputElement>(core((DOMElement *)self))->isAutoFilledAndViewable();
+    return downcast<HTMLInputElement>(core((DOMElement *)self))->autofilledAndViewable();
 }
 
 - (void)_setAutofilled:(BOOL)autofilled
 {
-    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutoFilled(autofilled);
+    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutofilled(autofilled);
 }
 
 - (void)_setAutoFilledAndViewable:(BOOL)autoFilledAndViewable
 {
-    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutoFilledAndViewable(autoFilledAndViewable);
+    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutofilledAndViewable(autoFilledAndViewable);
 }
 
 @end


### PR DESCRIPTION
#### 7a4de99c0908b404b8bf48c7fc602153b581fa20
<pre>
Replace autoFill with autofill for spelling consistency
<a href="https://bugs.webkit.org/show_bug.cgi?id=282553">https://bugs.webkit.org/show_bug.cgi?id=282553</a>

Reviewed by Anne van Kesteren.

Updated the spelling of HTMLInputElement&apos;s autofill member functions from autoFill to autofill for consistency.
Also removed &quot;is&quot; prefix from member functions as a preparation to expose them as JavaScript API in near future.

* LayoutTests/accessibility/auto-fill-crash.html:
* LayoutTests/accessibility/auto-fill-types.html:
* LayoutTests/accessibility/ios-simulator/strong-password-field.html:
* LayoutTests/accessibility/secure-field-value.html:
* LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html:
* LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible-expected.html:
* LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html:
* LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-disabled.html:
* LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html:
* LayoutTests/fast/forms/auto-fill-button/input-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-auto-filled-and-obscured.html:
* LayoutTests/fast/forms/auto-fill-button/input-contacts-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-disabled-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-loading-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-readonly-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-readonly-non-empty-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html:
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable.html:
* LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type-expected.txt:
* LayoutTests/fast/forms/auto-fill-button/last-auto-fill-button-type.html:
* LayoutTests/fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html:
* LayoutTests/fast/forms/auto-fill-button/resources/process-auto-fill-button-type-and-invoke-runTest.js:
(window.onload):
* LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html:
* LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes-expected.html:
* LayoutTests/fast/forms/auto-fill-button/show-correct-auto-fill-button-when-auto-fill-button-type-changes.html:
* LayoutTests/fast/forms/input-autofilled-and-obscured-clear-field-programatically.html:
* LayoutTests/fast/forms/input-autofilled-and-obscured-clear-form-programatically.html:
* LayoutTests/fast/forms/input-autofilled-and-obscured.html:
* LayoutTests/fast/forms/input-autofilled-and-viewable.html:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isValueAutofillAvailable const):
(WebCore::AccessibilityObject::valueAutofillButtonType const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::isAutofilled):
(WebCore::isAutofilledStrongPassword):
(WebCore::isAutofilledStrongPasswordViewable):
(WebCore::isAutofilledAndObscured):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::shouldIgnoreNodeInTextField):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::isInAutoFilledAndViewableField const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::resignStrongPasswordAppearance):
(WebCore::HTMLInputElement::reset):
(WebCore::HTMLInputElement::setValue):
(WebCore::HTMLInputElement::setValueFromRenderer):
(WebCore::HTMLInputElement::setAutofilled):
(WebCore::HTMLInputElement::setAutofilledAndViewable):
(WebCore::HTMLInputElement::setAutofilledAndObscured):
(WebCore::HTMLInputElement::setAutofillButtonType):
(WebCore::HTMLInputElement::createInnerTextStyle):
(WebCore::HTMLInputElement::setAutoFilled): Deleted.
(WebCore::HTMLInputElement::setAutoFilledAndViewable): Deleted.
(WebCore::HTMLInputElement::setAutoFilledAndObscured): Deleted.
(WebCore::HTMLInputElement::setShowAutoFillButton): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::shouldDrawCapsLockIndicator const):
(WebCore::TextFieldInputType::shouldDrawAutoFillButton const):
(WebCore::TextFieldInputType::updateAutoFillButton):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::isStrongPasswordTextField):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setAutofilled):
(WebCore::Internals::setAutofilledAndViewable):
(WebCore::Internals::setAutofilledAndObscured):
(WebCore::toAutofillButtonType):
(WebCore::toInternalsAutofillButtonType):
(WebCore::Internals::setAutofillButtonType):
(WebCore::Internals::autofillButtonType):
(WebCore::Internals::lastAutofillButtonType):
(WebCore::Internals::setAutoFilledAndViewable): Deleted.
(WebCore::Internals::setAutoFilledAndObscured): Deleted.
(WebCore::toAutoFillButtonType): Deleted.
(WebCore::toInternalsAutoFillButtonType): Deleted.
(WebCore::Internals::setShowAutoFillButton): Deleted.
(WebCore::Internals::autoFillButtonType): Deleted.
(WebCore::Internals::lastAutoFillButtonType): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp:
(webkit_web_form_manager_input_element_is_auto_filled):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilled const):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndViewable const):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndObscured const):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilled):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndViewable):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndObscured):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFillButtonEnabled const):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFillButtonEnabled):
(WebKit::InjectedBundleNodeHandle::htmlInputElementAutoFillButtonType const):
(WebKit::InjectedBundleNodeHandle::htmlInputElementLastAutoFillButtonType const):
(WebKit::InjectedBundleNodeHandle::isAutoFillAvailable const):
(WebKit::InjectedBundleNodeHandle::setAutoFillAvailable):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(-[DOMHTMLInputElement _isAutofilled]):
(-[DOMHTMLInputElement _isAutoFilledAndViewable]):
(-[DOMHTMLInputElement _setAutofilled:]):
(-[DOMHTMLInputElement _setAutoFilledAndViewable:]):

Canonical link: <a href="https://commits.webkit.org/286185@main">https://commits.webkit.org/286185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a0b48fd223f19220bfe3b20ce8b949b02854ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78072 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49034 "13 new passes 3 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39270 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46350 "Exiting early after 10 failures. 231 tests run. 1 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24576 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67477 "Found 1 new API test failure: TestWebKitAPI.WebKit.CopyInAutoFilledAndViewablePasswordField (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66436 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8536 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11588 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2288 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->