### PR TITLE
[JSC] DeferredWorkTimer::TicketData::isCancelled needs to verify dependencies

### DIFF
--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -60,7 +60,7 @@ inline Ref<DeferredWorkTimer::TicketData> DeferredWorkTimer::TicketData::create(
 inline VM& DeferredWorkTimer::TicketData::vm()
 {
     ASSERT(!isCancelled());
-    return target()->vm();
+    return target().vm();
 }
 
 inline void DeferredWorkTimer::TicketData::cancel()
@@ -101,8 +101,8 @@ void DeferredWorkTimer::doWork(VM& vm)
 
         // We shouldn't access the TicketData to get this globalObject until
         // after we confirm that the ticket is still valid (which we did above).
-        auto globalObject = ticket->target()->globalObject();
-        switch (globalObject->globalObjectMethodTable()->scriptExecutionStatus(globalObject, ticket->scriptExecutionOwner())) {
+        auto globalObject = ticket->target().globalObject();
+        switch (globalObject->globalObjectMethodTable()->scriptExecutionStatus(globalObject, &ticket->scriptExecutionOwner())) {
         case ScriptExecutionStatus::Suspended:
             suspendedTasks.append(std::make_tuple(ticket, WTFMove(task)));
             continue;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2747,7 +2747,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
                 // FIXME: This seems like it should remove the cancelled ticket? Although, it would likely have to deal with deadlocking somehow.
                 if (ticket->isCancelled())
                     continue;
-                visitor.appendUnbarriered(ticket->scriptExecutionOwner());
+                visitor.appendUnbarriered(&ticket->scriptExecutionOwner());
                 // The check above is just an optimization since between the check and here the mutator could cancel the ticket.
                 constexpr bool mayBeCancelled = true;
                 for (auto& dependency : ticket->dependencies(mayBeCancelled))

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -217,9 +217,9 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
 
     if (waiter->isAsync()) {
         waiter->scheduleWorkAndClear(listLocker, [resolveResult](DeferredWorkTimer::Ticket ticket) {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSPromise* promise = jsCast<JSPromise*>(&ticket->target());
             JSGlobalObject* globalObject = promise->globalObject();
-            ASSERT(ticket->globalObject() == globalObject);
+            ASSERT(&ticket->globalObject() == globalObject);
             VM& vm = promise->vm();
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
             promise->resolve(globalObject, result);
@@ -306,7 +306,7 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
             if (waiter->isAsync()) {
-                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->globalObject() == globalObject) {
+                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && &ticket->globalObject() == globalObject) {
                     dataLogLnIf(WaiterListsManagerInternal::verbose,
                         "<WaiterListManager> <Thread:", Thread::current(),
                         "> unregister JSGlobalObject is cancelling waiter=", *waiter,
@@ -391,9 +391,9 @@ void Waiter::dump(PrintStream& out) const
     auto ticket = this->ticket(NoLockingNecessary);
     out.print(", ticket=", RawPointer(ticket.get()));
     if (ticket && !ticket->isCancelled()) {
-        out.print(", m_ticket->globalObject=", RawPointer(ticket->globalObject()));
+        out.print(", m_ticket->globalObject=", RawPointer(&ticket->globalObject()));
         out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last().get())));
-        out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
+        out.print(", m_ticket->scriptExecutionOwner=", RawPointer(&ticket->scriptExecutionOwner()));
     }
 
     out.print(", m_timer=", RawPointer(m_timer.get()));

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -140,7 +140,7 @@ void StreamingCompiler::didComplete()
     switch (m_compilerMode) {
     case CompilerMode::Validation: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSPromise* promise = jsCast<JSPromise*>(&ticket->target());
             JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
@@ -161,7 +161,7 @@ void StreamingCompiler::didComplete()
 
     case CompilerMode::FullCompile: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSPromise* promise = jsCast<JSPromise*>(&ticket->target());
             JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
             JSObject* importObject = jsCast<JSObject*>(ticket->dependencies()[1].get());
             VM& vm = globalObject->vm();
@@ -209,7 +209,7 @@ void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
         m_eagerFailed = true;
     }
     auto ticket = std::exchange(m_ticket, nullptr);
-    JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+    JSPromise* promise = jsCast<JSPromise*>(&ticket->target());
     // The pending work TicketData was keeping the promise alive. We need to
     // make sure it is reachable from the stack before we remove it from the
     // pending work list. Note: m_ticket stores it as a PackedPtr, which is not


### PR DESCRIPTION
#### 92bbefbc5266b86b813de873d2f993abecadf1fc
<pre>
[JSC] DeferredWorkTimer::TicketData::isCancelled needs to verify dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=282564">https://bugs.webkit.org/show_bug.cgi?id=282564</a>
<a href="https://rdar.apple.com/139237618">rdar://139237618</a>

DeferredWorkTimer::TicketData::isCancelled is used to guarded that target()
cannot be a null. Consider this case:

                          JSGlobalObject -----
                                 ^           |
                                 |           |
                                 | S         | S
                                 |           |
                          W      |           |
             TicketData -----&gt; Target &lt;------|
                |                            |
                |  W                         |
                ------&gt; Dependencies &lt;--------

If one TicketData&apos;s Target and it&apos;s strongly referencing JSGlobalObject
(which also strongly references the Target) have no others are referencing
those two. At that point, GC thinks both of them are available for collecting.
However, our GC doesn&apos;t guarantee which will be collected first. Let&apos;s say Target
is collected first, then the TicketData&apos;s Weak&lt;Target&gt; would become a nullptr.
And before JSGlobalObject is going to be collected, DeferredWorkTimer::doWork
can be triggered.

In that case, this patch ensures the target is still valid before
moving forward. Since all dependencies are Weak in the DeferredWorkTimer::TicketData,
let&apos;s also make sure they are valid before doing the deferred task.

* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::TicketData::vm):
(JSC::DeferredWorkTimer::doWork):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
(JSC::DeferredWorkTimer::TicketData::target):
(JSC::DeferredWorkTimer::TicketData::hasValidDependencies const):
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::notifyWaiterImpl):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92bbefbc5266b86b813de873d2f993abecadf1fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26184 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58844 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17115 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24516 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80861 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74203 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67107 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66407 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8499 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96474 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2228 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21084 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->