### PR TITLE
Avoid allocating same string "UTF-8" repeatedly

### DIFF
--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -36,6 +36,7 @@ namespace WTF {
 
 const StaticAtomString nullAtomData { nullptr };
 const StaticAtomString emptyAtomData { &StringImpl::s_emptyAtomString };
+const StaticAtomString utf8AtomData { &StringImpl::s_utf8AtomString };
 
 template<AtomString::CaseConvertType type>
 ALWAYS_INLINE AtomString AtomString::convertASCIICase() const

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -258,9 +258,11 @@ struct StaticAtomString {
 static_assert(sizeof(AtomString) == sizeof(StaticAtomString), "AtomString and StaticAtomString must be the same size!");
 extern WTF_EXPORT_PRIVATE const StaticAtomString nullAtomData;
 extern WTF_EXPORT_PRIVATE const StaticAtomString emptyAtomData;
+extern WTF_EXPORT_PRIVATE const StaticAtomString utf8AtomData;
 
 inline const AtomString& nullAtom() { return *reinterpret_cast<const AtomString*>(&nullAtomData); }
 inline const AtomString& emptyAtom() { return *reinterpret_cast<const AtomString*>(&emptyAtomData); }
+inline const AtomString& utf8Atom() { return *reinterpret_cast<const AtomString*>(&utf8AtomData); }
 
 inline AtomString::AtomString(ASCIILiteral literal)
     : m_string(literal.length() ? AtomStringImpl::add(literal.span8()) : Ref { *emptyAtom().impl() })
@@ -349,5 +351,6 @@ template<> struct IntegerToStringConversionTrait<AtomString> {
 using WTF::AtomString;
 using WTF::nullAtom;
 using WTF::emptyAtom;
+using WTF::utf8Atom;
 
 #include <wtf/text/StringConcatenate.h>

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -112,6 +112,7 @@ void StringStats::printStats()
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringImpl);
 
 StringImpl::StaticStringImpl StringImpl::s_emptyAtomString("", StringImpl::StringAtom);
+StringImpl::StaticStringImpl StringImpl::s_utf8AtomString("UTF-8", StringImpl::StringAtom);
 
 StringImpl::~StringImpl()
 {

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -405,7 +405,9 @@ public:
     };
 
     WTF_EXPORT_PRIVATE static StaticStringImpl s_emptyAtomString;
+    WTF_EXPORT_PRIVATE static StaticStringImpl s_utf8AtomString;
     ALWAYS_INLINE static StringImpl* empty() { return reinterpret_cast<StringImpl*>(&s_emptyAtomString); }
+    ALWAYS_INLINE static StringImpl* utf8Atom() { return reinterpret_cast<StringImpl*>(&s_utf8AtomString); }
 
     // FIXME: Do these functions really belong in StringImpl?
     template<typename CharacterType>

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -584,6 +584,7 @@ float charactersToFloat(std::span<const UChar> data, size_t& parsedLength)
 
 const StaticString nullStringData { nullptr };
 const StaticString emptyStringData { &StringImpl::s_emptyAtomString };
+const StaticString utf8StringData { &StringImpl::s_utf8AtomString };
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -361,9 +361,11 @@ struct StaticString {
 static_assert(sizeof(String) == sizeof(StaticString), "String and StaticString must be the same size!");
 extern WTF_EXPORT_PRIVATE const StaticString nullStringData;
 extern WTF_EXPORT_PRIVATE const StaticString emptyStringData;
+extern WTF_EXPORT_PRIVATE const StaticString utf8StringData;
 
 inline const String& nullString() { return *reinterpret_cast<const String*>(&nullStringData); }
 inline const String& emptyString() { return *reinterpret_cast<const String*>(&emptyStringData); }
+inline const String& utf8String() { return *reinterpret_cast<const String*>(&utf8StringData); }
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<String>;
@@ -593,6 +595,7 @@ using WTF::find;
 using WTF::containsOnly;
 using WTF::reverseFind;
 using WTF::codePointCompareLessThan;
+using WTF::utf8String;
 
 #include <wtf/text/AtomString.h>
 

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -352,7 +352,7 @@ void TextResourceDecoder::setEncoding(const PAL::TextEncoding& encoding, Encodin
     // treat x-user-defined as windows-1252 (bug 18270)
     if (source == EncodingFromMetaTag && equalLettersIgnoringASCIICase(encoding.name(), "x-user-defined"_s))
         m_encoding = "windows-1252"_s;
-    else if (source == EncodingFromMetaTag || source == EncodingFromXMLHeader || source == EncodingFromCSSCharset)        
+    else if (source == EncodingFromMetaTag || source == EncodingFromXMLHeader || source == EncodingFromCSSCharset)
         m_encoding = encoding.closestByteBasedEquivalent();
     else
         m_encoding = encoding;


### PR DESCRIPTION
#### d64e7efdb2d92203173d89ac6038004e8e49d771
<pre>
Avoid allocating same string &quot;UTF-8&quot; repeatedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=282612">https://bugs.webkit.org/show_bug.cgi?id=282612</a>
&lt;<a href="https://rdar.apple.com/138947605">rdar://138947605</a>&gt;

Reviewed by NOBODY (OOPS!).

Based on the Blink change by Dave Tapuska &lt;dtapuska@chromium.org&gt;:
<a href="https://chromium.googlesource.com/chromium/src/+/8643e19a2b29eebed35d6fe4f14882ca470dc9fe">https://chromium.googlesource.com/chromium/src/+/8643e19a2b29eebed35d6fe4f14882ca470dc9fe</a>

* Source/WebCore/PAL/pal/text/TextEncoding.h:
(PAL::TextEncoding::name const):
* Source/WebCore/PAL/pal/text/TextEncodingDetector.h:
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::newTextCodec):
* Source/WTF/wtf/text/AtomString.cpp:
* Source/WTF/wtf/text/AtomString.h:
(WTF::utf8Atom):
* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::utf8Atom):
* Source/WTF/wtf/text/WTFString.cpp:
* Source/WTF/wtf/text/WTFString.h:
(WTF::utf8String):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d64e7efdb2d92203173d89ac6038004e8e49d771

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17185 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24619 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68195 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80965 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74301 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66462 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8575 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96571 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2327 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5131 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21103 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->