### PR TITLE
[iOS] Rendering in Jupyter notebook (MathJAX.js converting LaTeX) is broken due to data detection

### DIFF
--- a/LayoutTests/fast/dom/linkify-phone-numbers-expected.html
+++ b/LayoutTests/fast/dom/linkify-phone-numbers-expected.html
@@ -11,5 +11,6 @@
 <a href="foobar.html">408 111 222</a>
 <pre>408 111 222</pre>
 <code>408 111 222</code>
+<div>$\displaystyle \left(x + 1234567)\right$</div>
 </body>
 </html>

--- a/LayoutTests/fast/dom/linkify-phone-numbers.html
+++ b/LayoutTests/fast/dom/linkify-phone-numbers.html
@@ -3,8 +3,7 @@
 <head>
 <title>This tests the most common cases of linkifying/not linkifying phone numbers on iOS</title>
 <script>
-if (window.internals)
-    internals.settings.setTelephoneNumberParsingEnabled(true);
+window.internals?.settings.setTelephoneNumberParsingEnabled(true);
 </script>
 </head>
 <body>
@@ -15,5 +14,6 @@ if (window.internals)
 <a href="#">408 111 222</a>
 <pre>408 111 222</pre>
 <code>408 111 222</code>
+<div data-mime-type="text/latex">$\displaystyle \left(x + 1234567)\right$</div>
 </body>
 </html>


### PR DESCRIPTION
#### 51965fbac8b7d44d52321c3bb81a881a9a59923a
<pre>
[iOS] Rendering in Jupyter notebook (MathJAX.js converting LaTeX) is broken due to data detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=282567">https://bugs.webkit.org/show_bug.cgi?id=282567</a>
<a href="https://rdar.apple.com/116407458">rdar://116407458</a>

Reviewed by Richard Robinson, Ryosuke Niwa, and Abrar Rahman Protyasha.

Since at least iOS 7, the HTML parser automatically tries to detect phone numbers that appear within
plain text, and replaces them with links; for instance, a normal text node `+1234567` would be
replaced by an anchor element, `&lt;a href=&quot;tel:+1234567&quot;&gt;+1234567&lt;/a&gt;`. This sometimes causes
incompatibilities with certain JavaScript libraries that try to parse text at load time and use it
to convert the text nodes (and their container element) into formatted LaTeX.

Unfortunately, there isn&apos;t any obvious indication that we must avoid running data detection for this
text (e.g. based on the element type, style, or other attributes); the only indication of this comes
in the form of a `data-mime-type=&quot;text/latex&quot;` DOM attribute on a parent container of the text node.

* LayoutTests/fast/dom/linkify-phone-numbers-expected.html:
* LayoutTests/fast/dom/linkify-phone-numbers.html:

Adjust an existing layout test to cover this scenario.

* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::linkifyPhoneNumbers):

Walk up the tree to check for ancestor elements with `data-mime-type=&quot;text/latex&quot;`; I&apos;m doing this
here (when a phone number is about to be inserted) instead of in `disallowTelephoneNumberParsing`,
so that we don&apos;t incur the cost of a potentially expensive attribute lookup multiple times, for
every ancestor element of every text node in the DOM.

(WebCore::shouldParseTelephoneNumbersInNode):

Leave a FIXME here about the fact that on iOS, we perform an ancestor walk when parsing every single
text node in the DOM.

Canonical link: <a href="https://commits.webkit.org/286153@main">https://commits.webkit.org/286153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9330d67c7d422daf84b1a1663bb01f3712cf2b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80865 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16508 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8501 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5020 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->