### PR TITLE
Import updated web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Navigation aborted
 
 PASS scroll: scroll() should throw after preventDefault
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
@@ -15,7 +16,7 @@ promise_test(async t => {
     e.preventDefault();
     assert_throws_dom("InvalidStateError", () => e.scroll());
   }), { once : true });
-  await promise_rejects_dom(t, "AbortError", navigation.navigate("#frag").finished);
+  assertBothRejectDOM(t, navigation.navigate("#frag"), "AbortError");
 }, "scroll: scroll() should throw after preventDefault");
 </script>
 </body>


### PR DESCRIPTION
#### cff182d7e8d7085b893e9d6764f5767e3d264948
<pre>
Import updated web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=282575">https://bugs.webkit.org/show_bug.cgi?id=282575</a>

Reviewed by Tim Nguyen.

Follow up to <a href="https://github.com/WebKit/WebKit/pull/36043">https://github.com/WebKit/WebKit/pull/36043</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5188826c62ed6dfe4dbe85390dd67f41e253f7e7">https://github.com/web-platform-tests/wpt/commit/5188826c62ed6dfe4dbe85390dd67f41e253f7e7</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-after-preventDefault.html:

Canonical link: <a href="https://commits.webkit.org/286142@main">https://commits.webkit.org/286142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575ee13772d64652585e182aebdc329d4ea6118e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58845 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17117 "Found 1 new test failure: webgl/2.0.y/conformance/rendering/canvas-alpha-bug.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80871 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16503 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8508 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->