### PR TITLE
[iPad] Feedly App doesn't respond to left/right swipe gestures with trackpad

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -497,6 +497,7 @@ UIProcess/ios/CompactContextMenuPresenter.mm
 UIProcess/ios/DragDropInteractionState.mm
 UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
 UIProcess/ios/PageClientImplIOS.mm
+UIProcess/ios/PointerTouchCompatibilitySimulator.mm
 UIProcess/ios/ProcessStateMonitor.mm
 UIProcess/ios/RevealFocusedElementDeferrer.mm
 UIProcess/ios/SmartMagnificationController.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -189,9 +189,8 @@
 #import "WKWebExtensionControllerInternal.h"
 #endif
 
-#import "WebKitSwiftSoftLink.h"
-
 #if PLATFORM(IOS_FAMILY)
+#import "PointerTouchCompatibilitySimulator.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "UIKitSPI.h"
@@ -216,6 +215,8 @@
 #import "WKViewInternal.h"
 #import <WebCore/ColorMac.h>
 #endif
+
+#import "WebKitSwiftSoftLink.h"
 
 #if PLATFORM(WATCHOS)
 static const BOOL defaultAllowsViewportShrinkToFit = YES;
@@ -448,6 +449,11 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 #if PLATFORM(APPLETV)
     // FIXME: This is a workaround for <rdar://135515434> to prevent the tint color from being set to either solid black or white.
     self.tintColor = UIColor.systemBlueColor;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    if (WebKit::PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility())
+        _pointerTouchCompatibilitySimulator = WTF::makeUnique<WebKit::PointerTouchCompatibilitySimulator>(self);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -101,13 +101,14 @@ enum class WheelScrollGestureState : uint8_t;
 
 namespace WebKit {
 enum class ContinueUnsafeLoad : bool;
+class BrowsingWarning;
 class IconLoadingDelegate;
 class NavigationState;
+class PointerTouchCompatibilitySimulator;
 class ResourceLoadDelegate;
-class BrowsingWarning;
+class UIDelegate;
 class ViewSnapshot;
 class WebPageProxy;
-class UIDelegate;
 struct PrintInfo;
 #if PLATFORM(MAC)
 class WebViewImpl;
@@ -373,7 +374,8 @@ struct PerWebProcessState {
     NSUInteger _activeFocusedStateRetainCount;
 
     RetainPtr<NSArray<NSNumber *>> _scrollViewDefaultAllowedTouchTypes;
-#endif
+    std::unique_ptr<WebKit::PointerTouchCompatibilitySimulator> _pointerTouchCompatibilitySimulator;
+#endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(VISION)
     String _defaultSTSLabel;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "_WKTouchEventGenerator.h"
+#import "_WKTouchEventGeneratorInternal.h"
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -90,13 +90,6 @@ static void delayBetweenMove(int eventIndex, double elapsed)
         nanosleep(&moveDelay, NULL);
     }
 }
-
-// NOTE: this event synthesizer is derived from WebKitTestRunner code.
-// Compared to that version, this lacks support for stylus event simulation,
-// event stream, and only single touches are exposed via the touch/lift/move method calls.
-@interface _WKTouchEventGenerator ()
-@property (nonatomic, strong) NSMutableDictionary *eventCallbacks;
-@end
 
 @implementation _WKTouchEventGenerator {
     RetainPtr<IOHIDEventSystemClientRef> _ioSystemClient;
@@ -346,23 +339,38 @@ static void delayBetweenMove(int eventIndex, double elapsed)
     [self _updateTouchPoints:newLocations window:window];
 }
 
-- (void)touchDown:(CGPoint)location window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock
+- (void)touchDown:(CGPoint)location window:(UIWindow *)window
 {
     [self touchDown:location touchCount:1 window:window];
+}
+
+- (void)touchDown:(CGPoint)location window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock
+{
+    [self touchDown:location window:window];
     [self _sendMarkerHIDEventInWindow:window completionBlock:completionBlock];
+}
+
+- (void)liftUp:(CGPoint)location window:(UIWindow *)window
+{
+    [self liftUp:location touchCount:1 window:window];
 }
 
 - (void)liftUp:(CGPoint)location window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock
 {
-    [self liftUp:location touchCount:1 window:window];
+    [self liftUp:location window:window];
     [self _sendMarkerHIDEventInWindow:window completionBlock:completionBlock];
 }
 
-- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock
+- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds window:(UIWindow *)window
 {
     CGPoint locations[1];
     locations[0] = location;
     [self moveToPoints:locations touchCount:1 duration:seconds window:window];
+}
+
+- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock
+{
+    [self moveToPoint:location duration:seconds window:window];
     [self _sendMarkerHIDEventInWindow:window completionBlock:completionBlock];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGeneratorInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGeneratorInternal.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "_WKTouchEventGenerator.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+@interface _WKTouchEventGenerator ()
+
+- (void)touchDown:(CGPoint)location window:(UIWindow *)window;
+- (void)liftUp:(CGPoint)location window:(UIWindow *)window;
+- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds window:(UIWindow *)window;
+
+// NOTE: this event synthesizer is derived from WebKitTestRunner code.
+// Compared to that version, this lacks support for stylus event simulation,
+// event stream, and only single touches are exposed via the touch/lift/move method calls.
+@property (nonatomic, strong) NSMutableDictionary *eventCallbacks;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -33,6 +33,7 @@
 #import "LayerProperties.h"
 #import "NativeWebWheelEvent.h"
 #import "NavigationState.h"
+#import "PointerTouchCompatibilitySimulator.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteLayerTreeViews.h"
@@ -2188,6 +2189,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)scrollView:(WKBaseScrollView *)scrollView handleScrollUpdate:(WKBEScrollViewScrollUpdate *)update completion:(void (^)(BOOL handled))completion
 {
+    if (_pointerTouchCompatibilitySimulator)
+        _pointerTouchCompatibilitySimulator->handleScrollUpdate(scrollView, update);
+
     BOOL isHandledByDefault = !scrollView.scrollEnabled;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "WKBrowserEngineDefinitions.h"
+#import <WebCore/FloatPoint.h>
+#import <WebCore/FloatSize.h>
+#import <wtf/RunLoop.h>
+#import <wtf/WeakObjCPtr.h>
+
+@class UIWindow;
+@class WKBaseScrollView;
+@class WKWebView;
+
+namespace WebKit {
+
+class PointerTouchCompatibilitySimulator {
+    WTF_MAKE_NONCOPYABLE(PointerTouchCompatibilitySimulator);
+    WTF_MAKE_TZONE_ALLOCATED(PointerTouchCompatibilitySimulator);
+public:
+    static bool requiresPointerTouchCompatibility();
+
+    PointerTouchCompatibilitySimulator(WKWebView *);
+
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+    void handleScrollUpdate(WKBaseScrollView *, WKBEScrollViewScrollUpdate *);
+#endif
+
+    RetainPtr<WKWebView> view() const { return m_view.get(); }
+    RetainPtr<UIWindow> window() const { return [m_view window]; }
+
+private:
+    void resetState();
+    WebCore::FloatPoint locationInScreen() const;
+
+    const WeakObjCPtr<WKWebView> m_view;
+    RunLoop::Timer m_stateResetWatchdogTimer;
+    WebCore::FloatPoint m_centroid;
+    WebCore::FloatSize m_delta;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PointerTouchCompatibilitySimulator.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "UIKitSPI.h"
+#import "UIKitUtilities.h"
+#import "WKBaseScrollView.h"
+#import "WKWebViewInternal.h"
+#import "_WKTouchEventGeneratorInternal.h"
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+
+namespace WebKit {
+
+bool PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility()
+{
+    return WTF::IOSApplication::isFeedly();
+}
+
+PointerTouchCompatibilitySimulator::PointerTouchCompatibilitySimulator(WKWebView *view)
+    : m_view { view }
+    , m_stateResetWatchdogTimer { RunLoop::main(), this, &PointerTouchCompatibilitySimulator::resetState }
+{
+}
+
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+
+static constexpr auto predominantAxisDeltaRatio = 10;
+static constexpr auto minimumPredominantAxisDelta = 20;
+static constexpr auto stateResetTimerDelay = 50_ms;
+
+static bool hasPredominantHorizontalAxis(CGPoint delta)
+{
+    auto absoluteDeltaX = std::abs(delta.x);
+    return absoluteDeltaX >= minimumPredominantAxisDelta && absoluteDeltaX > std::abs(delta.y * predominantAxisDeltaRatio);
+}
+
+void PointerTouchCompatibilitySimulator::handleScrollUpdate(WKBaseScrollView *scrollView, WKBEScrollViewScrollUpdate *update)
+{
+    RetainPtr view = m_view.get();
+    RetainPtr window = [view window];
+    if (!window) {
+        resetState();
+        return;
+    }
+
+    switch (update.phase) {
+    case WKBEScrollViewScrollUpdatePhaseEnded:
+    case WKBEScrollViewScrollUpdatePhaseCancelled:
+        resetState();
+        return;
+    default:
+        break;
+    }
+
+    if (scrollView._wk_canScrollHorizontallyWithoutBouncing)
+        return;
+
+#if USE(BROWSERENGINEKIT)
+    auto translation = [update translationInView:view.get()];
+#else
+    auto delta = [update _adjustedAcceleratedDeltaInView:view.get()];
+    auto translation = CGPointMake(delta.dx, delta.dy);
+#endif
+    if (!hasPredominantHorizontalAxis(translation))
+        return;
+
+    bool isFirstTouch = m_delta.isZero();
+    m_delta.expand(translation.x, 0);
+    m_centroid = [update locationInView:view.get()];
+    m_stateResetWatchdogTimer.startOneShot(stateResetTimerDelay);
+
+    if (isFirstTouch)
+        [[_WKTouchEventGenerator sharedTouchEventGenerator] touchDown:locationInScreen() window:window.get()];
+    else
+        [[_WKTouchEventGenerator sharedTouchEventGenerator] moveToPoint:locationInScreen() duration:0 window:window.get()];
+}
+
+#endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+
+void PointerTouchCompatibilitySimulator::resetState()
+{
+    if (RetainPtr window = this->window(); window && !m_delta.isZero())
+        [[_WKTouchEventGenerator sharedTouchEventGenerator] liftUp:locationInScreen() window:window.get()];
+    m_centroid = { };
+    m_delta = { };
+    m_stateResetWatchdogTimer.stop();
+}
+
+WebCore::FloatPoint PointerTouchCompatibilitySimulator::locationInScreen() const
+{
+    CGPoint pointInView = m_centroid + m_delta;
+    return [view() convertPoint:pointInView toCoordinateSpace:[[[window() windowScene] screen] coordinateSpace]];
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2531,6 +2531,7 @@
 		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F40C3B712AB401C5007A3567 /* WKDatePickerPopoverController.h in Headers */ = {isa = PBXBuildFile; fileRef = F40C3B6F2AB40167007A3567 /* WKDatePickerPopoverController.h */; };
 		F41145682CD939E0004CDBD1 /* _WKTouchEventGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = F41145652CD939E0004CDBD1 /* _WKTouchEventGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F411457D2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */; };
 		F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */; };
 		F41795A62AC61B78007F5F12 /* CompactContextMenuPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */; };
 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
@@ -8182,8 +8183,11 @@
 		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
 		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
 		F410A19329AAC81E0082D554 /* RemoteGPURequestAdapterResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPURequestAdapterResponse.h; sourceTree = "<group>"; };
+		F41145632CD6F4B7004CDBD1 /* PointerTouchCompatibilitySimulator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PointerTouchCompatibilitySimulator.h; path = ios/PointerTouchCompatibilitySimulator.h; sourceTree = "<group>"; };
+		F41145642CD6F4B7004CDBD1 /* PointerTouchCompatibilitySimulator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = PointerTouchCompatibilitySimulator.mm; path = ios/PointerTouchCompatibilitySimulator.mm; sourceTree = "<group>"; };
 		F41145652CD939E0004CDBD1 /* _WKTouchEventGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTouchEventGenerator.h; sourceTree = "<group>"; };
 		F41145662CD939E0004CDBD1 /* _WKTouchEventGenerator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTouchEventGenerator.mm; sourceTree = "<group>"; };
+		F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTouchEventGeneratorInternal.h; sourceTree = "<group>"; };
 		F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKScrollViewTrackingTapGestureRecognizer.h; path = ios/WKScrollViewTrackingTapGestureRecognizer.h; sourceTree = "<group>"; };
 		F416F1BF2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKScrollViewTrackingTapGestureRecognizer.mm; path = ios/WKScrollViewTrackingTapGestureRecognizer.mm; sourceTree = "<group>"; };
 		F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CompactContextMenuPresenter.h; path = ios/CompactContextMenuPresenter.h; sourceTree = "<group>"; };
@@ -11205,6 +11209,8 @@
 				F4CF1E9C25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.mm */,
 				0FCB4E3618BBE044000FCFC9 /* PageClientImplIOS.h */,
 				0FCB4E3718BBE044000FCFC9 /* PageClientImplIOS.mm */,
+				F41145632CD6F4B7004CDBD1 /* PointerTouchCompatibilitySimulator.h */,
+				F41145642CD6F4B7004CDBD1 /* PointerTouchCompatibilitySimulator.mm */,
 				93E05E3E282CD55D000B69EB /* ProcessStateMonitor.h */,
 				93E05E3F282CD55F000B69EB /* ProcessStateMonitor.mm */,
 				F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */,
@@ -11621,6 +11627,7 @@
 				2DACE64D18ADBFF000E4CA76 /* _WKThumbnailViewInternal.h */,
 				F41145652CD939E0004CDBD1 /* _WKTouchEventGenerator.h */,
 				F41145662CD939E0004CDBD1 /* _WKTouchEventGenerator.mm */,
+				F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */,
 				7C2413011AACFA7500A58C15 /* _WKUserContentExtensionStore.h */,
 				7C2413001AACFA7500A58C15 /* _WKUserContentExtensionStore.mm */,
 				7C2413041AACFA9C00A58C15 /* _WKUserContentExtensionStoreInternal.h */,
@@ -16201,6 +16208,7 @@
 				2D6B371B18A967AD0042AE80 /* _WKThumbnailView.h in Headers */,
 				2DACE64E18ADBFF000E4CA76 /* _WKThumbnailViewInternal.h in Headers */,
 				F41145682CD939E0004CDBD1 /* _WKTouchEventGenerator.h in Headers */,
+				F411457D2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h in Headers */,
 				7C2413031AACFA7500A58C15 /* _WKUserContentExtensionStore.h in Headers */,
 				7C2413051AACFA9C00A58C15 /* _WKUserContentExtensionStoreInternal.h in Headers */,
 				7CA3793E1AC378B30079DC37 /* _WKUserContentExtensionStorePrivate.h in Headers */,


### PR DESCRIPTION
#### 70523aab320c9c768da1c44d5da7f6d983f5057a
<pre>
[iPad] Feedly App doesn&apos;t respond to left/right swipe gestures with trackpad
<a href="https://bugs.webkit.org/show_bug.cgi?id=282539">https://bugs.webkit.org/show_bug.cgi?id=282539</a>
<a href="https://rdar.apple.com/138044440">rdar://138044440</a>

Reviewed by Aditya Keerthi.

When using a trackpad to try and swipe horizontally between articles in the Feedly app on iPad,
nothing happens. In contrast, a horizontal pan gesture via direct touch works as expected. This is
because Feedly mostly wraps a web view which loads nearly all of their app&apos;s content; when viewing
an article, touch event listeners are used to detect when the user swipes horizontally, and then run
an animated transition to load the next or previous article. Because touch events are only
dispatched in response to actual digitizer events (as opposed to indirect touches via trackpad),
swiping horizontally with a trackpad results in nothing.

Ideally, Feedly would listen for `wheel` events and use similar logic to transition between articles
in this case. However, in lieu of the app adopting wheel events or a pan/swipe gesture recognizer,
we can add a quirk to make this work by automatically emitting a stream of touch events in response
to scrolling triggered by a 2-finger swipe on a trackpad. To achieve this, we add a new helper class
(`PointerTouchCompatibilitySimulator`) that&apos;s responsible for:

1.  Detecting mostly-horizontal trackpad scrolling deltas, and then
2.  Using `_WKTouchEventGenerator` (currently used to simulate touches for WebDriver on iOS) to
    synthesize touch events in the direction of the swipe, starting at the pointer location.

See below for more details.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):

Create a `PointerTouchCompatibilitySimulator` if needed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollView:handleScrollUpdate:completion:]):

Deliver scroll updates to the `PointerTouchCompatibilitySimulator`.

* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.h:
(-[_WKTouchEventGenerator touchDown:window:]):
(-[_WKTouchEventGenerator touchDown:window:completionBlock:]):
(-[_WKTouchEventGenerator liftUp:window:]):
(-[_WKTouchEventGenerator liftUp:window:completionBlock:]):
(-[_WKTouchEventGenerator moveToPoint:duration:window:]):
(-[_WKTouchEventGenerator moveToPoint:duration:window:completionBlock:]):

Refactor the touch event generator, exposing versions of several methods for synthesizing touch
events without requiring a completion handler (and consequently, marker HID events). This is because
marker events require the `UIApplication` subclass to explicitly use SPI to deliver HID events to
the touch event generator.

* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGeneratorInternal.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.h.

Add an internal header for `_WKTouchEventGenerator` where the new helper methods above are declared.

* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h: Copied from Source/WebKit/UIProcess/_WKTouchEventGenerator.h.
(WebKit::PointerTouchCompatibilitySimulator::view const):
(WebKit::PointerTouchCompatibilitySimulator::window const):
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm: Added.
(WebKit::PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility):
(WebKit::PointerTouchCompatibilitySimulator::PointerTouchCompatibilitySimulator):
(WebKit::hasPredominantHorizontalAxis):
(WebKit::PointerTouchCompatibilitySimulator::handleScrollUpdate):

Add a helper class to receive scroll updates and detect when scroll updates are mostly horizontal
(in the future, this could be extended to vertical directions, and even pinch or rotation gestures).
When a predominantly horizontal scroll deltas are detected, we then begin synthesizing touch events,
starting at the `-locationInView:` and moving away from this start location based on the values of
`-translationInView:`. Note that we also require a watchdog timer to ensure that we don&apos;t leave the
app in a state where pointer gestures are permanently stuck, by always ending the synthetic touch
event stream after ~50 ms with no further scrolling. This isn&apos;t necessary most of the time, because
we receive `BEScrollViewScrollUpdatePhase(Ended|Cancelled)` and immediately end the event stream,
but in practice it&apos;s possible that we never get this final update with ended/cancelled phase when
performing a swipe.

(WebKit::PointerTouchCompatibilitySimulator::resetState):
(WebKit::PointerTouchCompatibilitySimulator::locationInScreen const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/286150@main">https://commits.webkit.org/286150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225f20cc24fa7b800f47653b1960f9bea13fadfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17127 "Found 2 new test failures: webgl/2.0.y/conformance/context/context-release-with-workers.html webgl/2.0.y/conformance/rendering/canvas-alpha-bug.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46312 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22248 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80883 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1381 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/80883 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64424 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/80883 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16507 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8514 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5038 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2278 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->