### PR TITLE
[Win][MediaFoundation] the video is black blank for https://www.w3.org/2010/05/video/mediaevents.html

### DIFF
--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -401,11 +401,6 @@ bool MediaPlayerPrivateMediaFoundation::didLoadingProgress() const
     return m_loadingProgress;
 }
 
-void MediaPlayerPrivateMediaFoundation::setPresentationSize(const IntSize& size)
-{
-    m_size = size;
-}
-
 void MediaPlayerPrivateMediaFoundation::paint(GraphicsContext& context, const FloatRect& rect)
 {
     if (context.paintingDisabled() || !m_visible)
@@ -884,18 +879,21 @@ void MediaPlayerPrivateMediaFoundation::onBufferingStopped()
 
 void MediaPlayerPrivateMediaFoundation::onSessionStarted()
 {
+    RefPtr<MediaPlayer> player = m_player.get();
+    if (!player)
+        return;
     m_sessionEnded = false;
     if (m_seeking) {
         m_seeking = false;
         if (m_paused)
             m_mediaSession->Pause();
-        if (auto player = m_player.get())
-            player->timeChanged();
+        player->timeChanged();
         return;
     }
 
     if (auto videoDisplay = this->videoDisplay()) {
-        RECT rc = { 0, 0, m_size.width(), m_size.height() };
+        IntSize size = player->presentationSize();
+        RECT rc = { 0, 0, size.width(), size.height() };
         videoDisplay->SetVideoPosition(nullptr, &rc);
     }
 

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -109,8 +109,6 @@ public:
 
     bool didLoadingProgress() const final;
 
-    void setPresentationSize(const IntSize&) final;
-
     void paint(GraphicsContext&, const FloatRect&) final;
 
     DestinationColorSpace colorSpace() final;
@@ -130,7 +128,6 @@ private:
 
     WeakPtr<MediaPlayerPrivateMediaFoundation> m_weakThis;
     ThreadSafeWeakPtr<MediaPlayer> m_player;
-    IntSize m_size;
     bool m_visible;
     bool m_loadingProgress;
     bool m_paused;


### PR DESCRIPTION
#### 0cce879db374f2f7ad7649e44d57765316be36e9
<pre>
[Win][MediaFoundation] the video is black blank for <a href="https://www.w3.org/2010/05/video/mediaevents.html">https://www.w3.org/2010/05/video/mediaevents.html</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282586">https://bugs.webkit.org/show_bug.cgi?id=282586</a>

Reviewed by Don Olmstead.

MediaPlayerPrivateMediaFoundation was randomly failing to show the
video playback. m_size of MediaPlayerPrivateMediaFoundation was empty
in the case. setPresentationSize was called before an instance of
MediaPlayerPrivateMediaFoundation was created.
NullMediaPlayerPrivate::setPresentationSize was called in the case.

We should use MediaPlayer::presentationSize() to get the correct
presentation size. No longer need to override setPresentationSize.

* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::onSessionStarted):
(WebCore::MediaPlayerPrivateMediaFoundation::setPresentationSize): Deleted.
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:

Canonical link: <a href="https://commits.webkit.org/286175@main">https://commits.webkit.org/286175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff942aa8eabd697406076013d034bd9a47b73ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58868 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67125 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66425 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8522 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11583 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5050 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->