### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make GameControllerHaptic classes RefCounted

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -59,6 +59,7 @@ private:
 
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     GameControllerHapticEngines& ensureHapticEngines();
+    Ref<GameControllerHapticEngines> ensureProtectedHapticEngines() { return ensureHapticEngines(); }
 #endif
 
     RetainPtr<GCController> m_gcController;
@@ -66,7 +67,7 @@ private:
     Vector<SharedGamepadValue> m_axisValues;
     Vector<SharedGamepadValue> m_buttonValues;
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
-    std::unique_ptr<GameControllerHapticEngines> m_hapticEngines;
+    RefPtr<GameControllerHapticEngines> m_hapticEngines;
 #endif
 };
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -188,7 +188,7 @@ GameControllerHapticEngines& GameControllerGamepad::ensureHapticEngines()
 void GameControllerGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
-    ensureHapticEngines().playEffect(type, parameters, WTFMove(completionHandler));
+    ensureProtectedHapticEngines()->playEffect(type, parameters, WTFMove(completionHandler));
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(parameters);
@@ -199,8 +199,8 @@ void GameControllerGamepad::playEffect(GamepadHapticEffectType type, const Gamep
 void GameControllerGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
 {
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
-    if (m_hapticEngines)
-        m_hapticEngines->stopEffects();
+    if (RefPtr hapticEngines = m_hapticEngines)
+        hapticEngines->stopEffects();
 #endif
     completionHandler();
 }
@@ -209,8 +209,8 @@ void GameControllerGamepad::noLongerHasAnyClient()
 {
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     // Stop the haptics engine if it is running.
-    if (m_hapticEngines)
-        m_hapticEngines->stop([] { });
+    if (RefPtr hapticEngines = m_hapticEngines)
+        hapticEngines->stop([] { });
 #endif
 }
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -28,18 +28,10 @@
 #if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 
 #import <wtf/CompletionHandler.h>
+#import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
-
-namespace WebCore {
-class GameControllerHapticEffect;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::GameControllerHapticEffect> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -47,10 +39,10 @@ class GameControllerHapticEngines;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEffect : public CanMakeWeakPtr<GameControllerHapticEffect> {
+class GameControllerHapticEffect : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEffect> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEffect);
 public:
-    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
+    static RefPtr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
     ~GameControllerHapticEffect();
 
     void start(CompletionHandler<void(bool)>&&);

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -52,7 +52,7 @@ static double magnitudeToIntensity(double magnitude)
     return intensity;
 }
 
-std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)
+RefPtr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)
 {
     auto createPlayer = [&](CHHapticEngine *engine, double magnitude) -> RetainPtr<id> {
         NSDictionary* hapticDict = @{
@@ -98,7 +98,7 @@ std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(G
         RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create the haptic effect players");
         return nullptr;
     }
-    return std::unique_ptr<GameControllerHapticEffect>(new GameControllerHapticEffect(WTFMove(leftPlayer), WTFMove(rightPlayer)));
+    return adoptRef(new GameControllerHapticEffect(WTFMove(leftPlayer), WTFMove(rightPlayer)));
 }
 
 GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 
 #include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -36,24 +37,15 @@ OBJC_CLASS CHHapticEngine;
 OBJC_CLASS GCController;
 
 namespace WebCore {
-class GameControllerHapticEngines;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::GameControllerHapticEngines> : std::true_type { };
-}
-
-namespace WebCore {
 
 class GameControllerHapticEffect;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEngines : public CanMakeWeakPtr<GameControllerHapticEngines> {
+class GameControllerHapticEngines : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEngines> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEngines);
 public:
-    static std::unique_ptr<GameControllerHapticEngines> create(GCController *);
+    static Ref<GameControllerHapticEngines> create(GCController *);
     ~GameControllerHapticEngines();
 
     void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
@@ -70,7 +62,7 @@ private:
     explicit GameControllerHapticEngines(GCController *);
 
     void ensureStarted(GamepadHapticEffectType, CompletionHandler<void(bool)>&&);
-    std::unique_ptr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
+    RefPtr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
 
     RetainPtr<CHHapticEngine> m_leftHandleEngine;
     RetainPtr<CHHapticEngine> m_rightHandleEngine;
@@ -80,8 +72,8 @@ private:
     bool m_failedToStartRightHandleEngine { false };
     bool m_failedToStartLeftTriggerEngine { false };
     bool m_failedToStartRightTriggerEngine { false };
-    std::unique_ptr<GameControllerHapticEffect> m_currentDualRumbleEffect;
-    std::unique_ptr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
+    RefPtr<GameControllerHapticEffect> m_currentDualRumbleEffect;
+    RefPtr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0a5bd68731bf5871dbdfd54d2441d8dba32d757b
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make GameControllerHaptic classes RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=282577">https://bugs.webkit.org/show_bug.cgi?id=282577</a>

Reviewed by Geoffrey Garen.

Make GameControllerHapticEngines and GameControllerHapticEffect as RefCounted classes.

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
(WebCore::GameControllerGamepad::ensureProtectedHapticEngines):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::playEffect):
(WebCore::GameControllerGamepad::stopEffects):
(WebCore::GameControllerGamepad::noLongerHasAnyClient):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::create):
(WebCore::GameControllerHapticEngines::currentEffectForType):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::ensureStarted):

Canonical link: <a href="https://commits.webkit.org/286195@main">https://commits.webkit.org/286195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f84f1fdc94a36074d93e293343b309b52564e14b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17208 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39333 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24688 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2438 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16547 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2399 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->