### PR TITLE
[JSC] Fix ref-counting issues with Wasm GC types

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -172,6 +172,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     Vector<TypeIndex> importExceptionTypeIndices;
     Vector<TypeIndex> internalExceptionTypeIndices;
     Vector<Ref<TypeDefinition>> typeSignatures;
+    Vector<Ref<TypeDefinition>> recursionGroups;
 
     MemoryInformation memory;
 

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -388,7 +388,8 @@ ALWAYS_INLINE bool ParserBase::parseValueType(const ModuleInformation& info, Typ
                 ASSERT(static_cast<uint32_t>(heapType) >= info.typeCount() && static_cast<uint32_t>(heapType) < m_recursionGroupInformation.end);
                 ProjectionIndex groupIndex = static_cast<ProjectionIndex>(heapType - m_recursionGroupInformation.start);
                 RefPtr<TypeDefinition> def = TypeInformation::getPlaceholderProjection(groupIndex);
-                typeIndex = def->index();
+                RELEASE_ASSERT(def->refCount() > 2); // tbl + RefPtr + owner
+                typeIndex = def->index(); // Owned by TypeInformation placeholder projections singleton.
             } else {
                 ASSERT(static_cast<uint32_t>(heapType) < info.typeCount());
                 typeIndex = TypeInformation::get(info.typeSignatures[heapType].get());

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -115,11 +115,14 @@ auto SectionParser::parseType() -> PartialResult
             // Recursion group parsing will append the entries itself, as there may
             // be multiple entries that need to be added to the type section for
             // each recursion group.
-            if (!signature->is<RecursionGroup>()) {
+            if (signature->is<RecursionGroup>())
+                m_info->recursionGroups.append(signature.releaseNonNull());
+            else {
                 if (signature->hasRecursiveReference()) {
                     Vector<TypeIndex> types;
                     bool result = types.tryAppend(signature->index());
                     WASM_PARSER_FAIL_IF(!result, "can't allocate enough memory for Type section's "_s, i, "th signature"_s);
+                    // group takes ownership of signature via types, and projection takes ownership of group.
                     RefPtr<TypeDefinition> group = TypeInformation::typeDefinitionForRecursionGroup(types);
                     RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(group->index(), 0);
                     TypeInformation::registerCanonicalRTTForType(projection->index());
@@ -954,7 +957,8 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
     WASM_PARSER_FAIL_IF(typeCount > maxRecursionGroupCount, "number of types for recursion group at position "_s, position, " is too big "_s, typeCount, " maximum "_s, maxRecursionGroupCount);
     Vector<TypeIndex> types;
     WASM_PARSER_FAIL_IF(!types.tryReserveInitialCapacity(typeCount), "can't allocate enough memory for recursion group "_s, typeCount, " entries"_s);
-    RefPtr<TypeDefinition> firstSignature;
+    Vector<Ref<TypeDefinition>> signatures;
+    WASM_PARSER_FAIL_IF(!signatures.tryReserveInitialCapacity(typeCount), "can't allocate enough memory for recursion group "_s, typeCount, " entries"_s);
 
     SetForScope<RecursionGroupInformation> recursionGroupInfo(m_recursionGroupInformation, RecursionGroupInformation { true, m_info->typeCount(), m_info->typeCount() + typeCount });
 
@@ -986,11 +990,9 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
 
         WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for recursion group's "_s, i, "th signature"_s);
         types.append(signature->index());
-
-        if (!i)
-            firstSignature = signature;
+        signatures.append(signature.releaseNonNull());
     }
-
+    // Recursion group takes ownership of signatures via types.
     recursionGroup = TypeInformation::typeDefinitionForRecursionGroup(types);
 
     // Type definitions are normalized such that non-recursive, singleton recursion groups
@@ -999,32 +1001,37 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
     WASM_PARSER_FAIL_IF(!m_info->typeSignatures.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's "_s, typeCount, " type "_s, typeCount > 1 ? "indices"_s : "index"_s);
     WASM_PARSER_FAIL_IF(!m_info->rtts.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's "_s, typeCount, " RTT"_s, typeCount > 1 ? "s"_s : ""_s);
     if (typeCount > 1) {
+        Vector<Ref<TypeDefinition>> projections;
+        // Take ownership of all projections before unrolling since they can refer to each other.
         for (uint32_t i = 0; i < typeCount; ++i) {
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), i);
             WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's "_s, i, "th projection"_s);
-            TypeInformation::registerCanonicalRTTForType(projection->index());
-            m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
-            m_info->typeSignatures.append(projection.releaseNonNull());
+            projections.append(projection.releaseNonNull());
+        }
+        for (uint32_t i = 0; i < typeCount; ++i) {
+            TypeInformation::registerCanonicalRTTForType(projections[i]->index());
+            m_info->rtts.append(TypeInformation::getCanonicalRTT(projections[i]->index()));
+            m_info->typeSignatures.append(WTFMove(projections[i]));
         }
         // Checking subtyping requirements has to be deferred until we construct projections in case recursive references show up in the type.
         for (uint32_t i = 0; i < typeCount; ++i) {
-            const TypeDefinition& def = TypeInformation::get(types[i]).replacePlaceholders(recursionGroup->index());
-            if (def.is<Subtype>())
+            Ref def = TypeInformation::get(types[i]).replacePlaceholders(recursionGroup->index());
+            if (def->is<Subtype>())
                 WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(def));
         }
     } else if (typeCount) {
-        if (!firstSignature->hasRecursiveReference()) {
-            TypeInformation::registerCanonicalRTTForType(firstSignature->index());
-            m_info->rtts.append(TypeInformation::getCanonicalRTT(firstSignature->index()));
-            if (firstSignature->is<Subtype>())
-                WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(*firstSignature));
-            m_info->typeSignatures.append(firstSignature.releaseNonNull());
+        if (!signatures[0]->hasRecursiveReference()) {
+            TypeInformation::registerCanonicalRTTForType(signatures[0]->index());
+            m_info->rtts.append(TypeInformation::getCanonicalRTT(signatures[0]->index()));
+            if (signatures[0]->is<Subtype>())
+                WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(signatures[0]));
+            m_info->typeSignatures.append(WTFMove(signatures[0]));
         } else {
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), 0);
             WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's 0th projection"_s);
             TypeInformation::registerCanonicalRTTForType(projection->index());
             m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
-            if (firstSignature->is<Subtype>())
+            if (signatures[0]->is<Subtype>())
                 WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(projection->unroll()));
             m_info->typeSignatures.append(projection.releaseNonNull());
         }
@@ -1127,7 +1134,7 @@ auto SectionParser::parseSubtype(uint32_t position, RefPtr<TypeDefinition>& subt
         // If a parent type is in the same recursion group, the index needs to refer to the projection instead.
         else {
             RefPtr<TypeDefinition> projection = TypeInformation::getPlaceholderProjection(typeIndex - m_info->typeCount());
-            supertypeIndex = projection->index();
+            supertypeIndex = projection->index(); // Placeholders are owned by TypeInformation singleton.
         }
     }
 
@@ -1159,6 +1166,7 @@ auto SectionParser::parseSubtype(uint32_t position, RefPtr<TypeDefinition>& subt
         return { };
     }
 
+    // Subtype takes ownership of underlyingType.
     if (supertypeCount > 0)
         subtype = TypeInformation::typeDefinitionForSubtype({ supertypeIndex }, TypeInformation::get(*underlyingType), isFinal);
     else

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -815,14 +815,14 @@ public:
     template <typename T>
     const T* as() const { return const_cast<TypeDefinition*>(this)->as<T>(); }
 
-    TypeIndex index() const { return bitwise_cast<TypeIndex>(this); }
+    TypeIndex index() const;
 
     WTF::String toString() const;
     void dump(WTF::PrintStream& out) const;
     bool operator==(const TypeDefinition& rhs) const { return this == &rhs; }
     unsigned hash() const;
 
-    const TypeDefinition& replacePlaceholders(TypeIndex) const;
+    Ref<const TypeDefinition> replacePlaceholders(TypeIndex) const;
     const TypeDefinition& unroll() const;
     const TypeDefinition& expand() const;
     bool hasRecursiveReference() const;
@@ -839,6 +839,9 @@ public:
     static const constexpr TypeIndex invalidIndex = 0;
 
 private:
+    // Returns the TypeIndex of a potentially unowned (other than TypeInformation::m_typeSet) TypeDefinition.
+    TypeIndex unownedIndex() const { return bitwise_cast<TypeIndex>(this); }
+
     friend class TypeInformation;
     friend struct FunctionParameterTypes;
     friend struct StructParameterTypes;
@@ -939,7 +942,7 @@ public:
     static RefPtr<TypeDefinition> getPlaceholderProjection(ProjectionIndex);
     ALWAYS_INLINE const FunctionSignature* thunkFor(Type type) const { return thunkTypes[linearizeType(type.kind)]; }
 
-    static void addCachedUnrolling(TypeIndex, const TypeDefinition*);
+    static void addCachedUnrolling(TypeIndex, const TypeDefinition&);
     static std::optional<TypeIndex> tryGetCachedUnrolling(TypeIndex);
 
     // Every type definition that is in a module's signature list should have a canonical RTT registered for subtyping checks.


### PR DESCRIPTION
#### 3ec2959867b0ec050bc0d3c2c14147716da76f50
<pre>
[JSC] Fix ref-counting issues with Wasm GC types
<a href="https://bugs.webkit.org/show_bug.cgi?id=282576">https://bugs.webkit.org/show_bug.cgi?id=282576</a>
<a href="https://rdar.apple.com/139244985">rdar://139244985</a>

Reviewed by Yusuke Suzuki.

While parsing the wasm type section there are windows where
reference counts to a Wasm GC TypeDefinitions are not held
by the parser. During these windows, a
TypeInformation::tryCleanup() could free these
types out from under the parser. Close these windows.
Also add asserts to help verify and document.
The windows were:

1. parseRecursionGroup() needs to hold ref counts to each
element until it constructs the recursion group, which
takes ownership.

2. parseRecursionGroup() needs to create its projections
and hold references while they are being linked together.

3. While replacing placeholders, we need to be careful to
continue holding a ref count until the unrolling cache
takes ownership.

Also, RTT::tryCreateRTT() was missing an adoptRef which
I think would cause these to leak.

After parsing, everythng is owned by the parser&apos;s
WasmModuleInformation either directly, indirectly through
the TypeDefinition tree of (manual kept) ref counts, or
indirectly via the TypeInformation caches (which tie the
lifetime of the value to the key).

In addition to the added asserts, I also ran the
javascriptcore test with more instrumentation added
to TypeDefinition::deref() to help ensure references are no
longer dropped at the wrong times.

* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
(JSC::Wasm::SectionParser::parseSubtype):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::substitute):
(JSC::Wasm::substituteParent):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeDefinition::unroll const):
(JSC::Wasm::RTT::tryCreateRTT):
(JSC::Wasm::TypeInformation::addCachedUnrolling):
(JSC::Wasm::TypeInformation::tryCleanup):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::TypeDefinition::unownedIndex const):
(JSC::Wasm::TypeDefinition::index const): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeDefinition::index const):
(JSC::Wasm::TypeInformation::get):

Canonical link: <a href="https://commits.webkit.org/286140@main">https://commits.webkit.org/286140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/408da6a6300643ba5706cdcfca2e221da7da7422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58849 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17125 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24532 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68098 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80877 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74219 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66411 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8502 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96490 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11565 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2244 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21088 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->