### PR TITLE
Convert `ContentData::Type` to an enum class

### DIFF
--- a/Source/WebCore/rendering/style/ContentData.h
+++ b/Source/WebCore/rendering/style/ContentData.h
@@ -39,20 +39,20 @@ class RenderStyle;
 class ContentData {
     WTF_MAKE_TZONE_ALLOCATED(ContentData);
 public:
-    enum Type {
-        CounterDataType,
-        ImageDataType,
-        QuoteDataType,
-        TextDataType
+    enum class Type : uint8_t {
+        Counter,
+        Image,
+        Quote,
+        Text,
     };
     virtual ~ContentData() = default;
 
     Type type() const { return m_type; }
 
-    bool isCounter() const { return type() == CounterDataType; }
-    bool isImage() const { return type() == ImageDataType; }
-    bool isQuote() const { return type() == QuoteDataType; }
-    bool isText() const { return type() == TextDataType; }
+    bool isCounter() const { return type() == Type::Counter; }
+    bool isImage() const { return type() == Type::Image; }
+    bool isQuote() const { return type() == Type::Quote; }
+    bool isText() const { return type() == Type::Text; }
 
     virtual RenderPtr<RenderObject> createContentRenderer(Document&, const RenderStyle&) const = 0;
 
@@ -82,7 +82,7 @@ class ImageContentData final : public ContentData {
     WTF_MAKE_TZONE_ALLOCATED(ImageContentData);
 public:
     explicit ImageContentData(Ref<StyleImage>&& image)
-        : ContentData(ImageDataType)
+        : ContentData(Type::Image)
         , m_image(WTFMove(image))
     {
     }
@@ -114,7 +114,7 @@ class TextContentData final : public ContentData {
     WTF_MAKE_TZONE_ALLOCATED(TextContentData);
 public:
     explicit TextContentData(const String& text)
-        : ContentData(TextDataType)
+        : ContentData(Type::Text)
         , m_text(text)
     {
     }
@@ -138,7 +138,7 @@ class CounterContentData final : public ContentData {
     WTF_MAKE_TZONE_ALLOCATED(CounterContentData);
 public:
     explicit CounterContentData(std::unique_ptr<CounterContent> counter)
-        : ContentData(CounterDataType)
+        : ContentData(Type::Counter)
         , m_counter(WTFMove(counter))
     {
         ASSERT(m_counter);
@@ -170,7 +170,7 @@ class QuoteContentData final : public ContentData {
     WTF_MAKE_TZONE_ALLOCATED(QuoteContentData);
 public:
     explicit QuoteContentData(QuoteType quote)
-        : ContentData(QuoteDataType)
+        : ContentData(Type::Quote)
         , m_quote(quote)
     {
     }
@@ -196,13 +196,13 @@ inline bool operator==(const ContentData& a, const ContentData& b)
         return false;
 
     switch (a.type()) {
-    case ContentData::CounterDataType:
+    case ContentData::Type::Counter:
         return uncheckedDowncast<CounterContentData>(a) == uncheckedDowncast<CounterContentData>(b);
-    case ContentData::ImageDataType:
+    case ContentData::Type::Image:
         return uncheckedDowncast<ImageContentData>(a) == uncheckedDowncast<ImageContentData>(b);
-    case ContentData::QuoteDataType:
+    case ContentData::Type::Quote:
         return uncheckedDowncast<QuoteContentData>(a) == uncheckedDowncast<QuoteContentData>(b);
-    case ContentData::TextDataType:
+    case ContentData::Type::Text:
         return uncheckedDowncast<TextContentData>(a) == uncheckedDowncast<TextContentData>(b);
     }
 


### PR DESCRIPTION
#### 8a967a30b91cdacbd2f1e36a93039e9459296f8a
<pre>
Convert `ContentData::Type` to an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=282570">https://bugs.webkit.org/show_bug.cgi?id=282570</a>
<a href="https://rdar.apple.com/139241597">rdar://139241597</a>

Reviewed by Aditya Keerthi and Simon Fraser.

* Source/WebCore/rendering/style/ContentData.h:
(WebCore::ContentData::isCounter const):
(WebCore::ContentData::isImage const):
(WebCore::ContentData::isQuote const):
(WebCore::ContentData::isText const):
(WebCore::operator==):

Canonical link: <a href="https://commits.webkit.org/286132@main">https://commits.webkit.org/286132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a77631348369762cc653005256a0dadaea2d993a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79371 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77058 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/63507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78008 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/63507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39227 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/63507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21880 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/63507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2259 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16494 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2224 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->