### PR TITLE
Change other to be a const SecurityOrigin& in SecurityOrigin

### DIFF
--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -245,7 +245,7 @@ String DatabaseManager::fullPathForDatabase(SecurityOrigin& origin, const String
     {
         Locker locker { m_proposedDatabasesLock };
         for (auto* proposedDatabase : m_proposedDatabases) {
-            if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(&origin))
+            if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(origin))
                 return String();
         }
     }
@@ -257,7 +257,7 @@ DatabaseDetails DatabaseManager::detailsForNameAndOrigin(const String& name, Sec
     {
         Locker locker { m_proposedDatabasesLock };
         for (auto* proposedDatabase : m_proposedDatabases) {
-            if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(&origin)) {
+            if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(origin)) {
                 ASSERT(&proposedDatabase->details().thread() == &Thread::current() || isMainThread());
                 return proposedDatabase->details();
             }

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -91,7 +91,7 @@ std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
     if (frame->isMainFrame())
         return true;
 
-    if (securityOrigin->equal(&document->topOrigin()))
+    if (securityOrigin->equal(document->topOrigin()))
         return true;
 
     if (!frame->page())
@@ -160,7 +160,7 @@ std::optional<StorageAccessQuickResult> DocumentStorageAccess::requestStorageAcc
     if (frame->isMainFrame())
         return StorageAccessQuickResult::Grant;
 
-    if (securityOrigin.equal(&document->topOrigin()))
+    if (securityOrigin.equal(document->topOrigin()))
         return StorageAccessQuickResult::Grant;
 
     // If there is a sandbox, it has to allow the storage access API to be called.

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -551,7 +551,7 @@ void MemoryCache::removeResourcesWithOrigin(const SecurityOrigin& origin, const 
                 continue;
             }
             auto resourceOrigin = SecurityOrigin::create(resource.url());
-            if (resourceOrigin->equal(&origin))
+            if (resourceOrigin->equal(origin))
                 resourcesWithOrigin.append(resource);
         }
     }

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -588,22 +588,21 @@ Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, S
     return origin;
 }
 
-// FIXME: other should be a const SecurityOrigin& because we assume it is non-null.
-bool SecurityOrigin::equal(const SecurityOrigin* other) const
+bool SecurityOrigin::equal(const SecurityOrigin& other) const
 {
-    if (other == this)
+    if (&other == this)
         return true;
 
-    if (isOpaque() || other->isOpaque())
-        return data().opaqueOriginIdentifier() == other->data().opaqueOriginIdentifier();
+    if (isOpaque() || other.isOpaque())
+        return data().opaqueOriginIdentifier() == other.data().opaqueOriginIdentifier();
     
-    if (!isSameSchemeHostPort(*other))
+    if (!isSameSchemeHostPort(other))
         return false;
 
-    if (m_domainWasSetInDOM != other->m_domainWasSetInDOM)
+    if (m_domainWasSetInDOM != other.m_domainWasSetInDOM)
         return false;
 
-    if (m_domainWasSetInDOM && m_domain != other->m_domain)
+    if (m_domainWasSetInDOM && m_domain != other.m_domain)
         return false;
 
     return true;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -179,7 +179,7 @@ public:
     // For access checks, use isSameOriginDomain().
     // FIXME: If this method is really only useful for hash table keys, it
     // should be refactored into SecurityOriginHash.
-    WEBCORE_EXPORT bool equal(const SecurityOrigin*) const;
+    WEBCORE_EXPORT bool equal(const SecurityOrigin&) const;
 
     // This method checks for equality, ignoring the value of document.domain
     // (and whether it was set) but considering the host. It is used for postMessage.

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -198,7 +198,7 @@ bool SecurityPolicy::allowSubstituteDataAccessToLocal()
 
 bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const SecurityOrigin& targetOrigin, const URL& targetURL, const OriginAccessPatterns& patterns)
 {
-    ASSERT(targetOrigin.equal(SecurityOrigin::create(targetURL).ptr()));
+    ASSERT(targetOrigin.equal(SecurityOrigin::create(targetURL)));
     {
         Locker locker { originAccessMapLock };
         if (auto* list = originAccessMap().get(activeOrigin.data())) {

--- a/Source/WebCore/storage/StorageEventDispatcher.cpp
+++ b/Source/WebCore/storage/StorageEventDispatcher.cpp
@@ -53,7 +53,7 @@ static void dispatchStorageEvents(const String& key, const String& oldValue, con
             return;
         if (isSourceStorage(*storage))
             return;
-        if (!securityOrigin.equal(window.securityOrigin()))
+        if (!securityOrigin.equal(*window.securityOrigin()))
             return;
         windows.append(window);
     });

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -101,7 +101,7 @@ using namespace WebCore;
     if (![anObject isMemberOfClass:[WebSecurityOrigin class]])
         return NO;
     
-    return [self _core]->equal([anObject _core]);
+    return [self _core]->equal(*[anObject _core]);
 }
 
 - (void)dealloc


### PR DESCRIPTION
#### f385189a193a735f1eba80a443512a5e49056fa2
<pre>
Change other to be a const SecurityOrigin&amp; in SecurityOrigin
<a href="https://bugs.webkit.org/show_bug.cgi?id=282589">https://bugs.webkit.org/show_bug.cgi?id=282589</a>

Reviewed by Chris Dumez.

Change other to be a const SecurityOrigin&amp; because function assumes it is non-null.

* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::equal const):
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/Modules/webdatabase/DatabaseManager.cpp:
(WebCore::DatabaseManager::fullPathForDatabase):
(WebCore::DatabaseManager::detailsForNameAndOrigin):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeResourcesWithOrigin):
* Source/WebCore/page/SecurityPolicy.cpp:
(WebCore::SecurityPolicy::isAccessAllowed):
* Source/WebCore/storage/StorageEventDispatcher.cpp:
(WebCore::dispatchStorageEvents):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm:
(-[WebSecurityOrigin isEqual:]):

Canonical link: <a href="https://commits.webkit.org/287111@main">https://commits.webkit.org/287111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2901a5dcfe22a25ee6ccf38d1f8001f98edf0ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61340 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19267 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41656 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84359 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69566 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68821 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11158 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->