### PR TITLE
Combining CSS clip-path with any property that creates a new stacking context makes img element disappear

### DIFF
--- a/LayoutTests/compositing/masks/reference-clip-path-on-composited-image-expected.html
+++ b/LayoutTests/compositing/masks/reference-clip-path-on-composited-image-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    img {
+        margin: 10px;
+        width: 300px;
+        height: 300px;
+    }
+
+    .clipped {
+        clip-path: url(#clipper);
+    }
+</style>
+</head>
+<body>
+
+<img class="clipped" src="../resources/simple_image_opaque.png">
+
+<svg height="0">
+    <clipPath id="clipper" clipPathUnits="objectBoundingBox">
+        <rect x="0.25" y="0.25" width="0.5" height="0.5"/>
+    </clipPath>
+</svg>
+
+</body>
+</html>

--- a/LayoutTests/compositing/masks/reference-clip-path-on-composited-image.html
+++ b/LayoutTests/compositing/masks/reference-clip-path-on-composited-image.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    img {
+        margin: 10px;
+        width: 300px;
+        height: 300px;
+    }
+
+    .clipped {
+        clip-path: url(#clipper);
+    }
+    
+    .composited {
+        transform: translateZ(0);
+    }
+</style>
+</head>
+<body>
+
+<img class="clipped composited" src="../resources/simple_image_opaque.png">
+
+<svg height="0">
+    <clipPath id="clipper" clipPathUnits="objectBoundingBox">
+        <rect x="0.25" y="0.25" width="0.5" height="0.5"/>
+    </clipPath>
+</svg>
+
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -275,6 +275,11 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         return;
     }
 
+    if (paintInfo.phase == PaintPhase::ClippingMask && style().usedVisibility() == Visibility::Visible) {
+        paintClippingMask(paintInfo, adjustedPaintOffset);
+        return;
+    }
+
     LayoutRect paintRect = LayoutRect(adjustedPaintOffset, size());
     if (paintInfo.phase == PaintPhase::Outline || paintInfo.phase == PaintPhase::SelfOutline) {
         if (style().outlineWidth())
@@ -345,6 +350,7 @@ bool RenderReplaced::shouldPaint(PaintInfo& paintInfo, const LayoutPoint& paintO
         && paintInfo.phase != PaintPhase::SelfOutline
         && paintInfo.phase != PaintPhase::Selection
         && paintInfo.phase != PaintPhase::Mask
+        && paintInfo.phase != PaintPhase::ClippingMask
         && paintInfo.phase != PaintPhase::EventRegion
         && paintInfo.phase != PaintPhase::Accessibility)
         return false;


### PR DESCRIPTION
#### eb1b95267c74af38c345cac276ef69c4b70863c7
<pre>
Combining CSS clip-path with any property that creates a new stacking context makes img element disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=233553">https://bugs.webkit.org/show_bug.cgi?id=233553</a>
<a href="https://rdar.apple.com/86091397">rdar://86091397</a>

Reviewed by Said Abou-Hallawa.

When an image is composited and has a clip-path which references an SVG path, we make a mask layer,
and paint the clip-path into it, using the PaintPhase::ClippingMask phase.

RenderReplaced failed to implement support for this paint phase, so add it, similar to how
`RenderBlock::paintObject()` does.

* LayoutTests/compositing/masks/reference-clip-path-on-composited-image-expected.html: Added.
* LayoutTests/compositing/masks/reference-clip-path-on-composited-image.html: Added.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):

Canonical link: <a href="https://commits.webkit.org/286172@main">https://commits.webkit.org/286172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2df5f540ec972c51b54144fca4c81ea64157f22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67161 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8566 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2322 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->