### PR TITLE
REGRESSION(272476@main): No ligatures across `content: "f" "i"`

### DIFF
--- a/LayoutTests/fast/text/pseudo-element-ligatures-expected.html
+++ b/LayoutTests/fast/text/pseudo-element-ligatures-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+
+<body style="font-size: 1000%;">fi</body>

--- a/LayoutTests/fast/text/pseudo-element-ligatures.html
+++ b/LayoutTests/fast/text/pseudo-element-ligatures.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<style>
+body::before {
+    font-size: 1000%;
+    content: "f" "i";
+}
+</style>
+
+<body></body>


### PR DESCRIPTION
#### 6acf54cb2e6f20cc1149ed6ba10d22179d001296
<pre>
REGRESSION(272476@main): No ligatures across `content: &quot;f&quot; &quot;i&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282444">https://bugs.webkit.org/show_bug.cgi?id=282444</a>
<a href="https://rdar.apple.com/139079271">rdar://139079271</a>

Reviewed by NOBODY (OOPS!).

Add some logic in RenderTreeUpdater to concatenate continuous text fragments into one fragment.

This restores the old behavior pre-272476@main, but other cases remain broken.

* LayoutTests/fast/text/pseudo-element-ligatures-expected.html: Added.
* LayoutTests/fast/text/pseudo-element-ligatures.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::createContentRenderers):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6acf54cb2e6f20cc1149ed6ba10d22179d001296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2142 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58827 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17103 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77994 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48984 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46280 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21875 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67428 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22219 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80845 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2245 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1354 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67088 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66388 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10332 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8489 "Found 2 new test failures: fast/css-generated-content/text-before-table-col-crash.html fast/table/split-table-no-section-update-crash.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->