### PR TITLE
Nested backdrop filters don't compute opaque backdrop root state correctly.

### DIFF
--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-nested-expected.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-nested-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    .container {
+      display: grid;
+      backdrop-filter: blur(0px);
+    }
+
+    .container > * {
+      grid-area: -1/1;
+    }
+
+    .a {
+      position: relative;
+    }
+
+    .b {
+      background-color: rgba(0,0,0,0.01);
+    }
+  </style>
+</head>
+<body>
+
+  <div class="container">
+    <div class="a">The background on this text should not be black.</div>
+    <div class="b"></div>
+  </div>
+  
+</body>
+</html>

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-nested.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-nested.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-15128" />
+  <style>
+    .container {
+      display: grid;
+      backdrop-filter: blur(0px);
+    }
+
+    .container > * {
+      grid-area: -1/1;
+    }
+
+    .a {
+      backdrop-filter: blur(1px);
+    }
+
+    .b {
+      background-color: rgba(0,0,0,0.01);
+    }
+  </style>
+</head>
+<body>
+
+  <div class="container">
+    <div class="a">The background on this text should not be black.</div>
+    <div class="b"></div>
+  </div>
+  
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1898,7 +1898,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
     }
 
     if (isBackdropRoot())
-        commitState.backdropRootIsOpaque = backgroundColor().isOpaque();
+        childCommitState.backdropRootIsOpaque = backgroundColor().isOpaque();
 
     if (GraphicsLayerCA* maskLayer = downcast<GraphicsLayerCA>(m_maskLayer.get())) {
         maskLayer->setVisibleAndCoverageRects(rects);


### PR DESCRIPTION
#### 8504cfe233f4dcbe531709b6275ec0c40040d81f
<pre>
Nested backdrop filters don&apos;t compute opaque backdrop root state correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282581">https://bugs.webkit.org/show_bug.cgi?id=282581</a>
&lt;<a href="https://rdar.apple.com/139034016">rdar://139034016</a>&gt;

Reviewed by Simon Fraser.

* LayoutTests/css3/filters/backdrop/backdrop-filter-nested-expected.html: Added.
* LayoutTests/css3/filters/backdrop/backdrop-filter-nested.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::recursiveCommitChanges):

Canonical link: <a href="https://commits.webkit.org/286242@main">https://commits.webkit.org/286242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/905b7b45052c62480c3181e0ba19829f903d64fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17223 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22046 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81068 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1521 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67236 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8637 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5230 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->