### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
@@ -167,7 +167,7 @@ TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
     TestWebKitAPI::Util::run(&fetchComplete);
 }
 
-TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
+TEST(WKWebExtensionDataRecord, RemoveDataRecords)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
@@ -211,7 +211,7 @@ TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
     TestWebKitAPI::Util::run(&removalComplete);
 }
 
-TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)
+TEST(WKWebExtensionDataRecord, RemoveDataRecordsForMultipleContexts)
 {
     auto *backgroundScriptOne = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
@@ -244,7 +244,9 @@ TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)
     __block bool removalComplete = false;
     [testController fetchDataRecordsOfTypes:allDataTypesSet completionHandler:^(NSArray<WKWebExtensionDataRecord *> *dataRecords) {
         EXPECT_EQ(dataRecords.count, 2UL);
-        EXPECT_EQ(dataRecords[0].totalSizeInBytes + dataRecords[1].totalSizeInBytes, 237UL);
+        NSLog(@"KIARA: unique id: %@. size: %lu", dataRecords[0].uniqueIdentifier, static_cast<unsigned long>(dataRecords[0].totalSizeInBytes));
+        NSLog(@"KIARA: unique id: %@. size: %lu", dataRecords[1].uniqueIdentifier, static_cast<unsigned long>(dataRecords[1].totalSizeInBytes));
+        EXPECT_EQ(dataRecords[0].totalSizeInBytes + dataRecords[1].totalSizeInBytes, 158UL);
 
         [testController removeDataOfTypes:allDataTypesSet fromDataRecords:dataRecords completionHandler:^{
             EXPECT_EQ(dataRecords[0].errors.count, 0UL);


### PR DESCRIPTION
#### 2b92539a627b2dcc965a18226ea3c21b157e0e01
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm:
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, RemoveDataRecords)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, RemoveDataRecordsForMultipleContexts)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b92539a627b2dcc965a18226ea3c21b157e0e01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58818 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48976 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64360 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.RemoveDataRecords (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80815 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66374 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8474 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2184 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->