### PR TITLE
CredentialsContainer reject with AbortSignal reason

### DIFF
--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https-expected.txt
@@ -4,4 +4,5 @@ PASS navigator.credentials.create() with empty argument.
 PASS navigator.credentials.create() with bogus publicKey data
 PASS navigator.credentials.create() with bogus data
 PASS navigator.credentials.create() with abort signal set
+PASS navigator.credentials.create() aborted with custom reason
 

--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https.html
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https.html
@@ -31,4 +31,12 @@ promise_test(function(t) {
     return promise_rejects_dom(t, "AbortError",
         navigator.credentials.create(options));
 }, "navigator.credentials.create() with abort signal set");
+
+promise_test(function(t) {
+    const controller = new AbortController();
+    controller.abort("custom reason");
+
+    return promise_rejects_exactly(t, "custom reason",
+        navigator.credentials.create({ signal: controller.signal }));
+}, "navigator.credentials.create() aborted with custom reason");
 </script>

--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt
@@ -7,4 +7,5 @@ PASS navigator.credentials.get() with abort signal set
 PASS navigator.credentials.get() with multiple request types.
 PASS navigator.credentials.get() with a single mediation argument.
 PASS navigator.credentials.get() with only a mediation and signal.
+PASS navigator.credentials.get() aborted with custom reason
 

--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html
@@ -71,4 +71,12 @@ promise_test(async (t) => {
         assert_equals(e.message, "Missing request type.");
     }
 }, "navigator.credentials.get() with only a mediation and signal.");
+
+promise_test(function(t) {
+    const controller = new AbortController();
+    controller.abort("custom reason");
+
+    return promise_rejects_exactly(t, "custom reason",
+        navigator.credentials.get({ signal: controller.signal }));
+}, "navigator.credentials.get() aborted with custom reason");
 </script>

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -109,7 +109,7 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
     }
 
     if (options.signal && options.signal->aborted()) {
-        promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+        promise.rejectType<IDLAny>(options.signal->reason().getValue());
         return false;
     }
 


### PR DESCRIPTION
#### 3b99a41a6e45d0a94efde8027c011622826b5d89
<pre>
CredentialsContainer reject with AbortSignal reason
<a href="https://bugs.webkit.org/show_bug.cgi?id=258911">https://bugs.webkit.org/show_bug.cgi?id=258911</a>

Reviewed by Darin Adler.

The WebAuthn specification states that if the signal is aborted, the promise
should be rejected with the AbortSignal&apos;s reason.
Specifically, section 2.5.4 &quot;Create a credential&quot; point 10 states:
&gt; If options.signal is aborted, then return a promise rejected with options.signal&apos;s abort reason.

Spec: &lt;<a href="https://w3c.github.io/webappsec-credential-management">https://w3c.github.io/webappsec-credential-management</a>&gt;

* LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https-expected.txt: Rebaseline.
* LayoutTests/http/wpt/credential-management/credentialscontainer-create-basics.https.html:
Added test case for a custom abort reason.
* LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt: Rebaseline.
* LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html:
Added test case for a custom abort reason.
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::performCommonChecks):

Canonical link: <a href="https://commits.webkit.org/286208@main">https://commits.webkit.org/286208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee6403161869927e477515e8da197af1c401a203

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58957 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22019 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24689 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8613 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2400 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2425 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->